### PR TITLE
don't bother truncating tables that are already empty

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -63,9 +63,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     }
 
     @Value.Default
-    public int fetchBatchCount() {
-        return 5000;
-    }
+    public int fetchBatchCount() { return 5000; }
 
     @Value.Default
     public boolean safetyDisabled() {
@@ -84,7 +82,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
      */
     @Value.Default
     public int socketTimeoutMillis() {
-        return 2000;
+        return 2 * 1000;
     }
 
     /**
@@ -95,13 +93,16 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
      */
     @Value.Default
     public int socketQueryTimeoutMillis() {
-        return 62000;
+        return 62 * 1000;
     }
 
     @Value.Default
     public int cqlPoolTimeoutMillis() {
-        return 5000;
+        return 5 * 1000;
     }
+
+    @Value.Default
+    public int schemaMutationTimeoutMillis() { return 60 * 1000; }
 
     @Value.Default
     public int rangesConcurrency() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -64,7 +64,6 @@ public class CassandraConstants {
     static final String DEFAULT_RACK = "rack1";
     static final String SIMPLE_RF_TEST_KEYSPACE = "__simple_rf_test_keyspace__";
     static final String REPLICATION_FACTOR_OPTION = "replication_factor";
-    static final long SECONDS_TO_WAIT_FOR_SCHEMA_MUTATION_LOCK = 60;
     static final int GC_GRACE_SECONDS = 4 * 24 * 60 * 60; // 4 days; Hinted-Handoffs MUST expire well within this period for delete correctness (I believe we will be expiring hints in half this period)
     static final float TOMBSTONE_THRESHOLD_RATIO = 0.2f;
 


### PR DESCRIPTION
This is to reduce schema mutations further, mostly because of
people still using Cassandra 1.2, which has a terribly overly coarse
lock that makes truncates while compactions are happening trivial to
wait forever and timeout.

There is a fringe legitimate use case that this infringes upon, which is
people aware of tombstoned or TTL-expired data in their tables below
the atlas transaction/timestamp layer and who want this garbage cleaned
up before the next compaction by calling truncate manually.