### PR TITLE
Do not warn if an inconsistent table is a hidden table

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -1371,7 +1371,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     } else {
                         contents = value.getContents();
                     }
-                    tableToMetadataContents.put(tableRef, contents);
+                    if (!CassandraConstants.HIDDEN_TABLES.contains(tableRef)) {
+                        tableToMetadataContents.put(tableRef, contents);
+                    }
                 }
             }
         } finally {


### PR DESCRIPTION
@tmgordeeva 

Avoid printing false-positive log messages claiming that some tables do not exist but are represented in the metadata table. 

An example (incorrect) log line: 

` [2016-04-13 00:40:48,050] com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService: While getting metadata for tables, we found the following tables that do not exist in the database, but are represented in the metadata table: [_timestamp]`

This is a false positive, and it only gets printed because `tablesInDatabase` excludes hidden tables. This fix also excludes hidden tables from `tableToMetadataContents`, thus avoiding that warning. 