### PR TITLE
Make table names unique in a case-insensitive manner in dbkvs

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsKeyValueServiceTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsKeyValueServiceTest.java
@@ -16,11 +16,17 @@
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
 import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionManagerAwareDbKvs;
 import com.palantir.atlasdb.keyvalue.impl.AbstractAtlasDbKeyValueServiceTest;
+import com.palantir.exception.PalantirSqlException;
 
 public class DbkvsKeyValueServiceTest extends AbstractAtlasDbKeyValueServiceTest {
     @Override
@@ -34,9 +40,19 @@ public class DbkvsKeyValueServiceTest extends AbstractAtlasDbKeyValueServiceTest
         return kvs;
     }
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Override
     @Ignore
     public void testGetRangeWithHistory() {
         /* Have to ignore this test as it is an unsupported operation for this KVS */
+    }
+
+    @Test
+    public void testRejectCaseInsensitiveDuplicateTableName() {
+        keyValueService.createTable(TableReference.create(Namespace.EMPTY_NAMESPACE, "Duplicate"), AtlasDbConstants.GENERIC_TABLE_METADATA);
+        thrown.expect(PalantirSqlException.class);
+        keyValueService.createTable(TableReference.create(Namespace.EMPTY_NAMESPACE, "duplicate"), AtlasDbConstants.GENERIC_TABLE_METADATA);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresTableInitializer.java
@@ -53,6 +53,10 @@ public class PostgresTableInitializer implements DbTableInitializer {
                         "  CONSTRAINT pk_" + metadataTableName + " PRIMARY KEY (table_name) " +
                         ")",
                 "already exists");
+
+        executeIgnoringError(
+                "CREATE UNIQUE INDEX unique_lower_case_" + metadataTableName + "_index ON " + metadataTableName + " (lower(table_name))",
+                "already exists");
     }
 
     private void executeIgnoringError(String sql, String errorToIgnore) {


### PR DESCRIPTION
This was chosen as a safer alternative to a more aggressive change in #626 (which moves closer to the desired end state but could cause more serious issues)

