### PR TITLE
Feature/schema lock mutation extras

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
@@ -24,35 +24,33 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 public class HiddenTablesTest {
-    private final HiddenTables hiddenTables = new HiddenTables();
-
     @Test public void
     shouldSayTimestampIsHidden() {
-        assertThat(hiddenTables.isHidden(AtlasDbConstants.TIMESTAMP_TABLE), is(true));
+        assertThat(HiddenTables.isHidden(AtlasDbConstants.TIMESTAMP_TABLE), is(true));
     }
 
     @Test public void
     shouldSayMetadataIsHidden() {
-        assertThat(hiddenTables.isHidden(AtlasDbConstants.METADATA_TABLE), is(true));
+        assertThat(HiddenTables.isHidden(AtlasDbConstants.METADATA_TABLE), is(true));
     }
 
     @Test public void
     shouldSayAnOldStyleLocksTableIsHidden() {
-        assertThat(hiddenTables.isHidden(TableReference.createUnsafe("_locks")), is(true));
+        assertThat(HiddenTables.isHidden(TableReference.createUnsafe("_locks")), is(true));
     }
 
     @Test public void
     shouldSayANewStyleLocksTableIsHidden() {
-        assertThat(hiddenTables.isHidden(TableReference.createUnsafe("_locks_aaaa_123")), is(true));
+        assertThat(HiddenTables.isHidden(TableReference.createUnsafe("_locks_aaaa_123")), is(true));
     }
 
     @Test public void
     shouldSayANamespacedTableIsNotHidden() {
-        assertThat(hiddenTables.isHidden(TableReference.createFromFullyQualifiedName("namespace.table")), is(false));
+        assertThat(HiddenTables.isHidden(TableReference.createFromFullyQualifiedName("namespace.table")), is(false));
     }
 
     @Test public void
     shouldSayANonNamespacedVisibleTableIsNotHidden() {
-        assertThat(hiddenTables.isHidden(TableReference.createWithEmptyNamespace("table")), is(false));
+        assertThat(HiddenTables.isHidden(TableReference.createWithEmptyNamespace("table")), is(false));
     }
 }

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
@@ -24,33 +24,35 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 public class HiddenTablesTest {
+    private final HiddenTables hiddenTables = new HiddenTables();
+
     @Test public void
     shouldSayTimestampIsHidden() {
-        assertThat(HiddenTables.isHidden(AtlasDbConstants.TIMESTAMP_TABLE), is(true));
+        assertThat(hiddenTables.isHidden(AtlasDbConstants.TIMESTAMP_TABLE), is(true));
     }
 
     @Test public void
     shouldSayMetadataIsHidden() {
-        assertThat(HiddenTables.isHidden(AtlasDbConstants.METADATA_TABLE), is(true));
+        assertThat(hiddenTables.isHidden(AtlasDbConstants.METADATA_TABLE), is(true));
     }
 
     @Test public void
     shouldSayAnOldStyleLocksTableIsHidden() {
-        assertThat(HiddenTables.isHidden(TableReference.createUnsafe("_locks")), is(true));
+        assertThat(hiddenTables.isHidden(TableReference.createUnsafe("_locks")), is(true));
     }
 
     @Test public void
     shouldSayANewStyleLocksTableIsHidden() {
-        assertThat(HiddenTables.isHidden(TableReference.createUnsafe("_locks_aaaa_123")), is(true));
+        assertThat(hiddenTables.isHidden(TableReference.createUnsafe("_locks_aaaa_123")), is(true));
     }
 
     @Test public void
     shouldSayANamespacedTableIsNotHidden() {
-        assertThat(HiddenTables.isHidden(TableReference.createFromFullyQualifiedName("namespace.table")), is(false));
+        assertThat(hiddenTables.isHidden(TableReference.createFromFullyQualifiedName("namespace.table")), is(false));
     }
 
     @Test public void
     shouldSayANonNamespacedVisibleTableIsNotHidden() {
-        assertThat(HiddenTables.isHidden(TableReference.createWithEmptyNamespace("table")), is(false));
+        assertThat(hiddenTables.isHidden(TableReference.createWithEmptyNamespace("table")), is(false));
     }
 }

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
@@ -41,8 +41,8 @@ public class UniqueSchemaMutationLockTableTest {
 
     private UniqueSchemaMutationLockTable uniqueLockTable;
     private SchemaMutationLockTables lockTables;
-    private TableReference lockTable1 = TableReference.createWithEmptyNamespace(HiddenTables.LOCK_TABLE_PREFIX + UUID.randomUUID());
-    private TableReference lockTable2 = TableReference.createWithEmptyNamespace(HiddenTables.LOCK_TABLE_PREFIX + UUID.randomUUID());
+    private TableReference lockTable1 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + UUID.randomUUID());
+    private TableReference lockTable2 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + UUID.randomUUID());
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
@@ -41,8 +41,8 @@ public class UniqueSchemaMutationLockTableTest {
 
     private UniqueSchemaMutationLockTable uniqueLockTable;
     private SchemaMutationLockTables lockTables;
-    private TableReference lockTable1 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + UUID.randomUUID());
-    private TableReference lockTable2 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + UUID.randomUUID());
+    private TableReference lockTable1 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + "_" + UUID.randomUUID());
+    private TableReference lockTable2 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + "_" + UUID.randomUUID());
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
@@ -53,7 +53,6 @@ public class UniqueSchemaMutationLockTableTest {
         uniqueLockTable = new UniqueSchemaMutationLockTable(lockTables, LockLeader.I_AM_THE_LOCK_LEADER);
     }
 
