### PR TITLE
Let ThreadConfinedProxy handle the Decorator pattern

### DIFF
--- a/commons-db/src/main/java/com/palantir/nexus/db/Delegator.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/Delegator.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.nexus.db;
+
+/**
+ * Declares that this interface wraps and delegates to another object of type T.
+ * Similar in concept to {@link com.palantir.common.proxy.DelegatingInvocationHandler}.
+ * Useful when delegates occasionally need to be unwrapped.
+ */
+public interface Delegator<T> {
+    T getDelegate();
+}

--- a/commons-db/src/main/java/com/palantir/nexus/db/ThreadConfinedProxy.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/ThreadConfinedProxy.java
@@ -77,6 +77,8 @@ public class ThreadConfinedProxy extends AbstractInvocationHandler implements De
         if (Proxy.isProxyClass(proxy.getClass())) {
             InvocationHandler handler = Proxy.getInvocationHandler(proxy);
             changeHandlerThread(handler, oldThread, newThread);
+        } else if (proxy instanceof Delegator) {
+            changeThread(((Delegator) proxy).getDelegate(), oldThread, newThread);
         }
     }
 

--- a/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
@@ -21,20 +21,16 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.palantir.common.proxy.TimingProxy;
 import com.palantir.util.timer.LoggingOperationTimer;
@@ -328,16 +324,6 @@ public class ThreadConfinedProxyTest extends Assert {
         }
 
         @Override
-        public void replaceAll(UnaryOperator<String> operator) {
-            inner.replaceAll(operator);
-        }
-
-        @Override
-        public void sort(Comparator<? super String> c) {
-            inner.sort(c);
-        }
-
-        @Override
         public void clear() {
             inner.clear();
         }
@@ -397,30 +383,6 @@ public class ThreadConfinedProxyTest extends Assert {
             return inner.subList(fromIndex, toIndex);
         }
 
-        @Override
-        public Spliterator<String> spliterator() {
-            return inner.spliterator();
-        }
-
-        @Override
-        public boolean removeIf(Predicate<? super String> filter) {
-            return inner.removeIf(filter);
-        }
-
-        @Override
-        public Stream<String> stream() {
-            return inner.stream();
-        }
-
-        @Override
-        public Stream<String> parallelStream() {
-            return inner.parallelStream();
-        }
-
-        @Override
-        public void forEach(Consumer<? super String> action) {
-            inner.forEach(action);
-        }
     }
 }
 

--- a/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
@@ -16,10 +16,19 @@
 package com.palantir.nexus.db;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -229,6 +238,7 @@ public class ThreadConfinedProxyTest extends Assert {
         subject = TimingProxy.newProxyInstance(List.class, subject, LoggingOperationTimer.create(log));
         subject = ThreadConfinedProxy.newProxyInstance(List.class, subject,
                 ThreadConfinedProxy.Strictness.VALIDATE);
+        subject = new DelegatingArrayListString(subject);
         subject = TimingProxy.newProxyInstance(List.class, subject, LoggingOperationTimer.create(log));
 
         inputReference.set(subject);
@@ -239,6 +249,178 @@ public class ThreadConfinedProxyTest extends Assert {
 
         // We got delegated back, so we can use subject again
         assertEquals(testString, Iterables.getOnlyElement(subject));
+    }
+
+    private class DelegatingArrayListString implements List<String>, Delegator<List<String>> {
+        private final List<String> inner;
+        public DelegatingArrayListString(List<String> subject) {
+            inner = subject;
+        }
+
+        @Override
+        public List<String> getDelegate() {
+            return inner;
+        }
+
+        @Override
+        public int size() {
+            return inner.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return inner.isEmpty();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return inner.contains(o);
+        }
+
+        @Override
+        public Iterator<String> iterator() {
+            return inner.iterator();
+        }
+
+        @Override
+        public Object[] toArray() {
+            return inner.toArray();
+        }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            return inner.toArray(a);
+        }
+
+        @Override
+        public boolean add(String s) {
+            return inner.add(s);
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return inner.remove(o);
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            return inner.containsAll(c);
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends String> c) {
+            return inner.addAll(c);
+        }
+
+        @Override
+        public boolean addAll(int index, Collection<? extends String> c) {
+            return inner.addAll(index, c);
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            return inner.removeAll(c);
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            return inner.retainAll(c);
+        }
+
+        @Override
+        public void replaceAll(UnaryOperator<String> operator) {
+            inner.replaceAll(operator);
+        }
+
+        @Override
+        public void sort(Comparator<? super String> c) {
+            inner.sort(c);
+        }
+
+        @Override
+        public void clear() {
+            inner.clear();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return inner.equals(o);
+        }
+
+        @Override
+        public int hashCode() {
+            return inner.hashCode();
+        }
+
+        @Override
+        public String get(int index) {
+            return inner.get(index);
+        }
+
+        @Override
+        public String set(int index, String element) {
+            return inner.set(index, element);
+        }
+
+        @Override
+        public void add(int index, String element) {
+            inner.add(index, element);
+        }
+
+        @Override
+        public String remove(int index) {
+            return inner.remove(index);
+        }
+
+        @Override
+        public int indexOf(Object o) {
+            return inner.indexOf(o);
+        }
+
+        @Override
+        public int lastIndexOf(Object o) {
+            return inner.lastIndexOf(o);
+        }
+
+        @Override
+        public ListIterator<String> listIterator() {
+            return inner.listIterator();
+        }
+
+        @Override
+        public ListIterator<String> listIterator(int index) {
+            return inner.listIterator(index);
+        }
+
+        @Override
+        public List<String> subList(int fromIndex, int toIndex) {
+            return inner.subList(fromIndex, toIndex);
+        }
+
+        @Override
+        public Spliterator<String> spliterator() {
+            return inner.spliterator();
+        }
+
+        @Override
+        public boolean removeIf(Predicate<? super String> filter) {
+            return inner.removeIf(filter);
+        }
+
+        @Override
+        public Stream<String> stream() {
+            return inner.stream();
+        }
+
+        @Override
+        public Stream<String> parallelStream() {
+            return inner.parallelStream();
+        }
+
+        @Override
+        public void forEach(Consumer<? super String> action) {
+            inner.forEach(action);
+        }
     }
 }
 

--- a/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
@@ -17,7 +17,6 @@ package com.palantir.nexus.db;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -30,7 +29,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.palantir.common.proxy.TimingProxy;
 import com.palantir.util.timer.LoggingOperationTimer;


### PR DESCRIPTION
Needed for cases where we wrap a Connection using the Decorator pattern instead of dynamic proxies.