### PR TITLE
Feature/check in memory kvs correctness

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Value.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Value.java
@@ -45,6 +45,12 @@ public class Value implements Serializable {
         return new Value(contents, timestamp);
     }
 
+    @JsonCreator
+    public static Value createWithCopyOfData(@JsonProperty("contents") byte[] contents,
+                                             @JsonProperty("timestamp") long timestamp) {
+        return Value.create(Arrays.copyOf(contents, contents.length), timestamp);
+    }
+
     /**
      * The contents of the value.
      */

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Value.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Value.java
@@ -45,9 +45,7 @@ public class Value implements Serializable {
         return new Value(contents, timestamp);
     }
 
-    @JsonCreator
-    public static Value createWithCopyOfData(@JsonProperty("contents") byte[] contents,
-                                             @JsonProperty("timestamp") long timestamp) {
+    public static Value createWithCopyOfData(byte[] contents, long timestamp) {
         return Value.create(Arrays.copyOf(contents, contents.length), timestamp);
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -334,7 +334,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                 // Save memory by sharing rows.
                 row = nextKey.row;
             }
-            byte[] oldContents = table.entries.putIfAbsent(new Key(row, col, timestamp), Arrays.copyOf(contents, contents.length));
+            byte[] oldContents = table.entries.putIfAbsent(new Key(row, col, timestamp), copyOf(contents));
             if (oldContents != null && (doNotOverwriteWithSameValue || !Arrays.equals(oldContents, contents))) {
                 throw new KeyAlreadyExistsException("We already have a value for this timestamp");
             }
@@ -404,6 +404,10 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
     @Override
     public Set<TableReference> getAllTableNames() {
         return ImmutableSet.copyOf(tables.keySet());
+    }
+
+    private byte[] copyOf(byte[] contents) {
+        return Arrays.copyOf(contents, contents.length);
     }
 
     static class Table {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -111,7 +111,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                     }
                     if (lastEntry != null) {
                         long ts = lastEntry.getKey().ts;
-                        result.put(Cell.create(row, key.col), Value.create(copy(lastEntry.getValue()), ts));
+                        result.put(Cell.create(row, key.col), Value.createWithCopyOfData(lastEntry.getValue(), ts));
                     }
                 }
                 Iterators.size(cellIter);
@@ -132,7 +132,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                 Key key = lastEntry.getKey();
                 if (key.matchesCell(cell)) {
                     long ts = lastEntry.getKey().ts;
-                    result.put(cell, Value.create(copy(lastEntry.getValue()), ts));
+                    result.put(cell, Value.createWithCopyOfData(lastEntry.getValue(), ts));
                 }
             }
         }
@@ -161,7 +161,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                 }
                 if (lastEntry != null) {
                     long ts = lastEntry.getKey().ts;
-                    return Value.create(copy(lastEntry.getValue()), ts);
+                    return Value.createWithCopyOfData(lastEntry.getValue(), ts);
                 } else {
                     return null;
                 }
@@ -204,7 +204,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                     if (key.ts >= timestamp) {
                         break;
                     }
-                    values.add(Value.create(copy(entry.getValue()), key.ts));
+                    values.add(Value.createWithCopyOfData(entry.getValue(), key.ts));
                 }
                 if (!values.isEmpty()) {
                     return values;
@@ -213,10 +213,6 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                 }
             }
         });
-    }
-
-    private byte[] copy(byte[] value) {
-        return Arrays.copyOf(value, value.length);
     }
 
     private <T> ClosableIterator<RowResult<T>> getRangeInternal(TableReference tableRef,
@@ -338,7 +334,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                 // Save memory by sharing rows.
                 row = nextKey.row;
             }
-            byte[] oldContents = table.entries.putIfAbsent(new Key(row, col, timestamp), copy(contents));
+            byte[] oldContents = table.entries.putIfAbsent(new Key(row, col, timestamp), Arrays.copyOf(contents, contents.length));
             if (oldContents != null && (doNotOverwriteWithSameValue || !Arrays.equals(oldContents, contents))) {
                 throw new KeyAlreadyExistsException("We already have a value for this timestamp");
             }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -112,7 +112,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                     if (lastEntry != null) {
                         long ts = lastEntry.getKey().ts;
                         byte[] value = lastEntry.getValue();
-                        result.put(Cell.create(row, key.col), Value.create(value, ts));
+                        result.put(Cell.create(row, key.col), Value.create(Arrays.copyOf(value, value.length), ts));
                     }
                 }
                 Iterators.size(cellIter);
