### PR TITLE
Create abstract cli command for when you don't want to or can't init atlas services

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
@@ -19,7 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
-import com.palantir.atlasdb.cli.services.ServicesConfigModule;
+import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
 
 import io.airlift.airline.Option;
@@ -37,19 +37,19 @@ public abstract class AbstractCommand implements Callable<Integer> {
             description = "field in the config yaml file that contains the atlasdb configuration root")
     private String configRoot = AtlasDbConfigs.ATLASDB_CONFIG_ROOT;
 
-    private ServicesConfigModule scm;
+    private AtlasDbConfig config;
     
-    protected ServicesConfigModule getServicesConfigModule() {
-        if (scm == null) {
+    protected AtlasDbConfig getAtlasDbConfig() {
+        if (config == null) {
             try {
-                scm = ServicesConfigModule.create(configFile, configRoot);
+                config = AtlasDbConfigs.load(configFile, configRoot);
             } catch (IOException e) {
                 throw new RuntimeException(String.format("IOException thrown reading configuration file: %s",
                         configFile.getPath()), e);
             }
         }
         
-        return scm;
+        return config;
     }
 
 }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.cli.command;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import com.palantir.atlasdb.cli.services.ServicesConfigModule;
+import com.palantir.atlasdb.config.AtlasDbConfigs;
+
+import io.airlift.airline.Option;
+
+public abstract class AbstractCommand implements Callable<Integer> {
+
+    @Option(name = {"-c", "--config"},
+            title = "CONFIG PATH",
+            description = "path to yaml configuration file for atlasdb",
+            required = true)
+    private File configFile;
+
+    @Option(name = {"--config-root"},
+            title = "CONFIG ROOT",
+            description = "field in the config yaml file that contains the atlasdb configuration root")
+    private String configRoot = AtlasDbConfigs.ATLASDB_CONFIG_ROOT;
+
+    private ServicesConfigModule scm;
+    
+    protected ServicesConfigModule getServicesConfigModule() {
+        if (scm == null) {
+            try {
+                scm = ServicesConfigModule.create(configFile, configRoot);
+            } catch (IOException e) {
+                throw new RuntimeException(String.format("IOException thrown reading configuration file: %s",
+                        configFile.getPath()), e);
+            }
+        }
+        
+        return scm;
+    }
+
+}

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SingleBackendCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SingleBackendCommand.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.cli.services.AtlasDbServices;
 import com.palantir.atlasdb.cli.services.AtlasDbServicesFactory;
 import com.palantir.atlasdb.cli.services.DaggerAtlasDbServices;
+import com.palantir.atlasdb.cli.services.ServicesConfigModule;
 import com.palantir.common.base.Throwables;
 
 public abstract class SingleBackendCommand extends AbstractCommand {
@@ -37,12 +38,13 @@ public abstract class SingleBackendCommand extends AbstractCommand {
     public abstract int execute(AtlasDbServices services);
 
     private AtlasDbServices connect() throws IOException {
-        return DaggerAtlasDbServices.builder().servicesConfigModule(getServicesConfigModule()).build();
+        ServicesConfigModule scm = ServicesConfigModule.create(getAtlasDbConfig());
+        return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }
 
     @VisibleForTesting
     public <T extends AtlasDbServices> T connect(AtlasDbServicesFactory factory) throws IOException {
-        return factory.connect(getServicesConfigModule());
+        return factory.connect(ServicesConfigModule.create(getAtlasDbConfig()));
     }
 
 }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SingleBackendCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SingleBackendCommand.java
@@ -15,32 +15,15 @@
  */
 package com.palantir.atlasdb.cli.command;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.Callable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.cli.services.AtlasDbServices;
 import com.palantir.atlasdb.cli.services.AtlasDbServicesFactory;
 import com.palantir.atlasdb.cli.services.DaggerAtlasDbServices;
-import com.palantir.atlasdb.cli.services.ServicesConfigModule;
-import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.common.base.Throwables;
 
-import io.airlift.airline.Option;
-
-public abstract class SingleBackendCommand implements Callable<Integer> {
-
-    @Option(name = {"-c", "--config"},
-            title = "CONFIG PATH",
-            description = "path to yaml configuration file for atlasdb",
-            required = true)
-    private File configFile;
-
-    @Option(name = {"--config-root"},
-            title = "CONFIG ROOT",
-            description = "field in the config yaml file that contains the atlasdb configuration root")
-    private String configRoot = AtlasDbConfigs.ATLASDB_CONFIG_ROOT;
+public abstract class SingleBackendCommand extends AbstractCommand {
 
     @Override
     public Integer call() {
@@ -54,14 +37,12 @@ public abstract class SingleBackendCommand implements Callable<Integer> {
     public abstract int execute(AtlasDbServices services);
 
     private AtlasDbServices connect() throws IOException {
-        ServicesConfigModule scm = ServicesConfigModule.create(configFile, configRoot);
-        return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
+        return DaggerAtlasDbServices.builder().servicesConfigModule(getServicesConfigModule()).build();
     }
 
     @VisibleForTesting
     public <T extends AtlasDbServices> T connect(AtlasDbServicesFactory factory) throws IOException {
-        ServicesConfigModule scm = ServicesConfigModule.create(configFile, configRoot);
-        return factory.connect(scm);
+        return factory.connect(getServicesConfigModule());
     }
 
 }


### PR DESCRIPTION
@rjullman to review in immediate term

@joelea / @jboreiko / @clockfort this is so we can do the truncate locks table command (you obviously can't create the actual kvs, but I still want the config)