### PR TITLE
Lower log level from INFO to DEBUG

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueService.java
@@ -173,7 +173,7 @@ public class SweepStatsKeyValueService extends ForwardingKeyValueService {
         flushExecutor.shutdown();
         try {
             if (flushExecutor.awaitTermination(1, TimeUnit.MINUTES)) {
-                log.info("Successfully terminated flush executor");
+                log.debug("Successfully terminated flush executor");
             } else {
                 log.warn("Timed out while waiting for flush executor termination");
                 List<Runnable> pendingTasks = flushExecutor.shutdownNow();


### PR DESCRIPTION
This log line is hit every time an Atlas instance is shut down and is below the bar for logging during normal operations