@@ -134,7 +134,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                 if (key.matchesCell(cell)) {
                     long ts = lastEntry.getKey().ts;
                     byte[] value = lastEntry.getValue();
-                    result.put(cell, Value.create(value, ts));
+                    result.put(cell, Value.create(Arrays.copyOf(value, value.length), ts));
                 }
             }
         }
@@ -164,7 +164,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                 if (lastEntry != null) {
                     long ts = lastEntry.getKey().ts;
                     byte[] value = lastEntry.getValue();
-                    return Value.create(value, ts);
+                    return Value.create(Arrays.copyOf(value, value.length), ts);
                 } else {
                     return null;
                 }
@@ -207,7 +207,8 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
                     if (key.ts >= timestamp) {
                         break;
                     }
-                    values.add(Value.create(entry.getValue(), key.ts));
+                    byte[] value = entry.getValue();
+                    values.add(Value.create(Arrays.copyOf(value, value.length), key.ts));
                 }
                 if (!values.isEmpty()) {
                     return values;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
@@ -664,41 +664,45 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
     public void testCannotModifyValuesAfterWrite() {
         Cell cell = Cell.create(row0, column0);
         byte[] data = new byte[1];
-        byte[] unmodifiedData = writeToCell(cell, data);
+        byte[] originalData = copyOf(data);
+        writeToCell(cell, data);
 
-        data[0] = (byte) 50;
+        modifyValue(data);
 
-        assertThat(getForCell(cell), is(unmodifiedData));
+        assertThat(getForCell(cell), is(originalData));
     }
 
     @Test
     public void testCannotModifyValuesAfterGetRows() {
         Cell cell = Cell.create(row0, column0);
-        byte[] unmodifiedData = writeToCell(cell, new byte[1]);
+        byte[] originalData = new byte[1];
+        writeToCell(cell, originalData);
 
         modifyValue(getRowsForCell(cell));
 
-        assertThat(getRowsForCell(cell), is(unmodifiedData));
+        assertThat(getRowsForCell(cell), is(originalData));
     }
 
     @Test
     public void testCannotModifyValuesAfterGet() {
         Cell cell = Cell.create(row0, column0);
-        byte[] unmodifiedData = writeToCell(cell, new byte[1]);
+        byte[] originalData = new byte[1];
+        writeToCell(cell, originalData);
 
         modifyValue(getForCell(cell));
 
-        assertThat(getForCell(cell), is(unmodifiedData));
+        assertThat(getForCell(cell), is(originalData));
     }
 
     @Test
     public void testCannotModifyValuesAfterGetRange() {
         Cell cell = Cell.create(row0, column0);
-        byte[] unmodifiedData = writeToCell(cell, new byte[1]);
+        byte[] originalData = new byte[1];
+        writeToCell(cell, originalData);
 
         modifyValue(getOnlyItemInTableRange());
 
-        assertThat(getOnlyItemInTableRange(), is(unmodifiedData));
+        assertThat(getOnlyItemInTableRange(), is(originalData));
     }
 
     @Test
@@ -706,11 +710,12 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         assumeTrue(kvsSupportsGetRangeWithHistory());
 
         Cell cell = Cell.create(row0, column0);
-        byte[] unmodifiedData = writeToCell(cell, new byte[1]);
+        byte[] originalData = new byte[1];
+        writeToCell(cell, originalData);
 
         modifyValue(getOnlyItemInTableRangeWithHistory());
 
-        assertThat(getOnlyItemInTableRangeWithHistory(), is(unmodifiedData));
+        assertThat(getOnlyItemInTableRangeWithHistory(), is(originalData));
     }
 
     private boolean kvsSupportsGetRangeWithHistory() {
@@ -726,10 +731,13 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         retrievedValue[0] = (byte) 50;
     }
 
-    private byte[] writeToCell(Cell cell, byte[] data) {
+    private byte[] copyOf(byte[] contents) {
+        return Arrays.copyOf(contents, contents.length);
+    }
+
+    private void writeToCell(Cell cell, byte[] data) {
         Value val = Value.create(data, TEST_TIMESTAMP + 1);
         keyValueService.putWithTimestamps(TEST_TABLE, ImmutableMultimap.of(cell, val));
-        return Arrays.copyOf(data, data.length);
     }
 
     private byte[] getRowsForCell(Cell cell) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
@@ -703,7 +703,22 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
     }
 
     @Test
