### PR TITLE
Publish docs only on release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,13 +28,9 @@ test:
     - find . -type f -regex ".*/build/test-results/TEST-.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 
 deployment:
-  github-pages:
-    branch: develop
-    owner: palantir
-    commands:
-      - ./scripts/circle-ci/publish-github-page.sh
-  bintray:
+  publish:
     tag: /[0-9]+(\.[0-9]+){2}/
     owner: palantir
     commands:
+      - ./scripts/circle-ci/publish-github-page.sh
       - ./gradlew bintrayUpload -x test


### PR DESCRIPTION
- [x] Someone has been assigned to review this PR

**Reason for change**
- Closes #509 
- Right now, the latest published docs (and release notes) are for a as-yet-unreleased version. This can be confusing to users. 

