### PR TITLE
Add null wrapping / unwrapping to map installation

### DIFF
--- a/commons-executors/src/main/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocal.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocal.java
@@ -98,6 +98,11 @@ public class ExecutorInheritableThreadLocal<T> {
      * to perform cleanup activities on the child thread.
      * <p>
      * By default this method is a no-op, and should be overridden if different behavior is desired.
+     * <p>
+     * This will be run from a finally block, so it should not throw.
+     * <p>
+     * NOTE: This code isn't guaranteed to finish by the time future.get() returns in the calling thread.
+     * The completed Future is marked <code>isDone</code> and then this is run in a finally block.
      */
     protected void uninstallOnChildThread() {
         /* Do nothing. */

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocal.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocal.java
@@ -153,7 +153,7 @@ public class ExecutorInheritableThreadLocal<T> {
             // of existing thread locals (UserSessionClientInfo does this).
             mapForThisThread.set(newMap);
 
-            for (ExecutorInheritableThreadLocal<?> e : newMap.keySet()) {
+            for (ExecutorInheritableThreadLocal<?> e : map.keySet()) {
                 @SuppressWarnings("unchecked")
                 ExecutorInheritableThreadLocal<Object> eitl = (ExecutorInheritableThreadLocal<Object>) e;
                 eitl.set(eitl.callInstallOnChildThread(eitl.get()));

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocal.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocal.java
@@ -35,7 +35,9 @@ public class ExecutorInheritableThreadLocal<T> {
         }
     };
 
-    private static class NullWrapper {}
+    private enum NullWrapper {
+        INSTANCE
+    }
 
     public void set(T value) {
         mapForThisThread.get().put(this, wrapNull(value));
@@ -163,12 +165,12 @@ public class ExecutorInheritableThreadLocal<T> {
     }
 
     private static Object wrapNull(Object value) {
-        return value == null ? new NullWrapper() : value;
+        return value == null ? NullWrapper.INSTANCE : value;
     }
 
     @SuppressWarnings("unchecked")
     private T unwrapNull(Object ret) {
-        if (ret instanceof NullWrapper) {
+        if (ret == NullWrapper.INSTANCE) {
             return null;
         } else {
             return (T) ret;

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
@@ -37,6 +37,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.collect.ImmutableMap;
+
 /**
  * Please always use the static methods in this class instead of the ones in {@link
  * java.util.concurrent.Executors}, because the executors returned by these methods will propagate
@@ -470,7 +472,7 @@ public final class PTExecutors {
      * interface, then the returned {@code Runnable} will also implement {@code Future}.
      */
     public static Runnable wrap(final Runnable runnable) {
-        final ConcurrentMap<ExecutorInheritableThreadLocal<?>, Object> mapForNewThread =
+        final ImmutableMap<ExecutorInheritableThreadLocal<?>, Object> mapForNewThread =
                 ExecutorInheritableThreadLocal.getMapForNewThread();
         if (runnable instanceof Future<?>) {
             @SuppressWarnings("unchecked")
@@ -503,7 +505,7 @@ public final class PTExecutors {
     }
 
     public static <T> RunnableFuture<T> wrap(RunnableFuture<T> rf) {
-        final ConcurrentMap<ExecutorInheritableThreadLocal<?>, Object> mapForNewThread =
+        final ImmutableMap<ExecutorInheritableThreadLocal<?>, Object> mapForNewThread =
                 ExecutorInheritableThreadLocal.getMapForNewThread();
         return new ForwardingRunnableFuture<T>(rf) {
             @Override
@@ -524,7 +526,7 @@ public final class PTExecutors {
      * propagated through.
      */
     public static <T> Callable<T> wrap(final Callable<? extends T> callable) {
-        final ConcurrentMap<ExecutorInheritableThreadLocal<?>, Object> mapForNewThread =
+        final ImmutableMap<ExecutorInheritableThreadLocal<?>, Object> mapForNewThread =
                 ExecutorInheritableThreadLocal.getMapForNewThread();
         return new Callable<T>() {
             @Override

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
@@ -65,36 +65,43 @@ public class ExecutorInheritableThreadLocalTest extends Assert {
 
             @Override
             protected void uninstallOnChildThread() {
-                outputList.add(get() + 1);
+                // We don't add to count here because the future will return before it is complete.
+                // outputList.add(get() + 1);
             }
         };
 
-    private static final AtomicInteger nullCallCount = new AtomicInteger(0);
+    private static final ExecutorInheritableThreadLocal<AtomicInteger> nullCallCount = new ExecutorInheritableThreadLocal<AtomicInteger>() {
+        protected AtomicInteger initialValue() {
+            return new AtomicInteger(0);
+        }
+    };
     private static final ExecutorInheritableThreadLocal<Integer> nullInts = new ExecutorInheritableThreadLocal<Integer>() {
             @Override
             protected Integer initialValue() {
-                nullCallCount.incrementAndGet();
+                nullCallCount.get().incrementAndGet();
                 return null;
             }
 
             @Override
             protected Integer childValue(Integer parentValue) {
                 Preconditions.checkArgument(parentValue == null);
-                nullCallCount.incrementAndGet();
+                nullCallCount.get().incrementAndGet();
                 return null;
             }
 
             @Override
             protected Integer installOnChildThread(Integer childValue) {
                 Preconditions.checkArgument(childValue == null);
-                nullCallCount.incrementAndGet();
+                nullCallCount.get().incrementAndGet();
                 return null;
             }
 
             @Override
             protected void uninstallOnChildThread() {
                 Preconditions.checkArgument(get() == null);
-                nullCallCount.incrementAndGet();
+
+                // We don't add to count here because the future will return before it is complete.
+                // nullCallCount.get().incrementAndGet();
             }
         };
 
@@ -155,26 +162,26 @@ public class ExecutorInheritableThreadLocalTest extends Assert {
             }
         });
         future.get();
-        assertEquals(ImmutableList.of(11, 12, 13), outputList);
+        assertEquals(ImmutableList.of(11, 12), outputList);
     }
 
     @Test
     public void testAllNulls() throws InterruptedException, ExecutionException {
-        nullCallCount.set(0);
+        nullCallCount.set(new AtomicInteger(0));
         Preconditions.checkArgument(nullInts.get() == null);
-        assertEquals(1, nullCallCount.get());
+        assertEquals(1, nullCallCount.get().get());
         Future<?> future = exec.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
-                assertEquals(3, nullCallCount.get());
+                assertEquals(3, nullCallCount.get().get());
                 Preconditions.checkArgument(nullInts.get() == null);
-                assertEquals(3, nullCallCount.get());
+                assertEquals(3, nullCallCount.get().get());
                 return null;
             }
         });
         future.get();
-        assertEquals(4, nullCallCount.get());
+        assertEquals(3, nullCallCount.get().get());
         Preconditions.checkArgument(nullInts.get() == null);
-        assertEquals(4, nullCallCount.get());
+        assertEquals(3, nullCallCount.get().get());
     }
 }


### PR DESCRIPTION
This was found after seeing build timeouts on https://gerrit.yojoe.local/#/c/270786.  The timeouts occur after sql operations fail when the NullWrappers fail to cast properly.  This resolves that issue.  The testing story for this is not complete.