### PR TITLE
Drop perf logging to TRACE

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -558,7 +558,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                                 }
                             });
                         }
-                        log.info("Processed {} range requests for {} in {}ms",
+                        log.trace("Processed {} range requests for {} in {}ms",
                                 input.size(), tableRef, timer.elapsed(TimeUnit.MILLISECONDS));
                         return ret;
                     }


### PR DESCRIPTION
Otherwise this is rather verbose as most service requests are responded to by one or multiple atlas requests