### PR TITLE
#366 Bump up timeout addLockToQueue, avoiding flicker

### DIFF
--- a/lock-impl/src/test/java/com/palantir/lock/impl/ClientAwareLockTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ClientAwareLockTest.java
@@ -219,7 +219,7 @@ public final class ClientAwareLockTest {
 
     /** Tests that locks obey fair ordering. */
     @Test public void testFairness() throws Exception {
-        final Queue<String> orderingQueue = new ConcurrentLinkedQueue<>();
+        final Queue<String> orderingQueue = new ConcurrentLinkedQueue<String>();
         anonymousReadLock.lock();
         addLockToQueue(anonymousWriteLock, orderingQueue, "one");
         addLockToQueue(anonymousReadLock, orderingQueue, "two");
@@ -237,12 +237,15 @@ public final class ClientAwareLockTest {
 
     private <T> void addLockToQueue(final KnownClientLock lock, final Queue<? super T> queue,
             final T index) throws Exception {
-        executor.submit((Callable<Void>) () -> {
-            barrier.await();
-            lock.lock();
-            queue.add(index);
-            lock.unlock();
-            return null;
+        executor.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                barrier.await();
+                lock.lock();
+                queue.add(index);
+                lock.unlock();
+                return null;
+            }
         });
         barrier.await();
         Thread.sleep(20);

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ClientAwareLockTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ClientAwareLockTest.java
@@ -219,7 +219,7 @@ public final class ClientAwareLockTest {
 
     /** Tests that locks obey fair ordering. */
     @Test public void testFairness() throws Exception {
-        final Queue<String> orderingQueue = new ConcurrentLinkedQueue<String>();
+        final Queue<String> orderingQueue = new ConcurrentLinkedQueue<>();
         anonymousReadLock.lock();
         addLockToQueue(anonymousWriteLock, orderingQueue, "one");
         addLockToQueue(anonymousReadLock, orderingQueue, "two");
@@ -237,18 +237,15 @@ public final class ClientAwareLockTest {
 
     private <T> void addLockToQueue(final KnownClientLock lock, final Queue<? super T> queue,
             final T index) throws Exception {
-        executor.submit(new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                barrier.await();
-                lock.lock();
-                queue.add(index);
-                lock.unlock();
-                return null;
-            }
+        executor.submit((Callable<Void>) () -> {
+            barrier.await();
+            lock.lock();
+            queue.add(index);
+            lock.unlock();
+            return null;
         });
         barrier.await();
-        Thread.sleep(10);
+        Thread.sleep(20);
     }
 
     /** Tests that {@code lock()} handles thread interruptions properly. */


### PR DESCRIPTION
I don't really like this fix... here's a comment from @joelea a month ago that I second:

> I think we need to go through and add proper time controlled unit tests to this stuff, but this looks fine to make the build flakes go away right now.

Also, while I was here, I obeyed a few idea suggestions to use Java 8 syntax.