### PR TITLE
Fix/fix flaky test by not relying on tight timing 0.4.x

### DIFF
--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
     exclude group: 'org.hamcrest'
   }
+  testCompile 'com.jayway.awaitility:awaitility:1.6.5'
   testCompile 'org.mockito:mockito-core:' + libVersions.mockito
   compile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
   compile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
@@ -41,9 +41,11 @@ import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.exceptions.verification.TooLittleActualInvocations;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
+import com.jayway.awaitility.Awaitility;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.common.time.Clock;

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTest.java
@@ -89,10 +89,17 @@ public class PersistentTimestampServiceTest {
         PersistentTimestampService persistentTimestampService = PersistentTimestampService.create(timestampBoundStore, clock);
 
         persistentTimestampService.getFreshTimestamp();
-        Thread.sleep(10);
         persistentTimestampService.getFreshTimestamp();
-        Thread.sleep(10);
-        verify(timestampBoundStore, atLeast(2)).storeUpperLimit(anyLong());
+        Awaitility
+                .await()
+                .ignoreExceptionsMatching(e -> e.getCause() instanceof TooLittleActualInvocations)
+                .until(() -> {
+                    try {
+                        verify(timestampBoundStore, atLeast(2)).storeUpperLimit(anyLong());
+                    } catch (TooLittleActualInvocations e) {
+                        throw new RuntimeException(e);
+                    }
+                });
     }
 
     @Test


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
Backporting #527 

This is a low-risk, test-only change. Fixes internal 95137. 