### PR TITLE
Extra/encapsulate lock table name generation

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesTest.java
@@ -52,21 +52,21 @@ public class SchemaMutationLockTablesTest {
 
     @Test
     public void tableShouldExistAfterCreation() throws Exception {
-        lockTables.createLockTable(UUID.randomUUID());
+        lockTables.createLockTable();
         assertThat(lockTables.getAllLockTables(), hasSize(1));
     }
 
     @Test
     public void multipleLockTablesExistAfterCreation() throws Exception {
-        lockTables.createLockTable(UUID.randomUUID());
-        lockTables.createLockTable(UUID.randomUUID());
+        lockTables.createLockTable();
+        lockTables.createLockTable();
         assertThat(lockTables.getAllLockTables(), hasSize(2));
     }
 
     @Test
     public void multipleSchemaMutationLockTablesObjectsShouldReturnSameLockTables() throws Exception {
         SchemaMutationLockTables lockTables2 = new SchemaMutationLockTables(clientPool, config);
-        lockTables.createLockTable(UUID.randomUUID());
+        lockTables.createLockTable();
         assertThat(lockTables.getAllLockTables(), is(lockTables2.getAllLockTables()));
     }
 

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
@@ -56,7 +56,7 @@ public class UniqueSchemaMutationLockTableTest {
     @Test
     public void shouldReturnALockTableIfNoneExist() throws TException {
         when(lockTables.getAllLockTables()).thenReturn(Collections.EMPTY_SET, ImmutableSet.of(lockTable1));
-        when(lockTables.createLockTable(any(UUID.class))).thenReturn(lockTable1);
+        when(lockTables.createLockTable()).thenReturn(lockTable1);
 
         assertThat(uniqueLockTable.getOnlyTable(), is(lockTable1));
     }
@@ -74,7 +74,7 @@ public class UniqueSchemaMutationLockTableTest {
 
         uniqueLockTable.getOnlyTable();
 
-        verify(lockTables, never()).createLockTable(any(UUID.class));
+        verify(lockTables, never()).createLockTable();
     }
 
     @Test
@@ -94,7 +94,7 @@ public class UniqueSchemaMutationLockTableTest {
         try {
             uniqueLockTable.getOnlyTable();
         } finally {
-            verify(lockTables, never()).createLockTable(any(UUID.class));
+            verify(lockTables, never()).createLockTable();
         }
     }
 
@@ -108,7 +108,7 @@ public class UniqueSchemaMutationLockTableTest {
         try {
             uniqueLockTable.getOnlyTable();
         } finally {
-            verify(lockTables).createLockTable(any(UUID.class));
+            verify(lockTables).createLockTable();
         }
     }
 
@@ -120,7 +120,7 @@ public class UniqueSchemaMutationLockTableTest {
 
         uniqueLockTable.getOnlyTable();
 
-        verify(lockTables, never()).createLockTable(any(UUID.class));
+        verify(lockTables, never()).createLockTable();
     }
 
     @Test
@@ -137,7 +137,7 @@ public class UniqueSchemaMutationLockTableTest {
 
     @Test(expected = RuntimeException.class)
     public void shouldWrapThriftExceptions() throws TException {
-        when(lockTables.createLockTable(any(UUID.class))).thenThrow(TException.class);
+        when(lockTables.createLockTable()).thenThrow(TException.class);
 
         uniqueLockTable.getOnlyTable();
     }

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTableTest.java
@@ -18,14 +18,12 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.UUID;
 
 import org.apache.thrift.TException;
 import org.junit.Before;
@@ -41,8 +39,8 @@ public class UniqueSchemaMutationLockTableTest {
 
     private UniqueSchemaMutationLockTable uniqueLockTable;
     private SchemaMutationLockTables lockTables;
-    private TableReference lockTable1 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + UUID.randomUUID());
-    private TableReference lockTable2 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + UUID.randomUUID());
+    private TableReference lockTable1 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + "_1");
+    private TableReference lockTable2 = TableReference.createWithEmptyNamespace(SchemaMutationLockTables.LOCK_TABLE_PREFIX + "_2");
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -25,6 +25,7 @@ import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.thrift.TException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
@@ -53,7 +54,12 @@ public class SchemaMutationLockTables {
                 .collect(Collectors.toSet());
     }
 
-    public TableReference createLockTable(UUID uuid) throws TException {
+    public TableReference createLockTable() throws TException {
+        return createLockTable(UUID.randomUUID());
+    }
+
+    @VisibleForTesting
+    protected TableReference createLockTable(UUID uuid) throws TException {
         return clientPool.run(client -> createInternalLockTable(client, uuid));
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -25,7 +25,6 @@ import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.thrift.TException;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
@@ -58,11 +57,6 @@ public class SchemaMutationLockTables {
         return clientPool.run(this::createLockTable);
     }
 
-    @VisibleForTesting
-    protected TableReference createLockTable(UUID uuid) throws TException {
-        return clientPool.run(client -> createInternalLockTable(client, uuid));
-    }
-
     private TableReference createLockTable(Cassandra.Client client) throws TException {
         String lockTableName = LOCK_TABLE_PREFIX + "_" + getUniqueSuffix();
         TableReference lockTable = TableReference.createWithEmptyNamespace(lockTableName);
@@ -71,14 +65,8 @@ public class SchemaMutationLockTables {
     }
 
     private String getUniqueSuffix() {
+        // We replace '-' with '_' as hyphens are forbidden in Cassandra table names.
         return UUID.randomUUID().toString().replace('-','_');
-    }
-
-    private TableReference createInternalLockTable(Cassandra.Client client, UUID uuid) throws TException {
-        String lockTableName = LOCK_TABLE_PREFIX + "_" + uuid.toString().replace('-','_');
-        TableReference lockTable = TableReference.createWithEmptyNamespace(lockTableName);
-        createTableInternal(client, lockTable);
-        return lockTable;
     }
 
     private void createTableInternal(Cassandra.Client client, TableReference tableRef) throws TException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -55,12 +55,23 @@ public class SchemaMutationLockTables {
     }
 
     public TableReference createLockTable() throws TException {
-        return createLockTable(UUID.randomUUID());
+        return clientPool.run(this::createLockTable);
     }
 
     @VisibleForTesting
     protected TableReference createLockTable(UUID uuid) throws TException {
         return clientPool.run(client -> createInternalLockTable(client, uuid));
+    }
+
+    private TableReference createLockTable(Cassandra.Client client) throws TException {
+        String lockTableName = LOCK_TABLE_PREFIX + "_" + getUniqueSuffix();
+        TableReference lockTable = TableReference.createWithEmptyNamespace(lockTableName);
+        createTableInternal(client, lockTable);
+        return lockTable;
+    }
+
+    private String getUniqueSuffix() {
+        return UUID.randomUUID().toString().replace('-','_');
     }
 
     private TableReference createInternalLockTable(Cassandra.Client client, UUID uuid) throws TException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTable.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTable.java
@@ -19,7 +19,6 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Set;
-import java.util.UUID;
 
 import org.apache.thrift.TException;
 
@@ -64,7 +63,7 @@ public class UniqueSchemaMutationLockTable {
         return getSingleTable();
     }
 
-    private synchronized final TableReference ensureLockTableExists() throws TException {
+    private synchronized TableReference ensureLockTableExists() throws TException {
         Set<TableReference> tables = schemaMutationLockTables.getAllLockTables();
 
         if (tables.isEmpty()) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTable.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTable.java
@@ -68,7 +68,7 @@ public class UniqueSchemaMutationLockTable {
         Set<TableReference> tables = schemaMutationLockTables.getAllLockTables();
 
         if (tables.isEmpty()) {
-            schemaMutationLockTables.createLockTable(UUID.randomUUID());
+            schemaMutationLockTables.createLockTable();
         }
 
         return getSingleTable();


### PR DESCRIPTION
Do the "replace hyphen with underscore" in as few places as possible, and add an explanation where we do it of why we do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/717)
<!-- Reviewable:end -->
