### PR TITLE
Feature/fix flaky cassandra lock test

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraDbLockTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraDbLockTest.java
@@ -49,18 +49,15 @@ public class CassandraDbLockTest {
     public static final TableReference BAD_TABLE = TableReference.createFromFullyQualifiedName("foo.b@r");
     public static final TableReference GOOD_TABLE = TableReference.createFromFullyQualifiedName("foo.bar");
 
-    private static final int QUICK_TIMEOUT_MILLIS = 500;
-    private static final int SLOW_TIMEOUT_MILLIS = 60_000;
-
     @Before
     public void setUp() {
         ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = CassandraTestSuite.CASSANDRA_KVS_CONFIG
-                .withSchemaMutationTimeoutMillis(QUICK_TIMEOUT_MILLIS);
+                .withSchemaMutationTimeoutMillis(500);
         kvs = CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig));
 
         ImmutableCassandraKeyValueServiceConfig slowTimeoutConfig = CassandraTestSuite.CASSANDRA_KVS_CONFIG
-                .withSchemaMutationTimeoutMillis(SLOW_TIMEOUT_MILLIS);
+                .withSchemaMutationTimeoutMillis(60 * 1000);
         slowTimeoutKvs = CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(slowTimeoutConfig));
 
@@ -92,7 +89,7 @@ public class CassandraDbLockTest {
 
         Future tryToAcquireSecondLock = async(() -> kvs.waitForSchemaMutationLock());
 
-        Thread.sleep(CassandraKeyValueService.SCHEMA_MUTATION_TIMEOUT_MULTIPLIER * QUICK_TIMEOUT_MILLIS);
+        Thread.sleep(3 * 1000);
         assertThatFutureDidNotSucceedYet(tryToAcquireSecondLock);
 
         tryToAcquireSecondLock.cancel(true);

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraDbLockTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraDbLockTest.java
@@ -15,9 +15,6 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
@@ -96,17 +93,6 @@ public class CassandraDbLockTest {
         kvs.schemaMutationUnlock(firstLock);
     }
 
-    private void assertThatFutureDidNotSucceedYet(Future future) throws InterruptedException {
-        if (future.isDone()) {
-            try {
-                future.get();
-                throw new AssertionError("Future task should have failed but finished successfully");
-            } catch (ExecutionException e) {
-                // if execution is done, we expect it to have failed
-            }
-        }
-    }
-
     @Test
     public void testIdsAreRequestUnique() {
         long id = kvs.waitForSchemaMutationLock();
@@ -180,5 +166,16 @@ public class CassandraDbLockTest {
 
     private Future async(Runnable callable) {
         return executorService.submit(callable);
+    }
+
+    private void assertThatFutureDidNotSucceedYet(Future future) throws InterruptedException {
+        if (future.isDone()) {
+            try {
+                future.get();
+                throw new AssertionError("Future task should have failed but finished successfully");
+            } catch (ExecutionException e) {
+                // if execution is done, we expect it to have failed
+            }
+        }
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -132,6 +132,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     static final Logger log = LoggerFactory.getLogger(CassandraKeyValueService.class);
 
+    public static final int SCHEMA_MUTATION_TIMEOUT_MULTIPLIER = 4;
+
     private static final Function<Entry<Cell, Value>, Long> ENTRY_SIZING_FUNCTION = new Function<Entry<Cell, Value>, Long>() {
         @Override
         public Long apply(Entry<Cell, Value> input) {
@@ -1483,7 +1485,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             expected = ImmutableList.of(lockColumnWithValue(Longs.toByteArray(CassandraConstants.GLOBAL_DDL_LOCK_CLEARED_VALUE)));
                         }
 
-                        if (stopwatch.elapsed(TimeUnit.MILLISECONDS) > configManager.getConfig().schemaMutationTimeoutMillis() * 4) { // possibly dead remote locker
+                        if (stopwatch.elapsed(TimeUnit.MILLISECONDS) > configManager.getConfig().schemaMutationTimeoutMillis() * SCHEMA_MUTATION_TIMEOUT_MULTIPLIER) { // possibly dead remote locker
                             throw new TimeoutException(String.format("We have timed out waiting on the current schema mutation lock holder.  " +
                                     "We have tried to grab the lock for %d milliseconds unsuccessfully.  Please try restarting the AtlasDB client." +
                                     "If this occurs repeatedly it may indicate that the current lock holder has died without releasing the lock " +

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -132,8 +132,6 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     static final Logger log = LoggerFactory.getLogger(CassandraKeyValueService.class);
 
-    public static final int SCHEMA_MUTATION_TIMEOUT_MULTIPLIER = 4;
-
     private static final Function<Entry<Cell, Value>, Long> ENTRY_SIZING_FUNCTION = new Function<Entry<Cell, Value>, Long>() {
         @Override
         public Long apply(Entry<Cell, Value> input) {
@@ -1485,7 +1483,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             expected = ImmutableList.of(lockColumnWithValue(Longs.toByteArray(CassandraConstants.GLOBAL_DDL_LOCK_CLEARED_VALUE)));
                         }
 
-                        if (stopwatch.elapsed(TimeUnit.MILLISECONDS) > configManager.getConfig().schemaMutationTimeoutMillis() * SCHEMA_MUTATION_TIMEOUT_MULTIPLIER) { // possibly dead remote locker
+                        if (stopwatch.elapsed(TimeUnit.MILLISECONDS) > configManager.getConfig().schemaMutationTimeoutMillis() * 4) { // possibly dead remote locker
                             throw new TimeoutException(String.format("We have timed out waiting on the current schema mutation lock holder.  " +
                                     "We have tried to grab the lock for %d milliseconds unsuccessfully.  Please try restarting the AtlasDB client." +
                                     "If this occurs repeatedly it may indicate that the current lock holder has died without releasing the lock " +


### PR DESCRIPTION
Fixes #454 

The flakiness was caused because the SchemaMutationTimeout was close to test timeout. The `future` would sometimes fail with that timeout exception, if the SchemaMutationTimeout happened before our own timeout. 

This PR addresses the issue by changing the failure condition: the creation of the second lock must have either not succeeded yet, _or already failed with an exception_. 