### PR TITLE
Fix/guard ql statements

### DIFF
--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -366,9 +366,7 @@ public class SQLString extends BasicSQLString {
     }
 
     protected static ImmutableMap<String, FinalSQLString> getCachedUnregistered() {
-        synchronized (cacheLock) {
             return cachedUnregistered;
-        }
     }
 
     protected static void setCachedUnregistered(ImmutableMap<String, FinalSQLString> cachedUnregistered) {
@@ -378,9 +376,7 @@ public class SQLString extends BasicSQLString {
     }
 
     protected static ImmutableMap<String, FinalSQLString> getCachedKeyed() {
-        synchronized (cacheLock) {
             return cachedKeyed;
-        }
     }
 
     protected static void setCachedKeyed(ImmutableMap<String, FinalSQLString> cachedKeyed) {

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -58,10 +58,10 @@ public class SQLString extends BasicSQLString {
      * Value: the new SQLString to run instead.
      */
     @GuardedBy("cacheLock")
-    protected static volatile ImmutableMap<String, FinalSQLString> cachedUnregistered = ImmutableMap.of();
+    private static volatile ImmutableMap<String, FinalSQLString> cachedUnregistered = ImmutableMap.of();
     /** Rewritten registered queries */
     @GuardedBy("cacheLock")
-    protected static volatile ImmutableMap<String, FinalSQLString> cachedKeyed = ImmutableMap.of();
+    private static volatile ImmutableMap<String, FinalSQLString> cachedKeyed = ImmutableMap.of();
     /** All registered queries */
     protected static final ConcurrentMap<String, FinalSQLString> registeredValues = new ConcurrentHashMap<String, FinalSQLString>();
     /** DB-specific registered queries */
@@ -366,5 +366,29 @@ public class SQLString extends BasicSQLString {
 
     public static RegisteredSQLString getRegisteredQueryByKey(FinalSQLString key) {
          return new RegisteredSQLString(key.delegate);
+    }
+
+    protected static ImmutableMap<String, FinalSQLString> getCachedUnregistered() {
+        synchronized (cacheLock) {
+            return cachedUnregistered;
+        }
+    }
+
+    protected static void setCachedUnregistered(ImmutableMap<String, FinalSQLString> cachedUnregistered) {
+        synchronized (cacheLock) {
+            SQLString.cachedUnregistered = cachedUnregistered;
+        }
+    }
+
+    protected static ImmutableMap<String, FinalSQLString> getCachedKeyed() {
+        synchronized (cacheLock) {
+            return cachedKeyed;
+        }
+    }
+
+    protected static void setCachedKeyed(ImmutableMap<String, FinalSQLString> cachedKeyed) {
+        synchronized (cacheLock) {
+            SQLString.cachedKeyed = cachedKeyed;
+        }
     }
 }

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -232,7 +232,6 @@ public class SQLString extends BasicSQLString {
      * Creates an appropriate comment string for the beginning of a SQL statement
      * @param keyString Identifier for the SQL; will be null if the SQL is unregistered
      * @param dbType
-     * @param fromDB
      */
     private static String makeCommentString(String keyString, DBType dbType) {
         String registrationState;
@@ -296,9 +295,7 @@ public class SQLString extends BasicSQLString {
      * @param sqlFormat format string which takes one argument which is the
      * conjunction of clauses (from <code>clauses</code>) which modify the
      * query variant
-     * @param baseClause the filter required for all instances of the search type
      * @param type database type the search is for, null for all DBs
-     * @param keys keys for clauses that can be added to the search
      * @param clauses clauses (in the same order as their keys) which can narrow
      * the search
      */
@@ -346,7 +343,7 @@ public class SQLString extends BasicSQLString {
         /**
          * Should only be called inside SQLString because this class essentially verifies that we've
          * checked for updates.
-         * @param delegate
+         * @param sqlstring
          */
         private RegisteredSQLString(BasicSQLString sqlstring) {
             this.delegate = sqlstring;


### PR DESCRIPTION
Fixes #670.

Make the maps for the caches private to enforce safety if subclassing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/727)
<!-- Reviewable:end -->
