### PR TITLE
Do not log the stacktrace on failure to gain leadership.

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -23,6 +23,23 @@ Changelog
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
+v0.9.0
+=======
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |improved|
+         - The warning emitted when an attempted leadership election fails is now more descriptive.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/630>`__)
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
 v0.8.0
 =======
 
@@ -67,9 +84,6 @@ v0.7.0
          - Read heavy workflows with Cassandra KVS will now use substantially less heap. In worst-case testing this change resulted in a 10-100x reduction in client side heap size.
            However, this is very dependent on the particular scenario AtlasDB is being used in and most consumers should not expect a difference of this size.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/568>`__)
-
-    *    - |improved|
-         - The warning emitted when an attempted leadership election fails is now more descriptive. (#630)
 
 .. <<<<------------------------------------------------------------------------------------------------------------>>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -68,6 +68,9 @@ v0.7.0
            However, this is very dependent on the particular scenario AtlasDB is being used in and most consumers should not expect a difference of this size.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/568>`__)
 
+    *    - |improved|
+         - The warning emitted when an attempted leadership election fails is now more descriptive. (#630)
+
 .. <<<<------------------------------------------------------------------------------------------------------------>>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -33,34 +33,34 @@ v0.9.0
     :widths: 5 40
     :header-rows: 1
 
-    *   - Type
-        - Change
+    *    - Type
+         - Change
 
-    *   - |breaking|
-        - Inserting an empty (size = 0) value into a ``Cell`` will now throw an ``IllegalArgumentException``. (#156) Likely empty
-          values include empty strings and empty protobufs.
+    *    - |breaking|
+         - Inserting an empty (size = 0) value into a ``Cell`` will now throw an ``IllegalArgumentException``. (#156) Likely empty
+           values include empty strings and empty protobufs.
 
-          Atlas cannot currently distinguish between empty and deleted cells. In previous versions of Atlas, inserting
-          an empty value into a ``Cell`` would delete that cell. Thus, in this snippet,
+           Atlas cannot currently distinguish between empty and deleted cells. In previous versions of Atlas, inserting
+           an empty value into a ``Cell`` would delete that cell. Thus, in this snippet,
 
-          .. code-block:: java
+           .. code-block:: java
 
-              Transaction.put(table, ImmutableMap.of(myCell, new byte[0]))
-              Transaction.get(table, ImmutableSet.of(myCell)).get(myCell)
+               Transaction.put(table, ImmutableMap.of(myCell, new byte[0]))
+               Transaction.get(table, ImmutableSet.of(myCell)).get(myCell)
 
-          the second line will return ``null`` instead of a zero-length byte array.
+           the second line will return ``null`` instead of a zero-length byte array.
 
-          To minimize confusion, we explicitly disallow inserting an empty value into a cell by throwing an
-          ``IllegalArgumentException``.
+           To minimize confusion, we explicitly disallow inserting an empty value into a cell by throwing an
+           ``IllegalArgumentException``.
 
-          In particular, this change will break calls to ``Transaction.put(TableReference tableRef, Map<Cell, byte[]> values)``,
-          as well as generated code which uses this method, if any entry in ``values`` contains a zero-byte array. If your
-          product does not need to distinguish between empty and non-existent values, simply make sure all the ``values``
-          entries have positive length. If the distinction is necessary, you will need to explicitly differentiate the
-          two cases (for example, by introducing a sentinel value for empty cells).
+           In particular, this change will break calls to ``Transaction.put(TableReference tableRef, Map<Cell, byte[]> values)``,
+           as well as generated code which uses this method, if any entry in ``values`` contains a zero-byte array. If your
+           product does not need to distinguish between empty and non-existent values, simply make sure all the ``values``
+           entries have positive length. If the distinction is necessary, you will need to explicitly differentiate the
+           two cases (for example, by introducing a sentinel value for empty cells).
 
-          If any code deletes cells by calling ``Transaction.put(...)`` with an empty array, use
-          ``Transaction.delete(...)`` instead.
+           If any code deletes cells by calling ``Transaction.put(...)`` with an empty array, use
+           ``Transaction.delete(...)`` instead.
 
     *    - |improved|
          - The warning emitted when an attempted leadership election fails is now more descriptive.

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -345,10 +345,12 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             proposer.propose(seq, null);
         } catch (PaxosRoundFailureException e) {
             // We have failed trying to become the leader.
-            leaderLog.warn("Leadership was not gained because: " + e.getMessage() + ". "
-                    + "This should happen rarely and we should recover automatically. If this recurs often, try to "
-                    + "(1) ensure that most other nodes are reachable, and "
-                    + "(2) increase the randomWaitBeforeProposingLeadershipMs timeout in your configuration. ");
+            leaderLog.warn("Leadership was not gained.\n"
+                    + "This should happen rarely and we should recover automatically. If this recurs often, try to \n"
+                    + "  (1) ensure that most other nodes are reachable over the network, and \n"
+                    + "  (2) increase the randomWaitBeforeProposingLeadershipMs timeout in your configuration.\n"
+                    + "See the debug-level log for more details.");
+            leaderLog.debug("Specifically, leadership was not gained because of the following exception", e);
             return;
         } finally {
             lock.unlock();

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -346,6 +346,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
         } catch (PaxosRoundFailureException e) {
             // We have failed trying to become the leader.
             leaderLog.warn("Leadership was not gained");
+            leaderLog.debug("Leadership was not gained because this Paxos round failed: ", e);
             return;
         } finally {
             lock.unlock();

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -349,7 +349,6 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
                     + "This should happen rarely and we should recover automatically. If this recurs often, try to "
                     + "(1) ensure that most other nodes are reachable, and "
                     + "(2) increase the randomWaitBeforeProposingLeadershipMs timeout in your configuration. ");
-            leaderLog.debug("Leadership was not gained because this Paxos round failed: ", e);
             return;
         } finally {
             lock.unlock();

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -346,7 +346,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
         } catch (PaxosRoundFailureException e) {
             // We have failed trying to become the leader.
             leaderLog.warn("Leadership was not gained.\n"
-                    + "This should happen rarely and we should recover automatically. If this recurs often, try to \n"
+                    + "We should recover automatically. If this recurs often, try to \n"
                     + "  (1) ensure that most other nodes are reachable over the network, and \n"
                     + "  (2) increase the randomWaitBeforeProposingLeadershipMs timeout in your configuration.\n"
                     + "See the debug-level log for more details.");

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -345,7 +345,10 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             proposer.propose(seq, null);
         } catch (PaxosRoundFailureException e) {
             // We have failed trying to become the leader.
-            leaderLog.warn("Leadership was not gained");
+            leaderLog.warn("Leadership was not gained because: " + e.getMessage() + ". "
+                    + "This should happen rarely and we should recover automatically. If this recurs often, try to "
+                    + "(1) ensure that most other nodes are reachable, and "
+                    + "(2) increase the randomWaitBeforeProposingLeadershipMs timeout in your configuration. ");
             leaderLog.debug("Leadership was not gained because this Paxos round failed: ", e);
             return;
         } finally {

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -345,7 +345,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             proposer.propose(seq, null);
         } catch (PaxosRoundFailureException e) {
             // We have failed trying to become the leader.
-            leaderLog.warn("Leadership was not gained", e);
+            leaderLog.warn("Leadership was not gained");
             return;
         } finally {
             lock.unlock();


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Fixes #550 

The stacktrace for a PaxosRoundFailureException is not useful because it just indicates that
a Paxos round did not reach quorum without showing the underlying reason.

By removing the stack trace here, we get a cleaner log message: 

```
ete1_1 | WARN  [2016-06-28 14:55:35,270] com.palantir.paxos.PaxosQuorumChecker: We encountered an error while trying to request an acknowledgement from another paxos node. This could mean the node is down, or we cannot connect to it for some other reason.
ete1_1 | ! java.net.UnknownHostException: hostThatDoesNotExist
...
```

Will leave this at the warn level, because it's a relatively rare event that _does_ indicate some network weirdness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/630)
<!-- Reviewable:end -->
