### PR TITLE
Allow optional SSLConfiguration to be passed as part of the Cassandra configuration

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -19,6 +19,10 @@ dependencies {
 
   compile 'org.apache.commons:commons-pool2:2.4.2'
 
+  compile ('com.palantir.remoting:ssl-config:0.7.2') {
+    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+  }
+
   processor 'org.immutables:value:2.0.21'
 }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.remoting.ssl.SslConfiguration;
 
 @JsonDeserialize(as = ImmutableCassandraKeyValueServiceConfig.class)
 @JsonSerialize(as = ImmutableCassandraKeyValueServiceConfig.class)
@@ -49,6 +50,8 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     }
 
     public abstract boolean ssl();
+
+    public abstract Optional<SslConfiguration> sslConfiguration();
 
     public abstract int replicationFactor();
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -32,8 +32,10 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.pooling.PoolingContainer;
+import com.palantir.remoting.ssl.SslConfiguration;
 
 public class CassandraClientPoolingContainer implements PoolingContainer<Client> {
     private static final Logger log = LoggerFactory.getLogger(CassandraClientPoolingContainer.class);
@@ -133,6 +135,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         private int poolSize = 20;
         private String keyspace = "atlasdb";
         private boolean isSsl = false;
+        private Optional<SslConfiguration> sslConfiguration = Optional.absent();
         private int socketTimeoutMillis = 2000;
         private int socketQueryTimeoutMillis = 62000;
 
@@ -157,6 +160,11 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
             return this;
         }
 
+        public Builder sslConfiguration(SslConfiguration val) {
+            sslConfiguration = Optional.of(val);
+            return this;
+        }
+
         public Builder socketTimeout(int val){
             socketTimeoutMillis = val;
             return this;
@@ -172,6 +180,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                     new CassandraClientFactory(addr,
                             keyspace,
                             isSsl,
+                            sslConfiguration,
                             socketTimeoutMillis,
                             socketQueryTimeoutMillis);
             GenericObjectPoolConfig config = new GenericObjectPoolConfig();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -113,6 +113,7 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.exception.PalantirRuntimeException;
 import com.palantir.common.pooling.PoolingContainer;
+import com.palantir.remoting.ssl.SslConfiguration;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -223,13 +224,14 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         boolean safetyDisabled = config.safetyDisabled();
         String keyspace = config.keyspace();
         boolean ssl = config.ssl();
+        Optional<SslConfiguration> sslConfiguration = config.sslConfiguration();
         int socketTimeoutMillis = config.socketTimeoutMillis();
         int socketQueryTimeoutMillis = config.socketQueryTimeoutMillis();
 
         for (InetSocketAddress addr : addrList) {
             Cassandra.Client client = null;
             try {
-                client = CassandraClientFactory.getClientInternal(addr, ssl, socketTimeoutMillis, socketQueryTimeoutMillis);
+                client = CassandraClientFactory.getClientInternal(addr, ssl, sslConfiguration, socketTimeoutMillis, socketQueryTimeoutMillis);
 
                 validatePartitioner(client);
 
@@ -241,7 +243,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
                 tokenAwareMapper = TokenAwareMapper.create(configManager, clientPool);
                 createTableInternal(client, CassandraConstants.METADATA_TABLE);
-                CassandraVerifier.sanityCheckRingConsistency(currentHosts, keyspace, ssl, safetyDisabled, socketTimeoutMillis, socketQueryTimeoutMillis);
+                CassandraVerifier.sanityCheckRingConsistency(currentHosts, keyspace, ssl, sslConfiguration, safetyDisabled, socketTimeoutMillis, socketQueryTimeoutMillis);
                 upgradeFromOlderInternalSchema(client);
                 CassandraKeyValueServices.failQuickInInitializationIfClusterAlreadyInInconsistentState(client, config.safetyDisabled(), configManager.getConfig().schemaMutationTimeoutMillis());
                 return;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ManyClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ManyClientPoolingContainer.java
@@ -76,6 +76,7 @@ public class ManyClientPoolingContainer extends ForwardingPoolingContainer<Clien
                     Sets.union(containerMap.keySet(), toAdd),
                     keyspace,
                     isSsl,
+                    config.sslConfiguration(),
                     safetyDisabled,
                     socketTimeoutMillis,
                     socketQueryTimeoutMillis);


### PR DESCRIPTION
At present, the Cassandra configuration globally uses the system default SslSocketFactory. This adds an optional parameter to the Cassandra configuration to allow a user provided SslSocketFactory to be used. See #215 for related (brief) discussion.

At present this has not been tested - should I manually test this or is there somewhere that I can write automated tests?