### PR TITLE
Add profiling to longest running gradle task to figure out how to decrease build time

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,10 @@ machine:
   services:
     - docker
 
+general:
+  artifacts:
+    - "build/reports/profile"
+
 dependencies:
   pre:
     - sudo pip install docker-compose

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -12,7 +12,7 @@ SHARED=':atlasdb-tests-shared:check'
 ETE=':atlasdb-ete-tests:check'
 
 case $CIRCLE_NODE_INDEX in
-    0) ./gradlew --continue check -x $CASSANDRA -x $SHARED -x $ETE ;;
+    0) ./gradlew --profile --continue check -x $CASSANDRA -x $SHARED -x $ETE ;;
     1) ./gradlew --continue --parallel $CASSANDRA ;;
     2) ./gradlew --continue --parallel $SHARED $ETE && checkDocsBuild ;;
 esac


### PR DESCRIPTION
This will now have the main container (0) report in the build artifacts the run times of each of the gradle tasks to help use identify what should be pulled out to further decrease the build time.  If we want we can include this into the other containers as well if they start to be the slowest.