### PR TITLE
Better batch sizes for getFirstBatchForRanges

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/KeyValueServices.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/KeyValueServices.java
@@ -72,7 +72,7 @@ public class KeyValueServices {
         }
         RangeRequest requestWithHint = request;
         if (request.getBatchHint() == null) {
-            requestWithHint = request.withBatchHint(1);
+            requestWithHint = request.withBatchHint(100);
         }
         final ClosableIterator<RowResult<Value>> range = kv.getRange(tableName, requestWithHint, timestamp);
         try {


### PR DESCRIPTION
This was using the stupidly low batch size of 1, meaning we'd have to go back
and get more very often. This just changes the default.