### PR TITLE
Bugfix converting tablename to Cassandra Columnfamily name

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -318,7 +318,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         for (byte[] r : batch) {
                             rowNames.add(ByteBuffer.wrap(r));
                         }
-                        ColumnParent colFam = new ColumnParent(tableName);
+                        ColumnParent colFam = new ColumnParent(internalTableName(tableName));
                         Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal(client, tableName, rowNames, colFam, pred, readConsistency);
                         Map<Cell, Value> ret = Maps.newHashMap();
                         new ValueExtractor(ret).extractResults(results, startTs, ColumnSelection.all());


### PR DESCRIPTION
We should also add a few unit tests against Cassandra as part of Atlas
unbreakable to ensure this doesn't happen in the future.
