### PR TITLE
Update travis to continue check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ generated_testSrc/
 .factorypath
 out/
 atlasdb-cli/var/data/
+
+# Emacs temp files
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 - ps aux --sort=-%mem | awk 'NR<=10{print $0}'
 
 script:
-  - travis_wait ./gradlew --max-workers 2 check --stacktrace
+  - travis_wait ./gradlew --max-workers 2 check --stacktrace --continue
 env:
   matrix:
   - CI=true


### PR DESCRIPTION
Allows use to capture all problems detected with the build (assuming a tasks dependencies completed), hopefully causing us to require fewer builds to fix problems.