### PR TITLE
Bump docker-compose-rule to latest version, 0.17.2

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuite.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuite.java
@@ -54,7 +54,7 @@ public class CassandraTestSuite {
 
     public static final int THRIFT_PORT_NUMBER = 9160;
     @ClassRule
-    public static final DockerComposeRule composeRule = DockerComposeRule.builder()
+    public static final DockerComposeRule docker = DockerComposeRule.builder()
             .file("src/test/resources/docker-compose.yml")
             .waitingForHostNetworkedPort(THRIFT_PORT_NUMBER, toBeOpen())
             .saveLogsTo("container-logs")
@@ -70,7 +70,7 @@ public class CassandraTestSuite {
 
     @BeforeClass
     public static void waitUntilCassandraIsUp() throws IOException, InterruptedException {
-        DockerPort port = composeRule.hostNetworkedPort(THRIFT_PORT_NUMBER);
+        DockerPort port = docker.hostNetworkedPort(THRIFT_PORT_NUMBER);
         String hostname = port.getIp();
         CASSANDRA_THRIFT_ADDRESS = new InetSocketAddress(hostname, port.getExternalPort());
 

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuite.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuite.java
@@ -34,7 +34,7 @@ import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
-import com.palantir.docker.compose.DockerComposition;
+import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.connection.waiting.HealthCheck;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
@@ -54,7 +54,8 @@ public class CassandraTestSuite {
 
     public static final int THRIFT_PORT_NUMBER = 9160;
     @ClassRule
-    public static final DockerComposition composition = DockerComposition.of("src/test/resources/docker-compose.yml")
+    public static final DockerComposeRule composeRule = DockerComposeRule.builder()
+            .file("src/test/resources/docker-compose.yml")
             .waitingForHostNetworkedPort(THRIFT_PORT_NUMBER, toBeOpen())
             .saveLogsTo("container-logs")
             .build();
@@ -69,7 +70,7 @@ public class CassandraTestSuite {
 
     @BeforeClass
     public static void waitUntilCassandraIsUp() throws IOException, InterruptedException {
-        DockerPort port = composition.hostNetworkedPort(THRIFT_PORT_NUMBER);
+        DockerPort port = composeRule.hostNetworkedPort(THRIFT_PORT_NUMBER);
         String hostname = port.getIp();
         CASSANDRA_THRIFT_ADDRESS = new InetSocketAddress(hostname, port.getExternalPort());
 

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsTestSuite.java
@@ -41,7 +41,7 @@ public class DbkvsTestSuite {
 
     public static final int POSTGRES_PORT_NUMBER = 5432;
     @ClassRule
-    public static final DockerComposeRule composeRule = DockerComposeRule.builder()
+    public static final DockerComposeRule docker = DockerComposeRule.builder()
             .file("src/test/resources/docker-compose.yml")
             .waitingForHostNetworkedPort(POSTGRES_PORT_NUMBER, toBeOpen())
             .saveLogsTo("container-logs")
@@ -53,7 +53,7 @@ public class DbkvsTestSuite {
 
     @BeforeClass
     public static void waitUntilDbkvsIsUp() throws IOException, InterruptedException {
-        DockerPort port = composeRule.hostNetworkedPort(POSTGRES_PORT_NUMBER);
+        DockerPort port = docker.hostNetworkedPort(POSTGRES_PORT_NUMBER);
         POSTGRES_ADDRESS = new InetSocketAddress(port.getIp(), port.getExternalPort());
 
 

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsTestSuite.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.palantir.docker.compose.DockerComposition;
+import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.connection.waiting.HealthCheck;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
@@ -41,7 +41,8 @@ public class DbkvsTestSuite {
 
     public static final int POSTGRES_PORT_NUMBER = 5432;
     @ClassRule
-    public static final DockerComposition composition = DockerComposition.of("src/test/resources/docker-compose.yml")
+    public static final DockerComposeRule composeRule = DockerComposeRule.builder()
+            .file("src/test/resources/docker-compose.yml")
             .waitingForHostNetworkedPort(POSTGRES_PORT_NUMBER, toBeOpen())
             .saveLogsTo("container-logs")
             .build();
@@ -52,7 +53,7 @@ public class DbkvsTestSuite {
 
     @BeforeClass
     public static void waitUntilDbkvsIsUp() throws IOException, InterruptedException {
-        DockerPort port = composition.hostNetworkedPort(POSTGRES_PORT_NUMBER);
+        DockerPort port = composeRule.hostNetworkedPort(POSTGRES_PORT_NUMBER);
         POSTGRES_ADDRESS = new InetSocketAddress(port.getIp(), port.getExternalPort());
 
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -38,7 +38,7 @@ public class EteSetup {
     private static final Optional<SSLSocketFactory> NO_SSL = Optional.absent();
     private static final int ETE_PORT = 3828;
 
-    private static DockerComposeRule composeRule;
+    private static DockerComposeRule docker;
 
     protected <T> T createClientToSingleNode(Class<T> clazz) {
         return createClientFor(clazz, asPort("ete1"));
@@ -54,11 +54,11 @@ public class EteSetup {
     }
 
     private DockerPort asPort(String node) {
-        return composeRule.containers().container(node).port(ETE_PORT);
+        return docker.containers().container(node).port(ETE_PORT);
     }
 
     protected static RuleChain setupComposition(String name, String composeFile) {
-        composeRule = DockerComposeRule.builder()
+        docker = DockerComposeRule.builder()
                 .file(composeFile)
                 .waitingForService("ete1", toBeReady())
                 .saveLogsTo("container-logs/" + name)
@@ -66,7 +66,7 @@ public class EteSetup {
 
         return RuleChain
                 .outerRule(GRADLE_PREPARE_TASK)
-                .around(composeRule);
+                .around(docker);
     }
 
     private static <T> T createClientFor(Class<T> clazz, Container container) {

--- a/atlasdb-timelock-ete/src/test/java/com/palantir/atlasdb/timelock/TimelockServerEteTest.java
+++ b/atlasdb-timelock-ete/src/test/java/com/palantir/atlasdb/timelock/TimelockServerEteTest.java
@@ -42,7 +42,7 @@ public class TimelockServerEteTest {
     private static final int TIMELOCK_SERVER_PORT = 3828;
     private static final ImmutableList<String> TIMELOCK_NODES = ImmutableList.of("timelock1", "timelock2", "timelock3");
 
-    public static DockerComposeRule composeRule = DockerComposeRule.builder()
+    public static DockerComposeRule docker = DockerComposeRule.builder()
             .file("docker-compose.yml")
             .waitingForServices(TIMELOCK_NODES, toHaveElectedALeader())
             .saveLogsTo("container-logs")
@@ -53,7 +53,7 @@ public class TimelockServerEteTest {
     @ClassRule
     public static RuleChain rules = RuleChain
             .outerRule(gradle)
-            .around(composeRule);
+            .around(docker);
 
     @Test
     public void shouldBeAbleToGetTimestampsOffAClusterOfServices() throws Exception {
@@ -80,7 +80,7 @@ public class TimelockServerEteTest {
     }
 
     private DockerPort timelockPort(String container) {
-        return composeRule.containers().container(container).port(TIMELOCK_SERVER_PORT);
+        return docker.containers().container(container).port(TIMELOCK_SERVER_PORT);
     }
 
     private static HealthCheck<List<Container>> toHaveElectedALeader() {

--- a/atlasdb-timelock-ete/src/test/java/com/palantir/atlasdb/timelock/TimelockServerEteTest.java
+++ b/atlasdb-timelock-ete/src/test/java/com/palantir/atlasdb/timelock/TimelockServerEteTest.java
@@ -21,9 +21,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
 
-import static com.google.common.base.Throwables.propagate;
-
-import java.io.IOException;
 import java.util.List;
 
 import org.junit.ClassRule;
@@ -35,7 +32,6 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.ete.Gradle;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.docker.compose.DockerComposeRule;
-import com.palantir.docker.compose.DockerComposition;
 import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.connection.waiting.HealthCheck;

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -8,7 +8,7 @@ ext.libVersions =
     jmock:   '2.8.2',
     mockito: '1.10.17',
     dropwizard:   '0.8.2',
-    dockerComposeRule: '0.16.0',
+    dockerComposeRule: '0.17.2',
     commons_lang: '2.6',
     commons_lang3: '3.1',
     commons_io: '2.1',


### PR DESCRIPTION
Bump docker-compose-rule to 0.17.2, and replace usages of `DockerComposition` (which is now deprecated) with `DockerComposeRule`.

This is a minor internal change, and does not require any changes to docs/release notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/761)
<!-- Reviewable:end -->