-    public void testCannotModifyValuesAfterGetRangeWithHistory() {
+    public void testCannotModifyValuesAfterGetRangeWithHistoryIfSupported() {
+        if (kvsSupportsGetRangeWithHistory()) {
+            testCannotModifyValuesAfterGetRangeWithHistory();
+        }
+    }
+
+    private boolean kvsSupportsGetRangeWithHistory() {
+        try {
+            keyValueService.getRangeWithHistory(TEST_TABLE, RangeRequest.all(), TEST_TIMESTAMP);
+            return true;
+        } catch (UnsupportedOperationException e) {
+            return false;
+        }
+    }
+
+    private void testCannotModifyValuesAfterGetRangeWithHistory() {
         Cell cell = Cell.create(row0, column0);
         byte[] unmodifiedData = writeToCell(cell, new byte[1]);
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractAtlasDbKeyValueServiceTest.java
@@ -677,7 +677,7 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         Cell cell = Cell.create(row0, column0);
         byte[] unmodifiedData = writeToCell(cell, new byte[1]);
 
-        getRowsForCell(cell)[0] = (byte) 50;
+        modifyReference(getRowsForCell(cell));
 
         assertThat(getRowsForCell(cell), is(unmodifiedData));
     }
@@ -687,7 +687,7 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         Cell cell = Cell.create(row0, column0);
         byte[] unmodifiedData = writeToCell(cell, new byte[1]);
 
-        getForCell(cell)[0] = (byte) 50;
+        modifyReference(getForCell(cell));
 
         assertThat(getForCell(cell), is(unmodifiedData));
     }
@@ -697,9 +697,9 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         Cell cell = Cell.create(row0, column0);
         byte[] unmodifiedData = writeToCell(cell, new byte[1]);
 
-        getOnlyItemInTable()[0] = (byte) 50;
+        modifyReference(getOnlyItemInTableRange());
 
-        assertThat(getOnlyItemInTable(), is(unmodifiedData));
+        assertThat(getOnlyItemInTableRange(), is(unmodifiedData));
     }
 
     @Test
@@ -707,9 +707,13 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         Cell cell = Cell.create(row0, column0);
         byte[] unmodifiedData = writeToCell(cell, new byte[1]);
 
-        getOnlyItemInTableWithHistory()[0] = (byte) 50;
+        modifyReference(getOnlyItemInTableRangeWithHistory());
 
-        assertThat(getOnlyItemInTableWithHistory(), is(unmodifiedData));
+        assertThat(getOnlyItemInTableRangeWithHistory(), is(unmodifiedData));
+    }
+
+    private void modifyReference(byte[] retrievedValue) {
+        retrievedValue[0] = (byte) 50;
     }
 
     private byte[] writeToCell(Cell cell, byte[] data) {
@@ -726,7 +730,7 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         return keyValueService.get(TEST_TABLE, ImmutableMap.of(cell, TEST_TIMESTAMP + 3)).get(cell).getContents();
     }
 
-    private byte[] getOnlyItemInTable() {
+    private byte[] getOnlyItemInTableRange() {
         ClosableIterator<RowResult<Value>> rangeIterator = keyValueService.getRange(TEST_TABLE, RangeRequest.all(), TEST_TIMESTAMP + 3);
         byte[] contents = rangeIterator.next().getOnlyColumnValue().getContents();
 
@@ -734,7 +738,7 @@ public abstract class AbstractAtlasDbKeyValueServiceTest {
         return contents;
     }
 
-    private byte[] getOnlyItemInTableWithHistory() {
+    private byte[] getOnlyItemInTableRangeWithHistory() {
         ClosableIterator<RowResult<Set<Value>>> rangeIterator = keyValueService.getRangeWithHistory(TEST_TABLE, RangeRequest.all(), TEST_TIMESTAMP + 3);
         byte[] contents = Iterables.getOnlyElement(rangeIterator.next().getOnlyColumnValue()).getContents();
 


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Fixes #415. 

Ensure that the public methods on `InMemoryKeyValueService` don't leak references. 

Note that an alternative (and possibly cleaner) solution would be to do the array copy inside `Value.create`.  I didn't go that route for performance reasons -- `Cell.create` has an explicit comment about avoiding array copy for performance reasons, and the same argument presumably applies to `Value`. 