### PR TITLE
Move exception to debug, and add a friendlier explanation

### DIFF
--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/RetriableTransactions.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/RetriableTransactions.java
@@ -293,7 +293,8 @@ public final class RetriableTransactions {
             }
             // Great, that worked, fallthrough to below but don't commit.
         } catch (SQLException e) {
-            log.info("Failed to add/remove testId, attempting to create table...", e);
+            log.info("The table {} has not been created yet, so we will try to create it.", TABLE_NAME);
+            log.debug("To check whether the table exists we tried to use it. This caused an exception indicating that it did not exist. The exception was: ", e);
             Connection c = cm.getConnection();
             try {
                 c.createStatement().execute("CREATE TABLE " + TABLE_NAME + " (id " + varcharType + "(36) PRIMARY KEY, created TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");


### PR DESCRIPTION
Previously, `RetriableTransactions.createTxTable` used to log a scary-looking stack trace during normal operation.  This PR moves the stack trace to debug logging, and adds a clearer explanation of what is happening.  

This is a minor change, no release notes are necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/728)
<!-- Reviewable:end -->
