### PR TITLE
scylla compat

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTest.java
@@ -21,10 +21,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
+import org.apache.cassandra.thrift.CfDef;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Before;
@@ -33,11 +36,17 @@ import org.junit.Test;
 import org.slf4j.Logger;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AbstractAtlasDbKeyValueServiceTest;
+import com.palantir.atlasdb.keyvalue.impl.TableSplittingKeyValueService;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.atlasdb.table.description.TableDefinition;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
 
 public class CassandraKeyValueServiceTest extends AbstractAtlasDbKeyValueServiceTest {
     private KeyValueService keyValueService;
@@ -90,6 +99,45 @@ public class CassandraKeyValueServiceTest extends AbstractAtlasDbKeyValueService
         Preconditions.checkArgument(allTables.contains(table1));
         Preconditions.checkArgument(!allTables.contains(table2));
         Preconditions.checkArgument(!allTables.contains(table3));
+    }
+
+    @Test
+    public void testCfEqualityChecker() throws TException {
+        TableReference testTable = TableReference.createFromFullyQualifiedName("ns.never_seen");
+        byte[] tableMetadata = new TableDefinition() {{
+            rowName();
+            rowComponent("blob", ValueType.BLOB);
+            columns();
+            column("boblawblowlawblob", "col", ValueType.BLOB);
+            conflictHandler(ConflictHandler.IGNORE_ALL);
+            sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING);
+            explicitCompressionBlockSizeKB(8);
+            rangeScanAllowed();
+            ignoreHotspottingChecks();
+            negativeLookups();
+            cachePriority(TableMetadataPersistence.CachePriority.COLD);
+        }}.toTableMetadata().persistToBytes();
+
+
+        CassandraKeyValueService kvs;
+        if (keyValueService instanceof CassandraKeyValueService) {
+            kvs = (CassandraKeyValueService) keyValueService;
+        } else if (keyValueService instanceof TableSplittingKeyValueService) { // scylla tests
+            KeyValueService delegate = ((TableSplittingKeyValueService) keyValueService).getDelegate(testTable);
+            assert(delegate instanceof CassandraKeyValueService);
+            kvs = (CassandraKeyValueService) delegate;
+        } else {
+            throw new IllegalArgumentException("Can't run this cassandra-specific test against a non-cassandra KVS");
+        }
+
+        kvs.createTable(testTable, tableMetadata);
+
+        List<CfDef> knownCfs = kvs.clientPool.runWithRetry(client ->
+                client.describe_keyspace("atlasdb").getCf_defs());
+        knownCfs.forEach(knownCf -> System.out.println(knownCf.getName()));
+        CfDef clusterSideCf = Iterables.getOnlyElement(knownCfs.stream().filter(cf -> cf.getName().equals("ns__never_seen")).collect(Collectors.toList()));
+
+        assert(CassandraKeyValueServices.isMatchingCf(kvs.getCfForTable(testTable, tableMetadata), clusterSideCf));
     }
 
     @Test

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -135,7 +135,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
 
     @Value.Default
     public int cqlPoolTimeoutMillis() {
-        return 5 * 1000;
+        return 20 * 1000;
     }
 
     @Value.Default
@@ -146,6 +146,11 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     @Value.Default
     public int rangesConcurrency() {
         return 64;
+    }
+
+    @Value.Default
+    public boolean scyllaDB() {
+        return false;
     }
 
     public abstract Optional<CassandraJmxCompactionConfig> jmx();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -149,7 +149,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     }
 
     @Value.Default
