### PR TITLE
Don't wait so long on AGGRESSIVE_HARD_DELETE

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -42,7 +42,7 @@ public class AtlasDbConstants {
     public static final byte[] EMPTY_TABLE_METADATA = {}; // use carefully
     public static final byte[] GENERIC_TABLE_METADATA = new TableMetadata().persistToBytes();
 
-    public static final long SCRUBBER_RETRY_DELAY_MILLIS = 2000L;
+    public static final long SCRUBBER_RETRY_DELAY_MILLIS = 500L;
 
     public static final int MINIMUM_COMPRESSION_BLOCK_SIZE_KB = 4;
     public static final int DEFAULT_INDEX_COMPRESSION_BLOCK_SIZE_KB = 4;


### PR DESCRIPTION
We use AGGRESSIVE_HARD_DELETE in tests, to ensure that streams we've
written get cleaned up if they're capable of being cleaned up.

This takes a bunch of time, because it calls Scrubber.scrubImmediately
twice, which waits if the immutable timestamp < the commit timestamp.

Because the immutable timestamp is memoized for up to 1 second, the
first check will fail all of the time, and so the thread will go to
sleep for 2 seconds.

This means that each test takes 4 seconds.

This PR makes the retry rate 500ms instead, which should make our tests
run in expected time 1.75 seconds, I think, at the cost of a 50% chance
of an extra line in the logs. CPU cost is basically nothing as it's just
comparing two timestamps.

More generally, it'd be nice to get the immutable timestamp updating at
a rate of greater than once per second - but this one seems like an easy
win for us.