### PR TITLE
Support Token Aware Policy

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -39,7 +39,7 @@ public class CassandraConstants {
     static final double NEGATIVE_LOOKUPS_BLOOM_FILTER_FP_CHANCE = 0.01;
     static final String SIMPLE_STRATEGY = "org.apache.cassandra.locator.SimpleStrategy";
     static final String NETWORK_STRATEGY = "org.apache.cassandra.locator.NetworkTopologyStrategy";
-    static final String PARTITIONER = "com.palantir.atlasdb.keyvalue.cassandra.dht.AtlasDbPartitioner";
+    static final String PARTITIONER = "com.palantir.atlasdb.keyvalue.cassandra.dht.AtlasDbOrderedPartitioner";
     static final String PARTITIONER2 = "org.apache.cassandra.dht.ByteOrderedPartitioner";
     static final String DEFAULT_DC = "datacenter1";
     static final String DEFAULT_RACK = "rack1";

--- a/cassandra-partitioner/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/dht/AtlasDbOrderedPartitioner.java
+++ b/cassandra-partitioner/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/dht/AtlasDbOrderedPartitioner.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.BytesToken;
 
-public class AtlasDbPartitioner extends ByteOrderedPartitioner {
+public class AtlasDbOrderedPartitioner extends ByteOrderedPartitioner {
     private final Random r = new SecureRandom();
     private final AtomicInteger indexCounter = new AtomicInteger(r.nextInt(6));
 


### PR DESCRIPTION
The Datastax C* driver assumes that the partitioner will be named in a
certain fashion which can break use of the TokenAwarePolicy. This
renames the AtlasDbPartitioner to AtlasDbOrderedPartitioner so that
com.datastax.driver.core.Token#getFactory returns an ordered partitioner
token factory rather than null.

For more details see com.datastax.driver.core.Token#getFactory
https://github.com/datastax/java-driver/blob/2.1/driver-core/src/main/java/com/datastax/driver/core/Token.java#L50