### PR TITLE
Add release notes documenting the new defensive copy in InMemoryKVS

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -20,6 +20,25 @@ Changelog
 .. toctree::
   :hidden:
 
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
+v0.7.0
+=======
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |fixed|
+         - The in-memory key-value store now makes defensive copies of any data stored or retrieved.
+           This may lead to a slight performance degradation to users of InMemoryKVS (#552)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -53,12 +72,12 @@ v0.6.0
         - A potential race condition could cause timestamp allocation to never complete on a particular node (#462)
 
     *   - |fixed|
-        - An innocuous error was logged once for each TransactionManager about not being able to allocate 
+        - An innocuous error was logged once for each TransactionManager about not being able to allocate
           enough timestamps. The error has been downgraded to INFO and made less scary.
 
     *   - |fixed|
         - Serializable Transactions that read a column selection could consistently report conflicts when there were none.
-    
+
     *   - |fixed|
         - An excessively long Cassandra related logline was sometimes printed (#501)
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -38,20 +38,6 @@ v0.7.0
          - The in-memory key-value store now makes defensive copies of any data stored or retrieved.
            This may lead to a slight performance degradation to users of InMemoryKVS (#552)
 
-
-.. <<<<------------------------------------------------------------------------------------------------------------->>>>
-
-=======
-v0.6.1
-=======
-
-.. list-table::
-    :widths: 5 40
-    :header-rows: 1
-
-    *    - Type
-         - Change
-
     *    - |improved|
          - Reduced memory footprint of Cassandra KVS, esp. for workflows of many consecutive large reads (#568)
 


### PR DESCRIPTION
Didn't cut any releases since the fix (#552) except for 0.7.0-alpha and -beta, so we shouldn't need to amend anything. 