### PR TITLE
QA-95214 Explicitly confine connections to a specific thread.

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/SingleConnectionTransactionService.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/SingleConnectionTransactionService.java
@@ -73,7 +73,7 @@ public final class SingleConnectionTransactionService implements TransactionServ
                 Connections.commit(connection.getUnderlyingConnection());
                 return null;
             }
-        }, "atlas SQL commit"); //$NON-NLS-1$
+        }, "atlas SQL commit", connection.getUnderlyingConnection()); //$NON-NLS-1$
     }
 
     private Cell getTransactionCell(long startTimestamp) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
@@ -123,7 +123,7 @@ public class DbKvsGetRanges {
                 Connections.setAutoCommit(conn.getUnderlyingConnection(), autoCommitFlag);
                 return status;
             }
-        }, "metro setAutoCommit"); //$NON-NLS-1$
+        }, "metro setAutoCommit", conn.getUnderlyingConnection()); //$NON-NLS-1$
     }
 
     private Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstPagesFromDb(TableReference tableRef,

--- a/commons-db/src/main/java/com/palantir/nexus/db/ThreadConfinedProxy.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/ThreadConfinedProxy.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.nexus.db;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.Callable;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import org.apache.commons.lang.Validate;
+
+import com.google.common.reflect.AbstractInvocationHandler;
+import com.palantir.common.proxy.DelegatingInvocationHandler;
+import com.palantir.util.AssertUtils;
+
+/**
+ *  Dynamic Proxy for confining an object to a particular thread, but allowing explicit handoff.
+ *
+ *  For example, {@linkplain java.sql.Connection} objects are not thread-safe and are often passed around, sometimes between threads.  This
+ *  can lead to race conditions.  Wrapping a Connection in a ThreadConfinedProxy will enforce that we do not accidentally access the
+ *  Connection from multiple threads, provided we never expose the Connection outside of the proxy.
+ */
+public class ThreadConfinedProxy extends AbstractInvocationHandler implements DelegatingInvocationHandler {
+
+    public enum Strictness {
+        ASSERT_AND_LOG, VALIDATE
+    }
+
+    private final Object delegate;
+    private final Strictness strictness;
+
+    @GuardedBy("this")
+    private String threadName;
+    @GuardedBy("this")
+    private long threadId;
+
+
+    private ThreadConfinedProxy(Object delegate, Strictness strictness, String threadName, long threadId) {
+        this.delegate = delegate;
+        this.strictness = strictness;
+        this.threadName = threadName;
+        this.threadId = threadId;
+    }
+
+    /**
+     * Creates a new ThreadConfinedProxy with the given Strictness (ASSERT_AND_LOG or VALIDATE), initially assigned to the current thread.
+     */
+    public static <T> T newProxyInstance(Class<T> interfaceClass, T delegate, Strictness strictness) {
+        return newProxyInstance(interfaceClass, delegate, strictness, Thread.currentThread());
+    }
+
+    /**
+     * Explicitly passes the given ThreadConfinedProxy to a new thread.  If the proxy passed in is not a ThreadConfinedProxy, but is a
+     * different type of proxy that also uses a {@linkplain DelegatingInvocationHandler}, this method will recursively apply to the
+     * delegate.  This means that this method can handle arbitrarily nested DelegatingInvocationHandlers, including nested
+     * ThreadConfinedProxy objects.
+     *
+     */
+    public static void changeThread(Object proxy, Thread oldThread, Thread newThread) {
+        Validate.notNull(proxy, "Proxy argument must not be null");
+        if (Proxy.isProxyClass(proxy.getClass())) {
+            InvocationHandler handler = Proxy.getInvocationHandler(proxy);
+            changeHandlerThread(handler, oldThread, newThread);
+        }
+    }
+
+    /**
+     * Wraps a callable in a new callable that assigns ownership to the thread running the callable, then passes ownership back to
+     * the thread that called this method.
+     */
+    public static <T> Callable<T> threadLendingCallable(final Object proxy, final Callable<T> callable) {
+        if (proxy == null) {
+            return callable;
+        }
+        final Thread parent = Thread.currentThread();
+        return new Callable<T>() {
+            @Override
+            public T call() throws Exception {
+                Thread child = Thread.currentThread();
+                changeThread(proxy, parent, child);
+                try {
+                    return callable.call();
+                } finally {
+                    changeThread(proxy, child, parent);
+                }
+            }
+        };
+    }
+
+    private static void changeHandlerThread(InvocationHandler handler, Thread oldThread, Thread newThread) {
+        if (handler instanceof ThreadConfinedProxy) {
+            ((ThreadConfinedProxy) handler).changeThread(oldThread, newThread);
+        }
+        if (handler instanceof DelegatingInvocationHandler) {
+            changeThread(((DelegatingInvocationHandler) handler).getDelegate(), oldThread, newThread);
+        }
+    }
+
+    /**
+     * Creates a new ThreadConfinedProxy with the given Strictness (ASSERT_AND_LOG or VALIDATE), initially assigned to the given thread.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T newProxyInstance(Class<T> interfaceClass, T delegate, Strictness strictness, Thread current) {
+        return (T) Proxy.newProxyInstance(interfaceClass.getClassLoader(),
+                new Class<?>[] {interfaceClass}, new ThreadConfinedProxy(delegate, strictness, current.getName(), current.getId()));
+    }
+
+
+    @Override
+    protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
+        checkThread(method);
+        return method.invoke(delegate, args);
+    }
+
+    /*
+     * Enforce we were called from the correct thread.
+     * Note that thread names are not stable, so we must use thread IDs.
+     * Names are for help debugging.
+     *
+     * Synchronized for threadId and threadName.
+     */
+    private synchronized void checkThread(Method method) {
+        Thread current = Thread.currentThread();
+        if (threadId != current.getId()) {
+            String message = String.format(
+                    "Thread confinement violation: method %s#%s was called from thread %s (ID %s) instead of thread %s (ID %s)",
+                    method.getDeclaringClass().getCanonicalName(),
+                    method.getName(),
+                    current.getName(),
+                    current.getId(),
+                    threadName,
+                    threadId);
+
+            fail(message);
+        }
+    }
+
+    private void fail(String message) {
+        switch (strictness) {
+            case ASSERT_AND_LOG:
+                AssertUtils.assertAndLog(false, message);
+                break;
+            case VALIDATE:
+                Validate.isTrue(false, message);
+                break;
+        }
+    }
+
+    private synchronized void changeThread(Thread oldThread, Thread newThread) {
+        checkThreadChange(oldThread, newThread);
+        threadId = newThread.getId();
+        threadName = newThread.getName();
+    }
+
+    private void checkThreadChange(Thread oldThread, Thread newThread) {
+        if (oldThread.getId() != threadId) {
+            String message = String.format(
+                    "Thread confinement violation: tried to change threads from thread %s (ID %s) to thread %s (ID %s), but we expected thread %s (ID %s)",
+                    oldThread.getId(),
+                    oldThread.getName(),
+                    newThread.getId(),
+                    newThread.getName(),
+                    threadName,
+                    threadId);
+
+            fail(message);
+
+        }
+    }
+
+    @Override
+    public Object getDelegate() {
+        return delegate;
+    }
+}

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
@@ -405,7 +405,9 @@ public abstract class BasicSQL {
                     }
                 }
             }
