### PR TITLE
InMemoryKVS no longer violates ACID

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -337,7 +337,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                 // Save memory by sharing rows.
                 row = nextKey.row;
             }
-            byte[] oldContents = table.entries.putIfAbsent(new Key(row, col, timestamp), contents);
+            byte[] oldContents = table.entries.putIfAbsent(new Key(row, col, timestamp), Arrays.copyOf(contents, contents.length));
             if (oldContents != null && (doNotOverwriteWithSameValue || !Arrays.equals(oldContents, contents))) {
                 throw new KeyAlreadyExistsException("We already have a value for this timestamp");
             }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.keyvalue.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -654,6 +656,25 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         } catch (RuntimeException e) {
             // Expected
         }
+    }
+
+    @Test
+    public void testCannotModifyValuesAfterWrite() {
+        byte[] data = new byte[1];
+        byte[] unmodifiedData = Arrays.copyOf(data, data.length);
+
+        Cell cell = Cell.create(row0, column0);
+
+        Value val = Value.create(data, TEST_TIMESTAMP + 1);
+
+        keyValueService.putWithTimestamps(TEST_TABLE, ImmutableMultimap.of(cell, val));
+
+        data[0] = (byte) 50;
+
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(cell, TEST_TIMESTAMP + 3)).get(cell).getContents(),
+                is(unmodifiedData));
+
+        keyValueService.delete(TEST_TABLE, ImmutableMultimap.of(cell, TEST_TIMESTAMP + 1));
     }
 
     protected void putTestDataForMultipleTimestamps() {


### PR DESCRIPTION
At present, IMKVS does not copy arrays that are written to it. This means that
you are liable to see bad behaviour by doing expected safe things like
modifying an array that you used in a transaction (after the transaction
is committed?!)

As much as the InMemoryKVS is designed for testing only,
it's still pretty rubbish. For example, it meant that #288 was exhibited
on the streamstore method that wrote in multiple transactions when using
an in-memory kvs.