### PR TITLE
Use AbstractInvocationHandler as base class for Proxies

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/AsyncProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/AsyncProxy.java
@@ -15,12 +15,13 @@
  */
 package com.palantir.common.proxy;
 
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.concurrent.Future;
 
-public class AsyncProxy<T> implements InvocationHandler {
+import com.google.common.reflect.AbstractInvocationHandler;
+
+public class AsyncProxy<T> extends AbstractInvocationHandler {
 
     private final Future<T> futureResult;
 
@@ -35,7 +36,7 @@ public class AsyncProxy<T> implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
         return method.invoke(futureResult.get(), args);
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/MultiDelegateProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/MultiDelegateProxy.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.common.proxy;
 
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -28,6 +27,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.AbstractInvocationHandler;
 
 /**
  * This class will delegate functionality and return the value (or throw the exception) of
@@ -40,7 +40,7 @@ import com.google.common.collect.ImmutableList;
  * are/aren't called, but you want to use a Fake to do the work.
  * <p>
  */
-public class MultiDelegateProxy<T> implements InvocationHandler {
+public class MultiDelegateProxy<T> extends AbstractInvocationHandler {
     static private final Logger log = LoggerFactory.getLogger(MultiDelegateProxy.class);
 
     public static <T> T newProxyInstance(Class<T> interfaceClass, T mainDelegate, T... delegatesToCall) {
@@ -76,7 +76,7 @@ public class MultiDelegateProxy<T> implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
         try {
             for (T t : othersToCall.get()) {
                 try {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/remoting/proxy/FillInUrlProxy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/remoting/proxy/FillInUrlProxy.java
@@ -15,12 +15,12 @@
  */
 package com.palantir.atlasdb.keyvalue.remoting.proxy;
 
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Set;
 
+import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
@@ -44,7 +44,7 @@ import com.palantir.common.base.ClosableIterator;
  * @author htarasiuk
  *
  */
-public class FillInUrlProxy<T> implements InvocationHandler {
+public class FillInUrlProxy<T> extends AbstractInvocationHandler {
 
     final T delegate;
     final String pmsUri;
@@ -59,9 +59,9 @@ public class FillInUrlProxy<T> implements InvocationHandler {
      * case of an exception. Futhermore the iterators returned by this KVS will have
      * all their methods fill in the pmsUri as well.
      *
-     * @param delegate
-     * @param pmsUri
-     * @return
+     * @param delegate key value service delegate
+     * @param pmsUri partition map service URI
+     * @return proxied key value service
      */
     public static KeyValueService newFillInUrlProxy(KeyValueService delegate, String pmsUri) {
         // First make the kvs iterators fill in the pmsUri
@@ -80,7 +80,7 @@ public class FillInUrlProxy<T> implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
         try {
             return method.invoke(delegate, args);
         } catch (InvocationTargetException e) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbAutoCommitProxy.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbAutoCommitProxy.java
@@ -15,11 +15,11 @@
  */
 package com.palantir.atlasdb;
 
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
 import com.google.common.base.Function;
+import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
@@ -28,7 +28,7 @@ import com.palantir.atlasdb.transaction.api.TransactionTask;
  * Proxy which automatically wraps all calls to target interface in
  * transactions.
  */
-public class AtlasDbAutoCommitProxy<T> implements InvocationHandler {
+public class AtlasDbAutoCommitProxy<T> extends AbstractInvocationHandler {
     @SuppressWarnings("unchecked")
     public static <T> T newProxyInstance(Class<T> interfaceClass,
                                          TransactionManager txManager,
@@ -49,7 +49,7 @@ public class AtlasDbAutoCommitProxy<T> implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, final Method method, final Object[] args) throws Throwable {
+    protected Object handleInvocation(Object proxy, final Method method, final Object[] args) throws Throwable {
         return txManager.runTaskWithRetry(new TransactionTask<Object, Exception>() {
             @Override
             public Object execute(Transaction t) throws Exception {

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -6,4 +6,6 @@ dependencies {
   compile(group: "com.google.protobuf", name: "protobuf-java", version: "2.6.0")
   compile(group: "commons-lang", name: "commons-lang", version: libVersions.commons_lang)
   compile(group: "commons-io", name: "commons-io", version: "2.1")
+
+  testCompile(group: "org.mockito", name: "mockito-core", version: "1.9.5")
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -17,7 +17,6 @@ package com.palantir.leader.proxy;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -35,6 +34,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.net.HostAndPort;
+import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.leader.LeaderElectionService;
@@ -42,7 +42,7 @@ import com.palantir.leader.LeaderElectionService.LeadershipToken;
 import com.palantir.leader.LeaderElectionService.StillLeadingStatus;
 import com.palantir.leader.NotCurrentLeaderException;
 
-public final class AwaitingLeadershipProxy implements InvocationHandler {
+public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
 
     private static final Logger log = LoggerFactory.getLogger(AwaitingLeadershipProxy.class);
     private static final Logger leaderLog = LoggerFactory.getLogger("leadership");
@@ -141,7 +141,7 @@ public final class AwaitingLeadershipProxy implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
         final LeadershipToken leadershipToken = leadershipTokenRef.get();
 
         if (leadershipToken == null) {

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -1,0 +1,56 @@
+package com.palantir.leader.proxy;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.net.HostAndPort;
+import com.palantir.leader.LeaderElectionService;
+
+public class AwaitingLeadershipProxyTest {
+
+    @Test
+    public void shouldAllowObjectMethodsWhenLeading() throws Exception {
+        Runnable mockRunnable = mock(Runnable.class);
+        Supplier<Runnable> delegateSupplier = Suppliers.ofInstance(mockRunnable);
+        LeaderElectionService mockLeader = mock(LeaderElectionService.class);
+
+        when(mockLeader.getSuspectedLeaderInMemory()).thenReturn(Optional.<HostAndPort>absent());
+        when(mockLeader.isStillLeading(any(LeaderElectionService.LeadershipToken.class)))
+                .thenReturn(LeaderElectionService.StillLeadingStatus.LEADING);
+
+        Runnable proxy = AwaitingLeadershipProxy.newProxyInstance(Runnable.class, delegateSupplier, mockLeader);
+
+        assertNotNull(proxy.hashCode());
+        assertThat(proxy, equalTo(proxy));
+        assertThat(proxy.equals(null), equalTo(false));
+        assertThat(proxy.toString(), startsWith("com.palantir.leader.proxy.AwaitingLeadershipProxy@"));
+    }
+
+    @Test
+    public void shouldAllowObjectMethodsWhenNotLeading() throws Exception {
+        Runnable mockRunnable = mock(Runnable.class);
+        Supplier<Runnable> delegateSupplier = Suppliers.ofInstance(mockRunnable);
+        LeaderElectionService mockLeader = mock(LeaderElectionService.class);
+
+        when(mockLeader.getSuspectedLeaderInMemory()).thenReturn(Optional.<HostAndPort>absent());
+        when(mockLeader.isStillLeading(any(LeaderElectionService.LeadershipToken.class)))
+                .thenReturn(LeaderElectionService.StillLeadingStatus.NOT_LEADING);
+
+        Runnable proxy = AwaitingLeadershipProxy.newProxyInstance(Runnable.class, delegateSupplier, mockLeader);
+
+        assertNotNull(proxy.hashCode());
+        assertThat(proxy.equals(proxy), equalTo(true));
+        assertThat(proxy.equals(null), equalTo(false));
+        assertThat(proxy.toString(), startsWith("com.palantir.leader.proxy.AwaitingLeadershipProxy@"));
+    }
+}

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.leader.proxy;
 
 import static org.hamcrest.CoreMatchers.equalTo;


### PR DESCRIPTION
Do not proxy Object methods such as `hashCode`, `equals`, `toString` to avoid exceptions such as:

```
Exception in thread "main" com.palantir.leader.NotCurrentLeaderException: method invoked on a non-leader
    at com.palantir.leader.proxy.AwaitingLeadershipProxy.notCurrentLeaderException(AwaitingLeadershipProxy.java:190)
    at com.palantir.leader.proxy.AwaitingLeadershipProxy.notCurrentLeaderException(AwaitingLeadershipProxy.java:195)
    at com.palantir.leader.proxy.AwaitingLeadershipProxy.invoke(AwaitingLeadershipProxy.java:148)
    at com.sun.proxy.$Proxy61.hashCode(Unknown Source)
    at java.util.HashMap.hash(HashMap.java:338)
    at java.util.HashMap.put(HashMap.java:611)
    at java.util.HashSet.add(HashSet.java:219)
    at org.glassfish.jersey.model.internal.ComponentBag.register(ComponentBag.java:311)
    at org.glassfish.jersey.model.internal.CommonConfig.register(CommonConfig.java:464)
    at org.glassfish.jersey.server.ResourceConfig.register(ResourceConfig.java:452)
    at io.dropwizard.jersey.setup.JerseyEnvironment.register(JerseyEnvironment.java:37)
    at com.palantir.atlasdb.factory.TransactionManagers.createLockAndTimestampServices(TransactionManagers.java:215)
    at com.palantir.atlasdb.factory.TransactionManagers.create(TransactionManagers.java:98)
```
