### PR TITLE
Remove unused annotations

### DIFF
--- a/commons-annotations/src/main/java/com/palantir/annotations/PgPublicApi.java
+++ b/commons-annotations/src/main/java/com/palantir/annotations/PgPublicApi.java
@@ -36,11 +36,7 @@ import java.lang.annotation.Target;
  * but it wont be accessible to anyone else.
  */
 @Retention(RetentionPolicy.RUNTIME) // We need runtime for static analasys.
-@Target({ ElementType.TYPE,
-          ElementType.ANNOTATION_TYPE,
-          ElementType.METHOD,
-          ElementType.CONSTRUCTOR
-          })
+@Target({ ElementType.TYPE })
 @PgPublicApi // not part of the api, but must be in the api jar
 public @interface PgPublicApi {
     // marker annotation


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Removed PgPublicApi annotations for inner classes of PgPublicApi top-level class,
as per PgPublicApi's documentation 'If a class is annotated, then all static/inner
classes are automatically included'. Removed a PgPublicApi annotation for the package
com.palantir.config.help from package-info.java and added the annotation to all classes
in the said package. Made Type the only target for the PgPublicApi annotation