### PR TITLE
Bump Cassandra server tested against and cassandra-all objects from 2.2.1 to 2.2.7

### DIFF
--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -36,6 +36,7 @@ dependencies {
         exclude(module:'hibernate-validator')
         exclude(module:'libthrift')
         exclude(module:'commons-cli')
+        exclude(module:'jna')
     }
 
     compile 'org.apache.thrift:libthrift:' + libVersions.libthrift

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ task clean(type: Delete) {
     delete buildDir
 }
 
+subprojects {
+  task allDeps(type: DependencyReportTask) {}
+}
+
 apply from: 'idea.gradle'
 
 def ideaSetModuleLevel(idea, targetCompatibility) {

--- a/docker-containers/cassandra/Dockerfile
+++ b/docker-containers/cassandra/Dockerfile
@@ -1,4 +1,4 @@
-FROM cassandra:2.2.6
+FROM cassandra:2.2.7
 
 ENV CASSANDRA_CONFIG /etc/cassandra
 ENV CASSANDRA_YAML $CASSANDRA_CONFIG/cassandra.yaml

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -40,6 +40,10 @@ v0.11.0
          - A utility method was removed in the previous release, breaking an internal product that relied on it. This method has now been added back.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/661>`__)
 
+    *    - |changed|
+         - Updated our cassandra client from 2.2.1 to 2.2.7 (this corresponds to a bump of our cassandra docker testing version from 2.2.6 to 2.2.7).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/699>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -34,6 +34,7 @@ dependencies {
 
 configurations.matching({ it.name in ['compile', 'runtime'] }).all {
     resolutionStrategy {
+            force 'net.java.dev.jna:jna:' + libVersions.jna
             force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
             force 'org.slf4j:slf4j-api:' + libVersions.slf4j
         }

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -32,6 +32,13 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: libVersions.junit
 }
 
+configurations.matching({ it.name in ['compile', 'runtime'] }).all {
+    resolutionStrategy {
+            force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
+            force 'org.slf4j:slf4j-api:' + libVersions.slf4j
+        }
+}
+
 apply from: rootProject.file('gradle/javadoc.gradle'), to: javadoc
 
 license {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -2,6 +2,7 @@ ext.libVersions =
   [
     guava:   '18.0',
     slf4j:   '1.7.5',
+    jna:     '4.1.0',
     jsr305:  '1.3.9',
     junit:   '4.12',
     jmock:   '2.8.2',

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -17,7 +17,7 @@ ext.libVersions =
     immutables: '2.2.8',
     jackson: '2.5.1',
     jackson_annotation: '2.5.0',
-    cassandra: '2.2.1',
+    cassandra: '2.2.7',
     cassandra_driver_core: '2.2.0-rc3',
     groovy: '2.4.4',
     hamcrest: '1.3',


### PR DESCRIPTION
[ ] verify this bump does not require a C* upgrade from 2.2.1 to 2.2.7.  If it does it will require a more coordinated roll out.

I would also like input on the exclusion of jna.  The dep collision I had was between 4.0.0 and 4.1.0 but after excluding it I did not find a jna dependency in the atlasdb-ete-tests:dependencies which I find odd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/699)
<!-- Reviewable:end -->