-        }, sql.toString());
+        },
+                sql.toString(),
+                /* We no longer have a connection to worry about */ null);
     }
 
     private static <T> T runCancellablyInternal(final PreparedStatement ps, ResultSetVisitor<T> visitor, final FinalSQLString sql,
@@ -476,7 +478,7 @@ public abstract class BasicSQL {
                 public PreparedStatement call() throws Exception {
                     return createPreparedStatement(c, query.getQuery(), vs);
                 }
-            }, "SQL createPreparedStatement");
+            }, "SQL createPreparedStatement", c);
             return visitor.visit(ps);
         } catch (PalantirSqlException sqle) {
             throw wrapSQLExceptionWithVerboseLogging(sqle, query.getQuery(), vs);
@@ -543,7 +545,7 @@ public abstract class BasicSQL {
                     }
                 }, "execute", autoClose); //$NON-NLS-1$
             }
-        }, sql.toString());
+        }, sql.toString(), c);
     }
 
     protected boolean selectExistsInternal(final Connection c,
@@ -740,7 +742,7 @@ public abstract class BasicSQL {
                     }
                 }, "update", autoClose); //$NON-NLS-1$
             }
-        }, sql.toString());
+        }, sql.toString(), c);
     }
 
     protected void updateMany(final Connection c, final FinalSQLString sql, final Object vs[][])
@@ -783,7 +785,7 @@ public abstract class BasicSQL {
                 }
                 return null;
             }
-        }, sql.toString());
+        }, sql.toString(), c);
     }
 
     protected int insertOneCountRowsInternal(final Connection c,
@@ -802,7 +804,7 @@ public abstract class BasicSQL {
                     }
                 }, "insertOne"); //$NON-NLS-1$
             }
-        }, sql.toString());
+        }, sql.toString(), c);
     }
 
     public boolean insertMany(final Connection c, final FinalSQLString sql, final Object vs[][]) throws PalantirSqlException {
@@ -858,7 +860,7 @@ public abstract class BasicSQL {
                 }
                 return true;
             }
