### PR TITLE
Improve Cassandra KVS thread naming

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -5,6 +5,7 @@ apply from: "../gradle/shared.gradle"
 dependencies {
   compile project(":atlasdb-client")
   compile project(":atlasdb-api")
+  compile project(":commons-api")
   compile project(':timestamp-impl')
 
   compile('org.apache.cassandra:cassandra-all:' + libVersions.cassandra) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -17,8 +17,8 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -76,7 +76,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         final String origName = Thread.currentThread().getName();
         Thread.currentThread().setName(origName
                 + " calling cassandra host " + host
-                + " started at " + new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(new Date())
+                + " started at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now())
                 + " - " + count.getAndIncrement());
         try {
             return runWithGoodResource(f);


### PR DESCRIPTION
Use ThreadNamingCallable for parallel tasks in C*KVS
Use lambdas where possible for C*KVS tasks
Avoid instantiating SimpleDateFormat during task execution

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/712)
<!-- Reviewable:end -->
