### PR TITLE
allow underscores in table names

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -128,13 +128,6 @@ public class CassandraVerifier {
         return dataCenterToRack.keySet();
     }
 
-    static void sanityCheckTableName(String table) {
-        Validate.isTrue(!(table.startsWith("_") && table.contains("."))
-                || AtlasDbConstants.hiddenTables.contains(table)
-                || table.startsWith(AtlasDbConstants.TEMP_TABLE_PREFIX)
-                || table.startsWith(AtlasDbConstants.NAMESPACE_PREFIX), "invalid tableName: " + table);
-    }
-
     private static void logErrorOrThrow(String errorMessage, boolean safetyDisabled) {
         String safetyMessage = " This would have normally resulted in Palantir exiting, however safety checks have been disabled.";
         if (safetyDisabled) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -73,12 +73,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
 
     @Override
     public void createTable(String tableName, int maxValueSizeInBytes) {
-        Validate.isTrue(
-                (!tableName.startsWith("_") && tableName.contains("."))
-                || AtlasDbConstants.hiddenTables.contains(tableName)
-                || tableName.startsWith(AtlasDbConstants.TEMP_TABLE_PREFIX)
-                || tableName.startsWith(AtlasDbConstants.NAMESPACE_PREFIX),
-                "invalid tableName: " + tableName);
+        sanityCheckTableName(tableName);
         if (maxValueSizeInBytes <= 0) {
             maxValueSizeInBytes = 1;
         }
@@ -96,12 +91,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
             return;
         }
         for (String tableName : tableNamesToMaxValueSizeInBytes.keySet()) {
-            Validate.isTrue(
-                    !tableName.startsWith("_")
-                    || AtlasDbConstants.hiddenTables.contains(tableName)
-                    || tableName.startsWith(AtlasDbConstants.TEMP_TABLE_PREFIX)
-                    || tableName.startsWith(AtlasDbConstants.NAMESPACE_PREFIX),
-                    "invalid tableName: " + tableName);
+            sanityCheckTableName(tableName);
         }
 
         Map<String, Integer> tableNamesToFlooredMaxValueSizeInBytes = Maps.transformValues(tableNamesToMaxValueSizeInBytes, new Function<Integer, Integer>() {
@@ -114,6 +104,15 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
         });
 
         delegate.createTables(tableNamesToFlooredMaxValueSizeInBytes);
+    }
+
+    protected void sanityCheckTableName(String tableName) {
+        Validate.isTrue(
+                (!tableName.startsWith("_") && tableName.contains("."))
+                        || AtlasDbConstants.hiddenTables.contains(tableName)
+                        || tableName.startsWith(AtlasDbConstants.TEMP_TABLE_PREFIX)
+                        || tableName.startsWith(AtlasDbConstants.NAMESPACE_PREFIX),
+                "invalid tableName: " + tableName);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/Namespace.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/Namespace.java
@@ -28,7 +28,7 @@ public final class Namespace {
 
     public static Namespace create(String name) {
         Validate.isTrue(!Strings.isNullOrEmpty(name));
-        Validate.isTrue(isNamespaceValid(name), "'%s' contains invalid characters, only letters or numbers allowed.", name);
+        Validate.isTrue(isNamespaceValid(name), "'%s' contains invalid characters, only letters, numbers, or non-initial/non-trailing single underscores are allowed.", name);
         return new Namespace(name);
     }
 
@@ -70,7 +70,18 @@ public final class Namespace {
         for (int i = 0; i < namespace.length() ; i++) {
             char c = namespace.charAt(i);
             if (!Character.isLetterOrDigit(c)) {
-                return false;
+                // only underscores are additionally allowed
+                if (c != '_') {
+                    return false;
+                }
+                // underscores must be non-initial and non-trailing
+                else if (i == 0 || i == namespace.length() - 1) {
+                    return false;
+                }
+                // disallow double underscores
+                else if (namespace.charAt(i + 1) == '_') {
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
It is a little silly that we can't allow some kind of reasonable (non-numeric) delimiter in our table names.  Per @tjwilson90 's suggestion this changes our use of '_' to '__' (for namespacing) to allow clients to have underscores in table names.  I'm mostly interested in if this will break existing atlas code (basically everything is namespace mapped so this probably won't be a problem).  Thoughts?
@carrino @tjwilson90 @clockfort 