### PR TITLE
Handle unknown source locations in stack traces

### DIFF
--- a/leader-election-api/src/main/java/com/palantir/paxos/persistence/PaxosProtos.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/persistence/PaxosProtos.java
@@ -19,7 +19,6 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.Sets;
 import com.palantir.common.base.Throwables;
 import com.palantir.paxos.persistence.generated.PaxosPersistence.ExceptionProto;
@@ -55,7 +54,9 @@ public class PaxosProtos {
         StackTraceElementProto.Builder builder = StackTraceElementProto.newBuilder();
         builder.setDeclaringClass(real.getClassName());
         builder.setMethodName(real.getMethodName());
-        builder.setFileName(MoreObjects.firstNonNull(real.getFileName(), ""));
+        if (real.getFileName() != null) {
+            builder.setFileName(real.getFileName());
+        }
         builder.setLineNumber(real.getLineNumber());
         return builder.build();
     }
@@ -97,7 +98,7 @@ public class PaxosProtos {
     private static StackTraceElement fromProto(StackTraceElementProto proto) {
         return new StackTraceElement(proto.getDeclaringClass(),
                 proto.getMethodName(),
-                proto.getFileName(),
+                proto.hasFileName() ? proto.getFileName() : null,
                 proto.getLineNumber());
     }
 }


### PR DESCRIPTION
StackTraceElement special-cases null filenames to "Unknown Source",
but PaxosProtos special-cases null to the empty string, which leads
to a bug involving classes with no debug information attached, such
that round-trip serialization and deserialization of exceptions is
not stable. By way of example:

before: com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
after: com.sun.proxy.$Proxy2.processTestClass()

In general, this occurs with any stack trace element from rt.jar.

Instead of coercing nulls to empty strings on our end, just leave
the field unset in the protobuf and check for its presence during
deserialization.