### PR TITLE
Use SerializableTransactionManager instead of Snapshot

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -54,9 +54,9 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
+import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.leader.LeaderElectionService;
@@ -116,7 +116,7 @@ public class TransactionManagers {
         KeyValueService kvs = NamespacedKeyValueServices.wrapWithStaticNamespaceMappingKvs(rawKvs);
         kvs = new SweepStatsKeyValueService(kvs, lts.time());
 
-        SnapshotTransactionManager.createTables(kvs);
+        TransactionTables.createTables(kvs);
 
         LockClient lockClient = LockClient.of("atlas instance");
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -39,9 +39,9 @@ import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
+import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.lock.LockClient;
@@ -94,7 +94,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
         KeyValueService keyValueService = createTableMappingKv(ts);
 
         Schemas.createTablesAndIndexes(schema, keyValueService);
-        SnapshotTransactionManager.createTables(keyValueService);
+        TransactionTables.createTables(keyValueService);
 
         TransactionService transactionService = TransactionServices.createTransactionService(keyValueService);
         RemoteLockService lock = LockRefreshingLockService.create(LockServiceImpl.create(new LockServerOptions() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -38,8 +38,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                                           ConflictDetectionManager conflictDetectionManager,
                                           SweepStrategyManager sweepStrategyManager,
                                           Cleaner cleaner) {
-        super(
-                keyValueService,
+        this(keyValueService,
                 timestampService,
                 lockClient,
                 lockService,
@@ -47,7 +46,30 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 constraintModeSupplier,
                 conflictDetectionManager,
                 sweepStrategyManager,
-                cleaner);
+                cleaner,
+                false);
+    }
+
+    public SerializableTransactionManager(KeyValueService keyValueService,
+                                          TimestampService timestampService,
+                                          LockClient lockClient,
+                                          RemoteLockService lockService,
+                                          TransactionService transactionService,
+                                          Supplier<AtlasDbConstraintCheckingMode> constraintModeSupplier,
+                                          ConflictDetectionManager conflictDetectionManager,
+                                          SweepStrategyManager sweepStrategyManager,
+                                          Cleaner cleaner,
+                                          boolean allowHiddenTableAccess) {
+        super(keyValueService,
+                timestampService,
+                lockClient,
+                lockService,
+                transactionService,
+                constraintModeSupplier,
+                conflictDetectionManager,
+                sweepStrategyManager,
+                cleaner,
+                allowHiddenTableAccess);
     }
 
     @Override
@@ -68,7 +90,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 constraintModeSupplier.get(),
                 cleaner.getTransactionReadTimeoutMillis(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                false);
+                allowHiddenTableAccess);
     }
 
     public TimestampService getTimestampService() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -190,7 +190,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
      *                             to commit.  If these locks have expired then the commit will fail.
      * @param transactionTimeoutMillis
      */