-        }, sql.toString());
+        }, sql.toString(), c);
     }
 
     protected int updateCountRowsInternal(Connection c, FinalSQLString sql,

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/id/DbSequenceBackedIdGenerator.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/id/DbSequenceBackedIdGenerator.java
@@ -93,7 +93,14 @@ public class DbSequenceBackedIdGenerator implements IdGenerator {
                 }
                 return null;
             }
-        }, sql);
+        },
+                sql,
+                /*
+                 * This callable grabs the Connection itself, which is a direct violation of the comment on BasicSqlUtils#runUninterruptably,
+                 * which claims that doing so will fail.  There does not seem to be any actual reason to change this.  So, instead of
+                 * creating a connection outside the callable and passing it in this argument, we will simply pass null.
+                 */
+                null);
         return ids.length;
     }
 

--- a/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
@@ -1,0 +1,233 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.nexus.db;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Iterables;
+import com.palantir.common.proxy.TimingProxy;
+import com.palantir.util.timer.LoggingOperationTimer;
+
+public class ThreadConfinedProxyTest extends Assert {
+
+    Logger log = LoggerFactory.getLogger(ThreadConfinedProxyTest.class);
+
+    String testString = "test";
+
+    @Test
+    public void testCurrentThreadCanCreateAndUseSubject() {
+        @SuppressWarnings("unchecked")
+        List<String> subject = ThreadConfinedProxy.newProxyInstance(List.class, new ArrayList<String>(),
+                ThreadConfinedProxy.Strictness.VALIDATE);
+        subject.add(testString);
+        assertEquals(testString, Iterables.getOnlyElement(subject));
+    }
+
+    @Test
+    public void testExplicitThreadCanCreateAndUseSubject() throws InterruptedException {
+
+        final AtomicReference<List<String>> inputReference = new AtomicReference<>(null);
+        final AtomicBoolean outputReference = new AtomicBoolean(false);
+
+        Thread childThread = new Thread(() -> {
+            List<String> subjectInChildThread = inputReference.get();
+            subjectInChildThread.add(testString);
+            if (Iterables.getOnlyElement(subjectInChildThread).equals(testString)) {
+                outputReference.set(Boolean.TRUE);
+            }
+        });
+
+        @SuppressWarnings("unchecked")
+        List<String> subject = ThreadConfinedProxy.newProxyInstance(List.class, new ArrayList<String>(),
+                ThreadConfinedProxy.Strictness.VALIDATE, childThread);
+        inputReference.set(subject);
+        childThread.start();
+        childThread.join(10000);
+
+        assertTrue(outputReference.get());
+    }
+
+    @Test
+    public void testExplicitThreadCannotAndUseSubjectFromMainThread() throws InterruptedException {
+
+        final AtomicReference<List<String>> inputReference = new AtomicReference<>(null);
+        final AtomicBoolean outputReference = new AtomicBoolean(false);
+
+        Thread childThread = new Thread(() -> {
+            outputReference.set(true);
+            List<String> subjectInChildThread = inputReference.get();
+            subjectInChildThread.add(testString);
+            // Should fail
+            outputReference.set(false);
+
+        });
+
+        @SuppressWarnings("unchecked")
+        List<String> subject = ThreadConfinedProxy.newProxyInstance(List.class, new ArrayList<String>(),
+                ThreadConfinedProxy.Strictness.VALIDATE);
+        inputReference.set(subject);
+        childThread.start();
+        childThread.join(10000);
+
+        assertTrue(outputReference.get());
+    }
+
+
+    @Test
+    public void testMainThreadCanDelegateToExplicitThreadAndLoseAccessAndAbilityToDelegate() throws InterruptedException {
+
+        final AtomicReference<List<String>> inputReference = new AtomicReference<>(null);
+        final AtomicInteger outputReference = new AtomicInteger(0);
+
+        final Thread mainThread = Thread.currentThread();
+
+        Thread childThread = new Thread(() -> {
+            outputReference.compareAndSet(0, 1);
+            List<String> subjectInChildThread = inputReference.get();
+            ThreadConfinedProxy.changeThread(subjectInChildThread, mainThread, Thread.currentThread());
+            subjectInChildThread.add(testString);
+            if (Iterables.getOnlyElement(subjectInChildThread).equals(testString)) {
+                outputReference.compareAndSet(1, 2);
+            }
+
+        });
+
+        @SuppressWarnings("unchecked")
+        List<String> subject = ThreadConfinedProxy.newProxyInstance(List.class, new ArrayList<String>(),
+                ThreadConfinedProxy.Strictness.VALIDATE);
+        inputReference.set(subject);
+        childThread.start();
+        childThread.join(10000);
+
+        assertEquals(2, outputReference.get());
+
+        // Cannot be access from main thread anymore
+        try {
+            subject.add(testString);
+            fail();
+        } catch (Exception e) {
+            outputReference.compareAndSet(2, 3);
+        }
+
+        assertEquals(3, outputReference.get());
+
+        // Cannot give to another thread because main thread does not own it
+        Thread otherThread = new Thread(() -> {
+            outputReference.compareAndSet(3, 4);
+            List<String> subjectInChildThread = inputReference.get();
+            ThreadConfinedProxy.changeThread(subjectInChildThread, mainThread, Thread.currentThread());
+            outputReference.compareAndSet(4, 5);
+        });
+
+        otherThread.start();
+        otherThread.join(10000);
+        assertEquals(4, outputReference.get());
+
+        // Cannot give away from main thread either
+        try {
+            ThreadConfinedProxy.changeThread(subject, mainThread, otherThread);
+            fail();
+        } catch (Exception e) {
+            outputReference.compareAndSet(4, 5);
+        }
+        assertEquals(5, outputReference.get());
+    }
+
+
+
+    @Test
+    public void testChildThreadCanDelegateBackToMainThread() throws InterruptedException {
+
+        final AtomicReference<List<String>> inputReference = new AtomicReference<>(null);
+        final AtomicInteger outputReference = new AtomicInteger(0);
+
+        final Thread mainThread = Thread.currentThread();
+
+        Thread childThread = new Thread(() -> {
+            outputReference.compareAndSet(0, 1);
+            List<String> subjectInChildThread = inputReference.get();
+            ThreadConfinedProxy.changeThread(subjectInChildThread, mainThread, Thread.currentThread());
+            subjectInChildThread.add(testString);
+            if (Iterables.getOnlyElement(subjectInChildThread).equals(testString)) {
+                outputReference.compareAndSet(1, 2);
+            }
+            ThreadConfinedProxy.changeThread(subjectInChildThread, Thread.currentThread(), mainThread);
+        });
+
+        @SuppressWarnings("unchecked")
+        List<String> subject = ThreadConfinedProxy.newProxyInstance(List.class, new ArrayList<String>(),
+                ThreadConfinedProxy.Strictness.VALIDATE);
+        inputReference.set(subject);
+        childThread.start();
+        childThread.join(10000);
+
+        assertEquals(2, outputReference.get());
+
+        // We got delegated back, so we can use subject again
+        assertEquals(testString, Iterables.getOnlyElement(subject));
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDelegationCanHandleMoreProxies() throws InterruptedException {
+
+        final AtomicReference<List<String>> inputReference = new AtomicReference<>(null);
+        final AtomicInteger outputReference = new AtomicInteger(0);
+
+        final Thread mainThread = Thread.currentThread();
+
+        Thread childThread = new Thread(() -> {
+            outputReference.compareAndSet(0, 1);
+            List<String> subjectInChildThread = inputReference.get();
+            ThreadConfinedProxy.changeThread(subjectInChildThread, mainThread, Thread.currentThread());
+            subjectInChildThread.add(testString);
+            if (Iterables.getOnlyElement(subjectInChildThread).equals(testString)) {
+                outputReference.compareAndSet(1, 2);
+            }
+            ThreadConfinedProxy.changeThread(subjectInChildThread, Thread.currentThread(), mainThread);
+        });
+
+        // Make sure subject is wrapped in proxies, including multiple ThreadConfinedProxy objects, and also does not start with a
+        // ThreadConfinedProxy
+        List<String> subject = new ArrayList<>();
+        subject = ThreadConfinedProxy.newProxyInstance(List.class, subject,
+                ThreadConfinedProxy.Strictness.VALIDATE);
+        subject = TimingProxy.newProxyInstance(List.class, subject, LoggingOperationTimer.create(log));
+        subject = ThreadConfinedProxy.newProxyInstance(List.class, subject,
+                ThreadConfinedProxy.Strictness.VALIDATE);
+        subject = TimingProxy.newProxyInstance(List.class, subject, LoggingOperationTimer.create(log));
+
+        inputReference.set(subject);
+        childThread.start();
+        childThread.join(10000);
+
+        assertEquals(2, outputReference.get());
+
+        // We got delegated back, so we can use subject again
+        assertEquals(testString, Iterables.getOnlyElement(subject));
+    }
+}
+


### PR DESCRIPTION
- [ Clockfort] Someone has been assigned to review this PR

**Reason for change**
- As seen in QA-95214, we are getting primary key violations in tests sometimes when inserting into temp tables.  Since we clear the table and add IDs from a Set, this should not be possible.  One theory is that multiple threads are sharing a connection, and thus are sharing a temp table.  This change will catch that sort of race condition.

Sharing connections across threads can lead to race conditions,
which we appear to see in some tests.  Explicitly checking for
thread-safety violations will help prevent this potential issue.