### PR TITLE
Fix/oss dbkvs fixes

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -47,6 +47,6 @@ public class DbAtlasDbFactory implements AtlasDbFactory {
                 "DbAtlasDbFactory expects a raw kvs of type ConnectionManagerAwareDbKvs, found %s", rawKvs.getClass());
         ConnectionManagerAwareDbKvs dbkvs = (ConnectionManagerAwareDbKvs) rawKvs;
         return PersistentTimestampService.create(
-                new InDbTimestampBoundStore(dbkvs.getConnectionManager(), AtlasDbConstants.TIMESTAMP_TABLE));
+                InDbTimestampBoundStore.create(dbkvs.getConnectionManager(), AtlasDbConstants.TIMESTAMP_TABLE));
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionManagerAwareDbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionManagerAwareDbKvs.java
@@ -31,7 +31,6 @@ import com.palantir.nexus.db.sql.ConnectionBackedSqlConnectionImpl;
 import com.palantir.nexus.db.sql.SQL;
 import com.palantir.nexus.db.sql.SqlConnection;
 import com.palantir.nexus.db.sql.SqlConnectionHelper;
-import com.palantir.nexus.db.sql.SqlConnectionImpl;
 
 // This class should be removed and replaced by DbKvs when InDbTimestampStore depends directly on DbKvs
 public class ConnectionManagerAwareDbKvs extends ForwardingKeyValueService {
@@ -74,7 +73,10 @@ public class ConnectionManagerAwareDbKvs extends ForwardingKeyValueService {
         return new SqlConnectionSupplier() {
             @Override
             public SqlConnection get() {
-                return new ConnectionBackedSqlConnectionImpl(supplier.get(), () -> System.currentTimeMillis(), new SqlConnectionHelper(sql));
+                return new ConnectionBackedSqlConnectionImpl(
+                        supplier.get(),
+                        () -> { throw new UnsupportedOperationException("This Sql connection does not provide reliable timestamp."); },
+                        new SqlConnectionHelper(sql));
             }
 
             @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionManagerAwareDbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionManagerAwareDbKvs.java
@@ -27,6 +27,7 @@ import com.palantir.nexus.db.monitoring.timer.SqlTimers;
 import com.palantir.nexus.db.pool.ConnectionManager;
 import com.palantir.nexus.db.pool.HikariCPConnectionManager;
 import com.palantir.nexus.db.pool.ReentrantManagedConnectionSupplier;
+import com.palantir.nexus.db.sql.ConnectionBackedSqlConnectionImpl;
 import com.palantir.nexus.db.sql.SQL;
 import com.palantir.nexus.db.sql.SqlConnection;
 import com.palantir.nexus.db.sql.SqlConnectionHelper;
@@ -73,7 +74,7 @@ public class ConnectionManagerAwareDbKvs extends ForwardingKeyValueService {
         return new SqlConnectionSupplier() {
             @Override
             public SqlConnection get() {
-                return new SqlConnectionImpl(supplier, new SqlConnectionHelper(sql));
+                return new ConnectionBackedSqlConnectionImpl(supplier.get(), () -> System.currentTimeMillis(), new SqlConnectionHelper(sql));
             }
 
             @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -23,7 +23,6 @@ import com.palantir.atlasdb.keyvalue.dbkvs.PostgresDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbDdlTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableSize;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
 import com.palantir.util.VersionStrings;
@@ -59,9 +58,8 @@ public class PostgresDdlTable implements DbDdlTable {
                 ")",
                 "already exists");
         conns.get().insertOneUnregisteredQuery(
-                "INSERT INTO " + config.metadataTable().getQualifiedName() + " (table_name, table_size) VALUES (?, ?)",
-                tableName.getQualifiedName(),
-                TableSize.RAW.getId());
+                "INSERT INTO " + config.metadataTable().getQualifiedName() + " (table_name) VALUES (?)",
+                tableName.getQualifiedName());
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
@@ -50,7 +50,6 @@ public class PostgresTableInitializer implements DbTableInitializer {
                         "  table_name VARCHAR(2000) NOT NULL," +
                         "  table_size BIGINT NOT NULL," +
                         "  value      BYTEA NULL," +
-                        "  gc_ts      INT8 DEFAULT -1," +
                         "  CONSTRAINT pk_" + metadataTableName + " PRIMARY KEY (table_name) " +
                         ")",
                 "already exists");

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
@@ -48,7 +48,6 @@ public class PostgresTableInitializer implements DbTableInitializer {
         executeIgnoringError(
                 "CREATE TABLE " + metadataTableName + " (" +
                         "  table_name VARCHAR(2000) NOT NULL," +
-                        "  table_size BIGINT NOT NULL," +
                         "  value      BYTEA NULL," +
                         "  CONSTRAINT pk_" + metadataTableName + " PRIMARY KEY (table_name) " +
                         ")",

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
@@ -182,10 +182,10 @@ public final class InDbTimestampBoundStore implements TimestampBoundStore {
 
     private void writeLimit(Connection c, long limit) throws SQLException {
         String updateTs = "UPDATE " + timestampTable.getQualifiedName() + " SET last_allocated = ?";
-        PreparedStatement statement = c.prepareStatement(updateTs);
-        statement.setLong(1, limit);
-        statement.executeUpdate();
-        statement.close();
+        try (PreparedStatement statement = c.prepareStatement(updateTs)) {
+            statement.setLong(1, limit);
+            statement.executeUpdate();
+        }
     }
 
     private void createLimit(Connection c, long limit) throws SQLException {
@@ -194,9 +194,9 @@ public final class InDbTimestampBoundStore implements TimestampBoundStore {
     }
 
     private void createTimestampTable(Connection c) throws SQLException {
-        Statement statement = c.createStatement();
-        statement.execute("CREATE TABLE IF NOT EXISTS " + timestampTable.getQualifiedName() + " ( last_allocated int8 NOT NULL )");
-        statement.close();
+        try (Statement statement = c.createStatement()) {
+            statement.execute("CREATE TABLE IF NOT EXISTS " + timestampTable.getQualifiedName() + " ( last_allocated int8 NOT NULL )");
+        }
     }
 
     private DBType getDbType(Connection c) {


### PR DESCRIPTION
This also resolves an issue in which the InDbTimestampBoundStore was not properly creating the required _timestamp table, this has been amended.

This resolves a connection closing issue that arose from the type of SqlConnection impl we returned as part of instantiating dbkvs.  The intention is that a single connection is opened (and importantly referenced through the CloseTracker) per request (which the exception of batched requests) and that is used repeatedly and then closed by dbkvs after completing the action.  

Shout out to @SerialVelocity for tracking down this connection ref leak!

This should resolve the tracking issue, but still has the oddity of the SqlConnection impl requiring an unused timestamp service.  I have added the task of repairing this to the cruft ticket in the meantime.