### PR TITLE
Depend on shaded cassandra within repo

### DIFF
--- a/atlasdb-cassandra-tests/build.gradle
+++ b/atlasdb-cassandra-tests/build.gradle
@@ -7,7 +7,7 @@ dependencies {
   compile(project(":atlasdb-cassandra"))
   compile project(path: ":atlasdb-tests-shared", configuration: 'test')
   compile 'org.apache.cassandra:cassandra-all:2.1.5'
-  compile 'com.palantir.shaded.com.datastax.cassandra:datastax-cassandra-driver-core:0.2.0'
+  compile project(path: ':datastax-cassandra-driver-core', configuration: 'shadow')
 }
 
 jacoco {


### PR DESCRIPTION
We should either do this, or pull the shaded cassandra stuff out into a separate repo. It's weird for two pieces of the same repo to be linked via Artifactory (publication and consumption).
