### PR TITLE
Turn failover target retry logs into trace

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -132,7 +132,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
         long timeout = Math.min(maxBackoffMillis, Math.round(pow));
 
         try {
-            log.info("Pausing {}ms before retrying", timeout);
+            log.trace("Pausing {}ms before retrying", timeout);
             Thread.sleep(timeout);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

An internal product had a hell of a lot of these in their logs whenever anything goes wrong - seems no reason these should be anything above trace.
