### PR TITLE
change partitioner name in OSS atlas

### DIFF
--- a/cassandra-partitioner/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/dht/AtlasDbOrderedPartitioner.java
+++ b/cassandra-partitioner/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/dht/AtlasDbOrderedPartitioner.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 
-public class AtlasDbPartitioner extends ByteOrderedPartitioner {
+public class AtlasDbOrderedPartitioner extends ByteOrderedPartitioner {
     private final Random r = new SecureRandom();
     private final AtomicInteger indexCounter = new AtomicInteger(r.nextInt(6));
 


### PR DESCRIPTION
required for Datastax CQL driver to support token aware policy correctly (uses the String of the partitioner name, yuck)