### PR TITLE
fix simple schema updater

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SimpleSchemaUpdaterImpl.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SimpleSchemaUpdaterImpl.java
@@ -94,7 +94,8 @@ public class SimpleSchemaUpdaterImpl implements SimpleSchemaUpdater {
 
     @Override
     public void initializeSchema(final AtlasSchema schema) {
-        Preconditions.checkArgument(schema.getNamespace().equals(namespace), "Refusing to initialize namespace " + schema.getNamespace() + ", which doesn't match given Atlas namespace of " + namespace + ".");
+        Preconditions.checkArgument(namespace.equals(Namespace.EMPTY_NAMESPACE) || schema.getNamespace().equals(namespace),
+                "Refusing to initialize namespace " + schema.getNamespace() + ", which doesn't match given Atlas namespace of " + namespace + ".");
         Schemas.createTablesAndIndexes(schema.getLatestSchema(), kvs);
     }
 


### PR DESCRIPTION
an empty namespace can be used to indicate a cross namespace change so
the precondition check needs to be more lenient