### PR TITLE
Fix race condition in PersistentTimestampService

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -61,4 +61,7 @@ v0.4.1
     *   - |fixed|
         - Required projects are now Java 6 compliant
 
+    *   - |fixed|
+        - Fix potential race condition that could cause timestamp allocation to never complete.
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -98,7 +98,7 @@ public class PersistentTimestampService implements TimestampService {
 
     volatile Throwable allocationFailure = null;
     private void submitAllocationTask() {
-        if (isAllocationTaskSubmitted.compareAndSet(false, true) && isAllocationRequired(lastReturnedTimestamp.get(), upperLimitToHandOutInclusive.get())) {
+        if (isAllocationRequired(lastReturnedTimestamp.get(), upperLimitToHandOutInclusive.get()) && isAllocationTaskSubmitted.compareAndSet(false, true)) {
             final Exception createdException = new Exception("allocation task called from here");
             executor.submit(new Runnable() {
                 @Override

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -98,38 +98,34 @@ public class PersistentTimestampService implements TimestampService {
 
     volatile Throwable allocationFailure = null;
     private void submitAllocationTask() {
-        if (isAllocationTaskSubmitted.compareAndSet(false, true)) {
-            if (isAllocationRequired(lastReturnedTimestamp.get(), upperLimitToHandOutInclusive.get())) {
-                final Exception createdException = new Exception("allocation task called from here");
-                executor.submit(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            if (allocationFailure instanceof MultipleRunningTimestampServiceError) {
-                                // We cannot allocate timestamps anymore because another server is running.
-                                return;
-                            }
-                            allocateMoreTimestamps();
-                            lastAllocatedTime = clock.getTimeMillis();
-                            allocationFailure = null;
-                        } catch (Throwable e) { // (authorized)
-                            createdException.initCause(e);
-                            if (allocationFailure != null
-                                    && e.getClass().equals(allocationFailure.getClass())) {
-                                // QA-75825: don't keep logging error if we keep failing to allocate.
-                                log.info("Throwable while allocating timestamps.", createdException);
-                            } else {
-                                log.error("Throwable while allocating timestamps.", createdException);
-                            }
-                            allocationFailure = e;
-                        } finally {
-                            isAllocationTaskSubmitted.set(false);
+        if (isAllocationRequired(lastReturnedTimestamp.get(), upperLimitToHandOutInclusive.get()) && isAllocationTaskSubmitted.compareAndSet(false, true)) {
+            final Exception createdException = new Exception("allocation task called from here");
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        if (allocationFailure instanceof MultipleRunningTimestampServiceError) {
+                            // We cannot allocate timestamps anymore because another server is running.
+                            return;
                         }
+                        allocateMoreTimestamps();
+                        lastAllocatedTime = clock.getTimeMillis();
+                        allocationFailure = null;
+                    } catch (Throwable e) { // (authorized)
+                        createdException.initCause(e);
+                        if (allocationFailure != null
+                                && e.getClass().equals(allocationFailure.getClass())) {
+                            // QA-75825: don't keep logging error if we keep failing to allocate.
+                            log.info("Throwable while allocating timestamps.", createdException);
+                        } else {
+                            log.error("Throwable while allocating timestamps.", createdException);
+                        }
+                        allocationFailure = e;
+                    } finally {
+                        isAllocationTaskSubmitted.set(false);
                     }
-                });
-            } else {
-                isAllocationTaskSubmitted.set(false);
-            }
+                }
+            });
         }
     }
 

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -92,6 +93,18 @@ public class PersistentTimestampServiceTest {
         persistentTimestampService.getFreshTimestamp();
         Thread.sleep(10);
         verify(timestampBoundStore, atLeast(2)).storeUpperLimit(anyLong());
+    }
+
+    @Test
+    public void doNotIncrementUpperLimitTooManyTimes() {
+        // In the current implementation, it is possible for a single call to getFreshTimestamp to invoke storeUpperLimit more than once.
+        // However, the number of such invocations should not be massive
+        TimestampBoundStore timestampBoundStore = initialTimestampBoundStore();
+        PersistentTimestampService persistentTimestampService = PersistentTimestampService.create(timestampBoundStore);
+
+        persistentTimestampService.getFreshTimestamp();
+
+        verify(timestampBoundStore, atMost(2)).storeUpperLimit(anyLong());
     }
 
     @Test

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
@@ -18,6 +18,7 @@ package com.palantir.timestamp;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -90,7 +91,7 @@ public class PersistentTimestampServiceTest {
         Thread.sleep(10);
         persistentTimestampService.getFreshTimestamp();
         Thread.sleep(10);
-        verify(timestampBoundStore, times(2)).storeUpperLimit(anyLong());
+        verify(timestampBoundStore, atLeast(2)).storeUpperLimit(anyLong());
     }
 
     @Test


### PR DESCRIPTION
@joelea 

Fixes #462 

By swapping the order, it is no longer possible for isAllocationTaskSubmitted.compareAndSet(false, true) to happen and remain true forever. 