-    public boolean scyllaDB() {
+    public boolean scyllaDb() {
         return false;
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLFieldNameProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLFieldNameProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+
+public class CQLFieldNameProvider {
+    boolean isScylla;
+
+    public CQLFieldNameProvider(CassandraKeyValueServiceConfig config) {
+        isScylla = config.scyllaDB();
+    }
+
+    public String row() {
+        return isScylla? "key1" : "key";
+    }
+
+    public String column() {
+        return "column1";
+    }
+
+    public String timestamp() {
+        return "column2";
+    }
+
+    public String value() {
+        return "value";
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
@@ -25,6 +25,7 @@ import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -64,6 +65,7 @@ import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.datastax.driver.core.policies.WhiteListPolicy;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
+import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -84,6 +86,8 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import com.google.common.collect.TreeMultimap;
+import com.google.common.primitives.UnsignedBytes;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
@@ -353,18 +357,20 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                                                     final Iterable<byte[]> rows,
                                                     final long startTs) throws Exception {
         int rowCount = 0;
-        String getRowsQuery = "SELECT * FROM " + getFullTableName(tableRef) + " WHERE " + fieldName.row() + " = ?";
         Map<Cell, Value> result = Maps.newHashMap();
         final CassandraKeyValueServiceConfig config = configManager.getConfig();
         int fetchBatchCount = config.fetchBatchCount();
         for (final List<byte[]> batch : Iterables.partition(rows, fetchBatchCount)) {
             rowCount += batch.size();
             List<ResultSetFuture> resultSetFutures = Lists.newArrayListWithExpectedSize(rowCount);
+            String getRowsQuery = "SELECT * FROM " + getFullTableName(tableRef) + " WHERE " + fieldName.row() + " IN ("
+                    + Joiner.on(",").join(Iterables.limit(Iterables.cycle("?"), batch.size())) + ")";
             PreparedStatement preparedStatement = getPreparedStatement(tableRef, getRowsQuery, session);
-            for (byte[] row : batch) {
-                BoundStatement boundStatement = preparedStatement.bind(ByteBuffer.wrap(row));
-                resultSetFutures.add(session.executeAsync(boundStatement));
+            Object[] args = new Object[batch.size()];
+            for (int i = 0; i < batch.size(); i++) {
+                args[i] = ByteBuffer.wrap(batch.get(i));
             }
+            resultSetFutures.add(session.executeAsync(preparedStatement.bind(args)));
             for (ResultSetFuture resultSetFuture : resultSetFutures) {
                 ResultSet resultSet;
                 try {
@@ -427,33 +433,50 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                             boolean loadAllTs,
                             final Visitor<Multimap<Cell, Value>> visitor,
                             final ConsistencyLevel consistency) throws Exception {
-        String loadWithTsQuery = "SELECT * FROM " + getFullTableName(tableRef)
-                + " WHERE " + fieldName.row() + " = ?"
-                + " AND " + fieldName.column() + " = ?"
-                + " AND " + fieldName.timestamp() + " > ?"
-                + (!loadAllTs ? " LIMIT 1" : "");
-        CassandraKeyValueServiceConfig config = configManager.getConfig();
-        if (cells.size() > config.fetchBatchCount()) {
-            log.warn("A call to " + tableRef
-                    + " is performing a multiget " + cells.size()
-                    + " cells; this may indicate overly-large batching on a higher level.\n"
-                    + CassandraKeyValueServices.getFilteredStackTrace("com.palantir"));
-        }
-        PreparedStatement preparedStatement = getPreparedStatement(tableRef, loadWithTsQuery, session)
-                .setConsistencyLevel(consistency);
+        final CassandraKeyValueServiceConfig config = configManager.getConfig();
+
         List<ResultSetFuture> resultSetFutures = Lists.newArrayListWithCapacity(cells.size());
-
+        TreeMultimap<byte[], Cell> cellsByCol =
+                TreeMultimap.create(UnsignedBytes.lexicographicalComparator(), Ordering.natural());
         for (Cell cell : cells) {
-            ResultSetFuture resultSetFuture = session.executeAsync(
-                    preparedStatement.bind(
-                            ByteBuffer.wrap(cell.getRowName()),
-                            ByteBuffer.wrap(cell.getColumnName()),
-                            ~startTs));
-            resultSetFutures.add(resultSetFuture);
+            cellsByCol.put(cell.getColumnName(), cell);
+        }
+        for (Entry<byte[], SortedSet<Cell>> entry : Multimaps.asMap(cellsByCol).entrySet()) {
+            if (entry.getValue().size() > config.fetchBatchCount()) {
+                log.warn("A call to " + tableRef
+                        + " is performing a multiget " + entry.getValue().size()
+                        + " cells; this may indicate overly-large batching on a higher level.\n"
+                        + CassandraKeyValueServices.getFilteredStackTrace("com.palantir"));
+            }
+            for (List<Cell> batch : Iterables.partition(entry.getValue(), config.fetchBatchCount())) {
+                String rowBinds = Joiner.on(",").join(Iterables.limit(Iterables.cycle('?'), batch.size()));
+                final String loadWithTsQuery = "SELECT * FROM " + getFullTableName(tableRef)
+                        + " WHERE " + fieldName.row()
+                        + " IN (" + rowBinds
+                        + ") AND " + fieldName.column()
+                        + " = ? AND " + fieldName.timestamp()
+                        + " > ?" + (!loadAllTs ? " LIMIT 1" : "");
+                final PreparedStatement preparedStatement = getPreparedStatement(tableRef, loadWithTsQuery, session)
+                              .setConsistencyLevel(consistency);
+                Object[] args = new Object[batch.size() + 2];
+                for (int i = 0; i < batch.size(); i++) {
+                    args[i] = ByteBuffer.wrap(batch.get(i).getRowName());
+                }
+                args[batch.size()] = ByteBuffer.wrap(entry.getKey());
+                args[batch.size() + 1] = ~startTs;
+                ResultSetFuture resultSetFuture = session.executeAsync(
+                        preparedStatement.bind(args));
+                resultSetFutures.add(resultSetFuture);
+            }
         }
 
+        String loggedLoadWithTsQuery = "SELECT * FROM " + getFullTableName(tableRef) + " "
+                + "WHERE " + fieldName.row()
+                + " IN (?, ...) AND " + fieldName.column()
+                + " = ? AND " + fieldName.timestamp()
+                + " > ?" + (!loadAllTs ? " LIMIT 1" : "");
         for (ResultSetFuture rsf : resultSetFutures) {
-            visitResults(rsf.getUninterruptibly(), visitor, loadWithTsQuery, loadAllTs);
+            visitResults(rsf.getUninterruptibly(), visitor, loggedLoadWithTsQuery, loadAllTs);
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServices.java
@@ -277,15 +277,15 @@ public final class CQLKeyValueServices {
             chunkLength = explicitCompressionBlockSizeKB;
         }
 
-        queryBuilder.append("CREATE TABLE IF NOT EXISTS " + kvs.getFullTableName(tableRef) + " ( " // full table name (ks.cf)
-                + kvs.fieldName.row() + " blob, "
-                + kvs.fieldName.column() + " blob, "
-                + kvs.fieldName.timestamp() + " bigint, "
-                + kvs.fieldName.value() + " blob, "
+        queryBuilder.append("CREATE TABLE IF NOT EXISTS " + kvs.getFullTableName(tableRef) + " ( "
+                + kvs.fieldNameProvider.row() + " blob, "
+                + kvs.fieldNameProvider.column() + " blob, "
+                + kvs.fieldNameProvider.timestamp() + " bigint, "
+                + kvs.fieldNameProvider.value() + " blob, "
                 + "PRIMARY KEY ("
-                + kvs.fieldName.row() + ", "
-                + kvs.fieldName.column() + ", "
-                + kvs.fieldName.timestamp() + ")) "
+                + kvs.fieldNameProvider.row() + ", "
+                + kvs.fieldNameProvider.column() + ", "
+                + kvs.fieldNameProvider.timestamp() + ")) "
                 + "WITH COMPACT STORAGE ");
         queryBuilder.append("AND " + "bloom_filter_fp_chance = " + falsePositiveChance + " ");
         queryBuilder.append("AND caching = '{\"keys\":\"ALL\", \"rows_per_partition\":\"ALL\"}' ");
@@ -299,8 +299,8 @@ public final class CQLKeyValueServices {
         queryBuilder.append("AND compression = {'chunk_length_kb': '" + chunkLength + "', "
                 + "'sstable_compression': '" + CassandraConstants.DEFAULT_COMPRESSION_TYPE + "'}");
         queryBuilder.append("AND CLUSTERING ORDER BY ("
-                + kvs.fieldName.column() + " ASC, "
-                + kvs.fieldName.timestamp() + " ASC) ");
+                + kvs.fieldNameProvider.column() + " ASC, "
+                + kvs.fieldNameProvider.timestamp() + " ASC) ");
 
         BoundStatement createTableStatement =
                 kvs.getPreparedStatement(tableRef, queryBuilder.toString(), kvs.longRunningQuerySession)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServices.java
@@ -250,22 +250,6 @@ public final class CQLKeyValueServices {
         throw new IllegalStateException(sb.toString());
     }
 
-    static byte[] getRowName(Row row) {
-        return CassandraKeyValueServices.getBytesFromByteBuffer(row.getBytes(CassandraConstants.ROW_NAME));
-    }
-
-    static byte[] getColName(Row row) {
-        return CassandraKeyValueServices.getBytesFromByteBuffer(row.getBytes(CassandraConstants.COL_NAME_COL));
-    }
-
-    static long getTs(Row row) {
-        return ~row.getLong(CassandraConstants.TS_COL);
-    }
-
-    static byte[] getValue(Row row) {
-        return CassandraKeyValueServices.getBytesFromByteBuffer(row.getBytes(CassandraConstants.VALUE_COL));
-    }
-
     void createTableWithSettings(TableReference tableRef, byte[] rawMetadata, CQLKeyValueService kvs) {
         StringBuilder queryBuilder = new StringBuilder();
 
@@ -293,16 +277,15 @@ public final class CQLKeyValueServices {
             chunkLength = explicitCompressionBlockSizeKB;
         }
 
-        queryBuilder.append("CREATE TABLE IF NOT EXISTS "
-                + kvs.getFullTableName(tableRef) + " ( " // full table name (ks.cf)
-                + CassandraConstants.ROW_NAME + " blob, "
-                + CassandraConstants.COL_NAME_COL + " blob, "
-                + CassandraConstants.TS_COL + " bigint, "
-                + CassandraConstants.VALUE_COL + " blob, "
+        queryBuilder.append("CREATE TABLE IF NOT EXISTS " + kvs.getFullTableName(tableRef) + " ( " // full table name (ks.cf)
+                + kvs.fieldName.row() + " blob, "
+                + kvs.fieldName.column() + " blob, "
+                + kvs.fieldName.timestamp() + " bigint, "
+                + kvs.fieldName.value() + " blob, "
                 + "PRIMARY KEY ("
-                + CassandraConstants.ROW_NAME + ", "
-                + CassandraConstants.COL_NAME_COL + ", "
-                + CassandraConstants.TS_COL + ")) "
+                + kvs.fieldName.row() + ", "
+                + kvs.fieldName.column() + ", "
+                + kvs.fieldName.timestamp() + ")) "
                 + "WITH COMPACT STORAGE ");
         queryBuilder.append("AND " + "bloom_filter_fp_chance = " + falsePositiveChance + " ");
         queryBuilder.append("AND caching = '{\"keys\":\"ALL\", \"rows_per_partition\":\"ALL\"}' ");
@@ -316,8 +299,8 @@ public final class CQLKeyValueServices {
         queryBuilder.append("AND compression = {'chunk_length_kb': '" + chunkLength + "', "
                 + "'sstable_compression': '" + CassandraConstants.DEFAULT_COMPRESSION_TYPE + "'}");
         queryBuilder.append("AND CLUSTERING ORDER BY ("
-                + CassandraConstants.COL_NAME_COL + " ASC, "
-                + CassandraConstants.TS_COL + " ASC) ");
+                + kvs.fieldName.column() + " ASC, "
+                + kvs.fieldName.timestamp() + " ASC) ");
 
         BoundStatement createTableStatement =
                 kvs.getPreparedStatement(tableRef, queryBuilder.toString(), kvs.longRunningQuerySession)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLStatementCache.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLStatementCache.java
@@ -48,6 +48,9 @@ public class CQLStatementCache {
                 }
             });
 
+    // some errors are able to close the session,
+    // and the client driver we're using doesn't check and hands it back for us to use
+    @SuppressWarnings("checkstyle:parameterassignment")
     private PreparedStatement prepareSessionWithErrorHandling(Session currentSession, String query) {
         try {
             return currentSession.prepare(query);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLStatementCache.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLStatementCache.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -34,7 +35,7 @@ public class CQLStatementCache {
             .build(new CacheLoader<String, PreparedStatement>() {
                 @Override
                 public PreparedStatement load(String query) {
-                    return session.prepare(query);
+                    return prepareSessionWithErrorHandling(session, query);
                 }
             });
 
@@ -43,7 +44,20 @@ public class CQLStatementCache {
             .build(new CacheLoader<String, PreparedStatement>() {
                 @Override
                 public PreparedStatement load(String query) {
-                    return longRunningQuerySession.prepare(query);
+                    return prepareSessionWithErrorHandling(longRunningQuerySession, query);
                 }
             });
+
+    private PreparedStatement prepareSessionWithErrorHandling(Session currentSession, String query) {
+        try {
+            return currentSession.prepare(query);
+        } catch (NoHostAvailableException e) {
+            if (currentSession.isClosed()) {
+                currentSession = currentSession.getCluster().newSession();
+                return currentSession.prepare(query);
+            } else {
+                throw e;
+            }
+        }
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraApiVersion.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraApiVersion.java
@@ -50,4 +50,9 @@ public class CassandraApiVersion {
 
         return supportsCheckAndSet;
     }
+
+    @Override
+    public String toString() {
+        return versionString;
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -39,11 +39,6 @@ public final class CassandraConstants {
     static final int ABSOLUTE_MINIMUM_NUMBER_OF_TOKENS_PER_NODE = 32;
     static final long TS_SIZE = 4L;
 
-    static final String ROW_NAME = "key";
-    static final String COL_NAME_COL = "column1";
-    static final String TS_COL = "column2";
-    static final String VALUE_COL = "value";
-
     static final String DEFAULT_COMPRESSION_TYPE = "LZ4Compressor";
     static final String SSTABLE_SIZE_IN_MB = "80";
     static final double DEFAULT_LEVELED_COMPACTION_BLOOM_FILTER_FP_CHANCE = 0.1;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -200,12 +200,16 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     }
 
     protected void init() {
-        clientPool.runOneTimeStartupChecks();
-        if (configManager.getConfig().scyllaDB() && !configManager.getConfig().safetyDisabled()) {
-            throw new IllegalArgumentException("Not currently allowing Thrift-based access to ScyllaDB clusters; " +
-                    "there appears to be from our tests an existing correctness bug with semi-complex column selections");
+        if (configManager.getConfig().scyllaDb() && !configManager.getConfig().safetyDisabled()) {
+            throw new IllegalArgumentException("Not currently allowing Thrift-based access to ScyllaDB clusters;"
+                    + " there appears to be from our tests"
+                    + " an existing correctness bug with semi-complex column selections");
         }
-        boolean supportsCas = !configManager.getConfig().scyllaDB() && clientPool.runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
+
+        clientPool.runOneTimeStartupChecks();
+
+        boolean supportsCas = !configManager.getConfig().scyllaDb()
+                && clientPool.runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
 
         schemaMutationLock = new SchemaMutationLock(
                 supportsCas,
@@ -1416,7 +1420,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     if (!existingTablesLowerCased.contains(tableRefLowerCased)) {
                         client.system_add_column_family(getCfForTable(table, metadata));
                     } else {
-                        log.debug("Ignored call to create a table ({}) that already existed (case insensitive).", table);
+                        log.debug("Ignored call to create table ({}) that already existed (case insensitive).", table);
                     }
                 }
                 if (!tablesToCreate.isEmpty()) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -278,24 +278,21 @@ public final class CassandraKeyValueServices {
     public static boolean isMatchingCf(CfDef clientSide, CfDef clusterSide) {
         String tableName = clientSide.name;
         if (!Objects.equal(clientSide.compaction_strategy_options, clusterSide.compaction_strategy_options)) {
-            log.debug("Found client/server disagreement on compaction strategy options for {}."
-                    + " (client = ({}), server = ({}))",
+            log.info("Found client/server disagreement on compaction strategy options for {}. (client = ({}), server = ({}))",
                     tableName,
                     clientSide.compaction_strategy_options,
                     clusterSide.compaction_strategy_options);
             return false;
         }
         if (clientSide.gc_grace_seconds != clusterSide.gc_grace_seconds) {
-            log.debug("Found client/server disagreement on gc_grace_seconds for {}."
-                    + " (client = ({}), server = ({}))",
+            log.info("Found client/server disagreement on gc_grace_seconds for {}. (client = ({}), server = ({}))",
                     tableName,
                     clientSide.gc_grace_seconds,
                     clusterSide.gc_grace_seconds);
             return false;
         }
         if (clientSide.bloom_filter_fp_chance != clusterSide.bloom_filter_fp_chance) {
-            log.debug("Found client/server disagreement on bloom filter false positive chance for {}."
-                    + " (client = ({}), server = ({}))",
+            log.info("Found client/server disagreement on bloom filter false positive chance for {}. (client = ({}), server = ({}))",
                     tableName,
                     clientSide.bloom_filter_fp_chance,
                     clusterSide.bloom_filter_fp_chance);
@@ -303,24 +300,25 @@ public final class CassandraKeyValueServices {
         }
         if (!(clientSide.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY).equals(
                 clusterSide.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY)))) {
-            log.debug("Found client/server disagreement on compression chunk length for {}."
-                    + " (client = ({}), server = ({}))",
+            log.info("Found client/server disagreement on compression chunk length for {}. (client = ({}), server = ({}))",
                     tableName,
                     clientSide.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY),
                     clusterSide.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY));
             return false;
         }
         if (!Objects.equal(clientSide.compaction_strategy, clusterSide.compaction_strategy)) {
-            log.debug("Found client/server disagreement on compaction_strategy for {}."
-                    + " (client = ({}), server = ({}))",
-                    tableName,
-                    clientSide.compaction_strategy,
-                    clusterSide.compaction_strategy);
-            return false;
+            // consider equal "com.whatever.LevelledCompactionStrategy" and "LevelledCompactionStrategy". This String-based API stinks.
+            if (clientSide.compaction_strategy != null && clusterSide.compaction_strategy != null &&
+                    !(clientSide.compaction_strategy.contains(clientSide.compaction_strategy) || clusterSide.compaction_strategy.contains(clientSide.compaction_strategy))) {
+		    log.info("Found client/server disagreement on compaction_strategy for {}. (client = ({}), server = ({}))",
+		            tableName,
+		            clientSide.compaction_strategy,
+		            clusterSide.compaction_strategy);
+                    return false;
+	    }
         }
         if (clientSide.isSetPopulate_io_cache_on_flush() != clusterSide.isSetPopulate_io_cache_on_flush()) {
-            log.debug("Found client/server disagreement on populate_io_cache_on_flush for {}."
-                    + " (client = ({}), server = ({}))",
+            log.info("Found client/server disagreement on populate_io_cache_on_flush for {}. (client = ({}), server = ({}))",
                     tableName,
                     clientSide.isSetPopulate_io_cache_on_flush(),
                     clusterSide.isSetPopulate_io_cache_on_flush());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -283,6 +283,7 @@ public final class CassandraVerifier {
             underlyingCassandraClusterSupportsCASOperations = client -> {
                 try {
                     CassandraApiVersion serverVersion = new CassandraApiVersion(client.describe_version());
+                    log.debug("Connected cassandra thrift version is: " + serverVersion);
                     return serverVersion.supportsCheckAndSet();
                 } catch (TException ex) {
                     throw new UnsupportedOperationException("Couldn't determine underlying cassandra version;"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlFieldNameProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlFieldNameProvider.java
@@ -17,15 +17,15 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 
-public class CQLFieldNameProvider {
+public class CqlFieldNameProvider {
     boolean isScylla;
 
-    public CQLFieldNameProvider(CassandraKeyValueServiceConfig config) {
-        isScylla = config.scyllaDB();
+    public CqlFieldNameProvider(CassandraKeyValueServiceConfig config) {
+        isScylla = config.scyllaDb();
     }
 
     public String row() {
-        return isScylla? "key1" : "key";
+        return isScylla ? "key1" : "key";
     }
 
     public String column() {

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -285,15 +285,34 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
     }
 
     private State initialState() throws SQLException {
+        HikariDataSource dataSourcePool = getDatasourcePool();
+        boolean keep = false;
+
+        try {
+            // Setup monitoring
+            HikariPoolMXBean poolProxy = initPoolMbeans();
+            testDataSource(dataSourcePool);
+            keep = true;
+            return new State(StateType.NORMAL, 0, dataSourcePool, poolProxy, null);
+        } finally {
+            if (!keep) {
+                IOUtils.closeQuietly(dataSourcePool);
+            }
+        }
+    }
+
+    private HikariDataSource getDatasourcePool() {
         // Print a stack trace whenever we initialize a pool
         log.debug("Initializing connection pool: {}", connConfig, new RuntimeException("Initializing connection pool"));
 
         HikariDataSource dataSourcePool;
+
         try {
             try {
                 dataSourcePool = new HikariDataSource(connConfig.getHikariConfig());
             } catch (IllegalArgumentException e) {
-                if (e.getMessage().contains("A metric named")) { // allow multiple pools on same JVM
+                // allow multiple pools on same JVM (they need unique names / endpoints)
+                if (e.getMessage().contains("A metric named")) {
                     String poolName = connConfig.getHikariConfig().getPoolName();
                     connConfig.getHikariConfig().setPoolName((poolName + "-" + ThreadLocalRandom.current().nextInt()));
                     dataSourcePool = new HikariDataSource(connConfig.getHikariConfig());
@@ -331,22 +350,10 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
             throw e2;
         }
 
-        boolean keep = false;
-
-        try {
-            // Setup monitoring
-            HikariPoolMXBean poolProxy = initPoolMbeans();
-
-            testDataSource(dataSourcePool);
-
-            keep = true;
-            return new State(StateType.NORMAL, 0, dataSourcePool, poolProxy, null);
-        } finally {
-            if (!keep) {
-                IOUtils.closeQuietly(dataSourcePool);
-            }
-        }
+        return dataSourcePool;
     }
+
+
 
     private State elevatedState(State oldState) {
         HikariDataSource dataSourcePool = oldState.dataSourcePool;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -443,7 +443,7 @@ public class DbKvs extends AbstractKeyValueService {
         try {
             return runRead(tableRef, table -> getPageInternal(table, range, timestamp));
         } finally {
-            log.info("Call to KVS.getPage on table {} took {} ms.", tableRef, watch.elapsed(TimeUnit.MILLISECONDS));
+            log.debug("Call to KVS.getPage on table {} took {} ms.", tableRef, watch.elapsed(TimeUnit.MILLISECONDS));
         }
     }
 
@@ -527,7 +527,7 @@ public class DbKvs extends AbstractKeyValueService {
         try {
             return runRead(tableRef, table -> getTimestampsPageInternal(table, range, timestamp));
         } finally {
-            log.info("Call to KVS.getTimestampsPage on table {} took {} ms.",
+            log.debug("Call to KVS.getTimestampsPage on table {} took {} ms.",
                     tableRef, watch.elapsed(TimeUnit.MILLISECONDS));
         }
     }
@@ -674,7 +674,7 @@ public class DbKvs extends AbstractKeyValueService {
         try {
             return runRead(tableRef, table -> extractRowColumnRangePage(table, columnRangeSelection, ts, rows));
         } finally {
-            log.info("Call to KVS.getFirstRowColumnRangePage on table {} took {} ms.",
+            log.debug("Call to KVS.getFirstRowColumnRangePage on table {} took {} ms.",
                     tableRef, watch.elapsed(TimeUnit.MILLISECONDS));
         }
     }
@@ -1003,7 +1003,7 @@ public class DbKvs extends AbstractKeyValueService {
      */
     private <T> T runWriteFreshConnection(
             ConnectionSupplier conns, TableReference tableRef, Function<DbWriteTable, T> runner) {
-        log.info("Running in a new thread to turn autocommit on for write");
+        log.debug("Running in a new thread to turn autocommit on for write");
         AtomicReference<T> result = Atomics.newReference();
         Thread writeThread = new Thread(() -> {
             SqlConnection freshConn = conns.getFresh();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -175,7 +175,7 @@ public final class TableSplittingKeyValueService implements KeyValueService {
         return getDelegate(tableRef).getAllTimestamps(tableRef, cells, timestamp);
     }
 
-    private KeyValueService getDelegate(TableReference tableRef) {
+    public KeyValueService getDelegate(TableReference tableRef) {
         return tableDelegateFor(tableRef)
                 .or(namespaceDelegateFor(tableRef))
                 .or(delegates.get(0));

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/AgnosticLightResultSetImpl.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/AgnosticLightResultSetImpl.java
@@ -87,7 +87,7 @@ class AgnosticLightResultSetImpl implements AgnosticLightResultSet {
             results.close();
             hasBeenClosed = true;
             long elapsed = System.currentTimeMillis() - creationLocation.getCreatingThreadInfo().getTimestamp();
-            log.info("Closed {} after {}ms", this, elapsed);
+            log.debug("Closed {} after {}ms", this, elapsed);
         } catch(SQLException sqlex) {
             log.error("Caught SQLException", sqlex); //$NON-NLS-1$
         }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,6 +45,23 @@ v0.13.0
          - ``AtlasDbServer`` has been renamed to ``AtlasDbServiceServer``. Any products that are using this should switch to using the Java Feign client instead.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/801>`__)
 
+    *    - |fixed|
+         - Cassandra support for non-standard ports
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/771>`__)
+
+    *    - |fixed|
+         - A bug that could require Cassandra schema mutations every startup, which breaks HA guarantees
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/771>`__)
+
+    *    - |improved|
+         - Performance and reliability enhancements to the in-beta CQL KVS
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/771>`__)
+
+    *    - |fixed|
+         - A bug that meant a single JVM could not connect to multiple Postgres servers
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/771>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
- some flexibility for CQL field names
- some resiliancy for CQL errors that the datastax driver doesn't do a good job of catching (an error occurs, the connection closes, and the datastax client driver lets you check out the bad connection from the pool again without checking)
- allow instantiation of multiple hikari pools (this was so I could do some parallel testing, but this is just a good feature)
- add some useful debug logging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/771)
<!-- Reviewable:end -->
