### PR TITLE
introduce namespacing backdoor

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/Namespace.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/Namespace.java
@@ -32,7 +32,7 @@ public final class Namespace {
         return new Namespace(name);
     }
 
-    private Namespace(String name) {
+    Namespace(String name) {
         this.name = name;
     }
 


### PR DESCRIPTION
Allows internal code to ignore the strict checks applied in Namespace.create().