### PR TITLE
Rename AllTests to AllLeaderElectionTests

### DIFF
--- a/leader-election-impl/src/test/java/com/palantir/paxos/AllLeaderElectionTests.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/AllLeaderElectionTests.java
@@ -27,5 +27,5 @@ import com.palantir.paxos.persistence.ProtobufTest;
     PaxosConsensusFastTest.class,
     PaxosConsensusSlowTest.class
 })
-public class AllTests {
+public class AllLeaderElectionTests {
 }


### PR DESCRIPTION
We need to do this for the sake of having unique test suite names in pgdev. Also, "AllTests" is not a great name for a test suite, especially since it's only for a portion of the project and not whole thing.