### PR TITLE
Feature/fix flake 449

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/partition/util/EndpointRequestExecutor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/partition/util/EndpointRequestExecutor.java
@@ -34,7 +34,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 @ThreadSafe public class EndpointRequestExecutor {
     // This is a SOFT limit and might be sometimes exceeded due to
     // race conditions.
-    private static final int MAX_TASKS_PER_ENDPOINT = 32;
+    public static final int MAX_TASKS_PER_ENDPOINT = 32;
     private static final Logger log = LoggerFactory.getLogger(EndpointRequestExecutor.class);
 
     private final ConcurrentMap<Future<?>, KeyValueService> endpointByFuture;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
@@ -677,15 +677,6 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         keyValueService.delete(TEST_TABLE, ImmutableMultimap.of(cell, TEST_TIMESTAMP + 1));
     }
 
-    @Test
-    public void repeatedTest() throws Exception {
-        for(int i = 0; i < 300; i++) {
-            System.out.println("\ni=" + i);
-            setUp();
-            testCannotModifyValuesAfterWrite();
-        }
-    }
-
     protected void putTestDataForMultipleTimestamps() {
         keyValueService.put(TEST_TABLE,
                 ImmutableMap.of(Cell.create(row0, column0), value0_t0), TEST_TIMESTAMP);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
@@ -677,6 +677,15 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         keyValueService.delete(TEST_TABLE, ImmutableMultimap.of(cell, TEST_TIMESTAMP + 1));
     }
 
+    @Test
+    public void repeatedTest() throws Exception {
+        for(int i = 0; i < 300; i++) {
+            System.out.println("\ni=" + i);
+            setUp();
+            testCannotModifyValuesAfterWrite();
+        }
+    }
+
     protected void putTestDataForMultipleTimestamps() {
         keyValueService.put(TEST_TABLE,
                 ImmutableMap.of(Cell.create(row0, column0), value0_t0), TEST_TIMESTAMP);


### PR DESCRIPTION
- [x] Someone has been assigned to review this PR

**Reason for change**
- Fixes #449 

Short explanation: there was a concurrency bug that allows writes to happen after putWithTimestamps returns `PartitionedKeyValueService.putWithTimestamps` starts replicationFactor-many Futures, each	calling `putWithTimestamps` on the underlying KVS. However, the method only blocks on `completeWriteRequest`, which returns as soon as writeFactor-many of the Futures succeed. Therefore it was possible that replicationFactor - writeFactor of the Futures complete after putWithTimestamps already returned.

This PR adds synchronization to ensure that all started Futures complete before putWithTimestamps returns.
