### PR TITLE
ssl: false should override the presence of an SslConfiguration

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceConfigTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceConfigTest.java
@@ -1,0 +1,49 @@
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
+import com.palantir.remoting.ssl.SslConfiguration;
+
+public class CassandraKeyValueServiceConfigTest {
+    private static final InetSocketAddress SERVER_ADDRESS = InetSocketAddress.createUnresolved("localhost", 9160);
+    private static final SslConfiguration SSL_CONFIGURATION = SslConfiguration.of(Paths.get("./trustStore.jks"));
+
+    private static final ImmutableCassandraKeyValueServiceConfig CASSANDRA_CONFIG = ImmutableCassandraKeyValueServiceConfig.builder()
+            .addServers(SERVER_ADDRESS)
+            .replicationFactor(1)
+            .keyspace("atlasdb")
+            .build();
+
+
+    @Test
+    public void usingSslIfSslParamPresentAndTrue() {
+        assertTrue(CASSANDRA_CONFIG.withSsl(true).usingSsl());
+    }
+
+    @Test
+    public void notUsingSslIfSslParamPresentAndFalse() {
+        assertFalse(CASSANDRA_CONFIG.withSsl(false).usingSsl());
+    }
+
+    @Test
+    public void notUsingSslIfSslParamFalseAndSslConfigurationPresent() {
+        assertFalse(CASSANDRA_CONFIG.withSsl(false).withSslConfiguration(SSL_CONFIGURATION).usingSsl());
+    }
+
+    @Test
+    public void usingSslIfSslParamNotPresentAndSslConfigurationPresent() {
+        assertTrue(CASSANDRA_CONFIG.withSslConfiguration(SSL_CONFIGURATION).usingSsl());
+    }
+
+    @Test
+    public void notUsingSslIfSslParamNotPresentAndSslConfigurationNotPresent() {
+        assertFalse(CASSANDRA_CONFIG.usingSsl());
+    }
+}

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceConfigTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceConfigTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import static org.junit.Assert.assertFalse;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -148,7 +148,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
 
     @Value.Derived
     public boolean usingSsl() {
-        return (ssl().isPresent() && ssl().get()) || sslConfiguration().isPresent();
+        return ssl().or(sslConfiguration().isPresent());
     }
 
     @Value.Check

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -29,6 +29,24 @@ Changelog
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
+v0.11.2
+=======
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |changed|
+         - The ``ssl`` property now takes precedence over the new ``sslConfiguration`` block. This means that products
+           can add default truststore and keystore configuration to their Atlas config without overriding previously
+           made ssl decisions (setting ``ssl: false`` should cause ssl to not be used).
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
 v0.11.1
 =======
 


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

We want to add a default SslConfiguration to our internal application.
However, users may have explicitly disabled Ssl for communication with
their Cassandra, which will be broken by the presence of the new block
overriding the `ssl()` param..

Despite being deprecated, the `ssl()` param should override the presence
of an ssl config, meaning that we can apply this without being a breaking
change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/745)
<!-- Reviewable:end -->
