### PR TITLE
gentler cassandra connection pooling

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -21,11 +21,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.TreeMap;
 
 import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.cassandra.thrift.TokenRange;
+import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.transport.TTransportException;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -132,6 +134,13 @@ public class CassandraClientPoolTest {
         Assert.assertTrue(CassandraClientPool.isRetriableException(new TimedOutException()));
         Assert.assertTrue(CassandraClientPool.isRetriableException(new TTransportException()));
         Assert.assertTrue(CassandraClientPool.isRetriableException(new TTransportException(new SocketTimeoutException())));
+    }
+
+    @Test
+    public void testIsRetriableWithBackoffException() {
+        Assert.assertTrue(CassandraClientPool.isRetriableWithBackoffException(new NoSuchElementException()));
+        Assert.assertTrue(CassandraClientPool.isRetriableWithBackoffException(new UnavailableException()));
+        Assert.assertTrue(CassandraClientPool.isRetriableWithBackoffException(new TTransportException(new UnavailableException())));
     }
 
     @Test

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -419,11 +419,12 @@ public class CassandraClientPool {
 
     public <V, K extends Exception> V runWithRetryOnHost(InetSocketAddress specifiedHost, FunctionCheckedException<Cassandra.Client, V, K> f) throws K {
         int numTries = 0;
+        boolean shouldRetryOnDifferentHost = false;
         while (true) {
             CassandraClientPoolingContainer hostPool = currentPools.get(specifiedHost);
 
-            if (blacklistedHosts.containsKey(specifiedHost) || hostPool == null) {
-                log.warn("Randomly redirected a query intended for host {} because it was not currently a live member of the pool.", specifiedHost);
+            if (blacklistedHosts.containsKey(specifiedHost) || hostPool == null || shouldRetryOnDifferentHost) {
+                log.warn("Randomly redirected a query intended for host {}.", specifiedHost);
                 hostPool = getRandomGoodHost();
             }
 
@@ -432,6 +433,17 @@ public class CassandraClientPool {
             } catch (Exception e) {
                 numTries++;
                 this.<K>handleException(numTries, hostPool.getHost(), e);
+                if (isRetriableWithBackoffException(e)) {
+                    log.warn("Retrying with backoff a query intended for host {}.", hostPool.getHost(), e);
+                    try {
+                        Thread.sleep(numTries * 1000);
+                    } catch (InterruptedException i) {
+                        throw new RuntimeException(i);
+                    }
+                    if (numTries >= MAX_TRIES_SAME_HOST) {
+                        shouldRetryOnDifferentHost = true;
+                    }
+                }
             }
         }
     }
@@ -448,7 +460,7 @@ public class CassandraClientPool {
 
         @SuppressWarnings("unchecked")
     private <K extends Exception> void handleException(int numTries, InetSocketAddress host, Exception e) throws K {
-        if (isRetriableException(e)) {
+        if (isRetriableException(e) || isRetriableWithBackoffException(e)) {
             if (numTries >= MAX_TRIES_TOTAL) {
                 if (e instanceof TTransportException
                         && e.getCause() != null
@@ -535,8 +547,6 @@ public class CassandraClientPool {
         return t != null
                 && (t instanceof SocketTimeoutException
                 || t instanceof ClientCreationFailedException
-                || t instanceof UnavailableException
-                || t instanceof NoSuchElementException
                 || isConnectionException(t.getCause()));
     }
 
@@ -548,6 +558,14 @@ public class CassandraClientPool {
                 || t instanceof InsufficientConsistencyException
                 || isConnectionException(t)
                 || isRetriableException(t.getCause()));
+    }
+
+    @VisibleForTesting
+    static boolean isRetriableWithBackoffException(Throwable t) {
+        return t != null
+                && (t instanceof NoSuchElementException // pool for this node is fully in use
+                || t instanceof UnavailableException // remote cassandra node couldn't talk to enough other remote cassandra nodes to answer
+                || isRetriableWithBackoffException(t.getCause()));
     }
 
     final FunctionCheckedException<Cassandra.Client, Void, Exception> validatePartitioner = new FunctionCheckedException<Cassandra.Client, Void, Exception>() {


### PR DESCRIPTION
major changes:
- Fixes QA-94816, also see #388 for something related/public.
  The gist is that it's complicated whether or not you want to
  blacklist nodes that threw UnavailableExceptions

- Much gentler idle connection eviction logic;

     - gently takes pool down to min size over a few minutes.
       previously the 1 minute timeout was too low and people
       routinely re-opened the connections we just idled out.

     - adds in some randomness so that eviction of
       different hosts' pools happen at different times; instead
       of having a massive event every minute where hundreds of
       connections are closed all at once, they now happen
       gradually all the time.

- documentation for how it all fits together

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/667)
<!-- Reviewable:end -->
