### PR TITLE
fix check for table existence

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -88,6 +88,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
@@ -1167,7 +1168,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     for (TableReference table : tablesToCreate) {
                         CassandraVerifier.sanityCheckTableName(table);
 
-                        if (!existingTables.contains(table)) {
+                        TableReference lowerCaseTable = TableReference.createUnsafe(table.getQualifiedName().toLowerCase());
+                        if (!existingTables.contains(lowerCaseTable)) {
                             client.system_add_column_family(getCfForTable(table, tableNamesToTableMetadata.get(table)));
                         } else {
                             log.warn(String.format("Ignored call to create a table (%s) that already existed.", table));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -88,7 +88,6 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
-import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;


### PR DESCRIPTION
I'm pretty sure this is a P0 -- currently I think that all deployments of 0.3.35 using non-lowercase tablenames are broken.

Without this fix, you get the following error message on the second startup:
```
INFO  [2016-05-09 03:48:31,367] org.eclipse.jetty.util.log: Logging initialized @1778ms
WARN  [2016-05-09 03:48:31,486] io.dropwizard.lifecycle.setup.ExecutorServiceBuilder: Parameter 'maximumPoolSize' is conflicting with unbounded work queues
WARN  [2016-05-09 03:48:31,486] io.dropwizard.lifecycle.setup.ExecutorServiceBuilder: Parameter 'maximumPoolSize' is conflicting with unbounded work queues
ERROR [2016-05-09 03:48:32,525] com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService: Found a table _timestamp that did not have persisted Atlas metadata.If you recently did a Palantir update, try waiting until schema upgrades are completed on all backend CLIs/services etc and restarting this service.If this error re-occurs on subsequent attempted startups, please contact Palantir support.
WARN  [2016-05-09 03:48:32,553] com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService: Ignored call to create a table (_timestamp) that already existed.
WARN  [2016-05-09 03:48:32,635] com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService: Ignored call to create a table (_transactions) that already existed.
ERROR [2016-05-09 03:48:32,640] com.palantir.atlasdb.table.description.TableDefinition: First row component dummy of type VAR_LONG might cause hot-spotting with the partitioner in Cassandra.
WARN  [2016-05-09 03:48:32,645] com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService: Ignored call to create a table (sweep.priority) that already existed.
WARN  [2016-05-09 03:48:32,646] com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService: Ignored call to create a table (sweep.progress) that already existed.
WARN  [2016-05-09 03:48:32,668] com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer: Error occurred talking to host 'il-pg-alpha-142570.use1.palantir.global/10.0.16.116:9160': null
Exception in thread "main" com.palantir.common.exception.PalantirRuntimeException
        at com.palantir.common.base.Throwables.createPalantirRuntimeException(Throwables.java:100)
        at com.palantir.common.base.Throwables.createPalantirRuntimeException(Throwables.java:92)
        at com.palantir.common.base.Throwables.throwUncheckedException(Throwables.java:88)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService.createTables(CassandraKeyValueService.java:1185)
        at com.palantir.atlasdb.keyvalue.impl.TableRemappingKeyValueService.createTables(TableRemappingKeyValueService.java:86)
        at com.palantir.atlasdb.keyvalue.impl.NamespaceMappingKeyValueService.createTables(NamespaceMappingKeyValueService.java:210)
        at com.palantir.atlasdb.keyvalue.impl.ForwardingKeyValueService.createTables(ForwardingKeyValueService.java:67)
        at com.palantir.atlasdb.table.description.Schemas.createTables(Schemas.java:62)
        at com.palantir.atlasdb.table.description.Schemas.createTablesAndIndexes(Schemas.java:100)
        at com.palantir.atlasdb.factory.TransactionManagers.create(TransactionManagers.java:116)
        at com.palantir.atlasdb.factory.TransactionManagers.create(TransactionManagers.java:86)
        at com.palantir.stemma.StemmaServer.run(StemmaServer.java:144)
        at com.palantir.stemma.StemmaServer.run(StemmaServer.java:87)
        at io.dropwizard.cli.EnvironmentCommand.run(EnvironmentCommand.java:40)
        at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:77)
        at io.dropwizard.cli.Cli.run(Cli.java:70)
        at io.dropwizard.Application.run(Application.java:80)
        at com.palantir.stemma.StemmaServer.main(StemmaServer.java:93)
Caused by: InvalidRequestException(why:Cannot add already existing table "stemma__SourceToForkRepository" to keyspace "stemma2")
        at org.apache.cassandra.thrift.Cassandra$system_add_column_family_result$system_add_column_family_resultStandardScheme.read(Cassandra.java:43019)
        at org.apache.cassandra.thrift.Cassandra$system_add_column_family_result$system_add_column_family_resultStandardScheme.read(Cassandra.java:42997)
        at org.apache.cassandra.thrift.Cassandra$system_add_column_family_result.read(Cassandra.java:42931)
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:78)
        at org.apache.cassandra.thrift.Cassandra$Client.recv_system_add_column_family(Cassandra.java:1522)
        at org.apache.cassandra.thrift.Cassandra$Client.system_add_column_family(Cassandra.java:1509)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService$17.apply(CassandraKeyValueService.java:1171)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService$17.apply(CassandraKeyValueService.java:1156)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.runWithGoodResource(CassandraClientPoolingContainer.java:93)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.runWithPooledResource(CassandraClientPoolingContainer.java:77)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.runWithRetryOnHost(CassandraClientPool.java:353)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.runWithRetry(CassandraClientPool.java:339)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService.createTables(CassandraKeyValueService.java:1156)
        ... 14 more
```