### PR TITLE
refreshing cassandra config

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSerializableTransactionTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSerializableTransactionTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import org.junit.Ignore;
 
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
@@ -26,19 +27,21 @@ public class CQLKeyValueServiceSerializableTransactionTest extends
 
     @Override
     protected KeyValueService getKeyValueService() {
-        return CQLKeyValueService.create(ImmutableCassandraKeyValueServiceConfig.builder()
-                .addServers("localhost")
-                .port(9160)
-                .poolSize(20)
-                .keyspace("atlasdb")
-                .ssl(false)
-                .replicationFactor(1)
-                .mutationBatchCount(10000)
-                .mutationBatchSizeBytes(10000000)
-                .fetchBatchCount(1000)
-                .safetyDisabled(true)
-                .autoRefreshNodes(false)
-                .build());
+        return CQLKeyValueService.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(
+                        ImmutableCassandraKeyValueServiceConfig.builder()
+                                .addServers("localhost")
+                                .port(9160)
+                                .poolSize(20)
+                                .keyspace("atlasdb")
+                                .ssl(false)
+                                .replicationFactor(1)
+                                .mutationBatchCount(10000)
+                                .mutationBatchSizeBytes(10000000)
+                                .fetchBatchCount(1000)
+                                .safetyDisabled(true)
+                                .autoRefreshNodes(false)
+                                .build()));
     }
 
     @Override

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceTransactionTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceTransactionTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
@@ -23,19 +24,21 @@ public class CQLKeyValueServiceTransactionTest extends AbstractTransactionTest {
 
     @Override
     protected KeyValueService getKeyValueService() {
-        return CQLKeyValueService.create(ImmutableCassandraKeyValueServiceConfig.builder()
-                .addServers("localhost")
-                .port(9160)
-                .poolSize(20)
-                .keyspace("atlasdb")
-                .ssl(false)
-                .replicationFactor(1)
-                .mutationBatchCount(10000)
-                .mutationBatchSizeBytes(10000000)
-                .fetchBatchCount(1000)
-                .safetyDisabled(true)
-                .autoRefreshNodes(false)
-                .build());
+        return CQLKeyValueService.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(
+                        ImmutableCassandraKeyValueServiceConfig.builder()
+                                .addServers("localhost")
+                                .port(9160)
+                                .poolSize(20)
+                                .keyspace("atlasdb")
+                                .ssl(false)
+                                .replicationFactor(1)
+                                .mutationBatchCount(10000)
+                                .mutationBatchSizeBytes(10000000)
+                                .fetchBatchCount(1000)
+                                .safetyDisabled(true)
+                                .autoRefreshNodes(false)
+                                .build()));
     }
 
     @Override

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSerializableTransactionTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSerializableTransactionTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
@@ -24,19 +25,21 @@ public class CassandraKeyValueServiceSerializableTransactionTest extends
 
     @Override
     protected KeyValueService getKeyValueService() {
-        return CassandraKeyValueService.create(ImmutableCassandraKeyValueServiceConfig.builder()
-                .addServers("localhost")
-                .port(9160)
-                .poolSize(20)
-                .keyspace("atlasdb")
-                .ssl(false)
-                .replicationFactor(1)
-                .mutationBatchCount(10000)
-                .mutationBatchSizeBytes(10000000)
-                .fetchBatchCount(1000)
-                .safetyDisabled(false)
-                .autoRefreshNodes(false)
-                .build());
+        return CassandraKeyValueService.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(
+                        ImmutableCassandraKeyValueServiceConfig.builder()
+                                .addServers("localhost")
+                                .port(9160)
+                                .poolSize(20)
+                                .keyspace("atlasdb")
+                                .ssl(false)
+                                .replicationFactor(1)
+                                .mutationBatchCount(10000)
+                                .mutationBatchSizeBytes(10000000)
+                                .fetchBatchCount(1000)
+                                .safetyDisabled(false)
+                                .autoRefreshNodes(false)
+                                .build()));
     }
 
     @Override

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
@@ -23,19 +24,21 @@ public class CassandraKeyValueServiceTransactionTest extends AbstractTransaction
 
     @Override
     protected KeyValueService getKeyValueService() {
-        return CassandraKeyValueService.create(ImmutableCassandraKeyValueServiceConfig.builder()
-                .addServers("localhost")
-                .port(9160)
-                .poolSize(20)
-                .keyspace("atlasdb")
-                .ssl(false)
-                .replicationFactor(1)
-                .mutationBatchCount(10000)
-                .mutationBatchSizeBytes(10000000)
-                .fetchBatchCount(1000)
-                .safetyDisabled(false)
-                .autoRefreshNodes(false)
-                .build());
+        return CassandraKeyValueService.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(
+                        ImmutableCassandraKeyValueServiceConfig.builder()
+                                .addServers("localhost")
+                                .port(9160)
+                                .poolSize(20)
+                                .keyspace("atlasdb")
+                                .ssl(false)
+                                .replicationFactor(1)
+                                .mutationBatchCount(10000)
+                                .mutationBatchSizeBytes(10000000)
+                                .fetchBatchCount(1000)
+                                .safetyDisabled(false)
+                                .autoRefreshNodes(false)
+                                .build()));
     }
 
     @Override

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampTest.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 import com.palantir.timestamp.TimestampBoundStore;
@@ -30,19 +31,21 @@ public class CassandraTimestampTest {
 
     @Before
     public void setUp() {
-        kv = CassandraKeyValueService.create(ImmutableCassandraKeyValueServiceConfig.builder()
-                .addServers("localhost")
-                .port(9160)
-                .poolSize(20)
-                .keyspace("atlasdb")
-                .ssl(false)
-                .replicationFactor(1)
-                .mutationBatchCount(10000)
-                .mutationBatchSizeBytes(10000000)
-                .fetchBatchCount(1000)
-                .safetyDisabled(true)
-                .autoRefreshNodes(false)
-                .build());
+        kv = CassandraKeyValueService.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(
+                        ImmutableCassandraKeyValueServiceConfig.builder()
+                                .addServers("localhost")
+                                .port(9160)
+                                .poolSize(20)
+                                .keyspace("atlasdb")
+                                .ssl(false)
+                                .replicationFactor(1)
+                                .mutationBatchCount(10000)
+                                .mutationBatchSizeBytes(10000000)
+                                .fetchBatchCount(1000)
+                                .safetyDisabled(true)
+                                .autoRefreshNodes(false)
+                                .build()));
         kv.initializeFromFreshInstance();
         kv.dropTable(TIMESTAMP_TABLE);
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -34,12 +34,12 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
     }
     
     private static CassandraKeyValueService createKv(CassandraKeyValueServiceConfig config) {
-        return CassandraKeyValueService.create(config);
+        return CassandraKeyValueService.create(CassandraKeyValueServiceConfigManager.createSimpleManager(config));
     }
 
     @Override
     public TimestampService createTimestampService(KeyValueService rawKvs) {
-        Preconditions.checkArgument(rawKvs instanceof CassandraKeyValueService, 
+        Preconditions.checkArgument(rawKvs instanceof CassandraKeyValueService,
                 "TimestampService must be created from an instance of CassandraKeyValueService, found %s", rawKvs.getClass());
         return PersistentTimestampService.create(CassandraTimestampBoundStore.create((CassandraKeyValueService) rawKvs));
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigManager.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigManager.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.cassandra;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.palantir.common.concurrent.PTExecutors;
+
+public class CassandraKeyValueServiceConfigManager {
+    private static final Logger log = LoggerFactory.getLogger(CassandraKeyValueServiceConfigManager.class);
+
+    private final Supplier<CassandraKeyValueServiceConfig> configSupplier;
+    private final ScheduledExecutorService refreshExecutor;
+    private final long initDelay;
+    private final long refreshInterval;
+    private CassandraKeyValueServiceConfig config;
+    boolean isShutdown = false;
+
+    private static final long DEFAULT_INIT_DELAY = 1000 * 60;
+    private static final long DEFAULT_REFRESH_INTERVAL = 1000 * 10;
+
+    public static CassandraKeyValueServiceConfigManager createSimpleManager(CassandraKeyValueServiceConfig config) {
+        CassandraKeyValueServiceConfigManager ret =
+                new CassandraKeyValueServiceConfigManager(Suppliers.ofInstance(config), null, DEFAULT_INIT_DELAY, DEFAULT_REFRESH_INTERVAL);
+        ret.init();
+        return ret;
+    }
+
+    public static CassandraKeyValueServiceConfigManager create(Supplier<CassandraKeyValueServiceConfig> configSupplier) {
+        return create(configSupplier, DEFAULT_INIT_DELAY, DEFAULT_REFRESH_INTERVAL);
+    }
+
+    public static CassandraKeyValueServiceConfigManager create(Supplier<CassandraKeyValueServiceConfig> configSupplier,
+                                                               long initDelay,
+                                                               long refreshInterval) {
+        CassandraKeyValueServiceConfigManager ret =
+                new CassandraKeyValueServiceConfigManager(configSupplier, PTExecutors.newScheduledThreadPool(1), initDelay, refreshInterval);
+        ret.init();
+        return ret;
+    }
+
+    /**
+     * Refreshes the C* KVS config.
+     *
+     * @param configSupplier supplier that returns an up-to-date config
+     * @param refreshExecutor disables polling updates when null
+     * @param initDelay init delay on polling updates
+     * @param refreshInterval refresh interval for polling updates
+     */
+    private CassandraKeyValueServiceConfigManager(final Supplier<CassandraKeyValueServiceConfig> configSupplier,
+                                                  @Nullable ScheduledExecutorService refreshExecutor,
+                                                  long initDelay,
+                                                  long refreshInterval) {
+        this.configSupplier = configSupplier;
+        this.refreshExecutor = refreshExecutor;
+        this.config = configSupplier.get();
+        this.initDelay = initDelay;
+        this.refreshInterval = refreshInterval;
+    }
+
+    private void init() {
+        if (refreshExecutor != null) {
+            refreshExecutor.scheduleWithFixedDelay(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        config = configSupplier.get();
+                    }  catch (Throwable t) {
+                        // If any execution of the task encounters an exception, subsequent executions are suppressed for
+                        // ScheduledExecutorService.scheduleWithFixedDelay() we're catching Throwable (e.g. OutOfMemoryError,
+                        // NPE, SocketException, Cassandra network error, etc.) to ensure the task doesn't get killed.
+                        log.error("CassandraKeyValueServiceConfigManager encountered {}\n{}", t.getMessage(), t);
+                    }
+                }
+            }, initDelay, refreshInterval, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    public CassandraKeyValueServiceConfig getConfig() {
+        if (isShutdown) {
+            throw new RuntimeException("CassandraKeyValueServiceConfig is shutdown");
+        }
+        return config;
+    }
+
+    public void shutdown() {
+        isShutdown = true;
+        if (refreshExecutor != null) {
+            refreshExecutor.shutdown();
+        }
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
@@ -95,6 +95,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
@@ -144,7 +145,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                 }
             });
 
-    private final CassandraKeyValueServiceConfig config;
+    private final CassandraKeyValueServiceConfigManager configManager;
     private final CassandraClientPoolingManager cassandraClientPoolingManager;
     private final CassandraJMXCompactionManager compactionManager;
     private final ManyClientPoolingContainer containerPoolToUpdate;
@@ -167,9 +168,10 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         LIGHTWEIGHT_TRANSACTION_REQUIRED
     }
 
