### PR TITLE
Improve MessageDigest instance creation

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/util/crypto/MessageDigestPrototype.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/crypto/MessageDigestPrototype.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.util.crypto;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Use {@link MessageDigest} prototypes as a workaround for
+ * https://bugs.openjdk.java.net/browse/JDK-7092821, similar to Guava's
+ * workaround https://github.com/google/guava/issues/1197
+ */
+public enum MessageDigestPrototype {
+    MD5("MD5"), //$NON-NLS-1$
+    SHA1("SHA1"), //$NON-NLS-1$
+    SHA_256("SHA-256"); //$NON-NLS-1$
+
+    private final String algorithm;
+    private final MessageDigest prototype;
+    private final boolean supportsClone;
+
+    private MessageDigestPrototype(String algorithm) {
+        this.algorithm = Preconditions.checkNotNull(algorithm);
+        this.prototype = createDigest(algorithm);
+        this.supportsClone = supportsClone(prototype);
+    }
+
+    public MessageDigest newDigest() {
+        if (supportsClone) {
+            try {
+                return (MessageDigest) prototype.clone();
+            } catch (CloneNotSupportedException e) {
+                // fall through
+            }
+        }
+        return createDigest(algorithm);
+    }
+
+    private static boolean supportsClone(MessageDigest prototype) {
+        try {
+            prototype.clone();
+            return true;
+        } catch (CloneNotSupportedException e) {
+            return false;
+        }
+    }
+
+    private static MessageDigest createDigest(String algorithm) {
+        try {
+            return MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            // This should never happen.
+            throw new IllegalArgumentException("Invalid message digest: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/atlasdb-commons/src/main/java/com/palantir/util/crypto/Sha256Hash.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/crypto/Sha256Hash.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 import com.google.common.hash.HashCode;
@@ -133,12 +132,7 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
 
     /** Returns a {@link MessageDigest} for computing SHA-256 hashes. */
     public static MessageDigest getMessageDigest() {
-        try {
-            return MessageDigest.getInstance("SHA-256"); //$NON-NLS-1$
-        } catch (NoSuchAlgorithmException e) {
-            // This should never happen.
-            throw new IllegalStateException(e.getMessage());
-        }
+        return MessageDigestPrototype.SHA_256.newDigest();
     }
 
     /** Computes the SHA-256 hash for the given array of bytes. */

--- a/atlasdb-commons/src/test/java/com/palantir/util/AllAtlasCommonsTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/AllAtlasCommonsTests.java
@@ -20,10 +20,13 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.palantir.common.base.ThrowablesTest;
+import com.palantir.util.crypto.MessageDigestPrototypeTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-    ThrowablesTest.class})
+    ThrowablesTest.class,
+    MessageDigestPrototypeTest.class,
+})
 public class AllAtlasCommonsTests {
     // blank
 }

--- a/atlasdb-commons/src/test/java/com/palantir/util/crypto/MessageDigestPrototypeTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/crypto/MessageDigestPrototypeTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.util.crypto;
+
+import java.security.MessageDigest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.BaseEncoding;
+
+public class MessageDigestPrototypeTest {
+
+    @Test
+    public void testMD5() throws Exception {
+        MessageDigest digest = MessageDigestPrototype.MD5.newDigest();
+        Assert.assertEquals(digest.getAlgorithm(), "MD5");
+        Assert.assertNotSame(MessageDigestPrototype.MD5.newDigest(), digest);
+        byte[] result = digest.digest("Hello World".getBytes(Charsets.UTF_8));
+        Assert.assertEquals(
+                "B10A8DB164E0754105B7A99BE72E3FE5",
+                BaseEncoding.base16().encode(result));
+        Assert.assertEquals(16, result.length);
+    }
+
+    @Test
+    public void testSha1() throws Exception {
+        MessageDigest digest = MessageDigestPrototype.SHA1.newDigest();
+        Assert.assertEquals(digest.getAlgorithm(), "SHA1");
+        Assert.assertNotSame(MessageDigestPrototype.SHA1.newDigest(), digest);
+        byte[] result = digest.digest("Hello World".getBytes(Charsets.UTF_8));
+        Assert.assertEquals(
+                "0A4D55A8D778E5022FAB701977C5D840BBC486D0",
+                BaseEncoding.base16().encode(result));
+        Assert.assertEquals(20, result.length);
+    }
+
+    @Test
+    public void testSha256() throws Exception {
+        MessageDigest digest = MessageDigestPrototype.SHA_256.newDigest();
+        Assert.assertEquals(digest.getAlgorithm(), "SHA-256");
+        Assert.assertNotSame(MessageDigestPrototype.SHA_256.newDigest(), digest);
+        byte[] result = digest.digest("Hello World".getBytes(Charsets.UTF_8));
+        Assert.assertEquals(
+                "A591A6D40BF420404A011733CFB7B190D62C65BF0BCDA32B57B277D9AD9F146E",
+                BaseEncoding.base16().encode(result));
+        Assert.assertEquals(32, result.length);
+    }
+
+}


### PR DESCRIPTION
Avoid lock contention on java.security.Provider.getService by using
MessageDigest prototypes as a workaround for
https://bugs.openjdk.java.net/browse/JDK-7092821, similar to Guava's
workaround https://github.com/google/guava/issues/1197