### PR TITLE
Add split out logs for ETE tests

### DIFF
--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -63,10 +63,10 @@ public class EteSetup {
         }
     }
 
-    protected static RuleChain setupComposition(String composeFile) {
+    protected static RuleChain setupComposition(String name, String composeFile) {
         dockerComposition = DockerComposition.of(composeFile)
                 .waitingForService("ete1", toBeReady())
-                .saveLogsTo("container-logs")
+                .saveLogsTo("container-logs/" + name)
                 .build();
 
         return RuleChain

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/todo/CassandraNoLeaderTodoEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/todo/CassandraNoLeaderTodoEteTest.java
@@ -24,7 +24,7 @@ import com.palantir.timestamp.TimestampService;
 
 public class CassandraNoLeaderTodoEteTest extends TodoEteTest {
     @ClassRule
-    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("docker-compose.no-leader.cassandra.yml");
+    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("cassandra-no-leader", "docker-compose.no-leader.cassandra.yml");
 
     @Override
     protected TimestampService createTimestampClient() {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/todo/CassandraTodoEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/todo/CassandraTodoEteTest.java
@@ -23,7 +23,7 @@ import com.palantir.timestamp.TimestampService;
 
 public class CassandraTodoEteTest extends TodoEteTest {
     @ClassRule
-    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("docker-compose.cassandra.yml");
+    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("cassandra-ha", "docker-compose.cassandra.yml");
 
     @Override
     protected TimestampService createTimestampClient() {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/todo/DbKvsTodoEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/todo/DbKvsTodoEteTest.java
@@ -23,7 +23,7 @@ import com.palantir.timestamp.TimestampService;
 
 public class DbKvsTodoEteTest extends TodoEteTest {
     @ClassRule
-    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("docker-compose.dbkvs.yml");
+    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("dbkvs", "docker-compose.dbkvs.yml");
 
     @Override
     protected TimestampService createTimestampClient() {


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

This will split out the container logs for ETE tests on the circle nodes. The straight JUnit error will still be uninformative, but all the extra information required will all be present in the artifacts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/742)
<!-- Reviewable:end -->
