### PR TITLE
Fix Cassandra connection pool retrying

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -82,9 +82,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
             resource = clientPool.borrowObject();
             return f.apply(resource);
         } catch (Exception e) {
-            if (e instanceof TTransportException
-                    || e instanceof TProtocolException
-                    || e instanceof NoSuchElementException) {
+            if (isInvalidClientConnection(e)) {
                 log.warn("Not reusing resource {} due to {}", resource, e);
                 shouldReuse = false;
             }
@@ -104,6 +102,12 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 }
             }
         }
+    }
+
+    private static boolean isInvalidClientConnection(Exception e) {
+        return e instanceof TTransportException
+                || e instanceof TProtocolException
+                || e instanceof NoSuchElementException;
     }
 
     private void invalidateQuietly(Client resource) {


### PR DESCRIPTION
When a Cassandra connection is not available from the pool, a `NoSuchElementException` is thrown from `CassandraClientPoolingContainer`, and that exception is now properly handled in the
`RetriableManyHostPoolingContainer` to allow for retrying.