### PR TITLE
safely allow moving between RF=1 and RF=3

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -82,6 +82,9 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         return true;
     }
 
+    @Value.Default
+    public boolean clusterMeetsNormalConsistencyGuarantees() { return true; }
+
     /**
      * This is how long we will wait when we first open a socket to the cassandra server.
      * This should be long enough to enough to handle cross data center latency, but short enough

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -239,7 +239,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 if (strategyOptions.get(dc) != null) {
                     int currentRF = Integer.parseInt(strategyOptions.get(dc));
                     if (currentRF == config.replicationFactor()) {
-                        if (currentRF == 2) {
+                        if (currentRF == 2 && config.clusterMeetsNormalConsistencyGuarantees()) {
                             log.info("Setting Read Consistency to ONE, as cluster has only one datacenter at RF2.");
                             readConsistency = ConsistencyLevel.ONE;
                         }


### PR DESCRIPTION
The issue at heart is that a many node cluster
moving from RF=1 to RF=3 fully online will have
to move through RF=2, but temporarily won't have
the strong consistency guarantees normally afforded
by RF=2 'quorum' happening to be the same as 'all' in
a single-DC cluster. (a quorum of 2 is 2)

PDS-43637 is the person who would need this change.