### PR TITLE
Fix a bug where postgres would attempt to insert too many values at once

### DIFF
--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/impl/JdbcConstants.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/impl/JdbcConstants.java
@@ -59,4 +59,7 @@ public class JdbcConstants {
 
     public static final String MAX_TIMESTAMP = "max_timestamp";
     public static final Field<Long> T2_MAX_TIMESTAMP = field(TEMP_TABLE_2 + '.' + MAX_TIMESTAMP, Long.class);
+
+    // Postgres has a hard limit of 32767 values per insert.
+    public static final int MAX_VALUES_PER_BATCH = 3000;
 }


### PR DESCRIPTION
NOT FOR MERGE / NOT GENERALIZED

This solution is not generalized -- postgres should be able to handle 32767 values at once (according to https://blog.makk.es/postgresql-parameter-limitation.html), but in my testing on a single use case, it seemed to only be able to handle ~8000. I think this may have been because my atlas schema had 4 values. The constant I put in is a guess that unblocked my use case, and I figured I'd pass it back up to the atlas team to look at fixing in general. 

The exact error I saw was java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: 74312 on putBatch();