-
     @Test
     public void shouldReturnALockTableIfNoneExist() throws TException {
         when(lockTables.getAllLockTables()).thenReturn(Collections.EMPTY_SET, ImmutableSet.of(lockTable1));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -150,7 +150,6 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     private SchemaMutationLock schemaMutationLock;
     private final Optional<LeaderConfig> leaderConfig;
 
-    private final HiddenTables hiddenTables;
     private final UniqueSchemaMutationLockTable schemaMutationLockTable;
 
     private ConsistencyLevel readConsistency = ConsistencyLevel.LOCAL_QUORUM;
@@ -173,7 +172,6 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         this.clientPool = new CassandraClientPool(configManager.getConfig());
         this.compactionManager = compactionManager;
         this.leaderConfig = leaderConfig;
-        this.hiddenTables = new HiddenTables();
 
         SchemaMutationLockTables lockTables = new SchemaMutationLockTables(clientPool, configManager.getConfig());
         this.schemaMutationLockTable = new UniqueSchemaMutationLockTable(lockTables, whoIsTheLockCreator());
@@ -1383,7 +1381,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     @Override
     public Set<TableReference> getAllTableNames() {
-        return Sets.filter(getAllTablenamesInternal(), tr -> !hiddenTables.isHidden(tr));
+        return Sets.filter(getAllTablenamesInternal(), tr -> !HiddenTables.isHidden(tr));
     }
 
     private Set<TableReference> getAllTablenamesInternal() {
@@ -1446,7 +1444,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     } else {
                         contents = value.getContents();
                     }
-                    if (!hiddenTables.isHidden(tableRef)) {
+                    if (!HiddenTables.isHidden(tableRef)) {
                         tableToMetadataContents.put(tableRef, contents);
                     }
                 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -149,6 +149,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     protected final CassandraClientPool clientPool;
     private SchemaMutationLock schemaMutationLock;
     private final Optional<LeaderConfig> leaderConfig;
+    private final HiddenTables hiddenTables;
 
     private final UniqueSchemaMutationLockTable schemaMutationLockTable;
 
@@ -172,6 +173,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         this.clientPool = new CassandraClientPool(configManager.getConfig());
         this.compactionManager = compactionManager;
         this.leaderConfig = leaderConfig;
+        this.hiddenTables = new HiddenTables();
 
         SchemaMutationLockTables lockTables = new SchemaMutationLockTables(clientPool, configManager.getConfig());
         this.schemaMutationLockTable = new UniqueSchemaMutationLockTable(lockTables, whoIsTheLockCreator());
@@ -1381,7 +1383,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     @Override
     public Set<TableReference> getAllTableNames() {
-        return Sets.filter(getAllTablenamesInternal(), tr -> !HiddenTables.isHidden(tr));
+        return Sets.filter(getAllTablenamesInternal(), tr -> !hiddenTables.isHidden(tr));
     }
 
     private Set<TableReference> getAllTablenamesInternal() {
@@ -1444,7 +1446,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     } else {
                         contents = value.getContents();
                     }
-                    if (!HiddenTables.isHidden(tableRef)) {
+                    if (!hiddenTables.isHidden(tableRef)) {
                         tableToMetadataContents.put(tableRef, contents);
                     }
                 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
@@ -22,18 +22,17 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 class HiddenTables {
-    private TableReference lockTable;
-    private final Set<TableReference> hiddenTables;
-    public static final String LOCK_TABLE_PREFIX = "_locks";
+    private static final Set<TableReference> hiddenTables = ImmutableSet.of(
+            AtlasDbConstants.TIMESTAMP_TABLE,
+            AtlasDbConstants.METADATA_TABLE);
+    static final String LOCK_TABLE_PREFIX = "_locks";
 
 
-    HiddenTables() {
-        this.hiddenTables = ImmutableSet.of(
-                AtlasDbConstants.TIMESTAMP_TABLE,
-                AtlasDbConstants.METADATA_TABLE);
+    private HiddenTables() {
+        // Utility class
     }
 
-    boolean isHidden(TableReference tableReference) {
+    static boolean isHidden(TableReference tableReference) {
         return hiddenTables.contains(tableReference) || tableReference.getTablename().startsWith(LOCK_TABLE_PREFIX);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
@@ -22,17 +22,13 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 class HiddenTables {
-    private static final Set<TableReference> hiddenTables = ImmutableSet.of(
+    private static final Set<TableReference> HIDDEN_TABLES = ImmutableSet.of(
             AtlasDbConstants.TIMESTAMP_TABLE,
             AtlasDbConstants.METADATA_TABLE);
+
     static final String LOCK_TABLE_PREFIX = "_locks";
 
-
-    private HiddenTables() {
-        // Utility class
-    }
-
-    static boolean isHidden(TableReference tableReference) {
-        return hiddenTables.contains(tableReference) || tableReference.getTablename().startsWith(LOCK_TABLE_PREFIX);
+    boolean isHidden(TableReference tableReference) {
+        return HIDDEN_TABLES.contains(tableReference) || tableReference.getTablename().startsWith(LOCK_TABLE_PREFIX);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
@@ -26,9 +26,7 @@ class HiddenTables {
             AtlasDbConstants.TIMESTAMP_TABLE,
             AtlasDbConstants.METADATA_TABLE);
 
-    static final String LOCK_TABLE_PREFIX = "_locks";
-
     boolean isHidden(TableReference tableReference) {
-        return HIDDEN_TABLES.contains(tableReference) || tableReference.getTablename().startsWith(LOCK_TABLE_PREFIX);
+        return HIDDEN_TABLES.contains(tableReference) || tableReference.getTablename().startsWith(SchemaMutationLockTables.LOCK_TABLE_PREFIX);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
@@ -21,12 +21,12 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
-class HiddenTables {
+public class HiddenTables {
     private static final Set<TableReference> HIDDEN_TABLES = ImmutableSet.of(
             AtlasDbConstants.TIMESTAMP_TABLE,
             AtlasDbConstants.METADATA_TABLE);
 
-    boolean isHidden(TableReference tableReference) {
+    public boolean isHidden(TableReference tableReference) {
         return HIDDEN_TABLES.contains(tableReference) || tableReference.getTablename().startsWith(SchemaMutationLockTables.LOCK_TABLE_PREFIX);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -29,9 +29,12 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 public class SchemaMutationLockTables {
+    public static final String LOCK_TABLE_PREFIX = "_locks";
+
+    private static final Predicate<String> IS_LOCK_TABLE = table -> table.startsWith(LOCK_TABLE_PREFIX);
+
     private final CassandraClientPool clientPool;
     private final CassandraKeyValueServiceConfig config;
-    private static final Predicate<String> IS_LOCK_TABLE = table -> table.startsWith(HiddenTables.LOCK_TABLE_PREFIX);
 
     public SchemaMutationLockTables(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config) {
         this.clientPool = clientPool;
@@ -54,8 +57,8 @@ public class SchemaMutationLockTables {
         return clientPool.run(client -> createInternalLockTable(client, uuid));
     }
 
-    private final TableReference createInternalLockTable(Cassandra.Client client, UUID uuid) throws TException {
-        String lockTableName = HiddenTables.LOCK_TABLE_PREFIX + "_" + uuid.toString().replace('-','_');
+    private TableReference createInternalLockTable(Cassandra.Client client, UUID uuid) throws TException {
+        String lockTableName = LOCK_TABLE_PREFIX + "_" + uuid.toString().replace('-','_');
         TableReference lockTable = TableReference.createWithEmptyNamespace(lockTableName);
         createTableInternal(client, lockTable);
         return lockTable;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,6 +41,7 @@ v0.11.0
            This field helps us to determine a single node to create the necessary locks table for performing schema mutations without corruption. This safety will still be in place if you have no leader block.
            Changing your config to explicitly use this option is advised, but it is backwards compatible with old configurations. Please see `the cassandra configuration docs <https://palantir.github.io/atlasdb/html/configuration/cassandra_KVS_configuration.html>`__
            for details on how this works.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/594>`__)
 
     *    - |fixed|
          - A utility method was removed in the previous release, breaking an internal product that relied on it. This method has now been added back.


### PR DESCRIPTION
Made HiddenTables static as it had no behaviour (hat-tip to @hsaraogi for spotting).
Added the PR to release notes.

I tried to reproduce the _locks double-creation issue we saw on Friday, but without success - so I'm not pushing a test for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/714)
<!-- Reviewable:end -->
