### PR TITLE
Passwords should not be output in generated toString() methods

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Palantir Technologies
+ * Copyright 2016 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public abstract class ConnectionConfig {
     public abstract String type();
 
     public abstract String getDbLogin();
-    public abstract String getDbPassword();
+    public abstract MaskedValue getDbPassword();
 
     public abstract String getUrl();
     public abstract String getDriverClass();

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/MaskedValue.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/MaskedValue.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.nexus.db.pool.config;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonDeserialize(as = ImmutableMaskedValue.class)
+@JsonSerialize(as = ImmutableMaskedValue.class)
+@Value.Immutable(builder = false)
+public abstract class MaskedValue {
+    @Value.Parameter
+    abstract String value();
+    @Override
+    public String toString() { return "<REDACTED>"; }
+
+    public String unmasked() {
+        return value();
+    }
+}

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Palantir Technologies
+ * Copyright 2016 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,11 +98,12 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
 
     @Override
     @Value.Default
+    @Value.Auxiliary
     public Properties getHikariProperties() {
         Properties props = new Properties();
 
         props.setProperty("user", getDbLogin());
-        props.setProperty("password", getDbPassword());
+        props.setProperty("password", getDbPassword().unmasked());
 
         props.setProperty("oracle.net.keepAlive", "true");
         props.setProperty("oracle.jdbc.ReadTimeout", Long.toString(TimeUnit.SECONDS.toMillis(getSocketTimeoutSeconds())));

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Palantir Technologies
+ * Copyright 2016 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,11 +57,12 @@ public abstract class PostgresConnectionConfig extends ConnectionConfig {
 
     @Override
     @Value.Default
+    @Value.Auxiliary
     public Properties getHikariProperties() {
         Properties props = new Properties();
 
         props.setProperty("user", getDbLogin());
-        props.setProperty("password", getDbPassword());
+        props.setProperty("password", getDbPassword().unmasked());
 
         props.setProperty("tcpKeepAlive", "true");
         props.setProperty("socketTimeout", Integer.toString(getSocketTimeoutSeconds()));

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsTestSuite.java
@@ -29,6 +29,7 @@ import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.connection.waiting.HealthCheck;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 import com.palantir.nexus.db.pool.config.ConnectionConfig;
+import com.palantir.nexus.db.pool.config.ImmutableMaskedValue;
 import com.palantir.nexus.db.pool.config.ImmutablePostgresConnectionConfig;
 
 @RunWith(Suite.class)
@@ -59,7 +60,7 @@ public class DbkvsTestSuite {
         ConnectionConfig connectionConfig = ImmutablePostgresConnectionConfig.builder()
                 .dbName("atlas")
                 .dbLogin("palantir")
-                .dbPassword("palantir")
+                .dbPassword(ImmutableMaskedValue.of("palantir"))
                 .host(POSTGRES_ADDRESS.getHostName())
                 .port(POSTGRES_ADDRESS.getPort())
                 .build();

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
@@ -16,7 +16,10 @@
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,6 +63,15 @@ public class TestConfigLoading {
     public void testHikariLoginTimeout() throws IOException {
         ConnectionConfig connectionConfig = getConnectionConfig();
         verifyHikariProperty(connectionConfig, "loginTimeout", connectionConfig.getConnectionTimeoutSeconds());
+    }
+
+    @Test
+    public void testPasswordIsMasked() throws IOException {
+        ConnectionConfig connectionConfig = getConnectionConfig();
+        assertThat(connectionConfig.getDbPassword().unmasked(), equalTo("testpassword"));
+        assertThat(connectionConfig.getHikariProperties().getProperty("password"), equalTo("testpassword"));
+        assertThat(connectionConfig.toString(), not(containsString("testpassword")));
+        assertThat(connectionConfig.toString(), containsString("REDACTED"));
     }
 
     private ConnectionConfig getConnectionConfig() throws IOException {

--- a/atlasdb-dbkvs/src/test/resources/postgresTestConfig.yml
+++ b/atlasdb-dbkvs/src/test/resources/postgresTestConfig.yml
@@ -9,6 +9,6 @@ atlasdb:
       port: 1000
       dbName: test
       dbLogin: test
-      dbPassword: test
+      dbPassword: testpassword
       connectionTimeoutSeconds: 5
       socketTimeoutSeconds: 30

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -43,6 +43,9 @@ v0.12.0
          - If you do not specify a leader block in your config, AtlasDB will now still try to register the timestamp and lock endpoints necessary for other clients or CLIs to run in the same keyspace.
            This may require changes in setup logic for applications that have previously only ever run with no leader block.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/708>`__)
+    *    - |fixed|
+         - DB passwords are no longer output as part of the connection configuration ``toString()`` methods.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/755>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Prevents an issue seen where a stack trace helpfully tries to print the
config but also prints the password to the log files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/755)
<!-- Reviewable:end -->
