### PR TITLE
[lock] Printable ASCII lock descriptors

### DIFF
--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -9,8 +9,14 @@ repositories {
 
 libsDirName = file('build/artifacts')
 dependencies {
-  compile(project(":atlasdb-commons"))
-  compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
-  compile 'com.fasterxml.jackson.core:jackson-annotations:' + libVersions.jackson_annotation
-  compile 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
+    compile(project(":atlasdb-commons"))
+    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:' + libVersions.jackson_annotation
+    compile 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
+
+    testCompile(group: 'junit', name: 'junit', version: libVersions.junit) {
+        exclude group: 'org.hamcrest'
+    }
+    testCompile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
+    testCompile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
 }

--- a/lock-api/src/main/java/com/palantir/lock/LockDescriptor.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockDescriptor.java
@@ -36,7 +36,10 @@ import com.google.common.primitives.UnsignedBytes;
  */
 @Immutable
 public class LockDescriptor implements Comparable<LockDescriptor>, Serializable {
+
     private static final long serialVersionUID = 1L;
+    private static final CharMatcher BASIC_PRINTABLE_ASCII = CharMatcher.inRange(' ', '~');
+
     private final byte[] bytes;
 
     @JsonCreator
@@ -56,11 +59,12 @@ public class LockDescriptor implements Comparable<LockDescriptor>, Serializable 
 
     @Override
     public String toString() {
+        String lockIdAsString = getLockIdAsString();
         return getClass().getSimpleName() + " [" +
-                (CharMatcher.ASCII.matchesAllOf(getLockIdAsString()) ?
-                        getLockIdAsString():
+                (BASIC_PRINTABLE_ASCII.matchesAllOf(lockIdAsString) ?
+                        lockIdAsString :
                         BaseEncoding.base16().encode(bytes))
-                +"]";
+                + "]";
     }
 
     public byte[] getBytes() {

--- a/lock-api/src/main/java/com/palantir/lock/StringLockDescriptor.java
+++ b/lock-api/src/main/java/com/palantir/lock/StringLockDescriptor.java
@@ -35,6 +35,7 @@ public class StringLockDescriptor {
 
     /** Returns a {@code LockDescriptor} instance for the given lock ID. */
     public static LockDescriptor of(String lockId) {
+        Preconditions.checkNotNull(lockId);
         Preconditions.checkArgument(!Strings.isNullOrEmpty(lockId));
         return new LockDescriptor(lockId.getBytes(Charsets.UTF_8));
     }

--- a/lock-api/src/test/java/com/palantir/lock/LockDescriptorTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/LockDescriptorTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ * <p>
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://opensource.org/licenses/BSD-3-Clause
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.BaseEncoding;
+
+public class LockDescriptorTest {
+
+    private static final String HELLO_WORLD_LOCK_ID = "Hello world!";
+    private static final String OPPENHEIMER_LOCK_ID = "Now, I am become Death, the destroyer of worlds.";
+    private static final String MEANING_OF_LIFE_LOCK_ID = "~[42]";
+
+    @Test
+    public void testSimpleStringDescriptor() {
+        testAsciiLockDescriptors("abc123");
+        testAsciiLockDescriptors(HELLO_WORLD_LOCK_ID);
+        testAsciiLockDescriptors(OPPENHEIMER_LOCK_ID);
+        testAsciiLockDescriptors(MEANING_OF_LIFE_LOCK_ID);
+        testAsciiLockDescriptors(HELLO_WORLD_LOCK_ID + "/" + OPPENHEIMER_LOCK_ID);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidSimpleStringDescriptor() {
+        testAsciiLockDescriptors("");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullSimpleStringDescriptor() {
+        testAsciiLockDescriptors(null);
+    }
+
+    @Test
+    public void testEncodedStringDescriptor() {
+        testEncodedLockDescriptors("a\tb\nc\rd");
+        testEncodedLockDescriptors(HELLO_WORLD_LOCK_ID + "\n");
+        testEncodedLockDescriptors("\t" + OPPENHEIMER_LOCK_ID);
+        testEncodedLockId(new byte[0]);
+        testEncodedLockId(new byte[]{0x00});
+        testEncodedLockId(new byte[]{'h', 0x00, 0x10, 'i'});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidEncodedStringDescriptor() {
+        testEncodedLockDescriptors("");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullEncodedStringDescriptor() {
+        testEncodedLockDescriptors(null);
+    }
+
+    private void testAsciiLockDescriptors(String lockId) {
+        assertThat(StringLockDescriptor.of(lockId).toString(),
+                equalTo(expectedLockDescriptorToString(lockId)));
+
+        assertThat(ByteArrayLockDescriptor.of(stringToBytes(lockId)).toString(),
+                equalTo(expectedLockDescriptorToString(lockId)));
+    }
+
+    private void testEncodedLockDescriptors(String lockId) {
+        assertThat(StringLockDescriptor.of(lockId).toString(),
+                equalTo(expectedEncodedLockDescriptorToString(lockId)));
+
+        testEncodedLockId(stringToBytes(lockId));
+    }
+
+    private void testEncodedLockId(byte[] bytes) {
+        assertThat(ByteArrayLockDescriptor.of(bytes).toString(),
+                equalTo(expectedEncodedLockDescriptorToString(bytes)));
+    }
+
+    private static String expectedLockDescriptorToString(String lockId) {
+        assertNotNull(lockId);
+        return "LockDescriptor [" + lockId + "]";
+    }
+
+    private static String expectedEncodedLockDescriptorToString(String lockId) {
+        return expectedEncodedLockDescriptorToString(stringToBytes(lockId));
+    }
+
+    private static String expectedEncodedLockDescriptorToString(byte[] lockId) {
+        assertNotNull(lockId);
+        return "LockDescriptor [" + BaseEncoding.base16().encode(lockId) + "]";
+    }
+
+    private static byte[] stringToBytes(String lockId) {
+        return lockId.getBytes(Charsets.UTF_8);
+    }
+
+}


### PR DESCRIPTION
Print lock descriptors that contain only printable ASCII characters
between space ' ' (0x20) and '~' (0x7E).