### PR TITLE
Clean up paxos tests better

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -25,8 +25,8 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
@@ -79,7 +79,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
     final long randomWaitBeforeProposingLeadership;
     final long leaderPingResponseWaitMs;
 
-    final Executor executor;
+    final ExecutorService executor;
 
     final ConcurrentMap<String, PingableLeader> uuidToServiceCache = Maps.newConcurrentMap();
 
@@ -88,7 +88,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
                                       Map<PingableLeader, HostAndPort> potentialLeadersToHosts,
                                       ImmutableList<PaxosAcceptor> acceptors,
                                       ImmutableList<PaxosLearner> learners,
-                                      Executor executor,
+                                      ExecutorService executor,
                                       long updatePollingWaitInMs,
                                       long randomWaitBeforeProposingLeadership,
                                       long leaderPingResponseWaitMs) {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.Nullable;
@@ -43,7 +44,7 @@ public class PaxosProposerImpl implements PaxosProposer {
                                             ImmutableList<PaxosAcceptor> allAcceptors,
                                             ImmutableList<PaxosLearner> allLearners,
                                             int quorumSize,
-                                            Executor executor) {
+                                            ExecutorService executor) {
         return new PaxosProposerImpl(
                 localLearner,
                 allAcceptors,
@@ -60,14 +61,14 @@ public class PaxosProposerImpl implements PaxosProposer {
     final String uuid;
     final AtomicLong proposalNum;
 
-    private final Executor executor;
+    private final ExecutorService executor;
 
     private PaxosProposerImpl(PaxosLearner localLearner,
                               ImmutableList<PaxosAcceptor> acceptors,
                               ImmutableList<PaxosLearner> learners,
                               int quorumSize,
                               String uuid,
-                              Executor executor) {
+                              ExecutorService executor) {
         Preconditions.checkState(
                 quorumSize > acceptors.size() / 2,
                 "quorum size needs to be at least the majority of acceptors");

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusFastTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusFastTest.java
@@ -51,8 +51,8 @@ public class PaxosConsensusFastTest {
     }
 
     @After
-    public void teardown() {
-        PaxosConsensusTestUtils.teardown();
+    public void teardown() throws Exception {
+        PaxosConsensusTestUtils.teardown(state);
     }
 
     @Test

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusSlowTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusSlowTest.java
@@ -44,8 +44,8 @@ public class PaxosConsensusSlowTest {
     }
 
     @After
-    public void teardown() {
-        PaxosConsensusTestUtils.teardown();
+    public void teardown() throws Exception {
+        PaxosConsensusTestUtils.teardown(state);
     }
 
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosTestState.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosTestState.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.palantir.leader.LeaderElectionService;
@@ -30,12 +31,14 @@ public class PaxosTestState {
     private final List<PaxosAcceptor> acceptors;
     private final List<PaxosLearner> learners;
     private final List<AtomicBoolean> failureToggles;
+    private final ExecutorService executor;
 
-    public PaxosTestState(List<LeaderElectionService> leaders, List<PaxosAcceptor> acceptors, List<PaxosLearner> learners, List<AtomicBoolean> failureToggles) {
+    public PaxosTestState(List<LeaderElectionService> leaders, List<PaxosAcceptor> acceptors, List<PaxosLearner> learners, List<AtomicBoolean> failureToggles, ExecutorService executor) {
         this.leaders = leaders;
         this.acceptors = acceptors;
         this.learners = learners;
         this.failureToggles = failureToggles;
+        this.executor = executor;
     }
 
     public void goDown(int i) {
@@ -76,5 +79,9 @@ public class PaxosTestState {
 
     public PaxosLearner learner(int i) {
         return learners.get(i);
+    }
+
+    public ExecutorService getExecutor() {
+        return executor;
     }
 }


### PR DESCRIPTION
Make sure none of the threads any of the paxos pieces may
have spawned are still running before considering the test
"cleaned up."