### PR TITLE
upgrade feign-http to fix library bug

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -12,7 +12,10 @@ dependencies {
     compile('com.netflix.feign:feign-jaxrs:8.6.1') {
         exclude module: 'jsr311-api'
     }
-    compile "com.netflix.feign:feign-okhttp:8.6.1"
+    // versions below 8.10.0 have a bug where POST requets must have a body
+    compile('com.netflix.feign:feign-okhttp:8.10.1') {
+        exclude module: 'feign-core'
+    }
     compile 'javax.validation:validation-api:1.1.0.Final'
 
     processor 'org.immutables:value:2.0.21'


### PR DESCRIPTION
Version of feign-http before 8.10.0 require POST
requests to have a body. This breaks clustered
atlas setups when they call
TimestampService.getFreshTimestamp()

see https://github.com/Netflix/feign/blob/master/CHANGELOG.md