-    public SnapshotTransaction(KeyValueService keyValueService,
+    /* package */ SnapshotTransaction(KeyValueService keyValueService,
                                RemoteLockService lockService,
                                TimestampService timestampService,
                                TransactionService transactionService,
@@ -244,21 +244,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         this.transactionReadTimeoutMillis = null;
         this.readSentinelBehavior = readSentinelBehavior;
         this.allowHiddenTableAccess = false;
-    }
-
-    @Deprecated
-    public static SnapshotTransaction createReadOnly(KeyValueService keyValueService,
-                                                     TransactionService transactionService,
-                                                     RemoteLockService lockService,
-                                                     long startTimeStamp,
-                                                     AtlasDbConstraintCheckingMode constraintCheckingEnabled) {
-        return new SnapshotTransaction(
-                keyValueService,
-                transactionService,
-                lockService,
-                startTimeStamp,
-                constraintCheckingEnabled,
-                TransactionReadSentinelBehavior.THROW_EXCEPTION);
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -49,7 +49,7 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.timestamp.TimestampService;
 
-public class SnapshotTransactionManager extends AbstractLockAwareTransactionManager {
+/* package */ class SnapshotTransactionManager extends AbstractLockAwareTransactionManager {
     private final static int NUM_RETRIES = 10;
 
     final KeyValueService keyValueService;
@@ -64,7 +64,7 @@ public class SnapshotTransactionManager extends AbstractLockAwareTransactionMana
     final Cleaner cleaner;
     final boolean allowHiddenTableAccess;
 
-    public SnapshotTransactionManager(KeyValueService keyValueService,
+    protected SnapshotTransactionManager(KeyValueService keyValueService,
                                       TimestampService timestampService,
                                       LockClient lockClient,
                                       RemoteLockService lockService,
@@ -77,7 +77,7 @@ public class SnapshotTransactionManager extends AbstractLockAwareTransactionMana
                 constraintModeSupplier, conflictDetectionManager, sweepStrategyManager, cleaner, false);
     }
 
-    public SnapshotTransactionManager(KeyValueService keyValueService,
+    protected SnapshotTransactionManager(KeyValueService keyValueService,
                                       TimestampService timestampService,
                                       LockClient lockClient,
                                       RemoteLockService lockService,
@@ -221,14 +221,6 @@ public class SnapshotTransactionManager extends AbstractLockAwareTransactionMana
     @Override
     public RemoteLockService getLockService() {
         return lockService;
-    }
-
-    public static void createTables(KeyValueService keyValueService) {
-        keyValueService.createTable(TransactionConstants.TRANSACTION_TABLE, TransactionConstants.TRANSACTION_TABLE_METADATA.persistToBytes());
-    }
-
-    public static void deleteTables(KeyValueService keyValueService) {
-        keyValueService.dropTable(TransactionConstants.TRANSACTION_TABLE);
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTables.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTables.java
@@ -1,0 +1,13 @@
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+
+public class TransactionTables {
+    public static void createTables(KeyValueService keyValueService) {
+        keyValueService.createTable(TransactionConstants.TRANSACTION_TABLE, TransactionConstants.TRANSACTION_TABLE_METADATA.persistToBytes());
+    }
+
+    public static void deleteTables(KeyValueService keyValueService) {
+        keyValueService.dropTable(TransactionConstants.TRANSACTION_TABLE);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTables.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTables.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.atlasdb.transaction.impl;
 
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;

--- a/atlasdb-jdbc-tests/src/test/java/com/palantir/atlasdb/jdbc/JdbcSweeperTest.java
+++ b/atlasdb-jdbc-tests/src/test/java/com/palantir/atlasdb/jdbc/JdbcSweeperTest.java
@@ -30,9 +30,10 @@ import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
+import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
+import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockServerOptions;
@@ -55,8 +56,8 @@ public class JdbcSweeperTest extends AbstractSweeperTest {
         ConflictDetectionManager cdm = ConflictDetectionManagers.createDefault(kvs);
         SweepStrategyManager ssm = SweepStrategyManagers.createDefault(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        LockAwareTransactionManager txManager = new SnapshotTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
-        SnapshotTransactionManager.createTables(kvs);
+        LockAwareTransactionManager txManager = new SerializableTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
+        TransactionTables.createTables(kvs);
         Supplier<Long> tsSupplier = new Supplier<Long>() { @Override public Long get() { return sweepTimestamp.get(); }};
         sweepRunner = new SweepTaskRunnerImpl(txManager, kvs, tsSupplier, tsSupplier, txService, ssm, ImmutableList.<Follower>of());
     }

--- a/atlasdb-rocksdb-tests/src/test/java/com/palantir/atlasdb/cleaner/RocksDbSweeperTest.java
+++ b/atlasdb-rocksdb-tests/src/test/java/com/palantir/atlasdb/cleaner/RocksDbSweeperTest.java
@@ -30,9 +30,10 @@ import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
+import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
+import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockServerOptions;
@@ -57,8 +58,8 @@ public class RocksDbSweeperTest extends AbstractSweeperTest {
         ConflictDetectionManager cdm = ConflictDetectionManagers.createDefault(kvs);
         SweepStrategyManager ssm = SweepStrategyManagers.createDefault(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        LockAwareTransactionManager txManager = new SnapshotTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
-        SnapshotTransactionManager.createTables(kvs);
+        LockAwareTransactionManager txManager = new SerializableTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
+        TransactionTables.createTables(kvs);
         Supplier<Long> tsSupplier = new Supplier<Long>() { @Override public Long get() { return sweepTimestamp.get(); }};
         sweepRunner = new SweepTaskRunnerImpl(txManager, kvs, tsSupplier, tsSupplier, txService, ssm, ImmutableList.<Follower>of());
     }

--- a/atlasdb-server/src/main/java/com/palantir/atlasdb/impl/AtlasDbServiceImpl.java
+++ b/atlasdb-server/src/main/java/com/palantir/atlasdb/impl/AtlasDbServiceImpl.java
@@ -50,7 +50,7 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.RuntimeTransactionTask;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.impl.RawTransaction;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
+import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.TxTask;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
@@ -65,14 +65,14 @@ public class AtlasDbServiceImpl implements AtlasDbService {
             ConflictHandler.SERIALIZABLE);
 
     private final KeyValueService kvs;
-    private final SnapshotTransactionManager txManager;
+    private final SerializableTransactionManager txManager;
     private final Cache<TransactionToken, RawTransaction> transactions =
             CacheBuilder.newBuilder().expireAfterAccess(12, TimeUnit.HOURS).build();
     private final TableMetadataCache metadataCache;
 
 
     public AtlasDbServiceImpl(KeyValueService kvs,
-                              SnapshotTransactionManager txManager,
+                              SerializableTransactionManager txManager,
                               TableMetadataCache metadataCache) {
         this.kvs = kvs;
         this.txManager = txManager;

--- a/atlasdb-server/src/test/java/com/palantir/server/TransactionRemotingTest.java
+++ b/atlasdb-server/src/test/java/com/palantir/server/TransactionRemotingTest.java
@@ -55,7 +55,7 @@ import com.palantir.atlasdb.schema.generated.UpgradeMetadataTable.Status;
 import com.palantir.atlasdb.schema.generated.UpgradeMetadataTable.UpgradeMetadataRow;
 import com.palantir.atlasdb.schema.generated.UpgradeMetadataTable.UpgradeMetadataRowResult;
 import com.palantir.atlasdb.table.description.TableMetadata;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
+import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 
 import feign.Feign;
 import feign.jackson.JacksonDecoder;
@@ -67,7 +67,7 @@ import io.dropwizard.testing.junit.DropwizardClientRule;
 
 public class TransactionRemotingTest {
     public final static AtlasSchema schema = UpgradeSchema.INSTANCE;
-    public final SnapshotTransactionManager txMgr = InMemoryAtlasDbFactory.createInMemoryTransactionManager(schema);
+    public final SerializableTransactionManager txMgr = InMemoryAtlasDbFactory.createInMemoryTransactionManager(schema);
     public final KeyValueService kvs = txMgr.getKeyValueService();
     public final TableMetadataCache cache = new TableMetadataCache(kvs);
     public final ObjectMapper mapper = new ObjectMapper(); { mapper.registerModule(new AtlasJacksonModule(cache).createModule()); }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -27,7 +27,7 @@ import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
 import com.palantir.timestamp.TimestampService;
 
-public class TestTransactionManagerImpl extends SnapshotTransactionManager implements TestTransactionManager {
+public class TestTransactionManagerImpl extends SerializableTransactionManager implements TestTransactionManager {
     public TestTransactionManagerImpl(KeyValueService keyValueService,
                                       TimestampService timestampService,
                                       LockClient lockClient,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -33,11 +33,11 @@ import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.CachingTestTransactionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
 import com.palantir.atlasdb.transaction.impl.TestTransactionManager;
 import com.palantir.atlasdb.transaction.impl.TestTransactionManagerImpl;
+import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.common.concurrent.PTExecutors;
@@ -95,7 +95,7 @@ public class AtlasDbTestCase {
         keyValueServiceWithStats = new StatsTrackingKeyValueService(kvs);
         keyValueService = new TrackingKeyValueService(keyValueServiceWithStats);
         keyValueService.initializeFromFreshInstance();
-        SnapshotTransactionManager.createTables(kvs);
+        TransactionTables.createTables(kvs);
         Schemas.createTablesAndIndexes(UpgradeSchema.INSTANCE.getLatestSchema(), kvs);
         transactionService = TransactionServices.createTransactionService(kvs);
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/InMemorySweeperTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/InMemorySweeperTest.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
+import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
@@ -57,7 +57,7 @@ public class InMemorySweeperTest extends AbstractSweeperTest {
         ConflictDetectionManager cdm = ConflictDetectionManagers.createDefault(kvs);
         SweepStrategyManager ssm = SweepStrategyManagers.createDefault(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        LockAwareTransactionManager txManager = new SnapshotTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
+        LockAwareTransactionManager txManager = new SerializableTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
         Supplier<Long> tsSupplier = new Supplier<Long>() { @Override public Long get() { return sweepTimestamp.get(); }};
         sweepRunner = new SweepTaskRunnerImpl(txManager, kvs, tsSupplier, tsSupplier, txService, ssm, ImmutableList.<Follower>of());
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -44,7 +44,7 @@ import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
-import com.palantir.atlasdb.transaction.impl.SnapshotTransactionManager;
+import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -77,8 +77,8 @@ public class TableTasksTest {
         ConflictDetectionManager cdm = ConflictDetectionManagers.createDefault(kvs);
         SweepStrategyManager ssm = SweepStrategyManagers.createDefault(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        SnapshotTransactionManager snapshotTransactionManager = new SnapshotTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
-        txManager = snapshotTransactionManager;
+        SerializableTransactionManager transactionManager = new SerializableTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
+        txManager = transactionManager;
     }
 
     @After


### PR DESCRIPTION
This lets us actually use serializable transactions and should not affect transactions on tables that don't have serializable conflict handling.