### PR TITLE
dont log loading a tracing prefs that isn't enabled

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingPrefsConfig.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingPrefsConfig.java
@@ -53,7 +53,7 @@ public class TracingPrefsConfig implements Runnable {
                     tracingMinDurationToTraceMillis = Integer.parseInt(tracingPrefConfig.getProperty("min_duration_to_log_ms", "0"));
                     String tableString = tracingPrefConfig.getProperty("tables_to_trace", "");
                     tracedTables = ImmutableSet.copyOf(Splitter.on(",").trimResults().split(tableString));
-                    if (loadedConfig == false) { // only log leading edge event
+                    if (tracingEnabled && !loadedConfig) { // only log leading edge event
                         log.error("Successfully loaded an " + TRACING_PREF_FILENAME
                                 + " file. This is usually a large performance hit and should only be used for periods of debugging. "
                                 + "[tracing_enabled = " + tracingEnabled


### PR DESCRIPTION
at some point we started shipping an example prefs file
that always gets loaded, so you get this 'error' message
at startup by default now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/757)
<!-- Reviewable:end -->
