### PR TITLE
Fix/hikari config for dbkvs

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -125,6 +125,7 @@ public abstract class ConnectionConfig {
         config.setLeakDetectionThreshold(getUnreturnedConnectionTimeout());
         // Not a bug - we don't want to use connectionTimeout here, since Hikari uses a different terminology.
         // See https://github.com/brettwooldridge/HikariCP/wiki/Configuration - connectionTimeout = how long to wait for a connection to be opened.
+        // ConnectionConfig.connectionTimeoutSeconds is passed in via getHikariProperties(), in subclasses.
         config.setConnectionTimeout(getCheckoutTimeout());
 
         // TODO: See if driver supports JDBC4 (isValid()) and use it.

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -123,7 +123,9 @@ public abstract class ConnectionConfig {
         config.setMaxLifetime(TimeUnit.SECONDS.toMillis(getMaxConnectionAge()));
         config.setIdleTimeout(TimeUnit.SECONDS.toMillis(getMaxIdleTime()));
         config.setLeakDetectionThreshold(getUnreturnedConnectionTimeout());
-        config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(getConnectionTimeoutSeconds()));
+        // Not a bug - we don't want to use connectionTimeout here, since Hikari uses a different terminology.
+        // See https://github.com/brettwooldridge/HikariCP/wiki/Configuration - connectionTimeout = how long to wait for a connection to be opened.
+        config.setConnectionTimeout(getCheckoutTimeout());
 
         // TODO: See if driver supports JDBC4 (isValid()) and use it.
         config.setConnectionTestQuery(getTestQuery());

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -123,7 +123,7 @@ public abstract class ConnectionConfig {
         config.setMaxLifetime(TimeUnit.SECONDS.toMillis(getMaxConnectionAge()));
         config.setIdleTimeout(TimeUnit.SECONDS.toMillis(getMaxIdleTime()));
         config.setLeakDetectionThreshold(getUnreturnedConnectionTimeout());
-        config.setConnectionTimeout(getCheckoutTimeout());
+        config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(getConnectionTimeoutSeconds()));
 
         // TODO: See if driver supports JDBC4 (isValid()) and use it.
         config.setConnectionTestQuery(getTestQuery());

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
@@ -15,16 +15,49 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import java.io.File;
 import java.io.IOException;
 
 import org.junit.Test;
 
+import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
+import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.nexus.db.pool.config.ConnectionConfig;
+import com.zaxxer.hikari.HikariConfig;
 
 public class TestConfigLoading {
     @Test
     public void testLoadingConfig() throws IOException {
         AtlasDbConfigs.load(new File(getClass().getClassLoader().getResource("postgresTestConfig.yml").getFile()));
+    }
+
+    @Test
+    public void testHikariDefaults() throws IOException {
+        AtlasDbConfig config = AtlasDbConfigs.load(new File(getClass().getClassLoader().getResource("postgresTestConfig.yml").getFile()));
+        KeyValueServiceConfig keyValueServiceConfig = config.keyValueService();
+        DbKeyValueServiceConfig dbkvsConfig = (DbKeyValueServiceConfig) keyValueServiceConfig;
+        ConnectionConfig connectionConfig = dbkvsConfig.connection();
+        HikariConfig hikariConfig = connectionConfig.getHikariConfig();
+
+        // TODO
+//        assertThat(
+//                "Hikari socket timeout should be populated from connectionConfig",
+//                hikariConfig.getConnectionTimeout(),
+//                is(connectionConfig.getConnectionTimeoutSeconds() * 1000));
+
+        assertThat(
+                "Hikari connection timeout should be populated from connectionConfig",
+                hikariConfig.getConnectionTimeout(),
+                is(connectionConfig.getConnectionTimeoutSeconds() * 1000L));
+
+//        assertThat(
+//                "Hikari login timeout should be populated from connectionConfig",
+//                hikariConfig.getConnectionTimeout(),
+//                is(connectionConfig.getConnectionTimeoutSeconds() * 1000));
     }
 }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -29,10 +28,7 @@ import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
-import com.palantir.nexus.db.pool.HikariCPConnectionManager;
 import com.palantir.nexus.db.pool.config.ConnectionConfig;
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 
 public class TestConfigLoading {
     @Test
@@ -58,17 +54,6 @@ public class TestConfigLoading {
         verifyHikariProperty(connectionConfig, "loginTimeout", connectionConfig.getConnectionTimeoutSeconds());
     }
 
-    @Test
-    public void testHikariProperties() throws IOException, SQLException {
-        ConnectionConfig connectionConfig = getConnectionConfig();
-        HikariCPConnectionManager manager = new HikariCPConnectionManager(connectionConfig);
-
-        HikariConfig hikariConfig = connectionConfig.getHikariConfig();
-        HikariDataSource dataSource = new HikariDataSource(hikariConfig);
-        int loginTimeout = dataSource.getLoginTimeout();
-        assertThat(loginTimeout, is(connectionConfig.getConnectionTimeoutSeconds()));
-    }
-
     private ConnectionConfig getConnectionConfig() throws IOException {
         AtlasDbConfig config = AtlasDbConfigs.load(new File(getClass().getClassLoader().getResource("postgresTestConfig.yml").getFile()));
         KeyValueServiceConfig keyValueServiceConfig = config.keyValueService();
@@ -82,6 +67,6 @@ public class TestConfigLoading {
         assertThat(
                 String.format("Hikari property %s should be populated from connectionConfig", property),
                 Integer.valueOf(hikariProps.getProperty(property)),
-                is(expectedValueSeconds * 1000));
+                is(expectedValueSeconds));
     }
 }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
@@ -43,9 +43,17 @@ public class TestConfigLoading {
     }
 
     @Test
-    public void testHikariConnectionTimeout() throws IOException {
+    public void testHikariConnectTimeout() throws IOException {
         ConnectionConfig connectionConfig = getConnectionConfig();
         verifyHikariProperty(connectionConfig, "connectTimeout", connectionConfig.getConnectionTimeoutSeconds());
+    }
+
+    @Test
+    public void testHikariConnectionTimeout() throws IOException {
+        // Hikari uses "connectionTimeout" for how long the client will wait for a connection from the pool. In our parlance, this is checkoutTimeout
+        // Our connectionTimeout is instead translated to "connectTimeout", which is how long a connection can be open for.
+        ConnectionConfig connectionConfig = getConnectionConfig();
+        assertThat(connectionConfig.getHikariConfig().getConnectionTimeout(), is((long) connectionConfig.getCheckoutTimeout()));
     }
 
     @Test

--- a/atlasdb-dbkvs/src/test/resources/postgresTestConfig.yml
+++ b/atlasdb-dbkvs/src/test/resources/postgresTestConfig.yml
@@ -10,3 +10,5 @@ atlasdb:
       dbName: test
       dbLogin: test
       dbPassword: test
+      connectionTimeoutSeconds: 5
+      socketTimeoutSeconds: 30


### PR DESCRIPTION
Added tests for various Hikari configurations. These options were not being passed through to Hikari by AtlasDB 0.8.0, but were working on develop.

This closes #675.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/707)
<!-- Reviewable:end -->
