### PR TITLE
improved truncate that better matches cassandra internals

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -36,6 +36,7 @@ public class CassandraConstants {
     public static final int DEFAULT_CQL_PORT = 9042;
     static final int SECONDS_BETWEEN_GETTING_HOST_LIST = 600; // 10 min
     static final int SECONDS_WAIT_FOR_VERSIONS = 60;
+    static final int MAX_TRUNCATION_ATTEMPTS = 3; // tied to an exponential timeout, be careful if you change it
 
     static final int ABSOLUTE_MINIMUM_NUMBER_OF_TOKENS_PER_NODE = 32;
     static final long TS_SIZE = 4L;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -849,7 +850,6 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         final Set<String> tablesToTruncate = filterOutTrulyEmptyTables(tableNames);
         if (!tablesToTruncate.isEmpty()) {
             try {
-                trySchemaMutationLock();
                 clientPool.runWithPooledResource(new FunctionCheckedException<Client, Void, Exception>() {
                     @Override
                     public Void apply(Client client) throws Exception {
@@ -857,17 +857,16 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             if (shouldTraceQuery(tableName)) {
                                 ByteBuffer recv_trace = client.trace_next_query();
                                 Stopwatch stopwatch = Stopwatch.createStarted();
-                                client.truncate(internalTableName(tableName));
+                                truncateInternal(client, tableName);
                                 long duration = stopwatch.elapsed(TimeUnit.MILLISECONDS);
                                 if (duration > getMinimumDurationToTraceMillis()) {
                                     log.error("Traced a call to " + tableName + " that took " + duration + " ms."
                                             + " It will appear in system_traces with UUID=" + CassandraKeyValueServices.convertCassandraByteBufferUUIDtoString(recv_trace));
                                 }
                             } else {
-                                client.truncate(internalTableName(tableName));
+                                truncateInternal(client, tableName);
                             }
                         }
-                        CassandraKeyValueServices.waitForSchemaVersions(client, "(" + tablesToTruncate.size() + " tables in a call to truncateTables)", configManager.getConfig().schemaMutationTimeoutMillis());
                         return null;
                     }
 
@@ -880,8 +879,29 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 throw new PalantirRuntimeException("Creating tables requires all Cassandra nodes to be up and available.");
             } catch (Exception e) {
                 throw Throwables.throwUncheckedException(e);
-            } finally {
-                schemaMutationLock.unlock();
+            }
+        }
+    }
+
+    private void truncateInternal(Client client, String tableName) throws TException {
+        for (int tries = 1; tries <= CassandraConstants.MAX_TRUNCATION_ATTEMPTS; tries++) {
+            boolean successful = true;
+            try {
+                client.truncate(internalTableName(tableName));
+            } catch (TException e) {
+                log.error("Cluster was unavailable while we attempted a truncate for table " + tableName + "; we will try " + (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries) + " additional time(s). (" + e.getMessage() + ")");
+                if (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries == 0) {
+                    throw e;
+                }
+                successful = false;
+                try {
+                    Thread.sleep(new Random().nextInt((1 << (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries)) - 1) * 1000);
+                } catch (InterruptedException e1) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (successful) {
+                break;
             }
         }
     }


### PR DESCRIPTION
truncate cass-cluster-side already replicates some of the logic we were doing previously