### PR TITLE
Improvements to ConflictDetectionManager.

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
@@ -15,10 +15,11 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
@@ -38,10 +39,9 @@ public class ConflictDetectionManager {
         this.supplier = supplier;
         this.overrides = Maps.newConcurrentMap();
         this.cachedResult = RecomputingSupplier.create(() -> {
-            ImmutableMap.Builder<TableReference, ConflictHandler> ret = ImmutableMap.builder();
-            ret.putAll(this.supplier.get());
+            Map<TableReference, ConflictHandler> ret = new HashMap<>(this.supplier.get());
             ret.putAll(overrides);
-            return ret.build();
+            return Collections.unmodifiableMap(ret);
         });
     }
 
@@ -57,10 +57,7 @@ public class ConflictDetectionManager {
 
     public boolean isEmptyOrContainsTable(TableReference tableRef) {
         Map<TableReference, ConflictHandler> tableToConflict = cachedResult.get();
-        if (tableToConflict.isEmpty() || tableToConflict.containsKey(tableRef)) {
-            return true;
-        }
-        return false;
+        return tableToConflict.isEmpty() || tableToConflict.containsKey(tableRef);
     }
 
     public Map<TableReference, ConflictHandler> get() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
@@ -18,8 +18,8 @@ package com.palantir.atlasdb.transaction.impl;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
-import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
@@ -40,11 +40,11 @@ public class ConflictDetectionManagers {
     }
 
     public static ConflictDetectionManager createFromSchema(Schema schema) {
-        return new ConflictDetectionManager(RecomputingSupplier.create(Suppliers.ofInstance(getTablesToConflictDetect(schema))));
+        return new ConflictDetectionManager(Suppliers.ofInstance(getTablesToConflictDetect(schema)));
     }
 
     public static ConflictDetectionManager fromMap(final Map<TableReference, ConflictHandler> map) {
-        return new ConflictDetectionManager(RecomputingSupplier.create(Suppliers.ofInstance(map)));
+        return new ConflictDetectionManager(Suppliers.ofInstance(map));
     }
 
     /**
@@ -54,23 +54,23 @@ public class ConflictDetectionManagers {
         return new ConflictDetectionManager(getNoConflictDetectSupplier(kvs));
     }
 
-    private static RecomputingSupplier<Map<TableReference, ConflictHandler>> getNoConflictDetectSupplier(final KeyValueService kvs) {
-        return RecomputingSupplier.create(new Supplier<Map<TableReference, ConflictHandler>>() {
+    private static Supplier<Map<TableReference, ConflictHandler>> getNoConflictDetectSupplier(final KeyValueService kvs) {
+        return new Supplier<Map<TableReference, ConflictHandler>>() {
             @Override
             public Map<TableReference, ConflictHandler> get() {
                 Set<TableReference> tables = kvs.getAllTableNames();
                 return Maps.asMap(tables, Functions.constant(ConflictHandler.IGNORE_ALL));
             }
-        });
+        };
     }
 
-    private static RecomputingSupplier<Map<TableReference, ConflictHandler>> getTablesToConflictDetectSupplier(final KeyValueService keyValueService) {
-        return RecomputingSupplier.create(new Supplier<Map<TableReference, ConflictHandler>>() {
+    private static Supplier<Map<TableReference, ConflictHandler>> getTablesToConflictDetectSupplier(final KeyValueService keyValueService) {
+        return new Supplier<Map<TableReference, ConflictHandler>>() {
             @Override
             public Map<TableReference, ConflictHandler> get() {
                 return getTablesToConflictDetect(keyValueService);
             }
-        });
+        };
     }
 
     private static Map<TableReference, ConflictHandler> getTablesToConflictDetect(KeyValueService kvs) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
@@ -17,11 +17,9 @@ package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
-import com.google.common.base.Function;
 import com.google.common.base.Functions;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -40,11 +38,11 @@ public class ConflictDetectionManagers {
     }
 
     public static ConflictDetectionManager createFromSchema(Schema schema) {
-        return new ConflictDetectionManager(Suppliers.ofInstance(getTablesToConflictDetect(schema)));
+        return new ConflictDetectionManager(() -> getTablesToConflictDetect(schema));
     }
 
     public static ConflictDetectionManager fromMap(final Map<TableReference, ConflictHandler> map) {
-        return new ConflictDetectionManager(Suppliers.ofInstance(map));
+        return new ConflictDetectionManager(() -> map);
     }
 
     /**

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagerTest.java
@@ -1,0 +1,120 @@
+package com.palantir.atlasdb.transaction.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+
+public class ConflictDetectionManagerTest {
+
+    private static final TableReference TABLE_1 = TableReference.fromString("default.table1");
+    private static final TableReference TABLE_2 = TableReference.fromString("default.table2");
+    private static final TableReference TABLE_3 = TableReference.fromString("default.table3");
+    private static final TableReference TABLE_4 = TableReference.fromString("default.table4");
+
+    private Map<TableReference, ConflictHandler> map;
+    private AtomicInteger callCount;
+    private ConflictDetectionManager manager;
+
+    @Before
+    public void setUp() {
+        map = new HashMap<>();
+        callCount = new AtomicInteger(0);
+        manager = new ConflictDetectionManager(() -> {
+            callCount.incrementAndGet();
+            return map;
+        });
+    }
+
+    @Test
+    public void testEmptyManager() {
+        Assert.assertTrue(manager.isEmptyOrContainsTable(TableReference.fromString("default.table")));
+        Assert.assertTrue(manager.get().isEmpty());
+        manager.recompute();
+        Assert.assertTrue(manager.get().isEmpty());
+    }
+
+    @Test
+    public void testRecomputeNoOverrides() {
+        map.put(TABLE_1, ConflictHandler.IGNORE_ALL);
+        map.put(TABLE_3, ConflictHandler.IGNORE_ALL);
+
+        // Initial get() loads supplier properly
+        Assert.assertEquals(ImmutableMap.of(
+                        TABLE_1, ConflictHandler.IGNORE_ALL,
+                        TABLE_3, ConflictHandler.IGNORE_ALL),
+                manager.get());
+        Assert.assertEquals(1, callCount.get());
+
+        map.clear();
+        map.put(TABLE_1, ConflictHandler.RETRY_ON_VALUE_CHANGED);
+        map.put(TABLE_2, ConflictHandler.IGNORE_ALL);
+
+        // results are cached
+        Assert.assertEquals(ImmutableMap.of(
+                        TABLE_1, ConflictHandler.IGNORE_ALL,
+                        TABLE_3, ConflictHandler.IGNORE_ALL),
+                manager.get());
+        Assert.assertEquals(1, callCount.get());
+
+        manager.recompute();
+
+        // recompute() recomputes the cached result
+        Assert.assertEquals(ImmutableMap.of(
+                        TABLE_1, ConflictHandler.RETRY_ON_VALUE_CHANGED,
+                        TABLE_2, ConflictHandler.IGNORE_ALL),
+                manager.get());
+        Assert.assertEquals(2, callCount.get());
+    }
+
+    @Test
+    public void testWithOverrides() {
+        map.put(TABLE_1, ConflictHandler.IGNORE_ALL);
+        map.put(TABLE_3, ConflictHandler.IGNORE_ALL);
+
+        Assert.assertEquals(ImmutableMap.of(
+                TABLE_1, ConflictHandler.IGNORE_ALL,
+                TABLE_3, ConflictHandler.IGNORE_ALL),
+                manager.get());
+
+        manager.setConflictDetectionMode(TABLE_1, ConflictHandler.RETRY_ON_VALUE_CHANGED);
+        manager.setConflictDetectionMode(TABLE_2, ConflictHandler.RETRY_ON_VALUE_CHANGED);
+
+        Assert.assertEquals(ImmutableMap.of(
+                TABLE_1, ConflictHandler.RETRY_ON_VALUE_CHANGED,
+                TABLE_2, ConflictHandler.RETRY_ON_VALUE_CHANGED,
+                TABLE_3, ConflictHandler.IGNORE_ALL),
+                manager.get());
+
+        manager.removeConflictDetectionMode(TABLE_1);
+
+        Assert.assertEquals(ImmutableMap.of(
+                TABLE_1, ConflictHandler.IGNORE_ALL,
+                TABLE_2, ConflictHandler.RETRY_ON_VALUE_CHANGED,
+                TABLE_3, ConflictHandler.IGNORE_ALL),
+                manager.get());
+    }
+
+    @Test
+    public void testIsEmptyOrContainsTable() {
+        map.put(TABLE_1, ConflictHandler.IGNORE_ALL);
+        map.put(TABLE_3, ConflictHandler.IGNORE_ALL);
+
+        manager.setConflictDetectionMode(TABLE_1, ConflictHandler.RETRY_ON_VALUE_CHANGED);
+        manager.setConflictDetectionMode(TABLE_2, ConflictHandler.RETRY_ON_VALUE_CHANGED);
+
+        int startCount = callCount.get();
+        Assert.assertTrue(manager.isEmptyOrContainsTable(TABLE_1));
+        Assert.assertTrue(manager.isEmptyOrContainsTable(TABLE_2));
+        Assert.assertTrue(manager.isEmptyOrContainsTable(TABLE_3));
+        Assert.assertFalse(manager.isEmptyOrContainsTable(TABLE_4));
+        Assert.assertEquals(startCount, callCount.get());
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.atlasdb.transaction.impl;
 
 import java.util.HashMap;


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

ConflictDetectionManager previously didn't handle lots of tables well.
Every call to get() would involve creating a new copy of the
table->conflict handler map, and get() is called once for every
SerializableTransaction#get().

This refactors the class so that a new map copy is only created on config
modification, and calls to get() return a precomputed ImmutableMap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/640)
<!-- Reviewable:end -->
