### PR TITLE
fixed bug where schema mutation lock is unlocked when not locked

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -903,8 +903,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     @Override
     public void dropTable(final String tableName) {
+        boolean locked = false;
         try {
             trySchemaMutationLock();
+            locked = true;
             clientPool.runWithPooledResource(new FunctionCheckedException<Client, Void, Exception>() {
                 @Override
                 public Void apply(Client client) throws Exception {
@@ -926,7 +928,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         } finally {
-            schemaMutationLock.unlock();
+            if (locked) {
+                schemaMutationLock.unlock();
+            }
         }
     }
 
@@ -953,8 +957,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
      */
     @Override
     public void dropTables(final Set<String> tablesToDrop) {
+        boolean locked = false;
         try {
             trySchemaMutationLock();
+            locked = true;
             clientPool.runWithPooledResource(new FunctionCheckedException<Client, Void, Exception>() {
                 @Override
                 public Void apply(Client client) throws Exception {
@@ -985,15 +991,19 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         } finally {
-            schemaMutationLock.unlock();
+            if (locked) {
+                schemaMutationLock.unlock();
+            }
         }
     }
 
     @Override
     public void createTable(final String tableName, final int maxValueSizeInBytes) {
         CassandraVerifier.sanityCheckTableName(tableName);
+        boolean locked = false;
         try {
             trySchemaMutationLock();
+            locked = true;
             clientPool.runWithPooledResource(new FunctionCheckedException<Client, Void, Exception>() {
                 @Override
                 public Void apply(Client client) throws Exception {
@@ -1006,7 +1016,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         } finally {
-            schemaMutationLock.unlock();
+            if (locked) {
+                schemaMutationLock.unlock();
+            }
         }
     }
 
@@ -1033,8 +1045,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
      */
     @Override
     public void createTables(final Map<String, Integer> tableNamesToMaxValueSizeInBytes) {
+        boolean locked = false;
         try {
             trySchemaMutationLock();
+            locked = true;
             clientPool.runWithPooledResource(new FunctionCheckedException<Client, Void, Exception>() {
                 @Override
                 public Void apply(Client client) throws Exception {
@@ -1065,7 +1079,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         } finally {
-            schemaMutationLock.unlock();
+            if (locked) {
+                schemaMutationLock.unlock();
+            }
         }
     }
 
@@ -1172,8 +1188,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         }
 
         if (!newMetadata.isEmpty()) {
+            boolean locked = false;
             try {
                 trySchemaMutationLock();
+                locked = true;
                 clientPool.runWithPooledResource(new FunctionCheckedException<Client, Void, Exception>() {
                     @Override
                     public Void apply(Client client) throws Exception {
@@ -1190,7 +1208,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             } catch (Exception e) {
                 throw Throwables.throwUncheckedException(e);
             } finally {
-                schemaMutationLock.unlock();
+                if (locked) {
+                    schemaMutationLock.unlock();
+                }
             }
         }
     }
@@ -1306,8 +1326,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         Preconditions.checkArgument(gcGraceSeconds >= 0, "gcGraceSeconds:[%s] should not be negative", gcGraceSeconds);
         Preconditions.checkArgument(tombstone_threshold_ratio >= 0.0f && tombstone_threshold_ratio <= 1.0f, "tombstone_threshold_ratio:[%s] should be between [0.0, 1.0]", tombstone_threshold_ratio);
 
+        boolean locked = false;
         try {
             trySchemaMutationLock();
+            locked = true;
             clientPool.runWithPooledResource(new FunctionCheckedException<Client, Void, Exception>() {
                 @Override
                 public Void apply(Client client) throws NotFoundException, InvalidRequestException, TException {
@@ -1329,7 +1351,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         } catch (Exception e) {
             log.error("Exception encountered while setting {}.{} gc_grace_seconds to {}", keyspace, tableName, gcGraceSeconds, e);
         } finally {
-            schemaMutationLock.unlock();
+            if (locked) {
+                schemaMutationLock.unlock();
+            }
         }
     }
 }


### PR DESCRIPTION
If trySchemaMutationLock() fails, a lock that is never locked will be unlocked.