### PR TITLE
CassandraClientPool blacklisting changes

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -17,26 +17,33 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TreeMap;
 
 import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.cassandra.thrift.TokenRange;
 import org.apache.thrift.transport.TTransportException;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.LightweightOPPToken;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.WeightedHosts;
 import com.palantir.common.base.FunctionCheckedException;
 
 public class CassandraClientPoolTest {
@@ -108,7 +115,7 @@ public class CassandraClientPoolTest {
         kv.clientPool.blacklistedHosts.clear();
     }
 
-    private FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception> describeRing = new FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception>() {
+    private FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception> describeRing = new FunctionCheckedException<Client, List<TokenRange>, Exception>() {
         @Override
         public List<TokenRange> apply (Cassandra.Client client) throws Exception {
             return client.describe_ring("atlasdb");
@@ -128,4 +135,120 @@ public class CassandraClientPoolTest {
         Assert.assertTrue(CassandraClientPool.isRetriableException(new TTransportException(new SocketTimeoutException())));
     }
 
+    @Test
+    public void testWeightedHostsWithUniformActivity() {
+        Map<InetSocketAddress, CassandraClientPoolingContainer> pools = ImmutableMap.of(
+                new InetSocketAddress(0), createMockClientPoolingContainerWithUtilization(10),
+                new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(10),
+                new InetSocketAddress(2), createMockClientPoolingContainerWithUtilization(10));
+
+        TreeMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
+
+        int expectedWeight = result.firstEntry().getKey();
+        int prevKey = 0;
+        for (Map.Entry<Integer, InetSocketAddress> entry : result.entrySet()) {
+            int currWeight = entry.getKey() - prevKey;
+            Assert.assertEquals(expectedWeight, currWeight);
+            prevKey = entry.getKey();
+        }
+    }
+
+    @Test
+    public void testWeightedHostsWithLowActivityPool() {
+        InetSocketAddress lowActivityHost = new InetSocketAddress(2);
+        Map<InetSocketAddress, CassandraClientPoolingContainer> pools = ImmutableMap.of(
+                new InetSocketAddress(0), createMockClientPoolingContainerWithUtilization(10),
+                new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(10),
+                lowActivityHost, createMockClientPoolingContainerWithUtilization(0));
+
+        TreeMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
+
+        int largestWeight = result.firstEntry().getKey();
+        InetSocketAddress hostWithLargestWeight = result.firstEntry().getValue();
+        int prevKey = 0;
+        for (Map.Entry<Integer, InetSocketAddress> entry : result.entrySet()) {
+            int currWeight = entry.getKey() - prevKey;
+            prevKey = entry.getKey();
+            if (currWeight > largestWeight) {
+                largestWeight = currWeight;
+                hostWithLargestWeight = entry.getValue();
+            }
+        }
+        Assert.assertEquals(lowActivityHost, hostWithLargestWeight);
+    }
+
+    @Test
+    public void testWeightedHostsWithMaxActivityPool() {
+        InetSocketAddress highActivityHost = new InetSocketAddress(2);
+        Map<InetSocketAddress, CassandraClientPoolingContainer> pools = ImmutableMap.of(
+                new InetSocketAddress(0), createMockClientPoolingContainerWithUtilization(5),
+                new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(5),
+                highActivityHost, createMockClientPoolingContainerWithUtilization(20));
+
+        TreeMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
+
+        int smallestWeight = result.firstEntry().getKey();
+        InetSocketAddress hostWithSmallestWeight = result.firstEntry().getValue();
+        int prevKey = 0;
+        for (Map.Entry<Integer, InetSocketAddress> entry : result.entrySet()) {
+            int currWeight = entry.getKey() - prevKey;
+            prevKey = entry.getKey();
+            if (currWeight < smallestWeight) {
+                smallestWeight = currWeight;
+                hostWithSmallestWeight = entry.getValue();
+            }
+        }
+        Assert.assertEquals(highActivityHost, hostWithSmallestWeight);
+    }
+
+    @Test
+    public void testWeightedHostsWithNonZeroWeights() {
+        Map<InetSocketAddress, CassandraClientPoolingContainer> pools = ImmutableMap.of(
+                new InetSocketAddress(0), createMockClientPoolingContainerWithUtilization(5),
+                new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(10),
+                new InetSocketAddress(2), createMockClientPoolingContainerWithUtilization(15));
+
+        TreeMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
+
+        int prevKey = 0;
+        for (Map.Entry<Integer, InetSocketAddress> entry : result.entrySet()) {
+            int currWeight = entry.getKey() - prevKey;
+            Assert.assertThat(currWeight, Matchers.greaterThan(0));
+            prevKey = entry.getKey();
+        }
+    }
+
+    // Covers a bug where we used ceilingEntry instead of higherEntry
+    @Test
+    public void testSelectingHostFromWeightedHostsMatchesWeight() {
+        Map<InetSocketAddress, CassandraClientPoolingContainer> pools = ImmutableMap.of(
+                new InetSocketAddress(0), createMockClientPoolingContainerWithUtilization(5),
+                new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(10),
+                new InetSocketAddress(2), createMockClientPoolingContainerWithUtilization(15));
+        WeightedHosts weightedHosts = WeightedHosts.create(pools);
+        Map<InetSocketAddress, Integer> hostsToWeight = new HashMap<>();
+        int prevKey = 0;
+        for (Map.Entry<Integer, InetSocketAddress> entry : weightedHosts.hosts.entrySet()) {
+            hostsToWeight.put(entry.getValue(), entry.getKey() - prevKey);
+            prevKey = entry.getKey();
+        }
+
+        // Exhaustively test all indexes
+        Map<InetSocketAddress, Integer> numTimesSelected = new HashMap<>();
+        for (int index = 0; index < weightedHosts.hosts.lastKey(); index++) {
+            InetSocketAddress host = weightedHosts.getRandomHostInternal(index);
+            if (!numTimesSelected.containsKey(host)) {
+                numTimesSelected.put(host, 0);
+            }
+            numTimesSelected.put(host, numTimesSelected.get(host) + 1);
+        }
+
+        Assert.assertEquals(hostsToWeight, numTimesSelected);
+    }
+
+    private static CassandraClientPoolingContainer createMockClientPoolingContainerWithUtilization(int utilization) {
+        CassandraClientPoolingContainer mock = Mockito.mock(CassandraClientPoolingContainer.class);
+        Mockito.when(mock.getPoolUtilization()).thenReturn(utilization);
+        return mock;
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -19,11 +19,13 @@ import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeMap;
@@ -242,7 +245,7 @@ public class CassandraClientPool {
             livingHosts = pools.keySet();
         }
 
-        return pools.get(ImmutableList.copyOf(livingHosts).get(ThreadLocalRandom.current().nextInt(livingHosts.size())));
+        return pools.get(getRandomHostByActiveConnections(Maps.filterKeys(currentPools, livingHosts::contains)));
     }
 
     public InetSocketAddress getRandomHostForKey(byte[] key) {
@@ -263,8 +266,12 @@ public class CassandraClientPool {
             log.debug("Current ring view is: {} and our current host blacklist is {}", tokenMap, blacklistedHosts);
             return getRandomGoodHost().getHost();
         } else {
-            return currentPools.get(ImmutableList.copyOf(liveOwnerHosts).get(ThreadLocalRandom.current().nextInt(liveOwnerHosts.size()))).getHost();
+            return getRandomHostByActiveConnections(Maps.filterKeys(currentPools, liveOwnerHosts::contains));
         }
+    }
+
+    private static InetSocketAddress getRandomHostByActiveConnections(Map<InetSocketAddress, CassandraClientPoolingContainer> pools) {
+        return WeightedHosts.create(pools).getRandomHost();
     }
 
     public void runOneTimeStartupChecks() {
@@ -382,7 +389,8 @@ public class CassandraClientPool {
         return runOnHost(getRandomGoodHost().getHost(), f);
     }
 
-    public <V, K extends Exception> V runOnHost(InetSocketAddress specifiedHost, FunctionCheckedException<Cassandra.Client, V, K> f) throws K {
+    private <V, K extends Exception> V runOnHost(InetSocketAddress specifiedHost,
+                                                 FunctionCheckedException<Cassandra.Client, V, K> f) throws K {
         CassandraClientPoolingContainer hostPool = currentPools.get(specifiedHost);
         return hostPool.runWithPooledResource(f);
     }
@@ -490,4 +498,63 @@ public class CassandraClientPool {
                 || isRetriableException(t.getCause()));
     }
 
+    /**
+     * Weights hosts inversely by the number of active connections. {@link #getRandomHost()} should then be used to
+     * pick a random host
+     */
+    @VisibleForTesting
+    static class WeightedHosts {
+        final TreeMap<Integer, InetSocketAddress> hosts;
+
+        private WeightedHosts(TreeMap<Integer, InetSocketAddress> hosts) {
+            this.hosts = hosts;
+        }
+
+        static WeightedHosts create(Map<InetSocketAddress, CassandraClientPoolingContainer> pools) {
+            Preconditions.checkArgument(!pools.isEmpty(), "pools should be non-empty");
+            return new WeightedHosts(buildHostsWeightedByActiveConnections(pools));
+        }
+
+        /**
+         * The key for a host is the open upper bound of the weight. Since the domain is intended to be contiguous, the
+         * closed lower bound of that weight is the key of the previous entry.
+         * <p>
+         * The closed lower bound of the first entry is 0.
+         * <p>
+         * Every weight is guaranteed to be non-zero in size. That is, every key is guaranteed to be at least one larger
+         * than the previous key.
+         */
+        private static TreeMap<Integer, InetSocketAddress> buildHostsWeightedByActiveConnections(
+                Map<InetSocketAddress, CassandraClientPoolingContainer> pools) {
+
+            Map<InetSocketAddress, Integer> activeConnectionsByHost = new HashMap<>(pools.size());
+            int totalActiveConnections = 0;
+            for (InetSocketAddress host : pools.keySet()) {
+                int activeConnections = Math.max(pools.get(host).getPoolUtilization(), 0);
+                activeConnectionsByHost.put(host, activeConnections);
+                totalActiveConnections += activeConnections;
+            }
+
+            int lowerBoundInclusive = 0;
+            TreeMap<Integer, InetSocketAddress> weightedHosts = new TreeMap<>();
+            for (Entry<InetSocketAddress, Integer> entry : activeConnectionsByHost.entrySet()) {
+                // We want the weight to be inversely proportional to the number of active connections so that we pick
+                // less-active hosts. We add 1 to make sure that all ranges are non-empty
+                int weight = totalActiveConnections - entry.getValue() + 1;
+                weightedHosts.put(lowerBoundInclusive + weight, entry.getKey());
+                lowerBoundInclusive += weight;
+            }
+            return weightedHosts;
+        }
+
+        InetSocketAddress getRandomHost() {
+            int index = ThreadLocalRandom.current().nextInt(hosts.lastKey());
+            return getRandomHostInternal(index);
+        }
+
+        // This basically exists for testing
+        InetSocketAddress getRandomHostInternal(int index) {
+            return hosts.higherEntry(index).getValue();
+        }
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -18,26 +18,14 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.*;
 import org.apache.cassandra.thrift.Cassandra.Client;
-import org.apache.cassandra.thrift.CfDef;
-import org.apache.cassandra.thrift.InvalidRequestException;
-import org.apache.cassandra.thrift.KsDef;
-import org.apache.cassandra.thrift.NotFoundException;
-import org.apache.cassandra.thrift.SchemaDisagreementException;
-import org.apache.cassandra.thrift.TimedOutException;
-import org.apache.cassandra.thrift.TokenRange;
-import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
@@ -45,16 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableRangeMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Range;
-import com.google.common.collect.RangeMap;
-import com.google.common.collect.Sets;
+import com.google.common.collect.*;
 import com.google.common.collect.Sets.SetView;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedBytes;
@@ -263,7 +242,8 @@ public class CassandraClientPool {
         if (liveOwnerHosts.isEmpty()) {
             log.warn("Perf / cluster stability issue. Token aware query routing has failed because there are no known " +
                     "live hosts that claim ownership of the given range. Falling back to choosing a random live node. " +
-                    "For debugging, our current ring view is: {} and our current host blacklist is {}", tokenMap, blacklistedHosts);
+                    "Current state logged at DEBUG");
+            log.debug("Current ring view is: {} and our current host blacklist is {}", tokenMap, blacklistedHosts);
             return getRandomGoodHost().getHost();
         } else {
             return currentPools.get(ImmutableList.copyOf(liveOwnerHosts).get(ThreadLocalRandom.current().nextInt(liveOwnerHosts.size()))).getHost();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -18,14 +18,26 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.cassandra.thrift.*;
+import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Cassandra.Client;
+import org.apache.cassandra.thrift.CfDef;
+import org.apache.cassandra.thrift.InvalidRequestException;
+import org.apache.cassandra.thrift.KsDef;
+import org.apache.cassandra.thrift.NotFoundException;
+import org.apache.cassandra.thrift.SchemaDisagreementException;
+import org.apache.cassandra.thrift.TimedOutException;
+import org.apache.cassandra.thrift.TokenRange;
+import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
@@ -33,7 +45,16 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.collect.*;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedBytes;
@@ -199,6 +220,7 @@ public class CassandraClientPool {
 
     private void addToBlacklist(InetSocketAddress badHost) {
         blacklistedHosts.put(badHost, System.currentTimeMillis());
+        log.info("Blacklisted host '{}'", badHost);
     }
 
     private boolean isHostHealthy(InetSocketAddress host) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -85,7 +85,11 @@ import com.palantir.common.concurrent.PTExecutors;
  **/
 public class CassandraClientPool {
     private static final Logger log = LoggerFactory.getLogger(CassandraClientPool.class);
-    private static final int MAX_TRIES_SAME_HOST = 2;
+    /**
+     * This is the maximum number of times we'll accept connection failures to one host before blacklisting it. Note
+     * that subsequent hosts we try in the same call will actually be blacklisted after one connection failure
+     */
+    private static final int MAX_TRIES_SAME_HOST = 3;
     private static final int MAX_TRIES_TOTAL = 6;
 
     volatile RangeMap<LightweightOPPToken, List<InetSocketAddress>> tokenMap = ImmutableRangeMap.of();


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Changes to CassandraClientPool to fix some issues that we hit in our stress tests. Only significant functional change is a new pref for disabling blacklisting in CassandraClientPool. Ideally there would be some other pref we could piggyback off of, because having a pref just to disable this thing seems like a code smell. I couldn't think of anything clever though.

For context, the blacklisting as it is written now basically blacklists too eagerly in our stress tests. For reasons-that-I-can't-explain, cassandra will back up a bit, but our tests are relentless which causes the pools to hit their saturation point. Despite the average active connections being somewhere around 5-6, it will shoot up to ~25 (which is the max since our query_pool_size is set to 5) and suddenly cause hosts to be blacklisted. I think this setting is probably reasonable in production (although I would contest that it's still a bit too eager, especially since the way it's written now will blacklist subsequent hosts in a given runWithRetryOnHost after _one_ try), but I'd like to be able to disable it during our perf tests since it essentially degrades performance significantly for the entire 5 minutes that a host is blacklisted (since refreshPool defaults to a 5 minute period).