### PR TITLE
Feature/do not allocate timestmap batch on initialization

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
         exclude group: 'org.hamcrest'
     }
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.mockito:mockito-core:' + libVersions.mockito
 }
 
 configurations.matching({ it.name in ['compile', 'runtime'] }).all {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -4,6 +4,7 @@ ext.libVersions = [
     jsr305:  '1.3.9',
     junit:   '4.11',
     jmock:   '2.5.1',
+    mockito: '1.10.19',
     dropwizard:   '0.8.2',
     commons_lang: '2.6',
     joda_time: '2.7',

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
     exclude group: 'org.hamcrest'
   }
+  testCompile 'org.mockito:mockito-core:1.10.19'
   compile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
   compile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
 }

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
     exclude group: 'org.hamcrest'
   }
-  testCompile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'org.mockito:mockito-core:' + libVersions.mockito
   compile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
   compile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
 }

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -190,6 +190,9 @@ public class PersistentTimestampService implements TimestampService {
             }
             long newVal = Math.min(upperLimit, lastVal + numTimestampsRequested);
             if (lastReturnedTimestamp.compareAndSet(lastVal, newVal)) {
+                if (isAllocationRequired(newVal, upperLimit)) {
+                    submitAllocationTask();
+                }
                 return TimestampRange.createInclusiveRange(lastVal + 1, newVal);
             }
         }

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -51,27 +51,19 @@ public class PersistentTimestampService implements TimestampService {
     private long lastAllocatedTime;
 
     public static PersistentTimestampService create(TimestampBoundStore tbs) {
-        PersistentTimestampService ts = new PersistentTimestampService(
+        return create(
                 tbs,
-                tbs.getUpperLimit(),
                 new Clock() {
                     @Override
                     public long getTimeMillis() {
                         return System.currentTimeMillis();
                     }
                 });
-        return init(ts);
     }
 
     @VisibleForTesting
     protected static PersistentTimestampService create(TimestampBoundStore tbs, Clock clock) {
-        PersistentTimestampService ts = new PersistentTimestampService(tbs, tbs.getUpperLimit(), clock);
-        return init(ts);
-    }
-
-    private static PersistentTimestampService init(PersistentTimestampService ts) {
-        ts.allocateMoreTimestamps();
-        return ts;
+        return new PersistentTimestampService(tbs, tbs.getUpperLimit(), clock);
     }
 
     private PersistentTimestampService(TimestampBoundStore tbs, long lastUpperBound, Clock clock) {

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
@@ -143,12 +143,16 @@ public class PersistentTimestampServiceTest {
 
     private void getFreshTimestampsInParallel(PersistentTimestampService persistentTimestampService, int numTimes) {
         ExecutorService executorService = Executors.newFixedThreadPool(numTimes / 2);
-        Set<Future<?>> futures = IntStream.range(0, numTimes)
-                .mapToObj(i -> executorService.submit(() -> {
-                    persistentTimestampService.getFreshTimestamp();
-                }))
-                .collect(Collectors.toSet());
-        futures.forEach(Futures::getUnchecked);
+        try {
+            Set<Future<?>> futures = IntStream.range(0, numTimes)
+                    .mapToObj(i -> executorService.submit(() -> {
+                        persistentTimestampService.getFreshTimestamp();
+                    }))
+                    .collect(Collectors.toSet());
+            futures.forEach(Futures::getUnchecked);
+        } finally {
+            executorService.shutdown();
+        }
     }
 
     private TimestampBoundStore initialTimestampBoundStore() {

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
@@ -36,7 +36,9 @@ import java.util.stream.IntStream;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.google.common.util.concurrent.Futures;
 import com.palantir.common.concurrent.PTExecutors;
@@ -46,6 +48,9 @@ import com.palantir.common.time.Clock;
 public class PersistentTimestampServiceTest {
 
     private static final long TWO_MINUTES_IN_MILLIS = 120_000L;
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testFastForward() {
@@ -107,14 +112,10 @@ public class PersistentTimestampServiceTest {
     }
 
     @Test
-    public void notThrowOnCreateIfBoundStoreIsInvalid() {
-        PersistentTimestampService.create(failingTimestampBoundStore());
-    }
-
-    @Test(expected = ServiceNotAvailableException.class)
-    public void throwOnTimestampRequestIfBoundStoreIsInvalid() {
+    public void throwOnTimestampRequestIfBoundStoreCannotStoreNewUpperLimit() {
         PersistentTimestampService persistentTimestampService = PersistentTimestampService.create(failingTimestampBoundStore());
 
+        expectedException.expect(ServiceNotAvailableException.class);
         persistentTimestampService.getFreshTimestamp();
     }
 

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
@@ -37,20 +37,6 @@ import com.palantir.common.remoting.ServiceNotAvailableException;
 
 public class PersistentTimestampServiceTest {
     @Test
-    public void testCreation() {
-        Mockery m = new Mockery();
-        final TimestampBoundStore tbsMock = m.mock(TimestampBoundStore.class);
-        final long initialValue = 72;
-        m.checking(new Expectations() {{
-            oneOf(tbsMock).getUpperLimit();
-            will(returnValue(initialValue));
-            oneOf(tbsMock).storeUpperLimit(with(any(Long.class)));
-        }});
-        PersistentTimestampService.create(tbsMock);
-        m.assertIsSatisfied();
-    }
-    
-    @Test
     public void testFastForward() {
         Mockery m = new Mockery();
         final TimestampBoundStore tbsMock = m.mock(TimestampBoundStore.class);

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutionException;
@@ -59,6 +60,17 @@ public class PersistentTimestampServiceTest {
         }
         
         m.assertIsSatisfied();
+    }
+
+    @Test
+    public void incrementUpperLimitOnFirstFreshTimestampRequest() {
+        TimestampBoundStore timestampBoundStore = mock(TimestampBoundStore.class);
+        when(timestampBoundStore.getUpperLimit()).thenReturn(0L);
+        PersistentTimestampService persistentTimestampService = PersistentTimestampService.create(timestampBoundStore);
+
+        persistentTimestampService.getFreshTimestamp();
+
+        verify(timestampBoundStore).storeUpperLimit(PersistentTimestampService.ALLOCATION_BUFFER_SIZE);
     }
 
     @Test


### PR DESCRIPTION
This PR moves `allocateMoreTimestamps()` out of `PersistentTimestampService` initialization. 

If two timestamp servers are initialized in very quick succession (for example if the first gains and immediately loses leadership), one will fail with a "Timestamp limit changed underneath us" error. By moving the `allocateMoreTimestamps()` call out, this error is much less likely to happen. 

One potential downside is that `allocateMoreTimestamps` will get called on the first freshTimestamp request. This could make the request take slightly longer. 