### PR TITLE
add atlas timestamp cli

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasTimestampCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasTimestampCommand.java
@@ -1,0 +1,35 @@
+package com.palantir.atlasdb.cli;
+
+import com.palantir.atlasdb.cli.api.AtlasDbServices;
+import com.palantir.atlasdb.cli.api.SingleBackendCommand;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+@Command(name = "timestamp", description = "Get timestamp information")
+public class AtlasTimestampCommand extends SingleBackendCommand {
+    
+    @Option(name = {"-f", "--fresh"},
+            description = "Get a fresh timestamp")
+    private boolean fresh;
+    
+    @Option(name = {"-i", "--immutable"},
+    		description = "Get the current immutable timestamp")
+    private boolean immutable;
+    
+	@Override
+	protected int execute(AtlasDbServices services) {
+		long latestTimestamp = services.getTimestampService().getFreshTimestamp();
+
+        if (fresh || !(fresh || immutable)) {
+            System.out.println("Current timestamp is: " + latestTimestamp); // (authorized)
+        }
+
+        if (immutable) {
+        	long immutableTimestamp = services.getTransactionManager().getImmutableTimestamp();
+            System.out.println("Current immutable timestamp is: " + immutableTimestamp); // (authorized)
+        }
+
+        return 0;
+	}
+}

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasTimestampCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasTimestampCommand.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.atlasdb.cli;
 
 import com.palantir.atlasdb.cli.api.AtlasDbServices;

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/TitanCli.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/TitanCli.java
@@ -26,7 +26,7 @@ public class TitanCli {
         Cli.CliBuilder<Callable> builder = Cli.<Callable>builder("titan")
                 .withDescription("Perform common AtlasDB tasks")
                 .withDefaultCommand(Help.class)
-                .withCommands(Help.class);
+                .withCommands(Help.class, AtlasTimestampCommand.class);
 
         Cli<Callable> parser = builder.build();
         try {


### PR DESCRIPTION
@clockfort / @rjullman is this how you intended the CLIs to be written/used?

I didn't actually test this, and it's a bit different from your impl on PG CLock (which actually looks pretty buggy so I'll probably submit a CR on that end as well).  There wasn't a clear way to actually get the LockClient in order to go the getMinLockedInVersionId route, so the downside here is that if there is no immutable you don't get told, instead you just silently get a fresh one, and if you also asked for a fresh one then the two won't be the same one.