-    public static CQLKeyValueService create(CassandraKeyValueServiceConfig config) {
+    public static CQLKeyValueService create(CassandraKeyValueServiceConfigManager configManager) {
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         Preconditions.checkArgument(!config.servers().isEmpty(), "servers set was empty");
-        final CQLKeyValueService ret = new CQLKeyValueService(config);
+        final CQLKeyValueService ret = new CQLKeyValueService(configManager);
         try {
             ret.initializeFromFreshInstance(ImmutableList.copyOf(config.servers()), config.replicationFactor());
             ret.getPoolingManager().submitHostRefreshTask();
@@ -179,15 +181,15 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         return ret;
     }
 
-    private CQLKeyValueService(CassandraKeyValueServiceConfig config) {
-        super(PTExecutors.newFixedThreadPool(config.poolSize() * 2, new NamedThreadFactory(
+    private CQLKeyValueService(CassandraKeyValueServiceConfigManager configManager) {
+        super(PTExecutors.newFixedThreadPool(configManager.getConfig().poolSize() * 2, new NamedThreadFactory(
                 "CQLKeyValueService",
                 false)));
-        this.config = config;
-        this.containerPoolToUpdate = ManyClientPoolingContainer.create(config);
+        this.configManager = configManager;
+        this.containerPoolToUpdate = ManyClientPoolingContainer.create(configManager.getConfig());
         this.clientPool = new RetriablePoolingContainer(this.containerPoolToUpdate);
-        this.cassandraClientPoolingManager = new CassandraClientPoolingManager(containerPoolToUpdate, clientPool, config);
-        this.compactionManager = CassandraJMXCompactionManager.newInstance(config);
+        this.cassandraClientPoolingManager = new CassandraClientPoolingManager(containerPoolToUpdate, clientPool, configManager);
+        this.compactionManager = CassandraJMXCompactionManager.newInstance(configManager.getConfig());
     }
 
     private CassandraClientPoolingManager getPoolingManager() {
@@ -204,6 +206,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             }
         }
 
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         String keyspace = config.keyspace();
         int poolSize = config.poolSize();
         int poolTimeoutMillis = config.cqlPoolTimeoutMillis();
@@ -299,6 +302,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         clientPool.shutdownPooling();
         hostRefreshExecutor.shutdown();
         traceRetrievalExec.shutdown();
+        configManager.shutdown();
         if (compactionManager != null) {
             compactionManager.close();
         }
@@ -309,6 +313,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         Map<String, Throwable> errorsByHost = Maps.newHashMap();
         initializeConnectionPoolWithNewAPI(ImmutableSet.copyOf(hosts));
 
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         int port = config.port();
         String keyspace = config.keyspace();
         boolean ssl = config.ssl();
@@ -399,6 +404,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     }
 
     private void lowerConsistencyWhenSafe(Client client, KsDef ks, int desiredRf) {
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         Set<String> dcs;
         try {
             dcs = CassandraVerifier.sanityCheckDatacenters(client, desiredRf, config.safetyDisabled());
@@ -455,6 +461,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     private Map<Cell, Value> getRowsAllColsInternal(final String tableName,
                                              final Iterable<byte[]> rows,
                                              final long startTs) throws Exception {
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         int rowCount = 0;
         int fetchBatchCount = config.fetchBatchCount();
         String getRowsQuery = "SELECT * FROM " + getFullTableName(tableName) + " WHERE " + ROW_NAME
@@ -529,6 +536,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                             final long startTs,
                             final Visitor<Map<Cell, Value>> v,
                             final ConsistencyLevel consistency) throws Exception {
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         int fetchBatchCount = config.fetchBatchCount();
         Iterable<List<Cell>> partitions = Iterables.partition(cells, fetchBatchCount);
         int numPartitions = (cells.size() / fetchBatchCount)
@@ -632,6 +640,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
     private Map<Cell, Long> getLatestTimestampsInternal(final String tableName,
             Map<Cell, Long> timestampByCell) throws Exception {
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         int fetchBatchCount = config.fetchBatchCount();
         Iterable<List<Cell>> partitions = Iterables.partition(
                 timestampByCell.keySet(),
@@ -715,7 +724,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
     @Override
     protected int getMultiPutBatchCount() {
-        return config.mutationBatchCount();
+        return configManager.getConfig().mutationBatchCount();
     }
 
     @Override
@@ -763,6 +772,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
     private void putInternal(final String tableName, final Iterable<Map.Entry<Cell, Value>> values, TransactionType transactionType)
             throws Exception {
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         List<ResultSetFuture> resultSetFutures = Lists.newArrayList();
         int mutationBatchCount = config.mutationBatchCount();
         int mutationBatchSizeBytes = config.mutationBatchSizeBytes();
@@ -865,6 +875,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
     @Override
     public void delete(final String tableName, final Multimap<Cell, Long> keys) {
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         int cellCount = 0;
         int fetchBatchCount = config.fetchBatchCount();
         final String deleteQuery = "DELETE FROM " + getFullTableName(tableName) + " WHERE "
@@ -911,6 +922,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(String tableName,
                                                                                                            Iterable<RangeRequest> rangeRequests,
                                                                                                            long timestamp) {
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         int concurrency = config.rangesConcurrency();
         return KeyValueServices.getFirstBatchForRangesUsingGetRangeConcurrent(
                 executor,
@@ -1148,6 +1160,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     private Set<String> getAllTableNamesInternal() {
         BoundStatement boundStatement = statementCache.getUnchecked(
                 "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name = ?").bind();
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         boundStatement.setString("keyspace_name", config.keyspace());
         List<Row> rows = session.executeAsync(boundStatement).getUninterruptibly().all();
         Set<String> tableNames = Sets.newHashSetWithExpectedSize(rows.size());
@@ -1268,7 +1281,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     }
 
     private String getFullTableName(String tableName) {
-        return config.keyspace() + ".\"" + tableName + "\"";
+        return configManager.getConfig().keyspace() + ".\"" + tableName + "\"";
     }
 
     private byte[] getRowName(Row row) {
@@ -1375,6 +1388,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     @Override
     public void compactInternally(String tableName) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(tableName), "tableName:[%s] should not be null or empty", tableName);
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
         long compactionTimeoutSeconds = config.compactionTimeoutSeconds();
         try {
             alterGcGraceSeconds(tableName, 0);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingManager.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingManager.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
@@ -41,17 +41,17 @@ public class CassandraClientPoolingManager {
 
     private final ManyClientPoolingContainer containerPoolToUpdate;
     private final PoolingContainer<Client> clientPool;
-    private final CassandraKeyValueServiceConfig config;
+    private final CassandraKeyValueServiceConfigManager configManager;
     private final ScheduledExecutorService hostModificationExecutor = PTExecutors.newScheduledThreadPool(
             1,
             new ThreadFactoryBuilder().setDaemon(true).setNameFormat("HostModificationThreadPool-%d").build());
 
     public CassandraClientPoolingManager(ManyClientPoolingContainer containerPoolToUpdate,
                                          PoolingContainer<Client> clientPool,
-                                         CassandraKeyValueServiceConfig config) {
+                                         CassandraKeyValueServiceConfigManager configManager) {
         this.containerPoolToUpdate = containerPoolToUpdate;
         this.clientPool = clientPool;
-        this.config = config;
+        this.configManager = configManager;
     }
 
     /**
@@ -84,7 +84,7 @@ public class CassandraClientPoolingManager {
     }
 
     public void setHostsToCurrentHostNames(Set<String> hosts) {
-        containerPoolToUpdate.setNewHosts(ImmutableCassandraKeyValueServiceConfig.copyOf(config).withServers(hosts));
+        containerPoolToUpdate.setNewHosts(ImmutableCassandraKeyValueServiceConfig.copyOf(configManager.getConfig()).withServers(hosts));
     }
 
     public Set<String> getCurrentHostsFromServer(Client c) throws TException {
@@ -104,7 +104,7 @@ public class CassandraClientPoolingManager {
     }
 
     public boolean hostsAutoRefresh() {
-        return config.autoRefreshNodes();
+        return configManager.getConfig().autoRefreshNodes();
     }
 
 }

--- a/atlasdb-shell/src/main/java/com/palantir/atlasdb/shell/DefaultAtlasShellContextFactory.java
+++ b/atlasdb-shell/src/main/java/com/palantir/atlasdb/shell/DefaultAtlasShellContextFactory.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.shell;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -76,19 +77,21 @@ public class DefaultAtlasShellContextFactory implements AtlasShellContextFactory
 
     @Override
     public AtlasContext withReadOnlyTransactionManagerCassandra(String host, String port, String keyspace) {
-        CassandraKeyValueService kv = CassandraKeyValueService.create(ImmutableCassandraKeyValueServiceConfig.builder()
-                .addServers(host)
-                .port(Integer.parseInt(port))
-                .poolSize(20)
-                .keyspace(keyspace)
-                .ssl(false)
-                .replicationFactor(1)
-                .mutationBatchCount(10000)
-                .mutationBatchSizeBytes(10000000)
-                .fetchBatchCount(1000)
-                .safetyDisabled(false)
-                .autoRefreshNodes(false)
-                .build());
+        CassandraKeyValueService kv = CassandraKeyValueService.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(
+                        ImmutableCassandraKeyValueServiceConfig.builder()
+                                .addServers(host)
+                                .port(Integer.parseInt(port))
+                                .poolSize(20)
+                                .keyspace(keyspace)
+                                .ssl(false)
+                                .replicationFactor(1)
+                                .mutationBatchCount(10000)
+                                .mutationBatchSizeBytes(10000000)
+                                .fetchBatchCount(1000)
+                                .safetyDisabled(false)
+                                .autoRefreshNodes(false)
+                                .build()));
         TransactionService transactionService = TransactionServices.createTransactionService(kv);
         TransactionManager transactionManager = new ShellAwareReadOnlyTransactionManager(
                 kv,


### PR DESCRIPTION
Simple proof of concept for refreshing cassandra config.  The config manager provides no hard guarantees (a "probably is up to date config" guarantee) which as far as I can tell is good enough for our purposes.

Another approach is to just proxy the config behind something that polls in the background (writing some sort of SupplierProxy).  This approach could also be okay (and has cleaner code) but has a higher chance of leading to bizarre events because:
(1) a single kvs call uses two different configs
(2) some calls shell out to other background calls and it is simpler to reason about these if they have a truly immutable config (basically just a specific example of (1)).