### PR TITLE
upgrade postgres to 9.4.1209

### DIFF
--- a/atlasdb-timelock-server/build.gradle
+++ b/atlasdb-timelock-server/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile 'com.google.dagger:dagger:2.0.2'
 
     compile "org.rocksdb:rocksdbjni:4.1.0"
-    compile 'org.postgresql:postgresql:9.4.1208'
+    compile 'org.postgresql:postgresql:' + libVersions.postgresql
 
     compile 'org.apache.thrift:libthrift:' + libVersions.libthrift
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -34,7 +34,7 @@ ext.libVersions =
     // Severe performance regressions in 1202,3,4.
     // Severe correctness issues in 1204,5,6.
     // Update with care and caution.
-    postgresql: '9.4.1207.jre7',
+    postgresql: '9.4.1209',
 
     c3p0: '0.9.5.1',
     log4j: '1.2.17'


### PR DESCRIPTION
We are also trying to bump this dependency internally.

I still want to take another look at https://jdbc.postgresql.org/documentation/changelog.html#version_9.4.1208 and https://jdbc.postgresql.org/documentation/changelog.html#version_9.4.1209
to see if we are going to hit any breaking changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/722)
<!-- Reviewable:end -->
