### PR TITLE
Upgrade commons-codec library

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,7 @@
 |------------|---------|
 | [Apache Thrift, v. 0.9.1](https://thrift.apache.org/) | [Apache License, Version 2.0](http://www.apache.org/licenses/) |
 | [commons-cli, v. 1.3.1](https://commons.apache.org/) | [Apache License, Version 2.0](http://www.apache.org/licenses/) |
-| [commons-codec, v. 1.6](https://commons.apache.org/) | [Apache License, Version 2.0](http://www.apache.org/licenses/) |
+| [commons-codec, v. 1.10](https://commons.apache.org/) | [Apache License, Version 2.0](http://www.apache.org/licenses/) |
 | [commons-io, v. 2.6](http://commons.apache.org/) | [Apache License, Version 2.0](http://www.apache.org/licenses/) |
 | [commons-lang, v. 2.6, 3-3.1](http://commons.apache.org/) | [Apache License, Version 2.0](http://www.apache.org/licenses/) |
 | [commons-logging, v. 1.1.1](https://commons.apache.org/) | [Apache License, Version 2.0](http://www.apache.org/licenses/) |

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -32,6 +32,6 @@ configurations.matching({ it.name in ['compile', 'runtime'] }).all {
         force 'org.slf4j:slf4j-api:1.7.6'
         force 'org.xerial.snappy:snappy-java:' + libVersions.snappy
         force 'org.yaml:snakeyaml:1.12'
-        force 'commons-codec:commons-codec:1.6'
+        force 'commons-codec:commons-codec:' + libVersions.commons_codec
     }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -15,7 +15,7 @@ ext.libVersions = [
     cassandra_driver_core: '2.2.0-rc3',
     groovy: '2.4.4',
     hamcrest: '1.3',
-    commons_codec: '1.6',
+    commons_codec: '1.10',
     libthrift: '0.9.2',
     protobuf: '2.6.0'
 ]


### PR DESCRIPTION
Atlas DB is depending on an old version of commons-codec (from 2003). Bumping this version allows downstream dependencies to use a more-modern version as well without conflicts. C.f. QA-94736