### PR TITLE
Feature/remove memoizing supplier

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
         exclude group: 'org.hamcrest'
     }
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 configurations.matching({ it.name in ['compile', 'runtime'] }).all {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -45,7 +45,7 @@ public class ServiceDiscoveringAtlasSupplier {
                             "Have you annotated it with @AutoService(AtlasDbFactory.class)?"
                 ));
         keyValueService = memoize(() -> atlasFactory.createRawKeyValueService(config));
-        timestampService = memoize(() -> atlasFactory.createTimestampService(getKeyValueService()));
+        timestampService = () -> atlasFactory.createTimestampService(getKeyValueService());
     }
 
     public KeyValueService getKeyValueService() {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
@@ -15,9 +15,13 @@
  */
 package com.palantir.atlasdb.factory;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jmock.Mockery;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.Lists;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
@@ -29,7 +33,7 @@ public class AutoServiceAnnotatedAtlasDbFactory implements AtlasDbFactory {
 
     private static final Mockery context = new Mockery();
     private static final KeyValueService keyValueService = context.mock(KeyValueService.class);
-    private static final TimestampService timestampService = context.mock(TimestampService.class);
+    private static List<TimestampService> nextTimestampServices = new ArrayList<>();
 
 
     @Override
@@ -44,6 +48,10 @@ public class AutoServiceAnnotatedAtlasDbFactory implements AtlasDbFactory {
 
     @Override
     public TimestampService createTimestampService(KeyValueService rawKvs) {
-        return timestampService;
+        return nextTimestampServices.remove(0);
+    }
+
+    public static void nextTimestampServiceToReturn(TimestampService... timestampServices) {
+        nextTimestampServices = Lists.newArrayList(timestampServices);
     }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
@@ -71,6 +71,7 @@ public class ServiceDiscoveringAtlasSupplierTest {
 
     @Test
     public void returnDifferentTimestampServicesOnSubsequentCalls() {
+        // Need to get a newly-initialized timestamp service in case leadership changed between calls.
         ServiceDiscoveringAtlasSupplier supplier = new ServiceDiscoveringAtlasSupplier(kvsConfig);
         AutoServiceAnnotatedAtlasDbFactory.nextTimestampServiceToReturn(mock(TimestampService.class), mock(TimestampService.class));
 


### PR DESCRIPTION
Primary: @joelea 

We shouldn't be memoizing `TimestampService`s in `ServiceDiscoveringAtlasSupplier`; we should return a different `TimestampService` each time. 