### PR TITLE
More helpful error message when incorrect partitioner used

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
@@ -277,9 +277,9 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                 clusterName));
 
         if (!config.safetyDisabled()) {
-            Validate.isTrue(CassandraConstants.PARTITIONER.equals(partitioner)
-                            || CassandraConstants.PARTITIONER2.equals(partitioner),
-                    "partitioner is: " + partitioner);
+            Validate.isTrue(
+                    CassandraConstants.PARTITIONERS.contains(partitioner),
+                    "partitioner is " + partitioner + " but supported partitioners are " + CassandraConstants.PARTITIONERS);
         }
     }
 
@@ -321,10 +321,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                 client = CassandraClientPoolingContainer.getClientInternal(host, port, ssl, socketTimeoutMillis, socketQueryTimeoutMillis);
                 String partitioner = client.describe_partitioner();
                 if (!safetyDisabled) {
-                    Validate.isTrue(
-                            CassandraConstants.PARTITIONER.equals(partitioner)
-                                    || CassandraConstants.PARTITIONER2.equals(partitioner),
-                            "partitioner is: " + partitioner);
+                    Validate.isTrue(CassandraConstants.PARTITIONERS.contains(partitioner),
+                            "partitioner is " + partitioner + " but supported partitioners are " + CassandraConstants.PARTITIONERS);
                 }
                 KsDef ks = null;
                 try {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -17,12 +17,14 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Set;
 
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.ColumnDef;
 import org.apache.cassandra.thrift.TriggerDef;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
 
@@ -39,8 +41,9 @@ public class CassandraConstants {
     static final double NEGATIVE_LOOKUPS_BLOOM_FILTER_FP_CHANCE = 0.01;
     static final String SIMPLE_STRATEGY = "org.apache.cassandra.locator.SimpleStrategy";
     static final String NETWORK_STRATEGY = "org.apache.cassandra.locator.NetworkTopologyStrategy";
-    static final String PARTITIONER = "com.palantir.atlasdb.keyvalue.cassandra.dht.AtlasDbPartitioner";
-    static final String PARTITIONER2 = "org.apache.cassandra.dht.ByteOrderedPartitioner";
+    static final Set<String> PARTITIONERS = ImmutableSet.of(
+            "com.palantir.atlasdb.keyvalue.cassandra.dht.AtlasDbPartitioner",
+            "org.apache.cassandra.dht.ByteOrderedPartitioner");
     static final String DEFAULT_DC = "datacenter1";
     static final String DEFAULT_RACK = "rack1";
     static final String SIMPLE_RF_TEST_KEYSPACE = "__simple_rf_test_keyspace__";

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -195,9 +195,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 client = CassandraClientPoolingContainer.getClientInternal(addr, port, ssl, socketTimeoutMillis, socketQueryTimeoutMillis);
                 String partitioner = client.describe_partitioner();
                 if (safetyDisabled) {
-                    Validate.isTrue(CassandraConstants.PARTITIONER.equals(partitioner)
-                                    || CassandraConstants.PARTITIONER2.equals(partitioner),
-                            "partitioner is: " + partitioner);
+                    Validate.isTrue(CassandraConstants.PARTITIONERS.contains(partitioner),
+                            "partitioner is " + partitioner + " but supported partitioners are " + CassandraConstants.PARTITIONERS);
                 }
                 KsDef ks = null;
                 try {


### PR DESCRIPTION
When Cassandra has an incorrect partitioner set, the error returned does not explain what the problem is - it felt like an info log message and I had to look at the Atlas source code to work out why I had a problem. This tiny refactor prints a slightly more informative error message.