### PR TITLE
Fix/timestamp table metadata

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTest.java
@@ -16,6 +16,11 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -25,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
 
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -36,6 +42,7 @@ import com.palantir.atlasdb.keyvalue.impl.AbstractAtlasDbKeyValueServiceTest;
 public class CassandraKeyValueServiceTest extends AbstractAtlasDbKeyValueServiceTest {
     private KeyValueService keyValueService;
     private ExecutorService executorService;
+    private Logger logger = mock(Logger.class);
 
     @Before
     public void setupKVS() {
@@ -51,7 +58,7 @@ public class CassandraKeyValueServiceTest extends AbstractAtlasDbKeyValueService
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG), CassandraTestSuite.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG), CassandraTestSuite.LEADER_CONFIG, logger);
     }
 
     @Override
@@ -85,4 +92,8 @@ public class CassandraKeyValueServiceTest extends AbstractAtlasDbKeyValueService
         Preconditions.checkArgument(!allTables.contains(table3));
     }
 
+    @Test
+    public void shouldNotErrorForTimestampTableWhenCreatingCassandraKVS() throws Exception {
+        verify(logger, never()).error(startsWith("Found a table " + AtlasDbConstants.TIMESTAMP_TABLE));
+    }
 }

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampTest.java
@@ -38,6 +38,7 @@ public class CassandraTimestampTest {
 
     @After
     public void tearDown() {
+        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
         kv.teardown();
     }
 

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampTest.java
@@ -38,7 +38,6 @@ public class CassandraTimestampTest {
 
     @After
     public void tearDown() {
-        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
         kv.teardown();
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -58,7 +60,7 @@ public class CassandraExpiringKeyValueService extends CassandraKeyValueService i
     protected CassandraExpiringKeyValueService(CassandraKeyValueServiceConfigManager configManager,
                                                Optional<CassandraJmxCompactionManager> compactionManager,
                                                Optional<LeaderConfig> leaderConfig) {
-        super(configManager, compactionManager, leaderConfig);
+        super(LoggerFactory.getLogger(CassandraKeyValueService.class), configManager, compactionManager, leaderConfig);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -158,7 +158,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     private final ConsistencyLevel deleteConsistency = ConsistencyLevel.ALL;
 
     public static CassandraKeyValueService create(CassandraKeyValueServiceConfigManager configManager, Optional<LeaderConfig> leaderConfig) {
-        return create(configManager,leaderConfig, LoggerFactory.getLogger(CassandraKeyValueService.class));
+        return create(configManager, leaderConfig, LoggerFactory.getLogger(CassandraKeyValueService.class));
     }
 
     public static CassandraKeyValueService create(CassandraKeyValueServiceConfigManager configManager, Optional<LeaderConfig> leaderConfig, Logger log) {
@@ -168,7 +168,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         return ret;
     }
 
-    protected CassandraKeyValueService(Logger log, CassandraKeyValueServiceConfigManager configManager,
+    protected CassandraKeyValueService(Logger log,
+                                       CassandraKeyValueServiceConfigManager configManager,
                                        Optional<CassandraJmxCompactionManager> compactionManager,
                                        Optional<LeaderConfig> leaderConfig) {
         super(AbstractKeyValueService.createFixedThreadPool("Atlas Cassandra KVS",

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -135,7 +135,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
  */
 public class CassandraKeyValueService extends AbstractKeyValueService {
 
-    static final Logger log = LoggerFactory.getLogger(CassandraKeyValueService.class);
+    private final Logger log;
 
     private static final Function<Entry<Cell, Value>, Long> ENTRY_SIZING_FUNCTION = new Function<Entry<Cell, Value>, Long>() {
         @Override
@@ -158,17 +158,22 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     private final ConsistencyLevel deleteConsistency = ConsistencyLevel.ALL;
 
     public static CassandraKeyValueService create(CassandraKeyValueServiceConfigManager configManager, Optional<LeaderConfig> leaderConfig) {
+        return create(configManager,leaderConfig, LoggerFactory.getLogger(CassandraKeyValueService.class));
+    }
+
+    public static CassandraKeyValueService create(CassandraKeyValueServiceConfigManager configManager, Optional<LeaderConfig> leaderConfig, Logger log) {
         Optional<CassandraJmxCompactionManager> compactionManager = CassandraJmxCompaction.createJmxCompactionManager(configManager);
-        CassandraKeyValueService ret = new CassandraKeyValueService(configManager, compactionManager, leaderConfig);
+        CassandraKeyValueService ret = new CassandraKeyValueService(log, configManager, compactionManager, leaderConfig);
         ret.init();
         return ret;
     }
 
-    protected CassandraKeyValueService(CassandraKeyValueServiceConfigManager configManager,
+    protected CassandraKeyValueService(Logger log, CassandraKeyValueServiceConfigManager configManager,
                                        Optional<CassandraJmxCompactionManager> compactionManager,
                                        Optional<LeaderConfig> leaderConfig) {
         super(AbstractKeyValueService.createFixedThreadPool("Atlas Cassandra KVS",
                 configManager.getConfig().poolSize() * configManager.getConfig().servers().size()));
+        this.log = log;
         this.configManager = configManager;
         this.clientPool = new CassandraClientPool(configManager.getConfig());
         this.compactionManager = compactionManager;
@@ -224,7 +229,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         log.warn("Upgrading table {} to new internal Cassandra schema", tableRef);
                         tablesToUpgrade.put(tableRef, clusterSideMetadata);
                     }
-                } else if (!(tableRef.equals(AtlasDbConstants.METADATA_TABLE) || tableRef.equals(schemaMutationLockTable.getOnlyTable()))) { // only expected cases
+                } else if (!hiddenTables.isHidden(tableRef)) {
                     // Possible to get here from a race condition with another service starting up and performing schema upgrades concurrent with us doing this check
                     log.error("Found a table " + tableRef.getQualifiedName() + " that did not have persisted Atlas metadata. "
                             + "If you recently did a Palantir update, try waiting until schema upgrades are completed on all backend CLIs/services etc and restarting this service. "

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -46,6 +46,10 @@ v0.11.0
          - A utility method was removed in the previous release, breaking an internal product that relied on it. This method has now been added back.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/661>`__)
 
+    *    - |fixed|
+         - Remove unnecessary error message for missing _timestamp metadata table.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/716>`__)
+
     *    - |changed|
          - Updated our cassandra client from 2.2.1 to 2.2.7 (this corresponds to a bump of our cassandra docker testing version from 2.2.6 to 2.2.7).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/699>`__)


### PR DESCRIPTION
Fixes #636 

`getAllMetadataTables()` ignores all hidden tables, but the missing metadata error message was there for the `_timestamp` table. Now, we do not print such error messages for any hidden tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/716)
<!-- Reviewable:end -->
