### PR TITLE
support try locks in lock service

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingLockAwareTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingLockAwareTransactionManager.java
@@ -19,7 +19,7 @@ import com.google.common.base.Supplier;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionTask;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
 
@@ -36,7 +36,7 @@ public abstract class ForwardingLockAwareTransactionManager extends
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<HeldLocksToken> lockTokens,
                                                                 Supplier<LockRequest> lockSupplier,
                                                                 LockAwareTransactionTask<T, E> task)
             throws E, InterruptedException {
@@ -47,7 +47,7 @@ public abstract class ForwardingLockAwareTransactionManager extends
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<HeldLocksToken> lockTokens,
                                                                       LockAwareTransactionTask<T, E> task)
             throws E, TransactionFailedRetriableException {
         return delegate().runTaskWithLocksThrowOnConflict(lockTokens, task);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
@@ -27,7 +27,7 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.service.TransactionService;
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockService;
 
@@ -114,7 +114,7 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<HeldLocksToken> lockTokens,
                                                                 Supplier<LockRequest> lockSupplier,
                                                                 LockAwareTransactionTask<T, E> task)
             throws E, InterruptedException {
@@ -122,7 +122,7 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<HeldLocksToken> lockTokens,
                                                                       LockAwareTransactionTask<T, E> task)
             throws E, TransactionFailedRetriableException {
         throw new UnsupportedOperationException("this manager is read only");

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -18,11 +18,15 @@ package com.palantir.atlasdb.transaction.impl;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.annotation.Nullable;
+
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -36,6 +40,7 @@ import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.base.Throwables;
 import com.palantir.lock.AtlasTimestampLockDescriptor;
+import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
@@ -101,10 +106,18 @@ public class SnapshotTransactionManager extends AbstractLockAwareTransactionMana
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<HeldLocksToken> lockTokens,
                                                                       LockAwareTransactionTask<T, E> task)
             throws E, TransactionFailedRetriableException {
-        RawTransaction tx = setupRunTaskWithLocksThrowOnConflict(lockTokens);
+        Iterable<LockRefreshToken> lockRefreshTokens= Iterables.transform(lockTokens,
+                new Function<HeldLocksToken, LockRefreshToken>() {
+                    @Nullable
+                    @Override
+                    public LockRefreshToken apply(HeldLocksToken input) {
+                        return input.getLockRefreshToken();
+                    }
+                });
+        RawTransaction tx = setupRunTaskWithLocksThrowOnConflict(lockRefreshTokens);
         return finishRunTaskWithLockThrowOnConflict(tx, LockAwareTransactionTasks.asLockUnaware(task, lockTokens));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTransactionManager.java
@@ -21,7 +21,7 @@ import com.palantir.atlasdb.transaction.api.LockAwareTransactionTask;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionConflictException;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
 
@@ -78,14 +78,14 @@ public abstract class WrappingTransactionManager extends ForwardingLockAwareTran
     private <T, E extends Exception> LockAwareTransactionTask<T, E> wrapTask(final LockAwareTransactionTask<T, E> task) {
         return new LockAwareTransactionTask<T, E>() {
             @Override
-            public T execute(Transaction t, Iterable<LockRefreshToken> locks) throws E {
+            public T execute(Transaction t, Iterable<HeldLocksToken> locks) throws E {
                 return task.execute(wrap(t), locks);
             }
         };
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<HeldLocksToken> lockTokens,
                                                                       LockAwareTransactionTask<T, E> task) throws E,
             TransactionConflictException {
         return delegate().runTaskWithLocksThrowOnConflict(lockTokens, wrapTask(task));
@@ -104,7 +104,7 @@ public abstract class WrappingTransactionManager extends ForwardingLockAwareTran
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<HeldLocksToken> lockTokens,
                                                                 Supplier<LockRequest> lockSupplier,
                                                                 LockAwareTransactionTask<T, E> task)
             throws E, InterruptedException {

--- a/atlasdb-lock-api/src/main/java/com/palantir/atlasdb/transaction/api/LockAwareTransactionManager.java
+++ b/atlasdb-lock-api/src/main/java/com/palantir/atlasdb/transaction/api/LockAwareTransactionManager.java
@@ -16,7 +16,7 @@
 package com.palantir.atlasdb.transaction.api;
 
 import com.google.common.base.Supplier;
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
 
@@ -38,7 +38,7 @@ public interface LockAwareTransactionManager extends TransactionManager {
      * <p>
      * @throws LockAcquisitionException If the supplied lock request is not successfully acquired.
      */
-    <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<LockRefreshToken> lockTokens,
+    <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<HeldLocksToken> lockTokens,
                                                          Supplier<LockRequest> lockSupplier,
                                                          LockAwareTransactionTask<T, E> task) throws E, InterruptedException, LockAcquisitionException;
 
@@ -46,7 +46,7 @@ public interface LockAwareTransactionManager extends TransactionManager {
      * This method is the same as {@link #runTaskThrowOnConflict(TransactionTask)} except the created transaction
      * will not commit successfully if these locks are invalid by the time commit is run.
      */
-    <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<LockRefreshToken> lockTokens,
+    <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<HeldLocksToken> lockTokens,
                                                                LockAwareTransactionTask<T, E> task) throws E, TransactionFailedRetriableException;
 
 

--- a/atlasdb-lock-api/src/main/java/com/palantir/atlasdb/transaction/api/LockAwareTransactionTask.java
+++ b/atlasdb-lock-api/src/main/java/com/palantir/atlasdb/transaction/api/LockAwareTransactionTask.java
@@ -15,8 +15,8 @@
  */
 package com.palantir.atlasdb.transaction.api;
 
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.HeldLocksToken;
 
 public interface LockAwareTransactionTask<T, E extends Exception> {
-    T execute(Transaction t, Iterable<LockRefreshToken> heldLocks) throws E;
+    T execute(Transaction t, Iterable<HeldLocksToken> heldLocks) throws E;
 }

--- a/atlasdb-lock-api/src/main/java/com/palantir/atlasdb/transaction/api/LockAwareTransactionTasks.java
+++ b/atlasdb-lock-api/src/main/java/com/palantir/atlasdb/transaction/api/LockAwareTransactionTasks.java
@@ -16,7 +16,7 @@
 package com.palantir.atlasdb.transaction.api;
 
 import com.google.common.collect.ImmutableSet;
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.HeldLocksToken;
 
 public class LockAwareTransactionTasks {
 
@@ -27,7 +27,7 @@ public class LockAwareTransactionTasks {
     public static <T, E extends Exception> LockAwareTransactionTask<T, E> asLockAware(final TransactionTask<T, E> task) {
         return new LockAwareTransactionTask<T, E>() {
             @Override
-            public T execute(Transaction t, Iterable<LockRefreshToken> heldLocks) throws E {
+            public T execute(Transaction t, Iterable<HeldLocksToken> heldLocks) throws E {
                 return task.execute(t);
             }
 
@@ -39,10 +39,10 @@ public class LockAwareTransactionTasks {
     }
 
     public static <T, E extends Exception> TransactionTask<T, E> asLockUnaware(final LockAwareTransactionTask<T, E> task) {
-        return asLockUnaware(task, ImmutableSet.<LockRefreshToken>of());
+        return asLockUnaware(task, ImmutableSet.<HeldLocksToken>of());
     }
 
-    public static <T, E extends Exception> TransactionTask<T, E> asLockUnaware(final LockAwareTransactionTask<T, E> task, final Iterable<LockRefreshToken> locks) {
+    public static <T, E extends Exception> TransactionTask<T, E> asLockUnaware(final LockAwareTransactionTask<T, E> task, final Iterable<HeldLocksToken> locks) {
         return new TransactionTask<T, E>() {
             @Override
             public T execute(Transaction t) throws E {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbBackendDebugTransactionManager.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbBackendDebugTransactionManager.java
@@ -22,7 +22,7 @@ import com.palantir.atlasdb.transaction.api.LockAwareTransactionTasks;
 import com.palantir.atlasdb.transaction.api.TransactionConflictException;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.impl.ForwardingLockAwareTransactionManager;
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
 
 class AtlasDbBackendDebugTransactionManager extends ForwardingLockAwareTransactionManager {
@@ -45,7 +45,7 @@ class AtlasDbBackendDebugTransactionManager extends ForwardingLockAwareTransacti
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksWithRetry(Iterable<HeldLocksToken> lockTokens,
                                                                 Supplier<LockRequest> lockSupplier,
                                                                 LockAwareTransactionTask<T, E> task)
             throws E {
@@ -53,7 +53,7 @@ class AtlasDbBackendDebugTransactionManager extends ForwardingLockAwareTransacti
     }
 
     @Override
-    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<LockRefreshToken> lockTokens,
+    public <T, E extends Exception> T runTaskWithLocksThrowOnConflict(Iterable<HeldLocksToken> lockTokens,
                                                                       LockAwareTransactionTask<T, E> task)
             throws E, TransactionConflictException {
         return runTaskReadOnly(LockAwareTransactionTasks.asLockUnaware(task));

--- a/lock-api/src/main/java/com/palantir/lock/ForwardingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/ForwardingLockService.java
@@ -43,6 +43,17 @@ public abstract class ForwardingLockService extends ForwardingObject implements 
     }
 
     @Override
+    public HeldLocksToken lockAndGetHeldLocksAnonymously(LockRequest request) throws InterruptedException {
+        return delegate().lockAndGetHeldLocksAnonymously(request);
+    }
+
+    @Override
+    public HeldLocksToken lockAndGetHeldLocksWithClient(String client, LockRequest request)
+            throws InterruptedException {
+        return delegate().lockAndGetHeldLocksWithClient(client, request);
+    }
+
+    @Override
     public LockResponse lock(LockClient client, LockRequest request) throws InterruptedException {
         return delegate().lock(client, request);
     }

--- a/lock-api/src/main/java/com/palantir/lock/ForwardingRemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/ForwardingRemoteLockService.java
@@ -36,6 +36,17 @@ public abstract class ForwardingRemoteLockService extends ForwardingObject imple
     }
 
     @Override
+    public HeldLocksToken lockAndGetHeldLocksAnonymously(LockRequest request) throws InterruptedException {
+        return delegate().lockAndGetHeldLocksAnonymously(request);
+    }
+
+    @Override
+    public HeldLocksToken lockAndGetHeldLocksWithClient(String client, LockRequest request)
+            throws InterruptedException {
+        return delegate().lockAndGetHeldLocksWithClient(client, request);
+    }
+
+    @Override
     public boolean unlock(LockRefreshToken token) {
         return delegate().unlock(token);
     }

--- a/lock-api/src/main/java/com/palantir/lock/RemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/RemoteLockService.java
@@ -55,6 +55,26 @@ public interface RemoteLockService {
     LockRefreshToken lockWithClient(@PathParam("client") String client, LockRequest request) throws InterruptedException;
 
     /**
+     * This is the same as {@link #lockAnonymously(LockRequest)} but will return as many locks as can be acquired.
+     * @return a token for the locks acquired
+     */
+    @POST
+    @Path("try-lock-anonymously")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    HeldLocksToken lockAndGetHeldLocksAnonymously(LockRequest request) throws InterruptedException;
+
+    /**
+     * This is the same as {@link #lockWithClient(String, LockRequest)} but will return as many locks as can be acquired.
+     * @return a token for the locks acquired
+     */
+    @POST
+    @Path("try-lock/{client}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    HeldLocksToken lockAndGetHeldLocksWithClient(@PathParam("client") String client, LockRequest request) throws InterruptedException;
+
+    /**
      * Attempts to release the set of locks represented by the
      * <code>token</code> parameter. For locks which
      * have been locked multiple times reentrantly, this method decrements the

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -286,6 +286,8 @@ import com.palantir.util.Pair;
 
     @Override
     public LockRefreshToken lockAnonymously(LockRequest request) throws InterruptedException {
+        Preconditions.checkArgument(request.getLockGroupBehavior() == LockGroupBehavior.LOCK_ALL_OR_NONE,
+                "lockAnonymously() only supports LockGroupBehavior.LOCK_ALL_OR_NONE. Consider using lockAndGetHeldLocksAnonymously().");
         LockResponse result = lock(LockClient.ANONYMOUS, request);
         return result.success() ? result.getLockRefreshToken() : null;
     }
@@ -293,8 +295,22 @@ import com.palantir.util.Pair;
     @Override
     public LockRefreshToken lockWithClient(String client, LockRequest request)
             throws InterruptedException {
+        Preconditions.checkArgument(request.getLockGroupBehavior() == LockGroupBehavior.LOCK_ALL_OR_NONE,
+                "lockWithClient() only supports LockGroupBehavior.LOCK_ALL_OR_NONE. Consider using lockAndGetHeldLocksWithClient().");
         LockResponse result = lock(LockClient.of(client), request);
         return result.success() ? result.getLockRefreshToken() : null;
+    }
+
+    @Override
+    public HeldLocksToken lockAndGetHeldLocksAnonymously(LockRequest request) throws InterruptedException {
+        LockResponse result = lock(LockClient.ANONYMOUS, request);
+        return result.getToken();
+    }
+
+    @Override
+    public HeldLocksToken lockAndGetHeldLocksWithClient(String client, LockRequest request) throws InterruptedException {
+        LockResponse result = lock(LockClient.of(client), request);
+        return result.getToken();
     }
 
     @Override


### PR DESCRIPTION
This is one potential design for how to expose try locks.  Any feedback would be great -- @markelliot @carrino @clockfort 

One side effect of this approach is that a TransactionManager can not support with locks and try locks.  We could easily allow this by making two distinct interfaces (for running locks and try locks tasks) with different methods.  This would add code duplication but perhaps increase clarity.

Some name changes (e.g. from LockAware... -> LockTokenAware...) are probably appropriate.