### PR TITLE
Update config / dbfactories to use auto service, including dbkvs

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   compile 'org.apache.commons:commons-pool2:2.4.2'
 
   processor 'org.immutables:value:2.0.21'
+  processor 'com.google.auto.service:auto-service:1.0-rc2'
 }
 
 configurations.matching({ it.name in ['compile', 'runtime'] }).all {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.cassandra;
 
+import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
@@ -25,8 +26,9 @@ import com.palantir.atlasdb.versions.AtlasDbVersion;
 import com.palantir.timestamp.PersistentTimestampService;
 import com.palantir.timestamp.TimestampService;
 
+@AutoService(AtlasDbFactory.class)
 public class CassandraAtlasDbFactory implements AtlasDbFactory {
-    
+
     @Override
     public KeyValueService createRawKeyValueService(KeyValueServiceConfig config) {
         AtlasDbVersion.ensureVersionReported();
@@ -34,7 +36,7 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
                 "CassandraAtlasDbFactory expects a configuration of type CassandraKeyValueServiceConfig, found %s", config.getClass());
         return createKv((CassandraKeyValueServiceConfig) config);
     }
-    
+
     private static CassandraKeyValueService createKv(CassandraKeyValueServiceConfig config) {
         return CassandraKeyValueService.create(CassandraKeyValueServiceConfigManager.createSimpleManager(config));
     }
@@ -46,7 +48,7 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
                 "TimestampService must be created from an instance of CassandraKeyValueService, found %s", rawKvs.getClass());
         return PersistentTimestampService.create(CassandraTimestampBoundStore.create((CassandraKeyValueService) rawKvs));
     }
-    
+
     @Override
     public String getType() {
         return CassandraKeyValueServiceConfig.TYPE;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -24,10 +24,12 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.auto.service.AutoService;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
+@AutoService(KeyValueServiceConfig.class)
 @JsonDeserialize(as = ImmutableCassandraKeyValueServiceConfig.class)
 @JsonSerialize(as = ImmutableCassandraKeyValueServiceConfig.class)
 @JsonTypeName(CassandraKeyValueServiceConfig.TYPE)

--- a/atlasdb-cassandra/src/main/resources/META-INF/services/com.palantir.atlasdb.spi.AtlasDbFactory
+++ b/atlasdb-cassandra/src/main/resources/META-INF/services/com.palantir.atlasdb.spi.AtlasDbFactory
@@ -1,1 +1,0 @@
-com.palantir.atlasdb.cassandra.CassandraAtlasDbFactory

--- a/atlasdb-cassandra/src/main/resources/META-INF/services/com.palantir.atlasdb.spi.KeyValueServiceConfig
+++ b/atlasdb-cassandra/src/main/resources/META-INF/services/com.palantir.atlasdb.spi.KeyValueServiceConfig
@@ -1,1 +1,0 @@
-com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -11,4 +11,5 @@ dependencies {
   compile project(':commons-api')
 
   processor 'org.immutables:value:2.0.21'
+  processor "com.google.auto.service:auto-service:1.0-rc2"
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
+import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
@@ -24,10 +25,11 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.timestamp.PersistentTimestampService;
 import com.palantir.timestamp.TimestampService;
 
+@AutoService(AtlasDbFactory.class)
 public class DbAtlasDbFactory implements AtlasDbFactory {
     @Override
     public String getType() {
-        return "db";
+        return "postgres";
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleKeyValueServiceConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleKeyValueServiceConfig.java
@@ -17,12 +17,15 @@ package com.palantir.atlasdb.keyvalue.dbkvs;
 
 import org.immutables.value.Value;
 
+import com.google.auto.service.AutoService;
 import com.google.common.base.Supplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbTableFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OracleDbTableFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.db.oracle.JdbcHandler;
 
+@AutoService(KeyValueServiceConfig.class)
 @Value.Immutable
 public abstract class OracleKeyValueServiceConfig extends DbKeyValueServiceConfig {
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresKeyValueServiceConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresKeyValueServiceConfig.java
@@ -20,10 +20,13 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.auto.service.AutoService;
 import com.google.common.base.Supplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbTableFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.PostgresDbTableFactory;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
+@AutoService(KeyValueServiceConfig.class)
 @JsonDeserialize(as = ImmutablePostgresKeyValueServiceConfig.class)
 @JsonSerialize(as = ImmutablePostgresKeyValueServiceConfig.class)
 @JsonTypeName(PostgresKeyValueServiceConfig.TYPE)

--- a/atlasdb-rocksdb/build.gradle
+++ b/atlasdb-rocksdb/build.gradle
@@ -10,4 +10,5 @@ dependencies {
   compile "org.rocksdb:rocksdbjni:4.1.0"
 
   processor 'org.immutables:value:2.0.21'
+  processor "com.google.auto.service:auto-service:1.0-rc2"
 }

--- a/atlasdb-rocksdb/src/main/java/com/palantir/atlasdb/rocksdb/RocksDbAtlasDbFactory.java
+++ b/atlasdb-rocksdb/src/main/java/com/palantir/atlasdb/rocksdb/RocksDbAtlasDbFactory.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.rocksdb;
 
+import com.google.auto.service.AutoService;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -28,6 +29,7 @@ import com.palantir.atlasdb.versions.AtlasDbVersion;
 import com.palantir.timestamp.PersistentTimestampService;
 import com.palantir.timestamp.TimestampService;
 
+@AutoService(AtlasDbFactory.class)
 public class RocksDbAtlasDbFactory implements AtlasDbFactory {
 
     @Override

--- a/atlasdb-rocksdb/src/main/java/com/palantir/atlasdb/rocksdb/RocksDbKeyValueServiceConfig.java
+++ b/atlasdb-rocksdb/src/main/java/com/palantir/atlasdb/rocksdb/RocksDbKeyValueServiceConfig.java
@@ -23,6 +23,7 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.auto.service.AutoService;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.keyvalue.rocksdb.impl.ImmutableWriteOpts;
@@ -30,6 +31,7 @@ import com.palantir.atlasdb.keyvalue.rocksdb.impl.RocksComparatorName;
 import com.palantir.atlasdb.keyvalue.rocksdb.impl.WriteOpts;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
+@AutoService(KeyValueServiceConfig.class)
 @JsonDeserialize(as = ImmutableRocksDbKeyValueServiceConfig.class)
 @JsonSerialize(as = ImmutableRocksDbKeyValueServiceConfig.class)
 @JsonTypeName(RocksDbKeyValueServiceConfig.TYPE)

--- a/atlasdb-rocksdb/src/main/resources/META-INF/services/com.palantir.atlasdb.spi.AtlasDbFactory
+++ b/atlasdb-rocksdb/src/main/resources/META-INF/services/com.palantir.atlasdb.spi.AtlasDbFactory
@@ -1,1 +1,0 @@
-com.palantir.atlasdb.rocksdb.RocksDbAtlasDbFactory

--- a/atlasdb-rocksdb/src/main/resources/META-INF/services/com.palantir.atlasdb.spi.KeyValueServiceConfig
+++ b/atlasdb-rocksdb/src/main/resources/META-INF/services/com.palantir.atlasdb.spi.KeyValueServiceConfig
@@ -1,1 +1,0 @@
-com.palantir.atlasdb.rocksdb.RocksDbKeyValueServiceConfig


### PR DESCRIPTION
Didn't have dbkvs set up to be properly discovered so multipass was unable to load the config.  I also chose to modify the dbkvsdbfactory to return postgres for the time being.  This will allow the loading to work properly and the issue of loading postgres / oracle should be resolve #545 