### PR TITLE
remove method because it puts namespace on twice

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
@@ -328,11 +328,6 @@ public class Schema {
         }
     }
 
-    public void addCleanupTask(String tableName, OnCleanupTask task) {
-        String fullTableName = Schemas.getFullTableName(tableName, namespace);
-        cleanupTasks.put(fullTableName, Suppliers.ofInstance(task));
-    }
-
     public void addCleanupTask(String rawTableName, Supplier<OnCleanupTask> task) {
         cleanupTasks.put(rawTableName, task);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang.Validate;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSortedSet;


### PR DESCRIPTION
This method is broken because it adds double namespace to the cleanup task which means that task will never be run.