### PR TITLE
Enable baseline for atlasdb-cassandra

### DIFF
--- a/.baseline/checkstyle/checkstyle-suppressions.xml
+++ b/.baseline/checkstyle/checkstyle-suppressions.xml
@@ -22,6 +22,6 @@
     <suppress files="[/\\].*[/\\]generated_src[/\\]" checks="." />
     <suppress files="[/\\].*[/\\]generated_testSrc[/\\]" checks="." />
 
-    <!-- Temporarily suppress abbreviations in files that have KV in their name (examples: TransactionKVSWrapper, KVTableMappingService). -->
-    <suppress files="KV.*\.java$" checks="AbbreviationAsWordInName" />
+    <!-- Temporarily suppress abbreviations. -->
+    <suppress files="[/\\](.*KV.*|CQL.*KeyValueServices?|CQLStatementCache|StorageServiceMBean)\.java$" checks="AbbreviationAsWordInName" />
 </suppressions>

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NavigableMap;
 import java.util.NoSuchElementException;
-import java.util.TreeMap;
 
 import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.TimedOutException;
@@ -43,7 +43,7 @@ import com.google.common.collect.Range;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.LightweightOPPToken;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.LightweightOppToken;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.WeightedHosts;
 import com.palantir.common.base.FunctionCheckedException;
 
@@ -81,10 +81,10 @@ public class CassandraClientPoolTest {
     @Test
     public void testTokenMapping() {
         CassandraClientPool clientPool = kv.clientPool;
-        Map<Range<LightweightOPPToken>, List<InetSocketAddress>> mapOfRanges = kv.clientPool.tokenMap.asMapOfRanges();
+        Map<Range<LightweightOppToken>, List<InetSocketAddress>> mapOfRanges = kv.clientPool.tokenMap.asMapOfRanges();
 
-        for (Entry<Range<LightweightOPPToken>, List<InetSocketAddress>> entry : mapOfRanges.entrySet()) {
-            Range<LightweightOPPToken> tokenRange = entry.getKey();
+        for (Entry<Range<LightweightOppToken>, List<InetSocketAddress>> entry : mapOfRanges.entrySet()) {
+            Range<LightweightOppToken> tokenRange = entry.getKey();
             List<InetSocketAddress> hosts = entry.getValue();
 
             clientPool.getRandomHostForKey("A".getBytes());
@@ -150,7 +150,7 @@ public class CassandraClientPoolTest {
                 new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(10),
                 new InetSocketAddress(2), createMockClientPoolingContainerWithUtilization(10));
 
-        TreeMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
+        NavigableMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
 
         int expectedWeight = result.firstEntry().getKey();
         int prevKey = 0;
@@ -169,7 +169,7 @@ public class CassandraClientPoolTest {
                 new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(10),
                 lowActivityHost, createMockClientPoolingContainerWithUtilization(0));
 
-        TreeMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
+        NavigableMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
 
         int largestWeight = result.firstEntry().getKey();
         InetSocketAddress hostWithLargestWeight = result.firstEntry().getValue();
@@ -193,7 +193,7 @@ public class CassandraClientPoolTest {
                 new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(5),
                 highActivityHost, createMockClientPoolingContainerWithUtilization(20));
 
-        TreeMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
+        NavigableMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
 
         int smallestWeight = result.firstEntry().getKey();
         InetSocketAddress hostWithSmallestWeight = result.firstEntry().getValue();
@@ -216,7 +216,7 @@ public class CassandraClientPoolTest {
                 new InetSocketAddress(1), createMockClientPoolingContainerWithUtilization(10),
                 new InetSocketAddress(2), createMockClientPoolingContainerWithUtilization(15));
 
-        TreeMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
+        NavigableMap<Integer, InetSocketAddress> result = CassandraClientPool.WeightedHosts.create(pools).hosts;
 
         int prevKey = 0;
         for (Map.Entry<Integer, InetSocketAddress> entry : result.entrySet()) {

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
   }
 
+  compile group: 'com.google.code.findbugs', name: 'annotations', version: '2.0.3'
+
   processor 'org.immutables:value:' + libVersions.immutables
   processor 'com.google.auto.service:auto-service:1.0-rc2'
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -32,23 +32,32 @@ import com.palantir.timestamp.TimestampService;
 public class CassandraAtlasDbFactory implements AtlasDbFactory {
 
     @Override
-    public KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig) {
+    public KeyValueService createRawKeyValueService(
+            KeyValueServiceConfig config,
+            Optional<LeaderConfig> leaderConfig) {
         AtlasDbVersion.ensureVersionReported();
         Preconditions.checkArgument(config instanceof CassandraKeyValueServiceConfig,
-                "CassandraAtlasDbFactory expects a configuration of type CassandraKeyValueServiceConfig, found %s", config.getClass());
+                "CassandraAtlasDbFactory expects a configuration of type"
+                + " CassandraKeyValueServiceConfig, found %s", config.getClass());
         return createKv((CassandraKeyValueServiceConfig) config, leaderConfig);
     }
 
-    private static CassandraKeyValueService createKv(CassandraKeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig) {
-        return CassandraKeyValueService.create(CassandraKeyValueServiceConfigManager.createSimpleManager(config), leaderConfig);
+    private static CassandraKeyValueService createKv(
+            CassandraKeyValueServiceConfig config,
+            Optional<LeaderConfig> leaderConfig) {
+        return CassandraKeyValueService.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(config),
+                leaderConfig);
     }
 
     @Override
     public TimestampService createTimestampService(KeyValueService rawKvs) {
         AtlasDbVersion.ensureVersionReported();
         Preconditions.checkArgument(rawKvs instanceof CassandraKeyValueService,
-                "TimestampService must be created from an instance of CassandraKeyValueService, found %s", rawKvs.getClass());
-        return PersistentTimestampService.create(CassandraTimestampBoundStore.create((CassandraKeyValueService) rawKvs));
+                "TimestampService must be created from an instance of"
+                + " CassandraKeyValueService, found %s", rawKvs.getClass());
+        return PersistentTimestampService.create(
+                CassandraTimestampBoundStore.create((CassandraKeyValueService) rawKvs));
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraCredentialsConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraCredentialsConfig.java
@@ -24,9 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonSerialize(as = ImmutableCassandraCredentialsConfig.class)
 @Value.Immutable
 public interface CassandraCredentialsConfig {
+    String username();
 
-    public String username();
-    
-    public String password();
-    
+    String password();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -66,6 +66,8 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
      * This configuration value is deprecated in favor of using sslConfiguration.  If
      * true, read in trust and key store information from system properties unless
      * the sslConfiguration object is specified.
+     *
+     * @deprecated Use {@link #sslConfiguration()} instead.
      */
     @Deprecated
     public abstract Optional<Boolean> ssl();
@@ -91,7 +93,9 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     }
 
     @Value.Default
-    public int fetchBatchCount() { return 5000; }
+    public int fetchBatchCount() {
+        return 5000;
+    }
 
     @Value.Default
     public boolean safetyDisabled() {
@@ -104,7 +108,9 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     }
 
     @Value.Default
-    public boolean clusterMeetsNormalConsistencyGuarantees() { return true; }
+    public boolean clusterMeetsNormalConsistencyGuarantees() {
+        return true;
+    }
 
     /**
      * This is how long we will wait when we first open a socket to the cassandra server.
@@ -133,7 +139,9 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     }
 
     @Value.Default
-    public int schemaMutationTimeoutMillis() { return 60 * 1000; }
+    public int schemaMutationTimeoutMillis() {
+        return 60 * 1000;
+    }
 
     @Value.Default
     public int rangesConcurrency() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLExpiringKeyValueService.java
@@ -67,7 +67,8 @@ public final class CQLExpiringKeyValueService extends CQLKeyValueService impleme
                     tableRef,
                     KeyValueServices.toConstantTimestampValues(values.entrySet(), timestamp),
                     TransactionType.NONE,
-                    CassandraKeyValueServices.convertTtl(time, unit), false);
+                    CassandraKeyValueServices.convertTtl(time, unit),
+                    false);
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         }
@@ -80,7 +81,8 @@ public final class CQLExpiringKeyValueService extends CQLKeyValueService impleme
                     tableRef,
                     values.entries(),
                     TransactionType.NONE,
-                    CassandraKeyValueServices.convertTtl(time, unit), false);
+                    CassandraKeyValueServices.convertTtl(time, unit),
+                    false);
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeoutException;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,8 +119,10 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 public class CQLKeyValueService extends AbstractKeyValueService {
     private static final Logger log = LoggerFactory.getLogger(CQLKeyValueService.class);
 
-    private Cluster cluster, longRunningQueryCluster;
-    Session session, longRunningQuerySession;
+    private Cluster cluster;
+    private Cluster longRunningQueryCluster;
+    Session session;
+    Session longRunningQuerySession;
 
     CQLStatementCache cqlStatementCache;
     protected CQLKeyValueServices cqlKeyValueServices;
@@ -135,7 +137,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     private boolean limitBatchSizesToServerDefaults = false;
 
     public static CQLKeyValueService create(CassandraKeyValueServiceConfigManager configManager) {
-        Optional<CassandraJmxCompactionManager> compactionManager = CassandraJmxCompaction.createJmxCompactionManager(configManager);
+        Optional<CassandraJmxCompactionManager> compactionManager =
+                CassandraJmxCompaction.createJmxCompactionManager(configManager);
         final CQLKeyValueService ret = new CQLKeyValueService(configManager, compactionManager);
         ret.initializeConnectionPool();
         ret.performInitialSetup();
@@ -178,8 +181,10 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
         // Refuse to talk to nodes twice as (latency-wise) slow as the best one, over a timescale of 100ms,
         // and every 10s try to re-evaluate ignored nodes performance by giving them queries again.
-        // Note we are being purposely datacenter-irreverent here, instead relying on latency alone to approximate what DCAwareRR would do;
-        // this is because DCs for Atlas are always quite latency-close and should be used this way, not as if we have some cross-country backup DC.
+        // Note we are being purposely datacenter-irreverent here, instead relying on latency alone
+        // to approximate what DCAwareRR would do;
+        // this is because DCs for Atlas are always quite latency-close and should be used this way,
+        // not as if we have some cross-country backup DC.
         LoadBalancingPolicy policy = LatencyAwarePolicy.builder(new RoundRobinPolicy()).build();
 
         // If user wants, do not automatically add in new nodes to pool (useful during DC migrations / rebuilds)
@@ -188,7 +193,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         }
 
         // also try and select coordinators who own the data we're talking about to avoid an extra hop,
-        // but also shuffle which replica we talk to for a load balancing that comes at the expense of less effective caching
+        // but also shuffle which replica we talk to for a load balancing that comes at the expense
+        // of less effective caching
         policy = new TokenAwarePolicy(policy, true);
 
         clusterBuilder.withLoadBalancingPolicy(policy);
@@ -207,7 +213,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                 throw e;
             }
         } catch (IllegalStateException e) {
-            if (e.getMessage().contains("requested compression is not available")) { // god dammit datastax what did I do to _you_
+            // god dammit datastax what did I do to _you_
+            if (e.getMessage().contains("requested compression is not available")) {
                 clusterBuilder.withCompression(Compression.NONE);
                 cluster = clusterBuilder.build();
                 metadata = cluster.getMetadata();
@@ -218,7 +225,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
         session = cluster.connect();
 
-        clusterBuilder.withSocketOptions(new SocketOptions().setReadTimeoutMillis(CassandraConstants.LONG_RUNNING_QUERY_SOCKET_TIMEOUT_MILLIS));
+        clusterBuilder.withSocketOptions(new SocketOptions().setReadTimeoutMillis(
+                CassandraConstants.LONG_RUNNING_QUERY_SOCKET_TIMEOUT_MILLIS));
         longRunningQueryCluster = clusterBuilder.build();
         longRunningQuerySession = longRunningQueryCluster.connect();
 
@@ -253,7 +261,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         session.close();
         cluster.close();
         cqlKeyValueServices.shutdown();
-        if(compactionManager.isPresent()) {
+        if (compactionManager.isPresent()) {
             compactionManager.get().close();
         }
         longRunningQuerySession.close();
@@ -284,17 +292,19 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
         // node we're querying doesn't count itself as a peer
         if (peers.size() > 0 && !allNodesHaveSaneNumberOfVnodes) {
-            throw new IllegalStateException("All nodes in cluster must have sane number of vnodes (or cluster must consist of a single node).");
+            throw new IllegalStateException("All nodes in cluster must have sane number of vnodes"
+                    + " (or cluster must consist of a single node).");
         }
 
         Set<String> dcsInCluster = Sets.newHashSet();
-        for (Peer peer: peers) {
-            dcsInCluster.add(peer.data_center);
-                if (peer.data_center == null) {
-                    throw new IllegalStateException("Cluster should not mix datacenter-aware and non-datacenter-aware nodes.");
-                }
+        for (Peer peer : peers) {
+            dcsInCluster.add(peer.dataCenter);
+            if (peer.dataCenter == null) {
+                throw new IllegalStateException("Cluster should not mix datacenter-aware"
+                        + " and non-datacenter-aware nodes.");
             }
-            dcsInCluster.add(getLocalDataCenter());
+        }
+        dcsInCluster.add(getLocalDataCenter());
 
         if (metadata.getKeyspace(config.keyspace()) == null) { // keyspace previously didn't exist; we need to set it up
             createKeyspace(config.keyspace(), dcsInCluster);
@@ -306,7 +316,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
     private String getLocalDataCenter() {
         Local local = CQLKeyValueServices.getLocal(session);
-        return local.data_center;
+        return local.dataCenter;
     }
 
     @Override
@@ -363,15 +373,16 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                     throw Throwables.throwUncheckedException(t);
                 }
                 for (Row row : resultSet.all()) {
-                    Cell c = Cell.create(CQLKeyValueServices.getRowName(row), CQLKeyValueServices.getColName(row));
+                    Cell cell = Cell.create(CQLKeyValueServices.getRowName(row), CQLKeyValueServices.getColName(row));
                     if ((CQLKeyValueServices.getTs(row) < startTs)
-                            && (!result.containsKey(c) || (result.get(c).getTimestamp() < CQLKeyValueServices.getTs(row)))) {
+                            && (!result.containsKey(cell)
+                                    || (result.get(cell).getTimestamp() < CQLKeyValueServices.getTs(row)))) {
                         result.put(
                                 Cell.create(CQLKeyValueServices.getRowName(row), CQLKeyValueServices.getColName(row)),
                                 Value.create(CQLKeyValueServices.getValue(row), CQLKeyValueServices.getTs(row)));
                     }
                 }
-                cqlKeyValueServices.logTracedQuery(getRowsQuery, resultSet, session, cqlStatementCache.NORMAL_QUERY);
+                cqlKeyValueServices.logTracedQuery(getRowsQuery, resultSet, session, cqlStatementCache.normalQuery);
             }
         }
         if (rowCount > fetchBatchCount) {
@@ -415,19 +426,22 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                             final Set<Cell> cells,
                             final long startTs,
                             boolean loadAllTs,
-                            final Visitor<Multimap<Cell, Value>> v,
+                            final Visitor<Multimap<Cell, Value>> visitor,
                             final ConsistencyLevel consistency) throws Exception {
-        final String loadWithTsQuery = "SELECT * FROM " + getFullTableName(tableRef) + " "
-                + "WHERE " + CassandraConstants.ROW_NAME + " = ? AND " + CassandraConstants.COL_NAME_COL + " = ? AND " + CassandraConstants.TS_COL
-                + " > ?" + (!loadAllTs ? " LIMIT 1" : "");
-        final CassandraKeyValueServiceConfig config = configManager.getConfig();
+        String loadWithTsQuery = "SELECT * FROM " + getFullTableName(tableRef)
+                + " WHERE " + CassandraConstants.ROW_NAME + " = ?"
+                + " AND " + CassandraConstants.COL_NAME_COL + " = ?"
+                + " AND " + CassandraConstants.TS_COL + " > ?"
+                + (!loadAllTs ? " LIMIT 1" : "");
+        CassandraKeyValueServiceConfig config = configManager.getConfig();
         if (cells.size() > config.fetchBatchCount()) {
             log.warn("A call to " + tableRef
                     + " is performing a multiget " + cells.size()
                     + " cells; this may indicate overly-large batching on a higher level.\n"
                     + CassandraKeyValueServices.getFilteredStackTrace("com.palantir"));
         }
-        final PreparedStatement preparedStatement = getPreparedStatement(tableRef, loadWithTsQuery, session).setConsistencyLevel(consistency);
+        PreparedStatement preparedStatement = getPreparedStatement(tableRef, loadWithTsQuery, session)
+                .setConsistencyLevel(consistency);
         List<ResultSetFuture> resultSetFutures = Lists.newArrayListWithCapacity(cells.size());
 
         for (Cell cell : cells) {
@@ -440,7 +454,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         }
 
         for (ResultSetFuture rsf : resultSetFutures) {
-            visitResults(rsf.getUninterruptibly(), v, loadWithTsQuery, loadAllTs);
+            visitResults(rsf.getUninterruptibly(), visitor, loadWithTsQuery, loadAllTs);
         }
     }
 
@@ -449,7 +463,11 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         return Multimaps.asMap(Multimaps.index(cells, Cells.getRowFunction()));
     }
 
-    private void visitResults(ResultSet resultSet, Visitor<Multimap<Cell, Value>> v, String query, boolean loadAllTs) {
+    private void visitResults(
+            ResultSet resultSet,
+            Visitor<Multimap<Cell, Value>> visitor,
+            String query,
+            boolean loadAllTs) {
         List<Row> rows = resultSet.all();
         Multimap<Cell, Value> res;
         if (loadAllTs) {
@@ -461,8 +479,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             res.put(Cell.create(CQLKeyValueServices.getRowName(row), CQLKeyValueServices.getColName(row)),
                     Value.create(CQLKeyValueServices.getValue(row), CQLKeyValueServices.getTs(row)));
         }
-        cqlKeyValueServices.logTracedQuery(query, resultSet, session, cqlStatementCache.NORMAL_QUERY);
-        v.visit(res);
+        cqlKeyValueServices.logTracedQuery(query, resultSet, session, cqlStatementCache.normalQuery);
+        visitor.visit(res);
     }
 
     @Override
@@ -477,7 +495,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
     private Map<Cell, Long> getLatestTimestampsInternal(final TableReference tableRef,
                                                         Map<Cell, Long> timestampByCell) throws Exception {
-        final CassandraKeyValueServiceConfig config = configManager.getConfig();
+        CassandraKeyValueServiceConfig config = configManager.getConfig();
         int fetchBatchCount = config.fetchBatchCount();
         Iterable<List<Cell>> partitions = Iterables.partition(
                 timestampByCell.keySet(),
@@ -485,9 +503,14 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         int numPartitions = (timestampByCell.size() / fetchBatchCount)
                 + (timestampByCell.size() % fetchBatchCount > 0 ? 1 : 0);
         List<Future<Map<Cell, Long>>> futures = Lists.newArrayListWithCapacity(numPartitions);
-        final String loadOnlyTsQuery = "SELECT " + CassandraConstants.ROW_NAME + ", " + CassandraConstants.COL_NAME_COL + ", " + CassandraConstants.TS_COL
-                + " FROM " + getFullTableName(tableRef) + " " + "WHERE " + CassandraConstants.ROW_NAME + " = ? AND "
-                + CassandraConstants.COL_NAME_COL + " = ? LIMIT 1";
+        String loadOnlyTsQuery = "SELECT "
+                + CassandraConstants.ROW_NAME + ", "
+                + CassandraConstants.COL_NAME_COL + ", "
+                + CassandraConstants.TS_COL
+                + " FROM " + getFullTableName(tableRef)
+                + " WHERE " + CassandraConstants.ROW_NAME + " = ?"
+                + " AND " + CassandraConstants.COL_NAME_COL + " = ?"
+                + " LIMIT 1";
         if (timestampByCell.size() > fetchBatchCount) {
             log.warn("Re-batching in getLatestTimestamps a call to " + tableRef
                     + " that attempted to multiget " + timestampByCell.size()
@@ -513,9 +536,16 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                     for (ResultSetFuture resultSetFuture : resultSetFutures) {
                         ResultSet resultSet = resultSetFuture.getUninterruptibly();
                         for (Row row : resultSet.all()) {
-                            res.put(Cell.create(CQLKeyValueServices.getRowName(row), CQLKeyValueServices.getColName(row)), CQLKeyValueServices.getTs(row));
+                            res.put(Cell.create(
+                                    CQLKeyValueServices.getRowName(row),
+                                    CQLKeyValueServices.getColName(row)),
+                                    CQLKeyValueServices.getTs(row));
                         }
-                        cqlKeyValueServices.logTracedQuery(loadOnlyTsQuery, resultSet, session, cqlStatementCache.NORMAL_QUERY);
+                        cqlKeyValueServices.logTracedQuery(
+                                loadOnlyTsQuery,
+                                resultSet,
+                                session,
+                                cqlStatementCache.normalQuery);
                     }
                     return res;
                 }
@@ -562,7 +592,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     }
 
     @Override
-    public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, final long timestamp) throws KeyAlreadyExistsException {
+    public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp)
+            throws KeyAlreadyExistsException {
         Map<ResultSetFuture, TableReference> resultSetFutures = Maps.newHashMap();
         for (Entry<TableReference, ? extends Map<Cell, byte[]>> e : valuesByTable.entrySet()) {
             final TableReference table = e.getKey();
@@ -570,16 +601,17 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             NavigableMap<Cell, byte[]> sortedMap = ImmutableSortedMap.copyOf(e.getValue());
 
 
-            Iterable<List<Entry<Cell, byte[]>>> partitions = partitionByCountAndBytes(sortedMap.entrySet(),
-                    getMultiPutBatchCount(), getMultiPutBatchSizeBytes(), table, CQLKeyValueServices.MULTIPUT_ENTRY_SIZING_FUNCTION);
+            Iterable<List<Entry<Cell, byte[]>>> partitions = partitionByCountAndBytes(
+                    sortedMap.entrySet(),
+                    getMultiPutBatchCount(),
+                    getMultiPutBatchSizeBytes(),
+                    table,
+                    CQLKeyValueServices.MULTIPUT_ENTRY_SIZING_FUNCTION);
 
 
             for (final List<Entry<Cell, byte[]>> p : partitions) {
-                List<Entry<Cell, Value>> partition = Lists.transform(p, new Function<Entry<Cell, byte[]>, Entry<Cell, Value>>() {
-                    @Override
-                    public Entry<Cell, Value> apply(Entry<Cell, byte[]> input) {
-                        return Maps.immutableEntry(input.getKey(), Value.create(input.getValue(), timestamp));
-                    }});
+                List<Entry<Cell, Value>> partition = Lists.transform(p,
+                        input -> Maps.immutableEntry(input.getKey(), Value.create(input.getValue(), timestamp)));
                 resultSetFutures.put(getPutPartitionResultSetFuture(table, partition, TransactionType.NONE), table);
             }
         }
@@ -592,21 +624,32 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             } catch (Throwable t) {
                 throw Throwables.throwUncheckedException(t);
             }
-            cqlKeyValueServices.logTracedQuery(getPutQuery(result.getValue(), CassandraConstants.NO_TTL), resultSet, session, cqlStatementCache.NORMAL_QUERY);
+            cqlKeyValueServices.logTracedQuery(
+                    getPutQuery(result.getValue(), CassandraConstants.NO_TTL),
+                    resultSet,
+                    session,
+                    cqlStatementCache.normalQuery);
         }
     }
 
-    private void putInternal(final TableReference tableRef, final Iterable<Map.Entry<Cell, Value>> values, TransactionType transactionType)
-            throws Exception {
+    private void putInternal(
+            TableReference tableRef,
+            Iterable<Map.Entry<Cell, Value>> values,
+            TransactionType transactionType) throws Exception {
         putInternal(tableRef, values, transactionType, CassandraConstants.NO_TTL, false);
     }
 
-    protected void putInternal(final TableReference tableRef, final Iterable<Map.Entry<Cell, Value>> values, TransactionType transactionType, final int ttl, boolean recursive)
-            throws Exception {
+    protected void putInternal(
+            TableReference tableRef,
+            Iterable<Map.Entry<Cell, Value>> values,
+            TransactionType transactionType,
+            int ttl,
+            boolean recursive) throws Exception {
         List<ResultSetFuture> resultSetFutures = Lists.newArrayList();
         int mutationBatchCount = configManager.getConfig().mutationBatchCount();
-        long mutationBatchSizeBytes = limitBatchSizesToServerDefaults?
-                CQLKeyValueServices.UNCONFIGURED_DEFAULT_BATCH_SIZE_BYTES : configManager.getConfig().mutationBatchSizeBytes();
+        long mutationBatchSizeBytes = limitBatchSizesToServerDefaults
+                ? CQLKeyValueServices.UNCONFIGURED_DEFAULT_BATCH_SIZE_BYTES
+                : configManager.getConfig().mutationBatchSizeBytes();
         for (List<Entry<Cell, Value>> partition : partitionByCountAndBytes(
                 values,
                 mutationBatchCount,
@@ -622,13 +665,15 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             try {
                 resultSet = resultSetFuture.getUninterruptibly();
                 resultSet.all();
-                cqlKeyValueServices.logTracedQuery(putQuery, resultSet, session, cqlStatementCache.NORMAL_QUERY);
+                cqlKeyValueServices.logTracedQuery(putQuery, resultSet, session, cqlStatementCache.normalQuery);
                 if (!resultSet.wasApplied()) {
                     throw new KeyAlreadyExistsException("This transaction row already exists: " + putQuery);
                 }
             } catch (InvalidQueryException e) {
                 if (e.getMessage().contains("Batch too large") && !recursive) {
-                    log.error("Attempted a put to " + tableRef + " that the Cassandra server deemed to be too large to accept. Batch sizes on the Atlas-side have been artificially lowered to the Cassandra default maximum batch sizes.");
+                    log.error("Attempted a put to " + tableRef + " that the Cassandra server"
+                            + " deemed to be too large to accept. Batch sizes on the Atlas-side"
+                            + " have been artificially lowered to the Cassandra default maximum batch sizes.");
                     limitBatchSizesToServerDefaults = true;
                     try {
                         putInternal(tableRef, values, transactionType, ttl, true);
@@ -648,8 +693,13 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         return getPutQueryForPossibleTransaction(tableRef, transactionType, CassandraConstants.NO_TTL);
     }
 
-    private String getPutQueryForPossibleTransaction(TableReference tableRef, TransactionType transactionType, int ttl) {
-        return transactionType.equals(TransactionType.LIGHTWEIGHT_TRANSACTION_REQUIRED)? getPutUnlessExistsQuery(tableRef, ttl) : getPutQuery(tableRef, ttl);
+    private String getPutQueryForPossibleTransaction(
+            TableReference tableRef,
+            TransactionType transactionType,
+            int ttl) {
+        return transactionType.equals(TransactionType.LIGHTWEIGHT_TRANSACTION_REQUIRED)
+                ? getPutUnlessExistsQuery(tableRef, ttl)
+                : getPutQuery(tableRef, ttl);
     }
 
     private String getPutUnlessExistsQuery(TableReference tableRef, int ttl) {
@@ -661,7 +711,12 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     }
 
     protected String getPutQuery(TableReference tableName, int ttl) {
-        String putQuery = "INSERT INTO " + getFullTableName(tableName) + " (" + CassandraConstants.ROW_NAME + ", " + CassandraConstants.COL_NAME_COL + ", " + CassandraConstants.TS_COL + ", " + CassandraConstants.VALUE_COL + ") VALUES (?, ?, ?, ?)";
+        String putQuery = "INSERT INTO " + getFullTableName(tableName)
+                + " (" + CassandraConstants.ROW_NAME + ", "
+                + CassandraConstants.COL_NAME_COL + ", "
+                + CassandraConstants.TS_COL + ", "
+                + CassandraConstants.VALUE_COL + ")"
+                + " VALUES (?, ?, ?, ?)";
         if (ttl >= 0) {
             putQuery += " USING TTL " + ttl;
         }
@@ -678,7 +733,10 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                                                              List<Entry<Cell, Value>> partition,
                                                              TransactionType transactionType,
                                                              int ttl) {
-        PreparedStatement preparedStatement = getPreparedStatement(tableRef, getPutQueryForPossibleTransaction(tableRef, transactionType, ttl), session);
+        PreparedStatement preparedStatement = getPreparedStatement(
+                tableRef,
+                getPutQueryForPossibleTransaction(tableRef, transactionType, ttl),
+                session);
         preparedStatement.setConsistencyLevel(writeConsistency);
 
         // Be mindful when using the atomicity semantics of UNLOGGED batch statements.
@@ -714,31 +772,40 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
         for (TableReference tableRef : tablesToTruncate) {
             BoundStatement truncateStatement =
-                    getPreparedStatement(tableRef, String.format(truncateQuery, getFullTableName(tableRef)), longRunningQuerySession)
+                    getPreparedStatement(
+                            tableRef,
+                            String.format(truncateQuery, getFullTableName(tableRef)),
+                            longRunningQuerySession)
                             .setConsistencyLevel(ConsistencyLevel.ALL)
                             .bind();
 
             try {
                 ResultSet resultSet = longRunningQuerySession.execute(truncateStatement);
-                cqlKeyValueServices.logTracedQuery(truncateQuery, resultSet, session, cqlStatementCache.NORMAL_QUERY);
+                cqlKeyValueServices.logTracedQuery(truncateQuery, resultSet, session, cqlStatementCache.normalQuery);
             } catch (com.datastax.driver.core.exceptions.UnavailableException e) {
-                throw new InsufficientConsistencyException("Truncating tables requires all Cassandra nodes to be up and available.", e);
+                throw new InsufficientConsistencyException("Truncating tables requires all Cassandra"
+                        + " nodes to be up and available.", e);
             }
         }
 
-        CQLKeyValueServices.waitForSchemaVersionsToCoalesce("truncateTables(" + tablesToTruncate.size() + " tables)", this);
+        CQLKeyValueServices.waitForSchemaVersionsToCoalesce(
+                "truncateTables(" + tablesToTruncate.size() + " tables)",
+                this);
     }
 
     @Override
     public void delete(final TableReference tableRef, final Multimap<Cell, Long> keys) {
         int cellCount = 0;
-        final String deleteQuery = "DELETE FROM " + getFullTableName(tableRef) + " WHERE "
-                + CassandraConstants.ROW_NAME + " = ? AND " + CassandraConstants.COL_NAME_COL + " = ? AND " + CassandraConstants.TS_COL + " = ?";
-        final CassandraKeyValueServiceConfig config = configManager.getConfig();
+        String deleteQuery = "DELETE FROM " + getFullTableName(tableRef)
+                + " WHERE " + CassandraConstants.ROW_NAME + " = ?"
+                + " AND " + CassandraConstants.COL_NAME_COL + " = ?"
+                + " AND " + CassandraConstants.TS_COL + " = ?";
+        CassandraKeyValueServiceConfig config = configManager.getConfig();
         int fetchBatchCount = config.fetchBatchCount();
         for (final List<Cell> batch : Iterables.partition(keys.keySet(), fetchBatchCount)) {
             cellCount += batch.size();
-            PreparedStatement deleteStatement = getPreparedStatement(tableRef, deleteQuery, longRunningQuerySession).setConsistencyLevel(deleteConsistency);
+            PreparedStatement deleteStatement = getPreparedStatement(tableRef, deleteQuery, longRunningQuerySession)
+                    .setConsistencyLevel(deleteConsistency);
             List<ResultSetFuture> resultSetFutures = Lists.newArrayList();
             for (Cell key : batch) {
                 for (long ts : Ordering.natural().immutableSortedCopy(keys.get(key))) {
@@ -758,7 +825,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                 } catch (Throwable t) {
                     throw Throwables.throwUncheckedException(t);
                 }
-                cqlKeyValueServices.logTracedQuery(deleteQuery, resultSet, session, cqlStatementCache.NORMAL_QUERY);
+                cqlKeyValueServices.logTracedQuery(deleteQuery, resultSet, session, cqlStatementCache.normalQuery);
             }
         }
         if (cellCount > fetchBatchCount) {
@@ -772,9 +839,10 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     // TODO: after cassandra change: handle multiRanges
     @Override
     @Idempotent
-    public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(TableReference tableRef,
-                                                                                                           Iterable<RangeRequest> rangeRequests,
-                                                                                                           long timestamp) {
+    public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
+            TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            long timestamp) {
         int concurrency = configManager.getConfig().rangesConcurrency();
         return KeyValueServices.getFirstBatchForRangesUsingGetRangeConcurrent(
                 executor,
@@ -826,11 +894,12 @@ public class CQLKeyValueService extends AbstractKeyValueService {
                 HistoryExtractor.SUPPLIER);
     }
 
-    public <T, U> ClosableIterator<RowResult<U>> getRangeWithPageCreator(final TableReference tableRef,
-                                                                         final RangeRequest rangeRequest,
-                                                                         final long timestamp,
-                                                                         final com.datastax.driver.core.ConsistencyLevel consistency,
-                                                                         final Supplier<ResultsExtractor<T, U>> resultsExtractor) {
+    public <T, U> ClosableIterator<RowResult<U>> getRangeWithPageCreator(
+            TableReference tableRef,
+            RangeRequest rangeRequest,
+            long timestamp,
+            com.datastax.driver.core.ConsistencyLevel consistency,
+            Supplier<ResultsExtractor<T, U>> resultsExtractor) {
         if (rangeRequest.isReverse()) {
             throw new UnsupportedOperationException();
         }
@@ -838,7 +907,9 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             return ClosableIterators.wrap(ImmutableList.<RowResult<U>>of().iterator());
         }
         final int batchHint = rangeRequest.getBatchHint() == null ? 100 : rangeRequest.getBatchHint();
-        final ColumnSelection selection = rangeRequest.getColumnNames().isEmpty() ? ColumnSelection.all() : ColumnSelection.create(rangeRequest.getColumnNames());
+        final ColumnSelection selection = rangeRequest.getColumnNames().isEmpty()
+                ? ColumnSelection.all()
+                : ColumnSelection.create(rangeRequest.getColumnNames());
         final byte[] endExclusive = rangeRequest.getEndExclusive();
         final StringBuilder bindQuery = new StringBuilder();
         bindQuery.append("SELECT * FROM " + getFullTableName(tableRef) + " WHERE token("
@@ -849,73 +920,77 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         bindQuery.append("LIMIT " + batchHint);
         final String getLastRowQuery = "SELECT * FROM " + getFullTableName(tableRef) + " WHERE "
                 + CassandraConstants.ROW_NAME + " = ?";
-        return ClosableIterators.wrap(new AbstractPagingIterable<RowResult<U>, TokenBackedBasicResultsPage<RowResult<U>, byte[]>>() {
-            @Override
-            protected TokenBackedBasicResultsPage<RowResult<U>, byte[]> getFirstPage()
-                    throws Exception {
-                return getPage(rangeRequest.getStartInclusive());
-            }
-
-            @Override
-            protected TokenBackedBasicResultsPage<RowResult<U>, byte[]> getNextPage(TokenBackedBasicResultsPage<RowResult<U>, byte[]> previous)
-                    throws Exception {
-                return getPage(previous.getTokenForNextPage());
-            }
-
-            TokenBackedBasicResultsPage<RowResult<U>, byte[]> getPage(final byte[] startKey)
-                    throws Exception {
-                BoundStatement boundStatement = getPreparedStatement(tableRef, bindQuery.toString(), session)
-                        .setConsistencyLevel(consistency)
-                        .bind();
-
-                boundStatement.setBytes(0, ByteBuffer.wrap(startKey));
-                if (endExclusive.length > 0) {
-                    boundStatement.setBytes(1, ByteBuffer.wrap(endExclusive));
+        return ClosableIterators.wrap(
+                new AbstractPagingIterable<RowResult<U>, TokenBackedBasicResultsPage<RowResult<U>, byte[]>>() {
+                @Override
+                protected TokenBackedBasicResultsPage<RowResult<U>, byte[]> getFirstPage()
+                        throws Exception {
+                    return getPage(rangeRequest.getStartInclusive());
                 }
-                ResultSet resultSet = session.execute(boundStatement);
-                List<Row> rows = Lists.newArrayList(resultSet.all());
-                cqlKeyValueServices.logTracedQuery(bindQuery.toString(), resultSet, session, cqlStatementCache.NORMAL_QUERY);
-                byte[] maxRow = null;
-                ResultsExtractor<T, U> extractor = resultsExtractor.get();
-                for (Row row : rows) {
-                    byte[] rowName = CQLKeyValueServices.getRowName(row);
-                    if (maxRow == null) {
-                        maxRow = rowName;
-                    } else {
-                        maxRow = PtBytes.BYTES_COMPARATOR.max(maxRow, rowName);
+
+                @Override
+                protected TokenBackedBasicResultsPage<RowResult<U>, byte[]> getNextPage(
+                        TokenBackedBasicResultsPage<RowResult<U>, byte[]> previous)
+                        throws Exception {
+                    return getPage(previous.getTokenForNextPage());
+                }
+
+                TokenBackedBasicResultsPage<RowResult<U>, byte[]> getPage(final byte[] startKey)
+                        throws Exception {
+                    BoundStatement boundStatement = getPreparedStatement(tableRef, bindQuery.toString(), session)
+                            .setConsistencyLevel(consistency)
+                            .bind();
+
+                    boundStatement.setBytes(0, ByteBuffer.wrap(startKey));
+                    if (endExclusive.length > 0) {
+                        boundStatement.setBytes(1, ByteBuffer.wrap(endExclusive));
                     }
-                }
-                if (maxRow == null) {
-                    return new SimpleTokenBackedResultsPage<RowResult<U>, byte[]>(
-                            endExclusive,
-                            ImmutableList.<RowResult<U>> of(),
-                            false);
-                }
-                // get the rest of the last row
-                BoundStatement boundLastRow = getPreparedStatement(tableRef, getLastRowQuery, session).bind();
+                    ResultSet resultSet = session.execute(boundStatement);
+                    List<Row> rows = Lists.newArrayList(resultSet.all());
+                    cqlKeyValueServices.logTracedQuery(
+                            bindQuery.toString(), resultSet, session, cqlStatementCache.normalQuery);
+                    byte[] maxRow = null;
+                    ResultsExtractor<T, U> extractor = resultsExtractor.get();
+                    for (Row row : rows) {
+                        byte[] rowName = CQLKeyValueServices.getRowName(row);
+                        if (maxRow == null) {
+                            maxRow = rowName;
+                        } else {
+                            maxRow = PtBytes.BYTES_COMPARATOR.max(maxRow, rowName);
+                        }
+                    }
+                    if (maxRow == null) {
+                        return new SimpleTokenBackedResultsPage<>(
+                                endExclusive,
+                                ImmutableList.of(),
+                                false);
+                    }
+                    // get the rest of the last row
+                    BoundStatement boundLastRow = getPreparedStatement(tableRef, getLastRowQuery, session).bind();
 
-                boundLastRow.setBytes(CassandraConstants.ROW_NAME, ByteBuffer.wrap(maxRow));
-                try {
-                    resultSet = session.execute(boundLastRow);
-                } catch (com.datastax.driver.core.exceptions.UnavailableException e) {
-                    throw new InsufficientConsistencyException("This operation requires all Cassandra nodes to be up and available.", e);
+                    boundLastRow.setBytes(CassandraConstants.ROW_NAME, ByteBuffer.wrap(maxRow));
+                    try {
+                        resultSet = session.execute(boundLastRow);
+                    } catch (com.datastax.driver.core.exceptions.UnavailableException e) {
+                        throw new InsufficientConsistencyException("This operation requires all Cassandra"
+                                + " nodes to be up and available.", e);
+                    }
+                    rows.addAll(resultSet.all());
+                    cqlKeyValueServices.logTracedQuery(
+                            getLastRowQuery, resultSet, session, cqlStatementCache.normalQuery);
+                    for (Row row : rows) {
+                        extractor.internalExtractResult(
+                                timestamp,
+                                selection,
+                                CQLKeyValueServices.getRowName(row),
+                                CQLKeyValueServices.getColName(row),
+                                CQLKeyValueServices.getValue(row),
+                                CQLKeyValueServices.getTs(row));
+                    }
+                    SortedMap<byte[], SortedMap<byte[], U>> resultsByRow = Cells.breakCellsUpByRow(extractor.asMap());
+                    return ResultsExtractor.getRowResults(endExclusive, maxRow, resultsByRow);
                 }
-                rows.addAll(resultSet.all());
-                cqlKeyValueServices.logTracedQuery(getLastRowQuery, resultSet, session, cqlStatementCache.NORMAL_QUERY);
-                for (Row row : rows) {
-                    extractor.internalExtractResult(
-                            timestamp,
-                            selection,
-                            CQLKeyValueServices.getRowName(row),
-                            CQLKeyValueServices.getColName(row),
-                            CQLKeyValueServices.getValue(row),
-                            CQLKeyValueServices.getTs(row));
-                }
-                SortedMap<byte[], SortedMap<byte[], U>> resultsByRow = Cells.breakCellsUpByRow(extractor.asMap());
-                return ResultsExtractor.getRowResults(endExclusive, maxRow, resultsByRow);
-            }
-
-        }.iterator());
+            }.iterator());
     }
 
     @Override
@@ -929,31 +1004,31 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
         for (TableReference tableRef : tablesToDrop) {
             BoundStatement dropStatement =
-                    getPreparedStatement(tableRef, String.format(dropQuery, getFullTableName(tableRef)), longRunningQuerySession)
+                    getPreparedStatement(
+                            tableRef,
+                            String.format(dropQuery, getFullTableName(tableRef)),
+                            longRunningQuerySession)
                             .setConsistencyLevel(ConsistencyLevel.ALL)
                             .bind();
             try {
                 ResultSet resultSet = longRunningQuerySession.execute(dropStatement);
-                cqlKeyValueServices.logTracedQuery(dropQuery, resultSet, session, cqlStatementCache.NORMAL_QUERY);
+                cqlKeyValueServices.logTracedQuery(dropQuery, resultSet, session, cqlStatementCache.normalQuery);
             } catch (com.datastax.driver.core.exceptions.UnavailableException e) {
-                throw new InsufficientConsistencyException("Dropping tables requires all Cassandra nodes to be up and available.", e);
+                throw new InsufficientConsistencyException("Dropping tables requires all Cassandra"
+                        + " nodes to be up and available.", e);
             }
         }
 
         CQLKeyValueServices.waitForSchemaVersionsToCoalesce("dropTables(" + tablesToDrop.size() + " tables)", this);
 
         put(AtlasDbConstants.METADATA_TABLE, Maps.toMap(
-                        Lists.transform(Lists.newArrayList(tablesToDrop), new Function<TableReference, Cell>() {
-                            @Override
-                            public Cell apply(TableReference tableRef) {
-                                return CQLKeyValueServices.getMetadataCell(tableRef);
-                            }}),
+                        Lists.transform(Lists.newArrayList(tablesToDrop), CQLKeyValueServices::getMetadataCell),
                         Functions.constant(PtBytes.EMPTY_BYTE_ARRAY)),
                 System.currentTimeMillis());
     }
 
     private void createKeyspace(String keyspaceName, Set<String> dcsInCluster) {
-        String create_keyspace = "create keyspace if not exists %s with replication = %s and durable_writes = true";
+        String createKeyspace = "create keyspace if not exists %s with replication = %s and durable_writes = true";
         final CassandraKeyValueServiceConfig config = configManager.getConfig();
         String replication;
         replication = "{ 'class' : 'NetworkTopologyStrategy', ";
@@ -968,7 +1043,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
         longRunningQuerySession.execute(
                 getPreparedStatement(CassandraConstants.NO_TABLE,
-                        String.format(create_keyspace, keyspaceName, replication),
+                        String.format(createKeyspace, keyspaceName, replication),
                         longRunningQuerySession)
                         .setConsistencyLevel(ConsistencyLevel.ALL)
                         .bind());
@@ -984,29 +1059,32 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     @Override
     public void createTables(final Map<TableReference, byte[]> tableRefsToTableMetadata) {
         final CassandraKeyValueServiceConfig config = configManager.getConfig();
-        Collection<com.datastax.driver.core.TableMetadata> tables = cluster.getMetadata().getKeyspace(config.keyspace()).getTables();
-        Set<TableReference> existingTables = Sets.newHashSet(Iterables.transform(tables, new Function<com.datastax.driver.core.TableMetadata, TableReference>() {
-            @Override
-            public TableReference apply(com.datastax.driver.core.TableMetadata input) {
-                return TableReference.createUnsafe(input.getName());
-            }
-        }));
+        Collection<com.datastax.driver.core.TableMetadata> tables = cluster.getMetadata()
+                .getKeyspace(config.keyspace()).getTables();
+        Set<TableReference> existingTables = Sets.newHashSet(Iterables.transform(tables,
+                input -> TableReference.createUnsafe(input.getName())));
 
-        if (!existingTables.contains(AtlasDbConstants.METADATA_TABLE)) { // ScrubberStore likes to call createTable before our setup gets called...
-            cqlKeyValueServices.createTableWithSettings(AtlasDbConstants.METADATA_TABLE, AtlasDbConstants.EMPTY_TABLE_METADATA, this);
+        // ScrubberStore likes to call createTable before our setup gets called...
+        if (!existingTables.contains(AtlasDbConstants.METADATA_TABLE)) {
+            cqlKeyValueServices.createTableWithSettings(
+                    AtlasDbConstants.METADATA_TABLE,
+                    AtlasDbConstants.EMPTY_TABLE_METADATA,
+                    this);
         }
 
-        Sets.SetView<TableReference> tablesToCreate = Sets.difference(tableRefsToTableMetadata.keySet(), existingTables);
+        Set<TableReference> tablesToCreate = Sets.difference(tableRefsToTableMetadata.keySet(), existingTables);
         for (TableReference tableRef : tablesToCreate) {
             try {
                 cqlKeyValueServices.createTableWithSettings(tableRef, tableRefsToTableMetadata.get(tableRef), this);
             } catch (com.datastax.driver.core.exceptions.UnavailableException e) {
-                throw new InsufficientConsistencyException("Creating tables requires all Cassandra nodes to be up and available.", e);
+                throw new InsufficientConsistencyException("Creating tables requires all Cassandra"
+                        + " nodes to be up and available.", e);
             }
         }
 
         if (!tablesToCreate.isEmpty()) {
-            CQLKeyValueServices.waitForSchemaVersionsToCoalesce("createTables(" + tableRefsToTableMetadata.size() + " tables)", this);
+            CQLKeyValueServices.waitForSchemaVersionsToCoalesce("createTables(" + tableRefsToTableMetadata.size()
+                    + " tables)", this);
         }
 
         internalPutMetadataForTables(tableRefsToTableMetadata, false);
@@ -1015,34 +1093,28 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     @Override
     public Set<TableReference> getAllTableNames() {
         final CassandraKeyValueServiceConfig config = configManager.getConfig();
-        List<Row> rows = session.execute(cqlStatementCache.NORMAL_QUERY.getUnchecked(
+        List<Row> rows = session.execute(cqlStatementCache.normalQuery.getUnchecked(
                 "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name = ?")
                 .bind(config.keyspace()))
                 .all();
 
-        Set<TableReference> existingTables = Sets.newHashSet(Iterables.transform(rows, new Function<Row, TableReference>(){
-            @Override
-            public TableReference apply(Row row) {
-                return fromInternalTableName(row.getString("columnfamily_name"));
-            }}));
+        Set<TableReference> existingTables = Sets.newHashSet(Iterables.transform(rows,
+                row -> fromInternalTableName(row.getString("columnfamily_name"))));
 
-        return Sets.filter(existingTables, new Predicate<TableReference>() {
-            @Override
-            public boolean apply(TableReference tableRef) {
-                return !tableRef.getQualifiedName().startsWith("_") || tableRef.getQualifiedName().startsWith(AtlasDbConstants.NAMESPACE_PREFIX);
-            }
-        });
+        return Sets.filter(existingTables, tableRef ->
+                !tableRef.getQualifiedName().startsWith("_")
+                        || tableRef.getQualifiedName().startsWith(AtlasDbConstants.NAMESPACE_PREFIX));
     }
 
     @Override
     public byte[] getMetadataForTable(TableReference tableRef) {
         Cell cell = CQLKeyValueServices.getMetadataCell(tableRef);
-        Value v = get(AtlasDbConstants.METADATA_TABLE, ImmutableMap.of(cell, Long.MAX_VALUE)).get(
+        Value value = get(AtlasDbConstants.METADATA_TABLE, ImmutableMap.of(cell, Long.MAX_VALUE)).get(
                 cell);
-        if (v == null) {
+        if (value == null) {
             return new byte[0];
         } else {
-            return v.getContents();
+            return value.getContents();
         }
     }
 
@@ -1056,7 +1128,9 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         internalPutMetadataForTables(tableRefToMetadata, true);
     }
 
-    private void internalPutMetadataForTables(final Map<TableReference, byte[]> tableNameToMetadata, boolean possiblyNeedToPerformSettingsChanges) {
+    private void internalPutMetadataForTables(
+            Map<TableReference, byte[]> tableNameToMetadata,
+            boolean possiblyNeedToPerformSettingsChanges) {
         Map<Cell, byte[]> cellToMetadata = Maps.newHashMap();
         for (Entry<TableReference, byte[]> tableEntry : tableNameToMetadata.entrySet()) {
             byte[] existingMetadata = getMetadataForTable(tableEntry.getKey());
@@ -1070,7 +1144,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         if (!cellToMetadata.isEmpty()) {
             put(AtlasDbConstants.METADATA_TABLE, cellToMetadata, System.currentTimeMillis());
             if (possiblyNeedToPerformSettingsChanges) {
-                CQLKeyValueServices.waitForSchemaVersionsToCoalesce("putMetadataForTables(" + tableNameToMetadata.size() +" tables)", this);
+                CQLKeyValueServices.waitForSchemaVersionsToCoalesce(
+                        "putMetadataForTables(" + tableNameToMetadata.size() + " tables)", this);
             }
         }
     }
@@ -1097,7 +1172,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         try {
             loadWithTs(tableRef, cells, ts, true, collector, deleteConsistency);
         } catch (com.datastax.driver.core.exceptions.UnavailableException e) {
-            throw new InsufficientConsistencyException("Get all timestamps requires all Cassandra nodes to be up and available.", e);
+            throw new InsufficientConsistencyException("Get all timestamps requires all Cassandra"
+                    + " nodes to be up and available.", e);
         } catch (Throwable t) {
             throw Throwables.throwUncheckedException(t);
         }
@@ -1123,11 +1199,14 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
     @Override
     public void compactInternally(TableReference tableRef) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()), "tableName:[%s] should not be null or empty", tableRef);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()),
+                "tableName:[%s] should not be null or empty", tableRef);
         CassandraKeyValueServiceConfig config = configManager.getConfig();
         if (!compactionManager.isPresent()) {
-            log.error("No compaction client was configured, but compact was called. If you actually want to clear deleted data immediately " +
-                    "from Cassandra, lower your gc_grace_seconds setting and run `nodetool compact {} {}`.", config.keyspace(), tableRef);
+            log.error("No compaction client was configured, but compact was called."
+                    + " If you actually want to clear deleted data immediately"
+                    + " from Cassandra, lower your gc_grace_seconds setting and"
+                    + " run `nodetool compact {} {}`.", config.keyspace(), tableRef);
             return;
         }
 
@@ -1142,17 +1221,22 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         } catch (InterruptedException e) {
             log.error("Compaction for {}.{} was interrupted.", config.keyspace(), tableRef);
         } finally {
-            alterTableForCompaction(tableRef, CassandraConstants.GC_GRACE_SECONDS, CassandraConstants.TOMBSTONE_THRESHOLD_RATIO);
+            alterTableForCompaction(
+                    tableRef,
+                    CassandraConstants.GC_GRACE_SECONDS,
+                    CassandraConstants.TOMBSTONE_THRESHOLD_RATIO);
             CQLKeyValueServices.waitForSchemaVersionsToCoalesce("setting up tables post-compaction", this);
         }
     }
 
     private void alterTableForCompaction(TableReference tableRef, int gcGraceSeconds, float tombstoneThreshold) {
-        log.trace("Altering table {} to have gc_grace_seconds={} and tombstone_threshold=%.2f", tableRef, gcGraceSeconds, tombstoneThreshold);
+        log.trace("Altering table {} to have gc_grace_seconds={} and tombstone_threshold=%.2f",
+                tableRef, gcGraceSeconds, tombstoneThreshold);
         String alterTableQuery =
                 "ALTER TABLE " + getFullTableName(tableRef)
                         + " WITH gc_grace_seconds = " + gcGraceSeconds
-                        + " and compaction = {'class':'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'tombstone_threshold':"
+                        + " and compaction = {'class':'" + CassandraConstants.LEVELED_COMPACTION_STRATEGY
+                        + "', 'tombstone_threshold':"
                         + tombstoneThreshold + "};";
 
         BoundStatement alterTable = getPreparedStatement(tableRef, alterTableQuery, longRunningQuerySession)
@@ -1162,11 +1246,12 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         try {
             resultSet = longRunningQuerySession.execute(alterTable);
         } catch (UnavailableException e) {
-            throw new InsufficientConsistencyException("Alter table requires all Cassandra nodes to be up and available.", e);
+            throw new InsufficientConsistencyException("Alter table requires all Cassandra"
+                    + " nodes to be up and available.", e);
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         }
-        cqlKeyValueServices.logTracedQuery(alterTableQuery, resultSet, session, cqlStatementCache.NORMAL_QUERY);
+        cqlKeyValueServices.logTracedQuery(alterTableQuery, resultSet, session, cqlStatementCache.normalQuery);
     }
 
     PreparedStatement getPreparedStatement(TableReference tableRef, String query, Session sessionToBeUsed) {
@@ -1174,9 +1259,9 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             PreparedStatement statement;
 
             if (sessionToBeUsed == longRunningQuerySession) {
-                statement =  cqlStatementCache.LONG_RUNNING_QUERY.get(query).enableTracing();
+                statement =  cqlStatementCache.longRunningQuery.get(query).enableTracing();
             } else {
-                statement = cqlStatementCache.NORMAL_QUERY.get(query).enableTracing();
+                statement = cqlStatementCache.normalQuery.get(query).enableTracing();
             }
 
             if (shouldTraceQuery(tableRef)) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
@@ -19,7 +19,6 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -30,6 +29,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
 
@@ -1030,16 +1030,10 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     private void createKeyspace(String keyspaceName, Set<String> dcsInCluster) {
         String createKeyspace = "create keyspace if not exists %s with replication = %s and durable_writes = true";
         final CassandraKeyValueServiceConfig config = configManager.getConfig();
-        String replication;
-        replication = "{ 'class' : 'NetworkTopologyStrategy', ";
-        for (Iterator<String> iter = dcsInCluster.iterator(); iter.hasNext(); ) {
-            String datacenter = iter.next();
-            replication += "'" + datacenter + "' : " + config.replicationFactor();
-            if (iter.hasNext()) {
-                replication += ", ";
-            }
-        }
-        replication += "} ";
+
+        String replication = dcsInCluster.stream()
+                .map(datacenter -> "'" + datacenter + "' : " + config.replicationFactor())
+                .collect(Collectors.joining(", ", "{ 'class' : 'NetworkTopologyStrategy', ", "} "));
 
         longRunningQuerySession.execute(
                 getPreparedStatement(CassandraConstants.NO_TABLE,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServices.java
@@ -16,6 +16,8 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.net.InetAddress;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -55,6 +57,8 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.visitor.Visitor;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public final class CQLKeyValueServices {
     private static final Logger log = LoggerFactory.getLogger(CQLKeyValueService.class); // not a typo
 
@@ -82,6 +86,7 @@ public final class CQLKeyValueServices {
     private static final int MAX_TRIES = 20;
     private static final long TRACE_RETRIEVAL_MS_BETWEEN_TRIES = 500;
 
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     public void logTracedQuery(
             String tracedQuery,
             ResultSet resultSet,
@@ -155,6 +160,7 @@ public final class CQLKeyValueServices {
         }
     }
 
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
     static class Peer {
         InetAddress peer;
         String dataCenter;
@@ -186,6 +192,7 @@ public final class CQLKeyValueServices {
         return peers;
     }
 
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
     static class Local {
         String dataCenter;
         String rack;
@@ -410,7 +417,10 @@ public final class CQLKeyValueServices {
         }
     }
 
+    @SuppressWarnings("checkstyle:RegexpSinglelineJava")
     static Cell getMetadataCell(TableReference tableRef) {
-        return Cell.create(tableRef.getQualifiedName().getBytes(), "m".getBytes());
+        return Cell.create(
+                tableRef.getQualifiedName().getBytes(Charset.defaultCharset()),
+                "m".getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServices.java
@@ -55,33 +55,24 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.visitor.Visitor;
 
-public class CQLKeyValueServices {
+public final class CQLKeyValueServices {
     private static final Logger log = LoggerFactory.getLogger(CQLKeyValueService.class); // not a typo
 
-    static final int UNCONFIGURED_DEFAULT_BATCH_SIZE_BYTES = 50 * 1024; // this is used as a fallback when the user is using small server-side limiting of batches
-    static final Function<Entry<Cell, Value>, Long> PUT_ENTRY_SIZING_FUNCTION = new Function<Entry<Cell, Value>, Long>() {
-        @Override
-        public Long apply(Entry<Cell, Value> input) {
-            return input.getValue().getContents().length + CassandraConstants.TS_SIZE
+    // this is used as a fallback when the user is using small server-side limiting of batches
+    static final int UNCONFIGURED_DEFAULT_BATCH_SIZE_BYTES = 50 * 1024;
+    static final Function<Entry<Cell, Value>, Long> PUT_ENTRY_SIZING_FUNCTION = input ->
+            input.getValue().getContents().length
+                    + CassandraConstants.TS_SIZE
                     + Cells.getApproxSizeOfCell(input.getKey());
-        }
-    };
 
-    static final Function<Entry<Cell, byte[]>, Long> MULTIPUT_ENTRY_SIZING_FUNCTION = new Function<Entry<Cell, byte[]>, Long>() {
-        @Override
-        public Long apply(Entry<Cell, byte[]> entry) {
-            long totalSize = 0;
-            totalSize += entry.getValue().length;
-            totalSize += Cells.getApproxSizeOfCell(entry.getKey());
-            return totalSize;
-        }
-    };
+    static final Function<Entry<Cell, byte[]>, Long> MULTIPUT_ENTRY_SIZING_FUNCTION = entry ->
+            entry.getValue().length + Cells.getApproxSizeOfCell(entry.getKey());
 
     public void shutdown() {
         traceRetrievalExec.shutdown();
     }
 
-    static enum TransactionType {
+    enum TransactionType {
         NONE,
         LIGHTWEIGHT_TRANSACTION_REQUIRED
     }
@@ -91,7 +82,11 @@ public class CQLKeyValueServices {
     private static final int MAX_TRIES = 20;
     private static final long TRACE_RETRIEVAL_MS_BETWEEN_TRIES = 500;
 
-    public void logTracedQuery(final String tracedQuery, ResultSet resultSet, final Session session,  final LoadingCache<String, PreparedStatement> statementCache) {
+    public void logTracedQuery(
+            String tracedQuery,
+            ResultSet resultSet,
+            Session session,
+            LoadingCache<String, PreparedStatement> statementCache) {
         if (log.isInfoEnabled()) {
 
             List<ExecutionInfo> allExecutionInfo = Lists.newArrayList(resultSet.getAllExecutionInfo());
@@ -118,9 +113,9 @@ public class CQLKeyValueServices {
                             Row sessionRow = sessionFuture.getUninterruptibly().one();
 
                             if (sessionRow != null && !sessionRow.isNull("duration")) {
-                                ResultSetFuture eventFuture = session.executeAsync(
-                                        statementCache.getUnchecked(
-                                                "SELECT * FROM system_traces.events WHERE session_id = ?").bind(traceId));
+                                ResultSetFuture eventFuture = session.executeAsync(statementCache.getUnchecked(
+                                        "SELECT * FROM system_traces.events WHERE session_id = ?")
+                                        .bind(traceId));
                                 List<Row> eventRows = eventFuture.getUninterruptibly().all();
 
                                 sb.append(" requestType: ").append(sessionRow.getString("request"));
@@ -162,28 +157,28 @@ public class CQLKeyValueServices {
 
     static class Peer {
         InetAddress peer;
-        String data_center;
+        String dataCenter;
         String rack;
-        String release_version;
-        InetAddress rpc_address;
-        UUID schema_version;
+        String releaseVersion;
+        InetAddress rpcAddress;
+        UUID schemaVersion;
         Set<String> tokens;
     }
 
     public static Set<Peer> getPeers(Session session) {
-        PreparedStatement selectPeerInfo = session.prepare(
-                "select peer, data_center, rack, release_version, rpc_address, schema_version, tokens from system.peers;");
+        PreparedStatement selectPeerInfo = session.prepare("select peer, data_center, rack,"
+                + " release_version, rpc_address, schema_version, tokens from system.peers;");
 
         Set<Peer> peers = Sets.newHashSet();
 
-        for (Row row: session.execute(selectPeerInfo.bind()).all()) {
+        for (Row row : session.execute(selectPeerInfo.bind()).all()) {
             Peer peer = new Peer();
             peer.peer = row.getInet("peer");
-            peer.data_center = row.getString("data_center");
+            peer.dataCenter = row.getString("data_center");
             peer.rack = row.getString("rack");
-            peer.release_version = row.getString("release_version");
-            peer.rpc_address = row.getInet("rpc_address");
-            peer.schema_version = row.getUUID("schema_version");
+            peer.releaseVersion = row.getString("release_version");
+            peer.rpcAddress = row.getInet("rpc_address");
+            peer.schemaVersion = row.getUUID("schema_version");
             peer.tokens = row.getSet("tokens", String.class);
             peers.add(peer);
         }
@@ -192,7 +187,7 @@ public class CQLKeyValueServices {
     }
 
     static class Local {
-        String data_center;
+        String dataCenter;
         String rack;
     }
 
@@ -201,13 +196,18 @@ public class CQLKeyValueServices {
                 "select data_center, rack from system.local;");
         Row localRow = session.execute(selectLocalInfo.bind()).one();
         Local local = new Local();
-        local.data_center = localRow.getString("data_center");
+        local.dataCenter = localRow.getString("data_center");
         local.rack = localRow.getString("rack");
         return local;
     }
 
-    public static void waitForSchemaVersionsToCoalesce(String encapsulatingOperationDescription, CQLKeyValueService kvs) {
-        PreparedStatement peerInfoQuery = kvs.getPreparedStatement(CassandraConstants.NO_TABLE, "select peer, schema_version from system.peers;", kvs.session);
+    public static void waitForSchemaVersionsToCoalesce(
+            String encapsulatingOperationDescription,
+            CQLKeyValueService kvs) {
+        PreparedStatement peerInfoQuery = kvs.getPreparedStatement(
+                CassandraConstants.NO_TABLE,
+                "select peer, schema_version from system.peers;",
+                kvs.session);
         peerInfoQuery.setConsistencyLevel(ConsistencyLevel.ALL);
 
         Multimap<UUID, InetAddress> peerInfo = ArrayListMultimap.create();
@@ -223,21 +223,23 @@ public class CQLKeyValueServices {
                 return;
             }
             sleepTime = Math.min(sleepTime * 2, 5000);
-        } while (System.currentTimeMillis() < start + CassandraConstants.SECONDS_WAIT_FOR_VERSIONS*1000);
+        }
+        while (System.currentTimeMillis() < start + CassandraConstants.SECONDS_WAIT_FOR_VERSIONS * 1000);
 
         StringBuilder sb = new StringBuilder();
-        sb.append(String.format("Cassandra cluster cannot come to agreement on schema versions, during operation: %s.", encapsulatingOperationDescription));
+        sb.append(String.format("Cassandra cluster cannot come to agreement on schema versions,"
+                + " during operation: %s.", encapsulatingOperationDescription));
 
-        for ( Entry<UUID, Collection<InetAddress>> versionToPeer : peerInfo.asMap().entrySet()) {
+        for (Entry<UUID, Collection<InetAddress>> versionToPeer : peerInfo.asMap().entrySet()) {
             sb.append(String.format("%nAt schema version %s:", versionToPeer.getKey()));
-            for (InetAddress peer: versionToPeer.getValue()) {
+            for (InetAddress peer : versionToPeer.getValue()) {
                 sb.append(String.format("%n\tNode: %s", peer));
             }
         }
-        sb.append("\nFind the nodes above that diverge from the majority schema " +
-                "(or have schema 'UNKNOWN', which likely means they are down/unresponsive) " +
-                "and examine their logs to determine the issue. Fixing the underlying issue and restarting Cassandra " +
-                "should resolve the problem. You can quick-check this with 'nodetool describecluster'.");
+        sb.append("\nFind the nodes above that diverge from the majority schema"
+                + " (or have schema 'UNKNOWN', which likely means they are down/unresponsive)"
+                + " and examine their logs to determine the issue. Fixing the underlying issue and restarting Cassandra"
+                + " should resolve the problem. You can quick-check this with 'nodetool describecluster'.");
         throw new IllegalStateException(sb.toString());
     }
 
@@ -284,7 +286,8 @@ public class CQLKeyValueServices {
             chunkLength = explicitCompressionBlockSizeKB;
         }
 
-        queryBuilder.append("CREATE TABLE IF NOT EXISTS " + kvs.getFullTableName(tableRef) + " ( " // full table name (ks.cf)
+        queryBuilder.append("CREATE TABLE IF NOT EXISTS "
+                + kvs.getFullTableName(tableRef) + " ( " // full table name (ks.cf)
                 + CassandraConstants.ROW_NAME + " blob, "
                 + CassandraConstants.COL_NAME_COL + " blob, "
                 + CassandraConstants.TS_COL + " bigint, "
@@ -297,9 +300,11 @@ public class CQLKeyValueServices {
         queryBuilder.append("AND " + "bloom_filter_fp_chance = " + falsePositiveChance + " ");
         queryBuilder.append("AND caching = '{\"keys\":\"ALL\", \"rows_per_partition\":\"ALL\"}' ");
         if (appendHeavyAndReadLight) {
-            queryBuilder.append("AND compaction = { 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'} ");
+            queryBuilder.append("AND compaction = { 'class': '"
+                    + CassandraConstants.SIZE_TIERED_COMPACTION_STRATEGY + "'} ");
         } else {
-            queryBuilder.append("AND compaction = {'sstable_size_in_mb': '80', 'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'} ");
+            queryBuilder.append("AND compaction = {'sstable_size_in_mb': '80', 'class': '"
+                    + CassandraConstants.LEVELED_COMPACTION_STRATEGY + "'} ");
         }
         queryBuilder.append("AND compression = {'chunk_length_kb': '" + chunkLength + "', "
                 + "'sstable_compression': '" + CassandraConstants.DEFAULT_COMPRESSION_TYPE + "'}");
@@ -313,7 +318,7 @@ public class CQLKeyValueServices {
                         .bind();
         try {
             ResultSet resultSet = kvs.longRunningQuerySession.execute(createTableStatement);
-            logTracedQuery(queryBuilder.toString(), resultSet, kvs.session, kvs.cqlStatementCache.NORMAL_QUERY);
+            logTracedQuery(queryBuilder.toString(), resultSet, kvs.session, kvs.cqlStatementCache.normalQuery);
         } catch (Throwable t) {
             throw Throwables.throwUncheckedException(t);
         }
@@ -350,9 +355,10 @@ public class CQLKeyValueServices {
         sb.append("AND caching = '{\"keys\":\"ALL\", \"rows_per_partition\":\"ALL\"}' ");
 
         if (appendHeavyAndReadLight) {
-            sb.append("AND compaction = { 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'} ");
+            sb.append("AND compaction = { 'class': '" + CassandraConstants.SIZE_TIERED_COMPACTION_STRATEGY + "'} ");
         } else {
-            sb.append("AND compaction = {'sstable_size_in_mb': '80', 'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'} ");
+            sb.append("AND compaction = {'sstable_size_in_mb': '80', 'class': '"
+                    + CassandraConstants.LEVELED_COMPACTION_STRATEGY + "'} ");
         }
         sb.append("AND compression = {'chunk_length_kb': '" + chunkLength + "', "
                 + "'sstable_compression': '" + CassandraConstants.DEFAULT_COMPRESSION_TYPE + "'}");
@@ -369,7 +375,7 @@ public class CQLKeyValueServices {
     }
 
 
-    static interface ThreadSafeCQLResultVisitor extends Visitor<Multimap<Cell, Value>> {
+    interface ThreadSafeCQLResultVisitor extends Visitor<Multimap<Cell, Value>> {
         // marker
     }
 
@@ -378,7 +384,7 @@ public class CQLKeyValueServices {
         final ValueExtractor extractor = new ValueExtractor(collectedResults);
         final long startTs;
 
-        public StartTsResultsCollector(long startTs) {
+        StartTsResultsCollector(long startTs) {
             this.startTs = startTs;
         }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLStatementCache.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLStatementCache.java
@@ -22,14 +22,15 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
 public class CQLStatementCache {
-    Session session, longRunningQuerySession;
+    final Session session;
+    final Session longRunningQuerySession;
 
     CQLStatementCache(Session session, Session longRunningQuerySession) {
         this.session = session;
         this.longRunningQuerySession = longRunningQuerySession;
     }
 
-    final LoadingCache<String, PreparedStatement> NORMAL_QUERY = CacheBuilder.newBuilder()
+    final LoadingCache<String, PreparedStatement> normalQuery = CacheBuilder.newBuilder()
             .build(new CacheLoader<String, PreparedStatement>() {
                 @Override
                 public PreparedStatement load(String query) {
@@ -38,7 +39,7 @@ public class CQLStatementCache {
             });
 
 
-    final LoadingCache<String, PreparedStatement> LONG_RUNNING_QUERY = CacheBuilder.newBuilder()
+    final LoadingCache<String, PreparedStatement> longRunningQuery = CacheBuilder.newBuilder()
             .build(new CacheLoader<String, PreparedStatement>() {
                 @Override
                 public PreparedStatement load(String query) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraApiVersion.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraApiVersion.java
@@ -31,13 +31,16 @@ public class CassandraApiVersion {
         this.versionString = versionString;
         String[] components = versionString.split("\\.");
         if (components.length != 3) {
-            throw new UnsupportedOperationException(String.format("Illegal version of Thrift protocol detected; expected format '#.#.#', got '%s'", Arrays.toString(components)));
+            throw new UnsupportedOperationException(String.format(
+                    "Illegal version of Thrift protocol detected; expected format '#.#.#', got '%s'",
+                    Arrays.toString(components)));
         }
         majorVersion = Integer.parseInt(components[0]);
         minorVersion = Integer.parseInt(components[1]);
     }
 
-    // This corresponds to the version change in https://github.com/apache/cassandra/commit/8b0e1868e8cf813ddfc98d11448aa2ad363eccc1#diff-2fa34d46c5a51e59f77d866bbe7ca02aR55
+    // This corresponds to the version change in
+    // https://github.com/apache/cassandra/commit/8b0e1868e8cf8
     public boolean supportsCheckAndSet() {
         boolean supportsCheckAndSet = majorVersion > 19 || (majorVersion == 19 && minorVersion >= 37);
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -18,11 +18,11 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeMap;
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -76,7 +75,8 @@ import com.palantir.common.concurrent.PTExecutors;
  *
  *   *entirely new features
  *
- *   By our old system, this would be a RefreshingRetriableTokenAwareHealthCheckingManyHostCassandraClientPoolingContainerManager;
+ *   By our old system, this would be a
+ *   RefreshingRetriableTokenAwareHealthCheckingManyHostCassandraClientPoolingContainerManager;
  *   ... this is one of the reasons why there is a new system.
  **/
 public class CassandraClientPool {
@@ -88,21 +88,21 @@ public class CassandraClientPool {
     private static final int MAX_TRIES_SAME_HOST = 3;
     private static final int MAX_TRIES_TOTAL = 6;
 
-    volatile RangeMap<LightweightOPPToken, List<InetSocketAddress>> tokenMap = ImmutableRangeMap.of();
+    volatile RangeMap<LightweightOppToken, List<InetSocketAddress>> tokenMap = ImmutableRangeMap.of();
     Map<InetSocketAddress, Long> blacklistedHosts = Maps.newConcurrentMap();
     Map<InetSocketAddress, CassandraClientPoolingContainer> currentPools = Maps.newConcurrentMap();
     final CassandraKeyValueServiceConfig config;
     final ScheduledThreadPoolExecutor refreshDaemon;
 
-    public static class LightweightOPPToken implements Comparable<LightweightOPPToken> {
+    public static class LightweightOppToken implements Comparable<LightweightOppToken> {
         final byte[] bytes;
 
-        public LightweightOPPToken(byte[] bytes) {
+        public LightweightOppToken(byte[] bytes) {
             this.bytes = bytes;
         }
 
         @Override
-        public int compareTo(LightweightOPPToken other) {
+        public int compareTo(LightweightOppToken other) {
             return UnsignedBytes.lexicographicalComparator().compare(this.bytes, other.bytes);
         }
 
@@ -114,17 +114,19 @@ public class CassandraClientPool {
 
     public CassandraClientPool(CassandraKeyValueServiceConfig config) {
         this.config = config;
-        config.servers().forEach((server) -> currentPools.put(server, new CassandraClientPoolingContainer(server, config)));
+        config.servers().forEach(server ->
+                currentPools.put(server, new CassandraClientPoolingContainer(server, config)));
 
-        refreshDaemon = PTExecutors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setDaemon(true).setNameFormat("CassandraClientPoolRefresh-%d").build());
-        refreshDaemon.scheduleWithFixedDelay(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    refreshPool();
-                } catch (Throwable t) {
-                    log.error("Failed to refresh Cassandra KVS pool. Extended periods of being unable to refresh will cause perf degradation.", t);
-                }
+        refreshDaemon = PTExecutors.newScheduledThreadPool(1, new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("CassandraClientPoolRefresh-%d")
+                .build());
+        refreshDaemon.scheduleWithFixedDelay(() -> {
+            try {
+                refreshPool();
+            } catch (Throwable t) {
+                log.error("Failed to refresh Cassandra KVS pool."
+                        + " Extended periods of being unable to refresh will cause perf degradation.", t);
             }
         }, config.poolRefreshIntervalSeconds(), config.poolRefreshIntervalSeconds(), TimeUnit.SECONDS);
 
@@ -133,7 +135,8 @@ public class CassandraClientPool {
 
     public void shutdown() {
         refreshDaemon.shutdown();
-        currentPools.forEach((address, cassandraClientPoolingContainer) -> cassandraClientPoolingContainer.shutdownPooling());
+        currentPools.forEach((address, cassandraClientPoolingContainer) ->
+                cassandraClientPoolingContainer.shutdownPooling());
     }
 
     private synchronized void refreshPool() {
@@ -181,7 +184,8 @@ public class CassandraClientPool {
         try {
             currentPools.get(removedServerAddress).shutdownPooling();
         } catch (Exception e) {
-            log.warn("While removing a host ({}) from the pool, we were unable to gently cleanup resources.", removedServerAddress, e);
+            log.warn("While removing a host ({}) from the pool, we were unable to gently cleanup resources.",
+                    removedServerAddress, e);
         }
         currentPools.remove(removedServerAddress);
     }
@@ -199,8 +203,8 @@ public class CassandraClientPool {
                 currentState.append(
                         String.format("\tPOOL STATUS: Pooled host %s has %s out of %s connections checked out.%n",
                                 entry.getKey(),
-                                activeCheckouts > 0? Integer.toString(activeCheckouts) : "(unknown)",
-                                totalAllowed > 0? Integer.toString(totalAllowed) : "(not bounded)"));
+                                activeCheckouts > 0 ? Integer.toString(activeCheckouts) : "(unknown)",
+                                totalAllowed > 0 ? Integer.toString(totalAllowed) : "(not bounded)"));
             }
             log.debug(currentState.toString());
         }
@@ -214,7 +218,8 @@ public class CassandraClientPool {
                 InetSocketAddress host = blacklistedEntry.getKey();
                 if (isHostHealthy(host)) {
                     blacklistedHosts.remove(host);
-                    log.error("Added host {} back into the pool after a waiting period and successful health check.", host);
+                    log.error("Added host {} back into the pool after a waiting period and successful health check.",
+                            host);
                 }
             }
         }
@@ -232,7 +237,8 @@ public class CassandraClientPool {
             testingContainer.runWithPooledResource(validatePartitioner);
             return true;
         } catch (Exception e) {
-            log.error("We tried to add {} back into the pool, but got an exception that caused to us distrust this host further.", host, e);
+            log.error("We tried to add {} back into the pool, but got an exception"
+                    + " that caused to us distrust this host further.", host, e);
             return false;
         }
     }
@@ -242,7 +248,8 @@ public class CassandraClientPool {
 
         Set<InetSocketAddress> livingHosts = Sets.difference(pools.keySet(), blacklistedHosts.keySet());
         if (livingHosts.isEmpty()) {
-            log.error("There are no known live hosts in the connection pool. We're choosing one at random in a last-ditch attempt at forward progress.");
+            log.error("There are no known live hosts in the connection pool. We're choosing"
+                    + " one at random in a last-ditch attempt at forward progress.");
             livingHosts = pools.keySet();
         }
 
@@ -250,22 +257,22 @@ public class CassandraClientPool {
     }
 
     public InetSocketAddress getRandomHostForKey(byte[] key) {
-        List<InetSocketAddress> hostsForKey = tokenMap.get(new LightweightOPPToken(key));
+        List<InetSocketAddress> hostsForKey = tokenMap.get(new LightweightOppToken(key));
         SetView<InetSocketAddress> liveOwnerHosts;
 
         if (hostsForKey == null) {
-            log.debug(
-                    "We attempted to route your query to a cassandra host that already contains the relevant data. " +
-                    "However, the mapping of which host contains which data is not available yet. We will choose a random host instead.");
+            log.debug("We attempted to route your query to a cassandra host that already contains the relevant data."
+                    + " However, the mapping of which host contains which data is not available yet."
+                    + " We will choose a random host instead.");
             return getRandomGoodHost().getHost();
         } else {
             liveOwnerHosts = Sets.difference(ImmutableSet.copyOf(hostsForKey), blacklistedHosts.keySet());
         }
 
         if (liveOwnerHosts.isEmpty()) {
-            log.warn("Perf / cluster stability issue. Token aware query routing has failed because there are no known " +
-                    "live hosts that claim ownership of the given range. Falling back to choosing a random live node. " +
-                    "Current state logged at DEBUG");
+            log.warn("Perf / cluster stability issue. Token aware query routing has failed because there are no known "
+                    + "live hosts that claim ownership of the given range. Falling back to choosing a random live node."
+                    + " Current state logged at DEBUG");
             log.debug("Current ring view is: {} and our current host blacklist is {}", tokenMap, blacklistedHosts);
             return getRandomGoodHost().getHost();
         } else {
@@ -273,7 +280,8 @@ public class CassandraClientPool {
         }
     }
 
-    private static InetSocketAddress getRandomHostByActiveConnections(Map<InetSocketAddress, CassandraClientPoolingContainer> pools) {
+    private static InetSocketAddress getRandomHostByActiveConnections(
+            Map<InetSocketAddress, CassandraClientPoolingContainer> pools) {
         return WeightedHosts.create(pools).getRandomHost();
     }
 
@@ -285,8 +293,10 @@ public class CassandraClientPool {
             throw new RuntimeException(e);
         }
 
-        Map<InetSocketAddress, Exception> completelyUnresponsiveHosts = Maps.newHashMap(), aliveButInvalidPartitionerHosts = Maps.newHashMap();
-        boolean thisHostResponded, atLeastOneHostResponded = false;
+        Map<InetSocketAddress, Exception> completelyUnresponsiveHosts = Maps.newHashMap();
+        Map<InetSocketAddress, Exception> aliveButInvalidPartitionerHosts = Maps.newHashMap();
+        boolean thisHostResponded = false;
+        boolean atLeastOneHostResponded = false;
         for (InetSocketAddress host : currentPools.keySet()) {
             thisHostResponded = false;
             try {
@@ -309,15 +319,20 @@ public class CassandraClientPool {
 
         StringBuilder errorBuilderForEntireCluster = new StringBuilder();
         if (completelyUnresponsiveHosts.size() > 0) {
-            errorBuilderForEntireCluster.append("Performing routine startup checks, determined that the following hosts are unreachable for the following reasons: \n");
+            errorBuilderForEntireCluster.append("Performing routine startup checks,")
+                    .append(" determined that the following hosts are unreachable for the following reasons: \n");
             completelyUnresponsiveHosts.forEach((host, exception) ->
-                    errorBuilderForEntireCluster.append(String.format("\tHost: %s was marked unreachable via exception: %s%n", host.toString(), exception.toString())));
+                    errorBuilderForEntireCluster.append(String.format("\tHost: %s was marked unreachable"
+                            + " via exception: %s%n", host.toString(), exception.toString())));
         }
 
         if (aliveButInvalidPartitionerHosts.size() > 0) {
-            errorBuilderForEntireCluster.append("Performing routine startup checks, determined that the following hosts were alive but are configured with an invalid partitioner: \n");
+            errorBuilderForEntireCluster.append("Performing routine startup checks,")
+                    .append("determined that the following hosts were alive but are configured")
+                    .append("with an invalid partitioner: \n");
             aliveButInvalidPartitionerHosts.forEach((host, exception) ->
-                    errorBuilderForEntireCluster.append(String.format("\tHost: %s was marked as invalid partitioner via exception: %s%n", host.toString(), exception.toString())));
+                    errorBuilderForEntireCluster.append(String.format("\tHost: %s was marked as invalid partitioner"
+                            + " via exception: %s%n", host.toString(), exception.toString())));
         }
 
         if (atLeastOneHostResponded && aliveButInvalidPartitionerHosts.size() == 0) {
@@ -338,25 +353,27 @@ public class CassandraClientPool {
 
     private void refreshTokenRanges() {
         try {
-            ImmutableRangeMap.Builder<LightweightOPPToken, List<InetSocketAddress>> newTokenRing = ImmutableRangeMap.builder();
+            ImmutableRangeMap.Builder<LightweightOppToken, List<InetSocketAddress>> newTokenRing =
+                    ImmutableRangeMap.builder();
 
             // grab latest token ring view from a random node in the cluster
             List<TokenRange> tokenRanges = getRandomGoodHost().runWithPooledResource(describeRing);
 
-            if (tokenRanges.size() == 1) { // RangeMap needs a little help with weird 1-node, 1-vnode, this-entire-feature-is-useless case
+            // RangeMap needs a little help with weird 1-node, 1-vnode, this-entire-feature-is-useless case
+            if (tokenRanges.size() == 1) {
                 String onlyEndpoint = Iterables.getOnlyElement(Iterables.getOnlyElement(tokenRanges).getEndpoints());
-                InetSocketAddress onlyHost = new InetSocketAddress(onlyEndpoint, CassandraConstants.DEFAULT_THRIFT_PORT);
+                InetSocketAddress onlyHost = new InetSocketAddress(
+                        onlyEndpoint,
+                        CassandraConstants.DEFAULT_THRIFT_PORT);
                 newTokenRing.put(Range.all(), ImmutableList.of(onlyHost));
             } else { // normal case, large cluster with many vnodes
                 for (TokenRange tokenRange : tokenRanges) {
-                    List<InetSocketAddress> hosts = Lists.transform(tokenRange.getEndpoints(), new Function<String, InetSocketAddress>() {
-                        @Override
-                        public InetSocketAddress apply(String endpoint) {
-                            return new InetSocketAddress(endpoint, CassandraConstants.DEFAULT_THRIFT_PORT);
-                        }
-                    });
-                    LightweightOPPToken startToken = new LightweightOPPToken(BaseEncoding.base16().decode(tokenRange.getStart_token().toUpperCase()));
-                    LightweightOPPToken endToken = new LightweightOPPToken(BaseEncoding.base16().decode(tokenRange.getEnd_token().toUpperCase()));
+                    List<InetSocketAddress> hosts = Lists.transform(tokenRange.getEndpoints(),
+                            endpoint -> new InetSocketAddress(endpoint, CassandraConstants.DEFAULT_THRIFT_PORT));
+                    LightweightOppToken startToken = new LightweightOppToken(
+                            BaseEncoding.base16().decode(tokenRange.getStart_token().toUpperCase()));
+                    LightweightOppToken endToken = new LightweightOppToken(
+                            BaseEncoding.base16().decode(tokenRange.getEnd_token().toUpperCase()));
                     if (startToken.compareTo(endToken) <= 0) {
                         newTokenRing.put(Range.openClosed(startToken, endToken), hosts);
                     } else {
@@ -372,17 +389,21 @@ public class CassandraClientPool {
         }
     }
 
-    private FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception> describeRing = new FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception>() {
-        @Override
-        public List<TokenRange> apply (Cassandra.Client client) throws Exception {
-            return client.describe_ring(config.keyspace());
-        }};
+    private FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception> describeRing =
+            new FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception>() {
+                @Override
+                public List<TokenRange> apply(Cassandra.Client client) throws Exception {
+                    return client.describe_ring(config.keyspace());
+                }
+            };
 
-    public <V, K extends Exception> V runWithRetry(FunctionCheckedException<Cassandra.Client, V, K> f) throws K {
-       return runWithRetryOnHost(getRandomGoodHost().getHost(), f);
+    public <V, K extends Exception> V runWithRetry(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
+        return runWithRetryOnHost(getRandomGoodHost().getHost(), fn);
     }
 
-    public <V, K extends Exception> V runWithRetryOnHost(InetSocketAddress specifiedHost, FunctionCheckedException<Cassandra.Client, V, K> f) throws K {
+    public <V, K extends Exception> V runWithRetryOnHost(
+            InetSocketAddress specifiedHost,
+            FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
         int numTries = 0;
         boolean shouldRetryOnDifferentHost = false;
         while (true) {
@@ -394,7 +415,7 @@ public class CassandraClientPool {
             }
 
             try {
-                return hostPool.runWithPooledResource(f);
+                return hostPool.runWithPooledResource(fn);
             } catch (Exception e) {
                 numTries++;
                 this.<K>handleException(numTries, hostPool.getHost(), e);
@@ -413,38 +434,39 @@ public class CassandraClientPool {
         }
     }
 
-    public <V, K extends Exception> V run(FunctionCheckedException<Cassandra.Client, V, K> f) throws K {
-        return runOnHost(getRandomGoodHost().getHost(), f);
+    public <V, K extends Exception> V run(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
+        return runOnHost(getRandomGoodHost().getHost(), fn);
     }
 
     private <V, K extends Exception> V runOnHost(InetSocketAddress specifiedHost,
-                                                 FunctionCheckedException<Cassandra.Client, V, K> f) throws K {
+                                                 FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
         CassandraClientPoolingContainer hostPool = currentPools.get(specifiedHost);
-        return hostPool.runWithPooledResource(f);
+        return hostPool.runWithPooledResource(fn);
     }
 
-        @SuppressWarnings("unchecked")
-    private <K extends Exception> void handleException(int numTries, InetSocketAddress host, Exception e) throws K {
-        if (isRetriableException(e) || isRetriableWithBackoffException(e)) {
+    @SuppressWarnings("unchecked")
+    private <K extends Exception> void handleException(int numTries, InetSocketAddress host, Exception ex) throws K {
+        if (isRetriableException(ex) || isRetriableWithBackoffException(ex)) {
             if (numTries >= MAX_TRIES_TOTAL) {
-                if (e instanceof TTransportException
-                        && e.getCause() != null
-                        && (e.getCause().getClass() == SocketException.class)) {
-                    String msg = "Error writing to Cassandra socket. Likely cause: Exceeded maximum thrift frame size; unlikely cause: network issues.";
-                    log.error("Tried to connect to cassandra " + numTries + " times. " + msg, e);
-                    e = new TTransportException(((TTransportException) e).getType(), msg, e);
+                if (ex instanceof TTransportException
+                        && ex.getCause() != null
+                        && (ex.getCause().getClass() == SocketException.class)) {
+                    String msg = "Error writing to Cassandra socket. Likely cause:"
+                            + " Exceeded maximum thrift frame size; unlikely cause: network issues.";
+                    log.error("Tried to connect to cassandra " + numTries + " times. " + msg, ex);
+                    throw (K) new TTransportException(((TTransportException) ex).getType(), msg, ex);
                 } else {
-                    log.error("Tried to connect to cassandra " + numTries + " times.", e);
+                    log.error("Tried to connect to cassandra " + numTries + " times.", ex);
+                    throw (K) ex;
                 }
-                throw (K) e;
             } else {
-                log.warn("Error occurred talking to cassandra. Attempt {} of {}.", numTries, MAX_TRIES_TOTAL, e);
-                if (isConnectionException(e) && numTries >= MAX_TRIES_SAME_HOST) {
+                log.warn("Error occurred talking to cassandra. Attempt {} of {}.", numTries, MAX_TRIES_TOTAL, ex);
+                if (isConnectionException(ex) && numTries >= MAX_TRIES_SAME_HOST) {
                     addToBlacklist(host);
                 }
             }
         } else {
-            throw (K) e;
+            throw (K) ex;
         }
     }
 
@@ -473,7 +495,8 @@ public class CassandraClientPool {
             }
 
             if (tokenRangesToHost.isEmpty()) {
-                log.warn("Failed to get ring info for entire Cassandra cluster ({}); ring could not be checked for consistency.", config.keyspace());
+                log.warn("Failed to get ring info for entire Cassandra cluster ({});"
+                        + " ring could not be checked for consistency.", config.keyspace());
                 return;
             }
 
@@ -481,74 +504,78 @@ public class CassandraClientPool {
                 return;
             }
 
-            RuntimeException e = new IllegalStateException("Hosts have differing ring descriptions.  This can lead to inconsistent reads and lost data. ");
-            log.error("QA-86204 " + e.getMessage() + tokenRangesToHost, e);
+            RuntimeException ex = new IllegalStateException("Hosts have differing ring descriptions."
+                    + " This can lead to inconsistent reads and lost data. ");
+            log.error("QA-86204 " + ex.getMessage() + tokenRangesToHost, ex);
 
 
             // provide some easier to grok logging for the two most common cases
             if (tokenRangesToHost.size() > 2) {
-                for (Map.Entry<Set<TokenRange>, Collection<InetSocketAddress>> entry : tokenRangesToHost.asMap().entrySet()) {
-                    if (entry.getValue().size() == 1) {
-                        log.error("Host: " + entry.getValue().iterator().next() +
-                                " disagrees with the other nodes about the ring state.");
-                    }
-                }
+                tokenRangesToHost.asMap().entrySet().stream()
+                        .filter(entry -> entry.getValue().size() == 1)
+                        .forEach(entry -> log.error("Host: "
+                                + Iterables.getFirst(entry.getValue(), null)
+                                + " disagrees with the other nodes about the ring state."));
             }
             if (tokenRangesToHost.keySet().size() == 2) {
                 ImmutableList<Set<TokenRange>> sets = ImmutableList.copyOf(tokenRangesToHost.keySet());
                 Set<TokenRange> set1 = sets.get(0);
                 Set<TokenRange> set2 = sets.get(1);
-                log.error("Hosts are split.  group1: " + tokenRangesToHost.get(set1) +
-                        " group2: " + tokenRangesToHost.get(set2));
+                log.error("Hosts are split."
+                        + " group1: " + tokenRangesToHost.get(set1)
+                        + " group2: " + tokenRangesToHost.get(set2));
             }
 
-            CassandraVerifier.logErrorOrThrow(e.getMessage(), config.safetyDisabled());
+            CassandraVerifier.logErrorOrThrow(ex.getMessage(), config.safetyDisabled());
         }
     }
 
     @VisibleForTesting
-    static boolean isConnectionException(Throwable t) {
-        return t != null
-                && (t instanceof SocketTimeoutException
-                || t instanceof ClientCreationFailedException
-                || isConnectionException(t.getCause()));
+    static boolean isConnectionException(Throwable ex) {
+        return ex != null
+                && (ex instanceof SocketTimeoutException
+                || ex instanceof ClientCreationFailedException
+                || isConnectionException(ex.getCause()));
     }
 
     @VisibleForTesting
-    static boolean isRetriableException(Throwable t) {
-        return t != null
-                && (t instanceof TTransportException
-                || t instanceof TimedOutException
-                || t instanceof InsufficientConsistencyException
-                || isConnectionException(t)
-                || isRetriableException(t.getCause()));
+    static boolean isRetriableException(Throwable ex) {
+        return ex != null
+                && (ex instanceof TTransportException
+                || ex instanceof TimedOutException
+                || ex instanceof InsufficientConsistencyException
+                || isConnectionException(ex)
+                || isRetriableException(ex.getCause()));
     }
 
     @VisibleForTesting
-    static boolean isRetriableWithBackoffException(Throwable t) {
-        return t != null
-                && (t instanceof NoSuchElementException // pool for this node is fully in use
-                || t instanceof UnavailableException // remote cassandra node couldn't talk to enough other remote cassandra nodes to answer
-                || isRetriableWithBackoffException(t.getCause()));
+    static boolean isRetriableWithBackoffException(Throwable ex) {
+        return ex != null
+                // pool for this node is fully in use
+                && (ex instanceof NoSuchElementException
+                // remote cassandra node couldn't talk to enough other remote cassandra nodes to answer
+                || ex instanceof UnavailableException
+                || isRetriableWithBackoffException(ex.getCause()));
     }
 
-    final FunctionCheckedException<Cassandra.Client, Void, Exception> validatePartitioner = new FunctionCheckedException<Cassandra.Client, Void, Exception>() {
-        @Override
-        public Void apply(Cassandra.Client client) throws Exception {
-            CassandraVerifier.validatePartitioner(client, config);
-            return null;
-        }
-    };
+    final FunctionCheckedException<Cassandra.Client, Void, Exception> validatePartitioner =
+            new FunctionCheckedException<Cassandra.Client, Void, Exception>() {
+                @Override
+                public Void apply(Cassandra.Client client) throws Exception {
+                    CassandraVerifier.validatePartitioner(client, config);
+                    return null;
+                }
+            };
 
     /**
      * Weights hosts inversely by the number of active connections. {@link #getRandomHost()} should then be used to
      * pick a random host
      */
     @VisibleForTesting
-    static class WeightedHosts {
-        final TreeMap<Integer, InetSocketAddress> hosts;
+    static final class WeightedHosts {
+        final NavigableMap<Integer, InetSocketAddress> hosts;
 
-        private WeightedHosts(TreeMap<Integer, InetSocketAddress> hosts) {
+        private WeightedHosts(NavigableMap<Integer, InetSocketAddress> hosts) {
             this.hosts = hosts;
         }
 
@@ -566,7 +593,7 @@ public class CassandraClientPool {
          * Every weight is guaranteed to be non-zero in size. That is, every key is guaranteed to be at least one larger
          * than the previous key.
          */
-        private static TreeMap<Integer, InetSocketAddress> buildHostsWeightedByActiveConnections(
+        private static NavigableMap<Integer, InetSocketAddress> buildHostsWeightedByActiveConnections(
                 Map<InetSocketAddress, CassandraClientPoolingContainer> pools) {
 
             Map<InetSocketAddress, Integer> activeConnectionsByHost = new HashMap<>(pools.size());
@@ -578,7 +605,7 @@ public class CassandraClientPool {
             }
 
             int lowerBoundInclusive = 0;
-            TreeMap<Integer, InetSocketAddress> weightedHosts = new TreeMap<>();
+            NavigableMap<Integer, InetSocketAddress> weightedHosts = new TreeMap<>();
             for (Entry<InetSocketAddress, Integer> entry : activeConnectionsByHost.entrySet()) {
                 // We want the weight to be inversely proportional to the number of active connections so that we pick
                 // less-active hosts. We add 1 to make sure that all ranges are non-empty

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,6 +105,23 @@ public class CassandraClientPool {
         @Override
         public int compareTo(LightweightOppToken other) {
             return UnsignedBytes.lexicographicalComparator().compare(this.bytes, other.bytes);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            LightweightOppToken that = (LightweightOppToken) obj;
+            return Arrays.equals(bytes, that.bytes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(bytes);
         }
 
         @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -71,7 +71,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
     }
 
     @Override
-    public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<Client, V, K> f)
+    public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<Client, V, K> fn)
             throws K {
         final String origName = Thread.currentThread().getName();
         Thread.currentThread().setName(origName
@@ -79,7 +79,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 + " started at " + DateTimeFormatter.ISO_INSTANT.format(Instant.now())
                 + " - " + count.getAndIncrement());
         try {
-            return runWithGoodResource(f);
+            return runWithGoodResource(fn);
         } catch (Throwable t) {
             log.warn("Error occurred talking to host '{}': {}", host, t.toString());
             throw t;
@@ -88,14 +88,20 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         }
     }
 
+    @Override
+    public <V> V runWithPooledResource(Function<Client, V> fn) {
+        throw new UnsupportedOperationException("you should use FunctionCheckedException<?, ?, Exception> "
+                + "to ensure the TTransportException type is propagated correctly.");
+    }
+
     @SuppressWarnings("unchecked")
-    private <V, K extends Exception> V runWithGoodResource(FunctionCheckedException<Client, V, K> f)
+    private <V, K extends Exception> V runWithGoodResource(FunctionCheckedException<Client, V, K> fn)
             throws K {
         boolean shouldReuse = true;
         Client resource = null;
         try {
             resource = clientPool.borrowObject();
-            return f.apply(resource);
+            return fn.apply(resource);
         } catch (Exception e) {
             if (isInvalidClientConnection(e)) {
                 log.warn("Not reusing resource {} due to {}", resource, e.toString(), e);
@@ -125,13 +131,14 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         try {
             TTransport transport = idleClient.getInputProtocol().getTransport();
             if (transport instanceof TFramedTransport) {
-                Field readBuffer_ = ((TFramedTransport) transport).getClass().getDeclaredField("readBuffer_");
-                readBuffer_.setAccessible(true);
-                TMemoryInputTransport tMemoryInputTransport = (TMemoryInputTransport) readBuffer_.get(transport);
-                byte[] underlyingBuffer = tMemoryInputTransport.getBuffer();
+                Field readBuffer = ((TFramedTransport) transport).getClass().getDeclaredField("readBuffer_");
+                readBuffer.setAccessible(true);
+                TMemoryInputTransport memoryInputTransport = (TMemoryInputTransport) readBuffer.get(transport);
+                byte[] underlyingBuffer = memoryInputTransport.getBuffer();
                 if (underlyingBuffer != null) {
-                    log.debug("During {} check-in, cleaned up a read buffer of {} bytes", idleClient, underlyingBuffer.length);
-                    tMemoryInputTransport.clear();
+                    log.debug("During {} check-in, cleaned up a read buffer of {} bytes",
+                            idleClient, underlyingBuffer.length);
+                    memoryInputTransport.clear();
                 }
             }
         } catch (Exception e) {
@@ -139,10 +146,10 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         }
     }
 
-    private static boolean isInvalidClientConnection(Exception e) {
-        return e instanceof TTransportException
-                || e instanceof TProtocolException
-                || e instanceof NoSuchElementException;
+    private static boolean isInvalidClientConnection(Exception ex) {
+        return ex instanceof TTransportException
+                || ex instanceof TProtocolException
+                || ex instanceof NoSuchElementException;
     }
 
     private void invalidateQuietly(Client resource) {
@@ -152,12 +159,6 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         } catch (Exception e) {
             // Ignore
         }
-    }
-
-    @Override
-    public <V> V runWithPooledResource(Function<Client, V> f) {
-        throw new UnsupportedOperationException("you should use FunctionCheckedException<?, ?, Exception> "
-                + "to ensure the TTransportException type is propagated correctly.");
     }
 
     @Override
@@ -171,7 +172,9 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 .add("host", this.host)
                 .add("keyspace", config.keyspace())
                 .add("usingSsl", config.usingSsl())
-                .add("sslConfiguration", config.sslConfiguration().isPresent() ? config.sslConfiguration().get() : "unspecified")
+                .add("sslConfiguration", config.sslConfiguration().isPresent()
+                        ? config.sslConfiguration().get()
+                        : "unspecified")
                 .add("socketTimeoutMillis", config.socketTimeoutMillis())
                 .add("socketQueryTimeoutMillis", config.socketQueryTimeoutMillis())
                 .toString();
@@ -206,19 +209,24 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         poolConfig.setMaxIdle(5 * config.poolSize());
         poolConfig.setMaxTotal(5 * config.poolSize());
 
-        poolConfig.setBlockWhenExhausted(false); // immediately throw when we try and borrow from a full pool; dealt with at higher level
+        // immediately throw when we try and borrow from a full pool; dealt with at higher level
+        poolConfig.setBlockWhenExhausted(false);
         poolConfig.setMaxWaitMillis(config.socketTimeoutMillis());
 
-        poolConfig.setTestOnBorrow(true); // this test is free/just checks a boolean and does not block; borrow is still fast
+        // this test is free/just checks a boolean and does not block; borrow is still fast
+        poolConfig.setTestOnBorrow(true);
 
         poolConfig.setMinEvictableIdleTimeMillis(TimeUnit.MILLISECONDS.convert(3, TimeUnit.MINUTES));
-        // the randomness here is to prevent all of the pools for all of the hosts evicting all at at once, which isn't great for C*.
-        poolConfig.setTimeBetweenEvictionRunsMillis(TimeUnit.MILLISECONDS.convert(60 + ThreadLocalRandom.current().nextInt(10), TimeUnit.SECONDS));
-        poolConfig.setNumTestsPerEvictionRun(-3); // test one third of objects per eviction run  // (Apache Commons Pool has the worst API)
+        // the randomness here is to prevent all of the pools for all of the hosts
+        // evicting all at at once, which isn't great for C*.
+        poolConfig.setTimeBetweenEvictionRunsMillis(
+                TimeUnit.MILLISECONDS.convert(60 + ThreadLocalRandom.current().nextInt(10), TimeUnit.SECONDS));
+        // test one third of objects per eviction run  // (Apache Commons Pool has the worst API)
+        poolConfig.setNumTestsPerEvictionRun(-3);
         poolConfig.setTestWhileIdle(true);
 
         poolConfig.setJmxNamePrefix(host.getHostString());
 
-        return new GenericObjectPool<Client>(cassandraClientFactory, poolConfig);
+        return new GenericObjectPool<>(cassandraClientFactory, poolConfig);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConstants.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
-public class CassandraConstants {
+public final class CassandraConstants {
     static final int LONG_RUNNING_QUERY_SOCKET_TIMEOUT_MILLIS = 62000;
     public static final int DEFAULT_REPLICATION_FACTOR = 3;
     public static final int DEFAULT_THRIFT_PORT = 9160;
@@ -63,7 +63,9 @@ public class CassandraConstants {
     static final String DEFAULT_RACK = "rack1";
     static final String SIMPLE_RF_TEST_KEYSPACE = "__simple_rf_test_keyspace__";
     static final String REPLICATION_FACTOR_OPTION = "replication_factor";
-    static final int GC_GRACE_SECONDS = 4 * 24 * 60 * 60; // 4 days; Hinted-Handoffs MUST expire well within this period for delete correctness (I believe we will be expiring hints in half this period)
+    // 4 days; Hinted-Handoffs MUST expire well within this period for delete correctness
+    // (I believe we will be expiring hints in half this period)
+    static final int GC_GRACE_SECONDS = 4 * 24 * 60 * 60;
     static final float TOMBSTONE_THRESHOLD_RATIO = 0.2f;
 
     // JMX compaction related
@@ -84,12 +86,17 @@ public class CassandraConstants {
     public static final int NO_TTL = -1;
 
     static final String LEVELED_COMPACTION_STRATEGY = "org.apache.cassandra.db.compaction.LeveledCompactionStrategy";
-    static final String SIZE_TIERED_COMPACTION_STRATEGY = "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy";
+    static final String SIZE_TIERED_COMPACTION_STRATEGY =
+            "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy";
 
     public static final String GLOBAL_DDL_LOCK = "Global DDL lock";
     public static final String GLOBAL_DDL_LOCK_COLUMN_NAME = "id_with_lock";
     public static final long TIME_BETWEEN_LOCK_ATTEMPT_ROUNDS_MILLIS = 1000;
     public static final long GLOBAL_DDL_LOCK_CLEARED_VALUE = Long.MAX_VALUE;
+
+    private CassandraConstants() {
+        // Utility class
+    }
 
     // update CKVS.isMatchingCf if you update this method
     static CfDef getStandardCfDef(String keyspace, String internalTableName) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
@@ -102,12 +102,8 @@ public class CassandraExpiringKeyValueService extends CassandraKeyValueService i
 
 
             Iterable<List<Entry<Cell, byte[]>>> partitions = partitionByCountAndBytes(sortedMap.entrySet(),
-                    getMultiPutBatchCount(), getMultiPutBatchSizeBytes(), table, entry -> {
-                        long totalSize = 0;
-                        totalSize += entry.getValue().length;
-                        totalSize += Cells.getApproxSizeOfCell(entry.getKey());
-                        return totalSize;
-                    });
+                    getMultiPutBatchCount(), getMultiPutBatchSizeBytes(), table, entry ->
+                            entry.getValue().length + Cells.getApproxSizeOfCell(entry.getKey()));
 
             for (final List<Entry<Cell, byte[]>> p : partitions) {
                 callables.add(() -> {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedMap;
@@ -46,34 +45,42 @@ import com.palantir.atlasdb.keyvalue.impl.KeyValueServices;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.collect.Maps2;
 
-public class CassandraExpiringKeyValueService extends CassandraKeyValueService implements ExpiringKeyValueService{
+public class CassandraExpiringKeyValueService extends CassandraKeyValueService implements ExpiringKeyValueService {
 
-    public static CassandraExpiringKeyValueService create(CassandraKeyValueServiceConfigManager configManager, Optional<LeaderConfig> leaderConfig) {
+    public static CassandraExpiringKeyValueService create(
+            CassandraKeyValueServiceConfigManager configManager,
+            Optional<LeaderConfig> leaderConfig) {
         Preconditions.checkState(!configManager.getConfig().servers().isEmpty(), "address list was empty");
 
-        Optional<CassandraJmxCompactionManager> compactionManager = CassandraJmxCompaction.createJmxCompactionManager(configManager);
-        CassandraExpiringKeyValueService kvs = new CassandraExpiringKeyValueService(configManager, compactionManager, leaderConfig);
+        Optional<CassandraJmxCompactionManager> compactionManager =
+                CassandraJmxCompaction.createJmxCompactionManager(configManager);
+        CassandraExpiringKeyValueService kvs =
+                new CassandraExpiringKeyValueService(configManager, compactionManager, leaderConfig);
         kvs.init();
         return kvs;
     }
 
-    protected CassandraExpiringKeyValueService(CassandraKeyValueServiceConfigManager configManager,
-                                               Optional<CassandraJmxCompactionManager> compactionManager,
-                                               Optional<LeaderConfig> leaderConfig) {
+    protected CassandraExpiringKeyValueService(
+            CassandraKeyValueServiceConfigManager configManager,
+            Optional<CassandraJmxCompactionManager> compactionManager,
+            Optional<LeaderConfig> leaderConfig) {
         super(LoggerFactory.getLogger(CassandraKeyValueService.class), configManager, compactionManager, leaderConfig);
     }
 
     @Override
-    public void put(final TableReference tableRef, final Map<Cell, byte[]> values, final long timestamp, final long time, final TimeUnit unit) {
+    public void put(TableReference tableRef, Map<Cell, byte[]> values, long timestamp, long time, TimeUnit unit) {
         try {
-            putInternal(tableRef, KeyValueServices.toConstantTimestampValues(values.entrySet(), timestamp), CassandraKeyValueServices.convertTtl(time, unit));
+            putInternal(
+                    tableRef,
+                    KeyValueServices.toConstantTimestampValues(values.entrySet(), timestamp),
+                    CassandraKeyValueServices.convertTtl(time, unit));
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         }
     }
 
     @Override
-    public void putWithTimestamps(TableReference tableRef, Multimap<Cell, Value> values, final long time, final TimeUnit unit) {
+    public void putWithTimestamps(TableReference tableRef, Multimap<Cell, Value> values, long time, TimeUnit unit) {
         try {
             putInternal(tableRef, values.entries(), CassandraKeyValueServices.convertTtl(time, unit));
         } catch (Exception e) {
@@ -82,7 +89,11 @@ public class CassandraExpiringKeyValueService extends CassandraKeyValueService i
     }
 
     @Override
-    public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, final long timestamp, final long time, final TimeUnit unit) throws KeyAlreadyExistsException {
+    public void multiPut(
+            Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable,
+            long timestamp,
+            long time,
+            TimeUnit unit) throws KeyAlreadyExistsException {
         List<Callable<Void>> callables = Lists.newArrayList();
         for (Entry<TableReference, ? extends Map<Cell, byte[]>> e : valuesByTable.entrySet()) {
             final TableReference table = e.getKey();
@@ -91,25 +102,18 @@ public class CassandraExpiringKeyValueService extends CassandraKeyValueService i
 
 
             Iterable<List<Entry<Cell, byte[]>>> partitions = partitionByCountAndBytes(sortedMap.entrySet(),
-                    getMultiPutBatchCount(), getMultiPutBatchSizeBytes(), table, new Function<Entry<Cell, byte[]>, Long>(){
-
-                @Override
-                public Long apply(Entry<Cell, byte[]> entry) {
-                    long totalSize = 0;
-                    totalSize += entry.getValue().length;
-                    totalSize += Cells.getApproxSizeOfCell(entry.getKey());
-                    return totalSize;
-                }});
-
+                    getMultiPutBatchCount(), getMultiPutBatchSizeBytes(), table, entry -> {
+                        long totalSize = 0;
+                        totalSize += entry.getValue().length;
+                        totalSize += Cells.getApproxSizeOfCell(entry.getKey());
+                        return totalSize;
+                    });
 
             for (final List<Entry<Cell, byte[]>> p : partitions) {
-                callables.add(new Callable<Void>() {
-                    @Override
-                    public Void call() {
-                        Thread.currentThread().setName("Atlas expiry multiPut of " + p.size() + " cells into " + table);
-                        put(table, Maps2.fromEntries(p), timestamp, time, unit);
-                        return null;
-                    }
+                callables.add(() -> {
+                    Thread.currentThread().setName("Atlas expiry multiPut of " + p.size() + " cells into " + table);
+                    put(table, Maps2.fromEntries(p), timestamp, time, unit);
+                    return null;
                 });
             }
         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -28,7 +29,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -43,7 +43,6 @@ import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.Deletion;
-import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.KsDef;
@@ -122,9 +121,8 @@ import com.palantir.util.paging.SimpleTokenBackedResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
 /**
- *
- * each service can have one or many C* KVS.
- * For each C* KVS, it maintains a list of active nodes, and the client connections attached to each node
+ * Each service can have one or many C* KVS.
+ * For each C* KVS, it maintains a list of active nodes, and the client connections attached to each node:
  *
  * n1->c1, c2, c3
  * n2->c5, c4, c9
@@ -139,12 +137,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     private final Logger log;
 
-    private static final Function<Entry<Cell, Value>, Long> ENTRY_SIZING_FUNCTION = new Function<Entry<Cell, Value>, Long>() {
-        @Override
-        public Long apply(Entry<Cell, Value> input) {
-            return input.getValue().getContents().length + 4L + Cells.getApproxSizeOfCell(input.getKey());
-        }
-    };
+    private static final Function<Entry<Cell, Value>, Long> ENTRY_SIZING_FUNCTION = input ->
+            input.getValue().getContents().length + 4L + Cells.getApproxSizeOfCell(input.getKey());
 
     private final CassandraKeyValueServiceConfigManager configManager;
     private final Optional<CassandraJmxCompactionManager> compactionManager;
@@ -159,13 +153,23 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     private final ConsistencyLevel writeConsistency = ConsistencyLevel.EACH_QUORUM;
     private final ConsistencyLevel deleteConsistency = ConsistencyLevel.ALL;
 
-    public static CassandraKeyValueService create(CassandraKeyValueServiceConfigManager configManager, Optional<LeaderConfig> leaderConfig) {
+    public static CassandraKeyValueService create(
+            CassandraKeyValueServiceConfigManager configManager,
+            Optional<LeaderConfig> leaderConfig) {
         return create(configManager, leaderConfig, LoggerFactory.getLogger(CassandraKeyValueService.class));
     }
 
-    public static CassandraKeyValueService create(CassandraKeyValueServiceConfigManager configManager, Optional<LeaderConfig> leaderConfig, Logger log) {
-        Optional<CassandraJmxCompactionManager> compactionManager = CassandraJmxCompaction.createJmxCompactionManager(configManager);
-        CassandraKeyValueService ret = new CassandraKeyValueService(log, configManager, compactionManager, leaderConfig);
+    public static CassandraKeyValueService create(
+            CassandraKeyValueServiceConfigManager configManager,
+            Optional<LeaderConfig> leaderConfig,
+            Logger log) {
+        Optional<CassandraJmxCompactionManager> compactionManager =
+                CassandraJmxCompaction.createJmxCompactionManager(configManager);
+        CassandraKeyValueService ret = new CassandraKeyValueService(
+                log,
+                configManager,
+                compactionManager,
+                leaderConfig);
         ret.init();
         return ret;
     }
@@ -196,14 +200,22 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     protected void init() {
         clientPool.runOneTimeStartupChecks();
 
-        boolean supportsCAS = clientPool.runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
+        boolean supportsCas = clientPool.runWithRetry(
+                CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
 
-        schemaMutationLock = new SchemaMutationLock(supportsCAS, configManager, clientPool, writeConsistency, schemaMutationLockTable);
+        schemaMutationLock = new SchemaMutationLock(
+                supportsCas,
+                configManager,
+                clientPool,
+                writeConsistency,
+                schemaMutationLockTable);
 
         createTable(AtlasDbConstants.METADATA_TABLE, AtlasDbConstants.EMPTY_TABLE_METADATA);
         lowerConsistencyWhenSafe();
         upgradeFromOlderInternalSchema();
-        CassandraKeyValueServices.failQuickInInitializationIfClusterAlreadyInInconsistentState(clientPool, configManager.getConfig());
+        CassandraKeyValueServices.failQuickInInitializationIfClusterAlreadyInInconsistentState(
+                clientPool,
+                configManager.getConfig());
     }
 
     @Override
@@ -223,16 +235,22 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 TableReference tableRef = fromInternalTableName(clusterSideCf.getName());
                 if (metadataForTables.containsKey(tableRef)) {
                     byte[] clusterSideMetadata = metadataForTables.get(tableRef);
-                    CfDef clientSideCf = getCfForTable(fromInternalTableName(clusterSideCf.getName()), clusterSideMetadata);
-                    if (!CassandraKeyValueServices.isMatchingCf(clientSideCf, clusterSideCf)) { // mismatch; we have changed how we generate schema since we last persisted
+                    CfDef clientSideCf = getCfForTable(
+                            fromInternalTableName(clusterSideCf.getName()),
+                            clusterSideMetadata);
+                    if (!CassandraKeyValueServices.isMatchingCf(clientSideCf, clusterSideCf)) {
+                        // mismatch; we have changed how we generate schema since we last persisted
                         log.warn("Upgrading table {} to new internal Cassandra schema", tableRef);
                         tablesToUpgrade.put(tableRef, clusterSideMetadata);
                     }
                 } else if (!hiddenTables.isHidden(tableRef)) {
-                    // Possible to get here from a race condition with another service starting up and performing schema upgrades concurrent with us doing this check
-                    log.error("Found a table " + tableRef.getQualifiedName() + " that did not have persisted AtlasDB metadata. "
-                            + "If you recently did a Palantir update, try waiting until schema upgrades are completed on all backend CLIs/services etc and restarting this service. "
-                            + "If this error re-occurs on subsequent attempted startups, please contact Palantir support.");
+                    // Possible to get here from a race condition with another service starting up
+                    // and performing schema upgrades concurrent with us doing this check
+                    log.error("Found a table " + tableRef.getQualifiedName() + " that did not have persisted"
+                            + " AtlasDB metadata. If you recently did a Palantir update, try waiting until"
+                            + " schema upgrades are completed on all backend CLIs/services etc and restarting"
+                            + " this service. If this error re-occurs on subsequent attempted startups, please"
+                            + " contact Palantir support.");
                 }
             }
 
@@ -241,7 +259,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 putMetadataForTables(tablesToUpgrade);
             }
         } catch (TException e) {
-            log.error("Couldn't upgrade from an older internal Cassandra schema. New table-related settings may not have taken effect.");
+            log.error("Couldn't upgrade from an older internal Cassandra schema."
+                    + " New table-related settings may not have taken effect.");
         }
     }
 
@@ -252,7 +271,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
         try {
             dcs = clientPool.runWithRetry(client ->
-                    CassandraVerifier.sanityCheckDatacenters(client, config.replicationFactor(), config.safetyDisabled()));
+                    CassandraVerifier.sanityCheckDatacenters(
+                            client,
+                            config.replicationFactor(),
+                            config.safetyDisabled()));
             KsDef ksDef = clientPool.runWithRetry(client ->
                     client.describe_keyspace(config.keyspace()));
             strategyOptions = Maps.newHashMap(ksDef.getStrategy_options());
@@ -260,35 +282,37 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             if (dcs.size() == 1) {
                 String dc = dcs.iterator().next();
                 if (strategyOptions.get(dc) != null) {
-                    int currentRF = Integer.parseInt(strategyOptions.get(dc));
-                    if (currentRF == config.replicationFactor()) {
-                        if (currentRF == 2 && config.clusterMeetsNormalConsistencyGuarantees()) {
+                    int currentRf = Integer.parseInt(strategyOptions.get(dc));
+                    if (currentRf == config.replicationFactor()) {
+                        if (currentRf == 2 && config.clusterMeetsNormalConsistencyGuarantees()) {
                             log.info("Setting Read Consistency to ONE, as cluster has only one datacenter at RF2.");
                             readConsistency = ConsistencyLevel.ONE;
                         }
                     }
                 }
             }
-        } catch (InvalidRequestException e) {
-            return;
         } catch (TException e) {
             return;
         }
     }
 
     @Override
-    public Map<Cell, Value> getRows(final TableReference tableRef, final Iterable<byte[]> rows, ColumnSelection selection, final long startTs) {
+    public Map<Cell, Value> getRows(
+            TableReference tableRef,
+            Iterable<byte[]> rows,
+            ColumnSelection selection,
+            long startTs) {
         if (!selection.allColumnsSelected()) {
             return getRowsForSpecificColumns(tableRef, rows, selection, startTs);
         }
 
-        Set<Entry<InetSocketAddress, List<byte[]>>> rowsByHost =
-                partitionByHost(rows, Functions.<byte[]>identity()).entrySet();
+        Set<Entry<InetSocketAddress, List<byte[]>>> rowsByHost = partitionByHost(rows, Functions.identity()).entrySet();
         List<Callable<Map<Cell, Value>>> tasks = Lists.newArrayListWithCapacity(rowsByHost.size());
         for (final Map.Entry<InetSocketAddress, List<byte[]>> hostAndRows : rowsByHost) {
             tasks.add(ThreadNamingCallable.wrapWithThreadName(
-                    () -> CassandraKeyValueService.this.getRowsForSingleHost(hostAndRows.getKey(), tableRef, hostAndRows.getValue(), startTs),
-                    "Atlas getRows " + hostAndRows.getValue().size() + " rows from " + tableRef + " on " + hostAndRows.getKey(),
+                    () -> getRowsForSingleHost(hostAndRows.getKey(), tableRef, hostAndRows.getValue(), startTs),
+                    "Atlas getRows " + hostAndRows.getValue().size()
+                            + " rows from " + tableRef + " on " + hostAndRows.getKey(),
                     ThreadNamingCallable.Type.PREPEND));
         }
         List<Map<Cell, Value>> perHostResults = runAllTasksCancelOnFailure(tasks);
@@ -309,32 +333,45 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             int fetchBatchCount = configManager.getConfig().fetchBatchCount();
             for (final List<byte[]> batch : Lists.partition(rows, fetchBatchCount)) {
                 rowCount += batch.size();
-                result.putAll(clientPool.runWithRetryOnHost(host, new FunctionCheckedException<Client, Map<Cell, Value>, Exception>() {
-                    @Override
-                    public Map<Cell, Value> apply(Client client) throws Exception {
-                        // We want to get all the columns in the row so set start and end to empty.
-                        SliceRange slice = new SliceRange(ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY), ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY), false, Integer.MAX_VALUE);
-                        SlicePredicate pred = new SlicePredicate();
-                        pred.setSlice_range(slice);
+                result.putAll(clientPool.runWithRetryOnHost(host,
+                        new FunctionCheckedException<Client, Map<Cell, Value>, Exception>() {
+                            @Override
+                            public Map<Cell, Value> apply(Client client) throws Exception {
+                                // We want to get all the columns in the row so set start and end to empty.
+                                SliceRange slice = new SliceRange(
+                                        ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY),
+                                        ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY),
+                                        false,
+                                        Integer.MAX_VALUE);
+                                SlicePredicate pred = new SlicePredicate();
+                                pred.setSlice_range(slice);
 
-                        List<ByteBuffer> rowNames = wrap(rows);
+                                List<ByteBuffer> rowNames = wrap(rows);
 
-                        ColumnParent colFam = new ColumnParent(internalTableName(tableRef));
-                        Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal(client, tableRef, rowNames, colFam, pred, readConsistency);
-                        Map<Cell, Value> ret = Maps.newHashMap();
-                        new ValueExtractor(ret).extractResults(results, startTs, ColumnSelection.all());
-                        return ret;
-                    }
+                                ColumnParent colFam = new ColumnParent(internalTableName(tableRef));
+                                Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal(
+                                        client,
+                                        tableRef,
+                                        rowNames,
+                                        colFam,
+                                        pred,
+                                        readConsistency);
+                                Map<Cell, Value> ret = Maps.newHashMap();
+                                new ValueExtractor(ret).extractResults(results, startTs, ColumnSelection.all());
+                                return ret;
+                            }
 
-                    @Override
-                    public String toString() {
-                        return "multiget_slice(" + tableRef.getQualifiedName() + ", " + batch.size() + " rows" + ")";
-                    }
-                }));
+                            @Override
+                            public String toString() {
+                                return "multiget_slice(" + tableRef.getQualifiedName() + ", "
+                                        + batch.size() + " rows" + ")";
+                            }
+                        }));
             }
             if (rowCount > fetchBatchCount) {
-                log.warn("Rebatched in getRows a call to " + tableRef.getQualifiedName() + " that attempted to multiget "
-                        + rowCount + " rows; this may indicate overly-large batching on a higher level.\n"
+                log.warn("Rebatched in getRows a call to " + tableRef.getQualifiedName()
+                        + " that attempted to multiget " + rowCount
+                        + " rows; this may indicate overly-large batching on a higher level.\n"
                         + CassandraKeyValueServices.getFilteredStackTrace("com.palantir"));
             }
             return ImmutableMap.copyOf(result);
@@ -365,13 +402,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             }
         }
 
-        try {
-            StartTsResultsCollector collector = new StartTsResultsCollector(startTs);
-            loadWithTs(tableRef, cells, startTs, false, collector, readConsistency);
-            return collector.collectedResults;
-        } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
-        }
+        StartTsResultsCollector collector = new StartTsResultsCollector(startTs);
+        loadWithTs(tableRef, cells, startTs, false, collector, readConsistency);
+        return collector.collectedResults;
     }
 
     @Override
@@ -407,8 +440,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             Set<Cell> cells,
                             long startTs,
                             boolean loadAllTs,
-                            ThreadSafeResultVisitor v,
-                            ConsistencyLevel consistency) throws Exception {
+                            ThreadSafeResultVisitor visitor,
+                            ConsistencyLevel consistency) {
         Map<InetSocketAddress, List<Cell>> hostsAndCells =  partitionByHost(cells, Cells.getRowFunction());
         int totalPartitions = hostsAndCells.keySet().size();
 
@@ -421,7 +454,11 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         for (Map.Entry<InetSocketAddress, List<Cell>> hostAndCells : hostsAndCells.entrySet()) {
             if (log.isTraceEnabled()) {
                 log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
-                        hostsAndCells.values().size(), tableRef, loadAllTs ? "for all timestamps " : "", startTs, hostAndCells.getKey());
+                        hostsAndCells.values().size(),
+                        tableRef,
+                        loadAllTs ? "for all timestamps " : "",
+                        startTs,
+                        hostAndCells.getKey());
             }
 
             tasks.addAll(getLoadWithTsTasksForSingleHost(hostAndCells.getKey(),
@@ -429,7 +466,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     hostAndCells.getValue(),
                     startTs,
                     loadAllTs,
-                    v,
+                    visitor,
                     consistency));
         }
         runAllTasksCancelOnFailure(tasks);
@@ -441,19 +478,19 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                                                  final Collection<Cell> cells,
                                                                  final long startTs,
                                                                  final boolean loadAllTs,
-                                                                 final ThreadSafeResultVisitor v,
-                                                                 final ConsistencyLevel consistency) throws Exception {
+                                                                 final ThreadSafeResultVisitor visitor,
+                                                                 final ConsistencyLevel consistency) {
         final ColumnParent colFam = new ColumnParent(internalTableName(tableRef));
-        TreeMultimap<byte[], Cell> cellsByCol =
+        Multimap<byte[], Cell> cellsByCol =
                 TreeMultimap.create(UnsignedBytes.lexicographicalComparator(), Ordering.natural());
         for (Cell cell : cells) {
             cellsByCol.put(cell.getColumnName(), cell);
         }
         List<Callable<Void>> tasks = Lists.newArrayList();
         int fetchBatchCount = configManager.getConfig().fetchBatchCount();
-        for (Entry<byte[], SortedSet<Cell>> entry : Multimaps.asMap(cellsByCol).entrySet()) {
+        for (Entry<byte[], Collection<Cell>> entry : Multimaps.asMap(cellsByCol).entrySet()) {
             final byte[] col = entry.getKey();
-            SortedSet<Cell> columnCells = entry.getValue();
+            Collection<Cell> columnCells = entry.getValue();
             if (columnCells.size() > fetchBatchCount) {
                 log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to "
                                 + "multiget {} rows; this may indicate overly-large batching on a higher level.\n{}",
@@ -463,37 +500,43 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         CassandraKeyValueServices.getFilteredStackTrace("com.palantir"));
             }
             for (final List<Cell> partition : Lists.partition(ImmutableList.copyOf(columnCells), fetchBatchCount)) {
-                Callable<Void> multiGetCallable = () -> clientPool.runWithRetryOnHost(host, new FunctionCheckedException<Client, Void, Exception>() {
-                    @Override
-                    public Void apply(Client client) throws Exception {
-                        ByteBuffer start = CassandraKeyValueServices.makeCompositeBuffer(col, startTs - 1);
-                        ByteBuffer end = CassandraKeyValueServices.makeCompositeBuffer(col, -1);
-                        SliceRange slice = new SliceRange(start, end, false, loadAllTs ? Integer.MAX_VALUE : 1);
-                        SlicePredicate predicate = new SlicePredicate();
-                        predicate.setSlice_range(slice);
+                Callable<Void> multiGetCallable = () -> clientPool.runWithRetryOnHost(host,
+                        new FunctionCheckedException<Client, Void, Exception>() {
+                            @Override
+                            public Void apply(Client client) throws Exception {
+                                ByteBuffer start = CassandraKeyValueServices.makeCompositeBuffer(col, startTs - 1);
+                                ByteBuffer end = CassandraKeyValueServices.makeCompositeBuffer(col, -1);
+                                SliceRange slice = new SliceRange(start, end, false, loadAllTs ? Integer.MAX_VALUE : 1);
+                                SlicePredicate predicate = new SlicePredicate();
+                                predicate.setSlice_range(slice);
 
-                        List<ByteBuffer> rowNames = Lists.newArrayListWithCapacity(partition.size());
-                        for (Cell c : partition) {
-                            rowNames.add(ByteBuffer.wrap(c.getRowName()));
-                        }
+                                List<ByteBuffer> rowNames = Lists.newArrayListWithCapacity(partition.size());
+                                for (Cell c : partition) {
+                                    rowNames.add(ByteBuffer.wrap(c.getRowName()));
+                                }
 
-                        if (log.isTraceEnabled()) {
-                            log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
-                                    partition.size(), tableRef, loadAllTs ? "for all timestamps " : "", startTs, host);
-                        }
+                                if (log.isTraceEnabled()) {
+                                    log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
+                                            partition.size(),
+                                            tableRef,
+                                            loadAllTs ? "for all timestamps " : "",
+                                            startTs,
+                                            host);
+                                }
 
-                        Map<ByteBuffer, List<ColumnOrSuperColumn>> results =
-                                multigetInternal(client, tableRef, rowNames, colFam, predicate, consistency);
-                        v.visit(results);
-                        return null;
-                    }
+                                Map<ByteBuffer, List<ColumnOrSuperColumn>> results =
+                                        multigetInternal(client, tableRef, rowNames, colFam, predicate, consistency);
+                                visitor.visit(results);
+                                return null;
+                            }
 
-                    @Override
-                    public String toString() {
-                        return "multiget_slice(" + host + ", " + colFam + ", " + partition.size() + " cells" + ")";
-                    }
+                            @Override
+                            public String toString() {
+                                return "multiget_slice(" + host + ", " + colFam + ", "
+                                        + partition.size() + " cells" + ")";
+                            }
 
-                });
+                        });
                 tasks.add(ThreadNamingCallable.wrapWithThreadName(
                         multiGetCallable,
                         "Atlas loadWithTs " + partition.size() + " cells from " + tableRef + " on " + host,
@@ -515,7 +558,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             tasks.add(ThreadNamingCallable.wrapWithThreadName(() ->
                     getRowsColumnRangeIteratorForSingleHost(hostAndRows.getKey(), tableRef,
                             hostAndRows.getValue(), columnRangeSelection, timestamp),
-                    "Atlas getRowsColumnRange " + hostAndRows.getValue().size() + " rows from " + tableRef + " on " + hostAndRows.getKey(),
+                    "Atlas getRowsColumnRange " + hostAndRows.getValue().size()
+                            + " rows from " + tableRef + " on " + hostAndRows.getKey(),
                     ThreadNamingCallable.Type.PREPEND));
         }
         List<Map<byte[], RowColumnRangeIterator>> perHostResults = runAllTasksCancelOnFailure(tasks);
@@ -526,11 +570,12 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         return result;
     }
 
-    private Map<byte[], RowColumnRangeIterator> getRowsColumnRangeIteratorForSingleHost(InetSocketAddress host,
-                                                                                        TableReference tableRef,
-                                                                                        List<byte[]> rows,
-                                                                                        ColumnRangeSelection columnRangeSelection,
-                                                                                        long startTs) {
+    private Map<byte[], RowColumnRangeIterator> getRowsColumnRangeIteratorForSingleHost(
+            InetSocketAddress host,
+            TableReference tableRef,
+            List<byte[]> rows,
+            ColumnRangeSelection columnRangeSelection,
+            long startTs) {
         try {
             RowColumnRangeExtractor.RowColumnRangeResult firstPage =
                     getRowsColumnRangeForSingleHost(host, tableRef, rows, columnRangeSelection, startTs);
@@ -541,11 +586,16 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             for (Entry<byte[], Column> e : rowsToLastCompositeColumns.entrySet()) {
                 byte[] row = e.getKey();
                 byte[] col = CassandraKeyValueServices.decomposeName(e.getValue()).getLhSide();
-                // If we read a version of the cell before our start timestamp, it will be the most recent version readable to
-                // us and we can continue to the next column. Otherwise we have to continue reading this column.
-                LinkedHashMap<Cell, Value> rowResult = results.get(row);
+                // If we read a version of the cell before our start timestamp, it will be the most recent version
+                // readable to us and we can continue to the next column. Otherwise we have to continue reading
+                // this column.
+                Map<Cell, Value> rowResult = results.get(row);
                 boolean completedCell = (rowResult != null) && rowResult.containsKey(Cell.create(row, col));
-                boolean endOfRange = isEndOfColumnRange(completedCell, col, firstPage.getRowsToRawColumnCount().get(row), columnRangeSelection);
+                boolean endOfRange = isEndOfColumnRange(
+                        completedCell,
+                        col,
+                        firstPage.getRowsToRawColumnCount().get(row),
+                        columnRangeSelection);
                 if (!endOfRange) {
                     byte[] nextCol = getNextColumnRangeColumn(completedCell, col);
                     incompleteRowsToNextColumns.put(row, nextCol);
@@ -555,7 +605,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             Map<byte[], RowColumnRangeIterator> ret = Maps.newHashMapWithExpectedSize(rows.size());
             for (byte[] row : rowsToLastCompositeColumns.keySet()) {
                 Iterator<Entry<Cell, Value>> resultIterator;
-                LinkedHashMap<Cell, Value> result = results.get(row);
+                Map<Cell, Value> result = results.get(row);
                 if (result != null) {
                     resultIterator = result.entrySet().iterator();
                 } else {
@@ -567,7 +617,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 } else {
                     ColumnRangeSelection newColumnRange = new ColumnRangeSelection(nextCol,
                             columnRangeSelection.getEndCol(), columnRangeSelection.getBatchHint());
-                    ret.put(row, new LocalRowColumnRangeIterator(Iterators.concat(resultIterator, getRowColumnRange(host, tableRef, row, newColumnRange, startTs))));
+                    ret.put(row, new LocalRowColumnRangeIterator(Iterators.concat(
+                            resultIterator,
+                            getRowColumnRange(host, tableRef, row, newColumnRange, startTs))));
                 }
             }
             // We saw no Cassandra results at all for these rows, so the entire column range is empty for these rows.
@@ -586,61 +638,82 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                                              ColumnRangeSelection columnRangeSelection,
                                                              long startTs) {
         try {
-            return clientPool.runWithRetryOnHost(host, new FunctionCheckedException<Client, RowColumnRangeExtractor.RowColumnRangeResult, Exception>() {
-                @Override
-                public RowColumnRangeExtractor.RowColumnRangeResult apply(Client client) throws Exception {
-                    ByteBuffer start = columnRangeSelection.getStartCol().length == 0 ?
-                            ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY) :
-                            CassandraKeyValueServices.makeCompositeBuffer(columnRangeSelection.getStartCol(), startTs - 1);
-                    ByteBuffer end = columnRangeSelection.getEndCol().length == 0 ?
-                            ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY) :
-                            CassandraKeyValueServices.makeCompositeBuffer(RangeRequests.previousLexicographicName(columnRangeSelection.getEndCol()), -1);
-                    SliceRange slice = new SliceRange(start, end, false, columnRangeSelection.getBatchHint());
-                    SlicePredicate pred = new SlicePredicate();
-                    pred.setSlice_range(slice);
+            return clientPool.runWithRetryOnHost(host,
+                    new FunctionCheckedException<Client, RowColumnRangeExtractor.RowColumnRangeResult, Exception>() {
+                        @Override
+                        public RowColumnRangeExtractor.RowColumnRangeResult apply(Client client) throws Exception {
+                            ByteBuffer start = columnRangeSelection.getStartCol().length == 0
+                                    ? ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY)
+                                    : CassandraKeyValueServices.makeCompositeBuffer(
+                                            columnRangeSelection.getStartCol(),
+                                            startTs - 1);
+                            ByteBuffer end = columnRangeSelection.getEndCol().length == 0
+                                    ? ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY)
+                                    : CassandraKeyValueServices.makeCompositeBuffer(
+                                            RangeRequests.previousLexicographicName(columnRangeSelection.getEndCol()),
+                                            -1);
+                            SliceRange slice = new SliceRange(start, end, false, columnRangeSelection.getBatchHint());
+                            SlicePredicate pred = new SlicePredicate();
+                            pred.setSlice_range(slice);
 
-                    ColumnParent colFam = new ColumnParent(internalTableName(tableRef));
-                    Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal(client, tableRef, wrap(rows), colFam, pred, readConsistency);
+                            ColumnParent colFam = new ColumnParent(internalTableName(tableRef));
+                            Map<ByteBuffer, List<ColumnOrSuperColumn>> results =
+                                    multigetInternal(client, tableRef, wrap(rows), colFam, pred, readConsistency);
 
-                    RowColumnRangeExtractor extractor = new RowColumnRangeExtractor();
-                    extractor.extractResults(results, startTs);
+                            RowColumnRangeExtractor extractor = new RowColumnRangeExtractor();
+                            extractor.extractResults(results, startTs);
 
-                    return extractor.getRowColumnRangeResult();
-                }
+                            return extractor.getRowColumnRangeResult();
+                        }
 
-                @Override
-                public String toString() {
-                    return "multiget_slice(" + tableRef.getQualifiedName() + ", " + rows.size() + " rows, " + columnRangeSelection.getBatchHint() + " max columns)";
-                }
-            });
+                        @Override
+                        public String toString() {
+                            return "multiget_slice(" + tableRef.getQualifiedName() + ", "
+                                    + rows.size() + " rows, " + columnRangeSelection.getBatchHint() + " max columns)";
+                        }
+                    });
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         }
     }
 
-    private Iterator<Entry<Cell, Value>> getRowColumnRange(InetSocketAddress host, TableReference tableRef, final byte[] row,
-                                                           final ColumnRangeSelection columnRangeSelection, long startTs) {
-        return ClosableIterators.wrap(new AbstractPagingIterable<Entry<Cell, Value>, TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]>>() {
+    private Iterator<Entry<Cell, Value>> getRowColumnRange(
+            InetSocketAddress host,
+            TableReference tableRef,
+            byte[] row,
+            ColumnRangeSelection columnRangeSelection,
+            long startTs) {
+        return ClosableIterators.wrap(new AbstractPagingIterable<
+                Entry<Cell, Value>,
+                TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]>>() {
             @Override
             protected TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]> getFirstPage() throws Exception {
                 return page(columnRangeSelection.getStartCol());
             }
 
             @Override
-            protected TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]> getNextPage(TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]> previous) throws Exception {
+            protected TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]> getNextPage(
+                    TokenBackedBasicResultsPage<Entry<Cell, Value>,
+                            byte[]> previous) throws Exception {
                 return page(previous.getTokenForNextPage());
             }
 
             TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]> page(final byte[] startCol) throws Exception {
-                return clientPool.runWithRetryOnHost(host, new FunctionCheckedException<Client, TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]>, Exception>() {
+                return clientPool.runWithRetryOnHost(host, new FunctionCheckedException<
+                        Client,
+                        TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]>,
+                        Exception>() {
                     @Override
-                    public TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]> apply(Client client) throws Exception {
-                        ByteBuffer start = startCol.length == 0 ?
-                                ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY) :
-                                CassandraKeyValueServices.makeCompositeBuffer(startCol, startTs - 1);
-                        ByteBuffer end = columnRangeSelection.getEndCol().length == 0 ?
-                                ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY) :
-                                CassandraKeyValueServices.makeCompositeBuffer(RangeRequests.previousLexicographicName(columnRangeSelection.getEndCol()), -1);
+                    public TokenBackedBasicResultsPage<Entry<Cell, Value>, byte[]> apply(Client client)
+                            throws Exception {
+                        ByteBuffer start = startCol.length == 0
+                                ? ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY)
+                                : CassandraKeyValueServices.makeCompositeBuffer(startCol, startTs - 1);
+                        ByteBuffer end = columnRangeSelection.getEndCol().length == 0
+                                ? ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY)
+                                : CassandraKeyValueServices.makeCompositeBuffer(
+                                        RangeRequests.previousLexicographicName(columnRangeSelection.getEndCol()),
+                                        -1);
                         SliceRange slice = new SliceRange(start, end, false, columnRangeSelection.getBatchHint());
                         SlicePredicate pred = new SlicePredicate();
                         pred.setSlice_range(slice);
@@ -652,13 +725,13 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                 ImmutableList.of(rowByteBuffer), colFam, pred, readConsistency);
 
                         if (results.isEmpty()) {
-                            return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.<Entry<Cell, Value>>of(), false);
+                            return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
                         }
                         Map<Cell, Value> ret = Maps.newHashMap();
                         new ValueExtractor(ret).extractResults(results, startTs, ColumnSelection.all());
                         List<ColumnOrSuperColumn> values = Iterables.getOnlyElement(results.values());
                         if (values.isEmpty()) {
-                            return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.<Entry<Cell, Value>>of(), false);
+                            return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
                         }
                         ColumnOrSuperColumn lastColumn = values.get(values.size() - 1);
                         byte[] lastCol = CassandraKeyValueServices.decomposeName(lastColumn.getColumn()).getLhSide();
@@ -673,7 +746,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
                     @Override
                     public String toString() {
-                        return "multiget_slice(" + tableRef.getQualifiedName() + ", single row, " + columnRangeSelection.getBatchHint() + " batch hint)";
+                        return "multiget_slice(" + tableRef.getQualifiedName()
+                                + ", single row, " + columnRangeSelection.getBatchHint() + " batch hint)";
                     }
                 });
             }
@@ -683,10 +757,12 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     private boolean isEndOfColumnRange(boolean completedCell, byte[] lastCol, int numRawResults,
                                        ColumnRangeSelection columnRangeSelection) {
-        return (numRawResults < columnRangeSelection.getBatchHint()) ||
-                (completedCell &&
-                        (RangeRequests.isLastRowName(lastCol)
-                                || Arrays.equals(RangeRequests.nextLexicographicName(lastCol), columnRangeSelection.getEndCol())));
+        return (numRawResults < columnRangeSelection.getBatchHint())
+                || (completedCell
+                        && (RangeRequests.isLastRowName(lastCol)
+                                || Arrays.equals(
+                                        RangeRequests.nextLexicographicName(lastCol),
+                                        columnRangeSelection.getEndCol())));
     }
 
     private byte[] getNextColumnRangeColumn(boolean completedCell, byte[] lastCol) {
@@ -737,11 +813,13 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         Map<InetSocketAddress, Map<Cell, Value>> cellsByHost = partitionMapByHost(values);
         List<Callable<Void>> tasks = Lists.newArrayListWithCapacity(cellsByHost.size());
         for (final Map.Entry<InetSocketAddress, Map<Cell, Value>> entry : cellsByHost.entrySet()) {
-            tasks.add(ThreadNamingCallable.wrapWithThreadName(() -> {
+            tasks.add(
+                    ThreadNamingCallable.wrapWithThreadName(() -> {
                         putForSingleHostInternal(entry.getKey(), tableRef, entry.getValue().entrySet(), ttl);
                         return null;
                     },
-                    "Atlas putInternal " + entry.getValue().size() + " cell values to " + tableRef + " on " + entry.getKey(),
+                    "Atlas putInternal " + entry.getValue().size() + " cell values to "
+                            + tableRef + " on " + entry.getKey(),
                     ThreadNamingCallable.Type.PREPEND));
         }
         runAllTasksCancelOnFailure(tasks);
@@ -766,24 +844,24 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
                         ColumnOrSuperColumn colOrSup = new ColumnOrSuperColumn();
                         colOrSup.setColumn(col);
-                        Mutation m = new Mutation();
-                        m.setColumn_or_supercolumn(colOrSup);
+                        Mutation mutation = new Mutation();
+                        mutation.setColumn_or_supercolumn(colOrSup);
 
                         ByteBuffer rowName = ByteBuffer.wrap(cell.getRowName());
 
                         Map<String, List<Mutation>> rowPuts = map.get(rowName);
                         if (rowPuts == null) {
-                            rowPuts = Maps.<String, List<Mutation>>newHashMap();
+                            rowPuts = Maps.newHashMap();
                             map.put(rowName, rowPuts);
                         }
 
                         List<Mutation> tableMutations = rowPuts.get(internalTableName(tableRef));
                         if (tableMutations == null) {
-                            tableMutations = Lists.<Mutation>newArrayList();
+                            tableMutations = Lists.newArrayList();
                             rowPuts.put(internalTableName(tableRef), tableMutations);
                         }
 
-                        tableMutations.add(m);
+                        tableMutations.add(mutation);
                     }
                     batchMutateInternal(client, tableRef, map, writeConsistency);
                 }
@@ -792,14 +870,16 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
             @Override
             public String toString() {
-                return "batch_mutate(" + host + ", " + tableRef.getQualifiedName() + ", " + Iterables.size(values) + " values, " + ttl + " ttl sec)";
+                return "batch_mutate(" + host + ", " + tableRef.getQualifiedName() + ", "
+                        + Iterables.size(values) + " values, " + ttl + " ttl sec)";
             }
         });
     }
 
     // Overridden to batch more intelligently than the default implementation.
     @Override
-    public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, final long timestamp) throws KeyAlreadyExistsException {
+    public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp)
+            throws KeyAlreadyExistsException {
         List<TableCellAndValue> flattened = Lists.newArrayList();
         for (Map.Entry<TableReference, ? extends Map<Cell, byte[]>> tableAndValues : valuesByTable.entrySet()) {
             for (Map.Entry<Cell, byte[]> entry : tableAndValues.getValue().entrySet()) {
@@ -828,7 +908,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         List<Callable<Void>> tasks = Lists.newArrayList();
         for (final List<TableCellAndValue> batch : partitioned) {
             final Set<TableReference> tableRefs = extractTableNames(batch);
-            tasks.add(ThreadNamingCallable.wrapWithThreadName(() -> {
+            tasks.add(
+                    ThreadNamingCallable.wrapWithThreadName(() -> {
                         multiPutForSingleHostInternal(host, tableRefs, batch, timestamp);
                         return null;
                     },
@@ -870,12 +951,15 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         Map<ByteBuffer, Map<String, List<Mutation>>> map = Maps.newHashMap();
         for (TableCellAndValue tableCellAndValue : batch) {
             Cell cell = tableCellAndValue.cell;
-            Column col = createColumn(cell, Value.create(tableCellAndValue.value, timestamp), CassandraConstants.NO_TTL);
+            Column col = createColumn(
+                    cell,
+                    Value.create(tableCellAndValue.value, timestamp),
+                    CassandraConstants.NO_TTL);
 
             ColumnOrSuperColumn colOrSup = new ColumnOrSuperColumn();
             colOrSup.setColumn(col);
-            Mutation m = new Mutation();
-            m.setColumn_or_supercolumn(colOrSup);
+            Mutation mutation = new Mutation();
+            mutation.setColumn_or_supercolumn(colOrSup);
 
             ByteBuffer rowName = ByteBuffer.wrap(cell.getRowName());
 
@@ -891,7 +975,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 rowPuts.put(internalTableName(tableCellAndValue.tableRef), tableMutations);
             }
 
-            tableMutations.add(m);
+            tableMutations.add(mutation);
         }
         return map;
     }
@@ -947,24 +1031,24 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 tableRefs.stream().map(TableReference::getQualifiedName).collect(Collectors.joining(", ")));
     }
 
-    private void logTraceResults(long duration, Set<TableReference> tableRefs, ByteBuffer recv_trace, boolean failed) {
+    private void logTraceResults(long duration, Set<TableReference> tableRefs, ByteBuffer recvTrace, boolean failed) {
         if (failed || duration > getMinimumDurationToTraceMillis()) {
             log.error("Traced a call to {} that {}took {} ms. It will appear in system_traces with UUID={}",
                     tableRefs.stream().map(TableReference::getQualifiedName).collect(Collectors.joining(", ")),
                     failed ? "failed and " : "",
                     duration,
-                    CassandraKeyValueServices.convertCassandraByteBufferUUIDtoString(recv_trace));
+                    CassandraKeyValueServices.convertCassandraByteBufferUuidToString(recvTrace));
         }
     }
 
-    private Map<ByteBuffer, List<ColumnOrSuperColumn>> multigetInternal(Client client,
-                                                                        TableReference tableRef,
-                                                                        List<ByteBuffer> rowNames,
-                                                                        ColumnParent colFam,
-                                                                        SlicePredicate pred,
-                                                                        ConsistencyLevel consistency) throws TException {
-        return run(client, tableRef,
-                () -> client.multiget_slice(rowNames, colFam, pred, consistency));
+    private Map<ByteBuffer, List<ColumnOrSuperColumn>> multigetInternal(
+            Client client,
+            TableReference tableRef,
+            List<ByteBuffer> rowNames,
+            ColumnParent colFam,
+            SlicePredicate pred,
+            ConsistencyLevel consistency) throws TException {
+        return run(client, tableRef, () -> client.multiget_slice(rowNames, colFam, pred, consistency));
     }
 
     @Override
@@ -991,7 +1075,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     }
                 });
             } catch (UnavailableException e) {
-                throw new PalantirRuntimeException("Creating tables requires all Cassandra nodes to be up and available.");
+                throw new PalantirRuntimeException("Creating tables requires all Cassandra nodes"
+                        + " to be up and available.");
             } catch (Exception e) {
                 throw Throwables.throwUncheckedException(e);
             }
@@ -1007,13 +1092,16 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     return true;
                 });
             } catch (TException e) {
-                log.error("Cluster was unavailable while we attempted a truncate for table " + tableRef.getQualifiedName() + "; we will try " + (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries) + " additional time(s). (" + e.getMessage() + ")");
+                log.error("Cluster was unavailable while we attempted a truncate for table "
+                        + tableRef.getQualifiedName() + "; we will try "
+                        + (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries) + " additional time(s).", e);
                 if (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries == 0) {
                     throw e;
                 }
                 successful = false;
                 try {
-                    Thread.sleep(new Random().nextInt((1 << (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries)) - 1) * 1000);
+                    Thread.sleep(new Random()
+                            .nextInt((1 << (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries)) - 1) * 1000);
                 } catch (InterruptedException e1) {
                     Thread.currentThread().interrupt();
                 }
@@ -1052,14 +1140,16 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                 maps.put(mapIndex, Maps.<ByteBuffer, Map<String, List<Mutation>>>newHashMap());
                             }
                             Map<ByteBuffer, Map<String, List<Mutation>>> map = maps.get(mapIndex);
-                            ByteBuffer colName = CassandraKeyValueServices.makeCompositeBuffer(cellVersions.getKey().getColumnName(), ts);
+                            ByteBuffer colName = CassandraKeyValueServices.makeCompositeBuffer(
+                                    cellVersions.getKey().getColumnName(),
+                                    ts);
                             SlicePredicate pred = new SlicePredicate();
                             pred.setColumn_names(Arrays.asList(colName));
                             Deletion del = new Deletion();
                             del.setPredicate(pred);
                             del.setTimestamp(Long.MAX_VALUE);
-                            Mutation m = new Mutation();
-                            m.setDeletion(del);
+                            Mutation mutation = new Mutation();
+                            mutation.setDeletion(del);
                             ByteBuffer rowName = ByteBuffer.wrap(cellVersions.getKey().getRowName());
                             if (!map.containsKey(rowName)) {
                                 map.put(rowName, Maps.<String, List<Mutation>>newHashMap());
@@ -1068,7 +1158,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             if (!rowPuts.containsKey(internalTableName(tableRef))) {
                                 rowPuts.put(internalTableName(tableRef), Lists.<Mutation>newArrayList());
                             }
-                            rowPuts.get(internalTableName(tableRef)).add(m);
+                            rowPuts.get(internalTableName(tableRef)).add(mutation);
                             mapIndex++;
                             numVersions += cellVersions.getValue().size();
                         }
@@ -1083,7 +1173,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
                 @Override
                 public String toString() {
-                    return "delete_batch_mutate(" + host + ", " + tableRef.getQualifiedName() + ", " + numVersions + " total versions of " + cellVersionsMap.size() + " keys)";
+                    return "delete_batch_mutate(" + host + ", " + tableRef.getQualifiedName() + ", "
+                            + numVersions + " total versions of " + cellVersionsMap.size() + " keys)";
                 }
             });
         } catch (Exception e) {
@@ -1099,26 +1190,34 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
         boolean negativeLookups = false;
         double falsePositiveChance = CassandraConstants.DEFAULT_LEVELED_COMPACTION_BLOOM_FILTER_FP_CHANCE;
-        int explicitCompressionBlockSizeKB = 0;
+        int explicitCompressionBlockSizeKb = 0;
         boolean appendHeavyAndReadLight = false;
         TableMetadataPersistence.CachePriority cachePriority = TableMetadataPersistence.CachePriority.WARM;
 
         if (!CassandraKeyValueServices.isEmptyOrInvalidMetadata(rawMetadata)) {
             TableMetadata tableMetadata = TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(rawMetadata);
             negativeLookups = tableMetadata.hasNegativeLookups();
-            explicitCompressionBlockSizeKB = tableMetadata.getExplicitCompressionBlockSizeKB();
+            explicitCompressionBlockSizeKb = tableMetadata.getExplicitCompressionBlockSizeKB();
             appendHeavyAndReadLight = tableMetadata.isAppendHeavyAndReadLight();
             cachePriority = tableMetadata.getCachePriority();
         }
 
-        if (explicitCompressionBlockSizeKB != 0) {
-            compressionOptions.put(CassandraConstants.CFDEF_COMPRESSION_TYPE_KEY, CassandraConstants.DEFAULT_COMPRESSION_TYPE);
-            compressionOptions.put(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY, Integer.toString(explicitCompressionBlockSizeKB));
+        if (explicitCompressionBlockSizeKb != 0) {
+            compressionOptions.put(
+                    CassandraConstants.CFDEF_COMPRESSION_TYPE_KEY,
+                    CassandraConstants.DEFAULT_COMPRESSION_TYPE);
+            compressionOptions.put(
+                    CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY,
+                    Integer.toString(explicitCompressionBlockSizeKb));
         } else {
             // We don't really need compression here nor anticipate it will garner us any gains
             // (which is why we're doing such a small chunk size), but this is how we can get "free" CRC checking.
-            compressionOptions.put(CassandraConstants.CFDEF_COMPRESSION_TYPE_KEY, CassandraConstants.DEFAULT_COMPRESSION_TYPE);
-            compressionOptions.put(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY, Integer.toString(AtlasDbConstants.MINIMUM_COMPRESSION_BLOCK_SIZE_KB));
+            compressionOptions.put(
+                    CassandraConstants.CFDEF_COMPRESSION_TYPE_KEY,
+                    CassandraConstants.DEFAULT_COMPRESSION_TYPE);
+            compressionOptions.put(
+                    CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY,
+                    Integer.toString(AtlasDbConstants.MINIMUM_COMPRESSION_BLOCK_SIZE_KB));
         }
 
         if (negativeLookups) {
@@ -1127,7 +1226,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
         if (appendHeavyAndReadLight) {
             cf.setCompaction_strategy(CassandraConstants.SIZE_TIERED_COMPACTION_STRATEGY);
-            cf.setCompaction_strategy_optionsIsSet(false); // clear out the now nonsensical "keep it at 80MB per sstable" option from LCS
+            // clear out the now nonsensical "keep it at 80MB per sstable" option from LCS
+            cf.setCompaction_strategy_optionsIsSet(false);
             if (!negativeLookups) {
                 falsePositiveChance = CassandraConstants.DEFAULT_SIZE_TIERED_COMPACTION_BLOOM_FILTER_FP_CHANCE;
             } else {
@@ -1146,6 +1246,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 break;
             case HOTTEST:
                 cf.setPopulate_io_cache_on_flushIsSet(true);
+                break;
+            default:
+                throw new PalantirRuntimeException("Unknown cache priority: " + cachePriority);
         }
 
         cf.setBloom_filter_fp_chance(falsePositiveChance);
@@ -1156,9 +1259,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     //TODO: after cassandra change: handle multiRanges
     @Override
     @Idempotent
-    public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(TableReference tableRef,
-                                                                                                           Iterable<RangeRequest> rangeRequests,
-                                                                                                           long timestamp) {
+    public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
+            TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            long timestamp) {
         int concurrency = configManager.getConfig().rangesConcurrency();
         return KeyValueServices.getFirstBatchForRangesUsingGetRangeConcurrent(
                 executor, this, tableRef, rangeRequests, timestamp, concurrency);
@@ -1169,27 +1273,47 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     // TODO: after cassandra change: handle column filtering
     @Override
     @Idempotent
-    public ClosableIterator<RowResult<Value>> getRange(TableReference tableRef, final RangeRequest rangeRequest, final long timestamp) {
+    public ClosableIterator<RowResult<Value>> getRange(
+            TableReference tableRef,
+            RangeRequest rangeRequest,
+            long timestamp) {
         return getRangeWithPageCreator(tableRef, rangeRequest, timestamp, readConsistency, ValueExtractor.SUPPLIER);
     }
 
     @Override
     @Idempotent
-    public ClosableIterator<RowResult<Set<Long>>> getRangeOfTimestamps(TableReference tableRef, RangeRequest rangeRequest, long timestamp) {
-        return getRangeWithPageCreator(tableRef, rangeRequest, timestamp, deleteConsistency, TimestampExtractor.SUPPLIER);
+    public ClosableIterator<RowResult<Set<Long>>> getRangeOfTimestamps(
+            TableReference tableRef,
+            RangeRequest rangeRequest,
+            long timestamp) {
+        return getRangeWithPageCreator(
+                tableRef,
+                rangeRequest,
+                timestamp,
+                deleteConsistency,
+                TimestampExtractor.SUPPLIER);
     }
 
     @Override
     @Idempotent
-    public ClosableIterator<RowResult<Set<Value>>> getRangeWithHistory(TableReference tableRef, RangeRequest rangeRequest, long timestamp) {
-        return getRangeWithPageCreator(tableRef, rangeRequest, timestamp, deleteConsistency, HistoryExtractor.SUPPLIER);
+    public ClosableIterator<RowResult<Set<Value>>> getRangeWithHistory(
+            TableReference tableRef,
+            RangeRequest rangeRequest,
+            long timestamp) {
+        return getRangeWithPageCreator(
+                tableRef,
+                rangeRequest,
+                timestamp,
+                deleteConsistency,
+                HistoryExtractor.SUPPLIER);
     }
 
-    public <T, U> ClosableIterator<RowResult<U>> getRangeWithPageCreator(final TableReference tableRef,
-                                                                         final RangeRequest rangeRequest,
-                                                                         final long timestamp,
-                                                                         final ConsistencyLevel consistency,
-                                                                         final Supplier<ResultsExtractor<T, U>> resultsExtractor) {
+    public <T, U> ClosableIterator<RowResult<U>> getRangeWithPageCreator(
+            TableReference tableRef,
+            RangeRequest rangeRequest,
+            long timestamp,
+            ConsistencyLevel consistency,
+            Supplier<ResultsExtractor<T, U>> resultsExtractor) {
         if (rangeRequest.isReverse()) {
             throw new UnsupportedOperationException();
         }
@@ -1197,7 +1321,11 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             return ClosableIterators.wrap(ImmutableList.<RowResult<U>>of().iterator());
         }
         final int batchHint = rangeRequest.getBatchHint() == null ? 100 : rangeRequest.getBatchHint();
-        SliceRange slice = new SliceRange(ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY), ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY), false, Integer.MAX_VALUE);
+        SliceRange slice = new SliceRange(
+                ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY),
+                ByteBuffer.wrap(PtBytes.EMPTY_BYTE_ARRAY),
+                false,
+                Integer.MAX_VALUE);
         final SlicePredicate pred = new SlicePredicate();
         pred.setSlice_range(slice);
 
@@ -1212,15 +1340,20 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     }
 
                     @Override
-                    protected TokenBackedBasicResultsPage<RowResult<U>, byte[]> getNextPage(TokenBackedBasicResultsPage<RowResult<U>, byte[]> previous) throws Exception {
+                    protected TokenBackedBasicResultsPage<RowResult<U>, byte[]> getNextPage(
+                            TokenBackedBasicResultsPage<RowResult<U>, byte[]> previous) throws Exception {
                         return page(previous.getTokenForNextPage());
                     }
 
                     TokenBackedBasicResultsPage<RowResult<U>, byte[]> page(final byte[] startKey) throws Exception {
                         InetSocketAddress host = clientPool.getRandomHostForKey(startKey);
-                        return clientPool.runWithRetryOnHost(host, new FunctionCheckedException<Client, TokenBackedBasicResultsPage<RowResult<U>, byte[]>, Exception>() {
+                        return clientPool.runWithRetryOnHost(host, new FunctionCheckedException<
+                                Client,
+                                TokenBackedBasicResultsPage<RowResult<U>, byte[]>,
+                                Exception>() {
                             @Override
-                            public TokenBackedBasicResultsPage<RowResult<U>, byte[]> apply(Client client) throws Exception {
+                            public TokenBackedBasicResultsPage<RowResult<U>, byte[]> apply(Client client)
+                                    throws Exception {
                                 final byte[] endExclusive = rangeRequest.getEndExclusive();
 
                                 KeyRange keyRange = new KeyRange(batchHint);
@@ -1239,15 +1372,17 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                             () -> client.get_range_slices(colFam, pred, keyRange, consistency));
                                 } catch (UnavailableException e) {
                                     if (consistency.equals(ConsistencyLevel.ALL)) {
-                                        throw new InsufficientConsistencyException("This operation requires all Cassandra nodes to be up and available.", e);
+                                        throw new InsufficientConsistencyException("This operation requires all"
+                                                + " Cassandra nodes to be up and available.", e);
                                     } else {
                                         throw e;
                                     }
                                 }
 
-                                Map<ByteBuffer, List<ColumnOrSuperColumn>> colsByKey = CassandraKeyValueServices.getColsByKey(firstPage);
-                                TokenBackedBasicResultsPage<RowResult<U>, byte[]> page =
-                                        resultsExtractor.get().getPageFromRangeResults(colsByKey, timestamp, selection, endExclusive);
+                                Map<ByteBuffer, List<ColumnOrSuperColumn>> colsByKey =
+                                        CassandraKeyValueServices.getColsByKey(firstPage);
+                                TokenBackedBasicResultsPage<RowResult<U>, byte[]> page = resultsExtractor.get()
+                                        .getPageFromRangeResults(colsByKey, timestamp, selection, endExclusive);
                                 if (page.moreResultsAvailable() && firstPage.size() < batchHint) {
                                     // If get_range_slices didn't return the full number of results, there's no
                                     // point to trying to get another page
@@ -1305,7 +1440,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             log.warn("Ignored call to drop a table ({}) that did not exist.", table);
                         }
                     }
-                    CassandraKeyValueServices.waitForSchemaVersions(client, "(all tables in a call to dropTables)", configManager.getConfig().schemaMutationTimeoutMillis());
+                    CassandraKeyValueServices.waitForSchemaVersions(
+                            client,
+                            "(all tables in a call to dropTables)",
+                            configManager.getConfig().schemaMutationTimeoutMillis());
                     return null;
                 }
             });
@@ -1346,7 +1484,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 for (TableReference table : tablesToCreate) {
                     CassandraVerifier.sanityCheckTableName(table);
 
-                    TableReference tableRefLowerCased = TableReference.createUnsafe(table.getQualifiedName().toLowerCase());
+                    TableReference tableRefLowerCased = TableReference
+                            .createUnsafe(table.getQualifiedName().toLowerCase());
                     if (!existingTablesLowerCased.contains(tableRefLowerCased)) {
                         client.system_add_column_family(getCfForTable(table, tableNamesToTableMetadata.get(table)));
                     } else {
@@ -1354,7 +1493,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     }
                 }
                 if (!tablesToCreate.isEmpty()) {
-                    CassandraKeyValueServices.waitForSchemaVersions(client, "(all tables in a call to createTables)", configManager.getConfig().schemaMutationTimeoutMillis());
+                    CassandraKeyValueServices.waitForSchemaVersions(
+                            client,
+                            "(all tables in a call to createTables)",
+                            configManager.getConfig().schemaMutationTimeoutMillis());
                 }
                 return null;
             });
@@ -1397,24 +1539,24 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     @Override
     public byte[] getMetadataForTable(TableReference tableRef) {
         Cell cell = getMetadataCell(tableRef);
-        Value v = get(AtlasDbConstants.METADATA_TABLE, ImmutableMap.of(cell, Long.MAX_VALUE)).get(cell);
-        if (v == null) {
+        Value value = get(AtlasDbConstants.METADATA_TABLE, ImmutableMap.of(cell, Long.MAX_VALUE)).get(cell);
+        if (value == null) {
             return AtlasDbConstants.EMPTY_TABLE_METADATA;
         } else {
             if (!getAllTablenamesInternal().contains(tableRef)) {
-                log.error("While getting metadata, found a table, {}, with stored table metadata " +
-                        "but no corresponding existing table in the underlying KVS. " +
-                        "This is not necessarily a bug, but warrants further inquiry.", tableRef.getQualifiedName());
-                }
-            return v.getContents();
+                log.error("While getting metadata, found a table, {}, with stored table metadata "
+                        + "but no corresponding existing table in the underlying KVS. "
+                        + "This is not necessarily a bug, but warrants further inquiry.", tableRef.getQualifiedName());
+            }
+            return value.getContents();
         }
     }
 
     @Override
     public Map<TableReference, byte[]> getMetadataForTables() {
         Map<TableReference, byte[]> tableToMetadataContents = Maps.newHashMap();
-        ClosableIterator<RowResult<Value>> range = getRange(AtlasDbConstants.METADATA_TABLE, RangeRequest.all(), Long.MAX_VALUE);
-        try {
+        try (ClosableIterator<RowResult<Value>> range =
+                getRange(AtlasDbConstants.METADATA_TABLE, RangeRequest.all(), Long.MAX_VALUE);) {
             while (range.hasNext()) {
                 RowResult<Value> valueRow = range.next();
                 Iterable<Entry<Cell, Value>> cells = valueRow.getCells();
@@ -1433,14 +1575,16 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     }
                 }
             }
-        } finally {
-            range.close();
         }
         return tableToMetadataContents;
     }
 
-    private Cell getMetadataCell(TableReference tableRef) { // would have preferred an explicit charset, but thrift uses default internally
-        return Cell.create(tableRef.getQualifiedName().getBytes(Charset.defaultCharset()), "m".getBytes());
+    @SuppressWarnings("checkstyle:RegexpSinglelineJava")
+    private Cell getMetadataCell(TableReference tableRef) {
+        // would have preferred an explicit charset, but thrift uses default internally
+        return Cell.create(
+                tableRef.getQualifiedName().getBytes(Charset.defaultCharset()),
+                "m".getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
@@ -1453,21 +1597,28 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         internalPutMetadataForTables(tableRefToMetadata, true);
     }
 
-    private void internalPutMetadataForTables(final Map<TableReference, byte[]> unfilteredTableNameToMetadata, final boolean possiblyNeedToPerformSettingsChanges) {
-        Map<TableReference, byte[]> tableNameToMetadata = Maps.filterValues(unfilteredTableNameToMetadata, Predicates.not(Predicates.equalTo(AtlasDbConstants.EMPTY_TABLE_METADATA)));
+    private void internalPutMetadataForTables(
+            Map<TableReference, byte[]> unfilteredTableNameToMetadata,
+            boolean possiblyNeedToPerformSettingsChanges) {
+        Map<TableReference, byte[]> tableNameToMetadata = Maps.filterValues(
+                unfilteredTableNameToMetadata,
+                Predicates.not(Predicates.equalTo(AtlasDbConstants.EMPTY_TABLE_METADATA)));
         if (tableNameToMetadata.isEmpty()) {
             return;
         }
 
-        final Map<Cell, byte[]> metadataRequestedForUpdate = Maps.newHashMapWithExpectedSize(tableNameToMetadata.size());
+        Map<Cell, byte[]> metadataRequestedForUpdate = Maps.newHashMapWithExpectedSize(tableNameToMetadata.size());
         for (Entry<TableReference, byte[]> tableEntry : tableNameToMetadata.entrySet()) {
             metadataRequestedForUpdate.put(getMetadataCell(tableEntry.getKey()), tableEntry.getValue());
         }
 
-        Map<Cell, Long> requestForLatestDbSideMetadata = Maps.transformValues(metadataRequestedForUpdate, Functions.constant(Long.MAX_VALUE));
+        Map<Cell, Long> requestForLatestDbSideMetadata = Maps.transformValues(
+                metadataRequestedForUpdate,
+                Functions.constant(Long.MAX_VALUE));
 
         // technically we're racing other services from here on, during an update period,
-        // but the penalty for not caring is just some superfluous schema mutations and a few dead rows in the metadata table.
+        // but the penalty for not caring is just some superfluous schema mutations and a
+        // few dead rows in the metadata table.
         Map<Cell, Value> persistedMetadata = get(AtlasDbConstants.METADATA_TABLE, requestForLatestDbSideMetadata);
         final Map<Cell, byte[]> newMetadata = Maps.newHashMap();
         final Collection<CfDef> updatedCfs = Lists.newArrayList();
@@ -1475,7 +1626,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             Value val = persistedMetadata.get(entry.getKey());
             if (val == null || !Arrays.equals(val.getContents(), entry.getValue())) {
                 newMetadata.put(entry.getKey(), entry.getValue());
-                updatedCfs.add(getCfForTable(TableReference.createUnsafe(new String(entry.getKey().getRowName())), entry.getValue()));
+                updatedCfs.add(getCfForTable(
+                        TableReference.createUnsafe(new String(entry.getKey().getRowName())),
+                        entry.getValue()));
             }
         }
 
@@ -1484,7 +1637,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         }
 
         if (possiblyNeedToPerformSettingsChanges) {
-            schemaMutationLock.runWithLock(() -> putMetadataForTablesWithLock(possiblyNeedToPerformSettingsChanges, newMetadata, updatedCfs));
+            schemaMutationLock.runWithLock(() ->
+                    putMetadataForTablesWithLock(possiblyNeedToPerformSettingsChanges, newMetadata, updatedCfs));
         } else {
             try {
                 putMetadataForTablesWithLock(possiblyNeedToPerformSettingsChanges, newMetadata, updatedCfs);
@@ -1494,26 +1648,31 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         }
     }
 
-    private void putMetadataForTablesWithLock(final boolean possiblyNeedToPerformSettingsChanges, final Map<Cell, byte[]> newMetadata, final Collection<CfDef> updatedCfs) throws Exception {
-        clientPool.runWithRetry(new FunctionCheckedException<Client, Void, Exception>() {
-            @Override
-            public Void apply(Client client) throws Exception {
-                if (possiblyNeedToPerformSettingsChanges) {
-                    for (CfDef cf : updatedCfs) {
-                        client.system_update_column_family(cf);
-                    }
-
-                    CassandraKeyValueServices.waitForSchemaVersions(client, "(all tables in a call to putMetadataForTables)", configManager.getConfig().schemaMutationTimeoutMillis());
+    private void putMetadataForTablesWithLock(
+            boolean possiblyNeedToPerformSettingsChanges,
+            Map<Cell, byte[]> newMetadata,
+            Collection<CfDef> updatedCfs) throws Exception {
+        clientPool.runWithRetry(client -> {
+            if (possiblyNeedToPerformSettingsChanges) {
+                for (CfDef cf : updatedCfs) {
+                    client.system_update_column_family(cf);
                 }
-                // Done with actual schema mutation, push the metadata
-                put(AtlasDbConstants.METADATA_TABLE, newMetadata, System.currentTimeMillis());
-                return null;
+
+                CassandraKeyValueServices.waitForSchemaVersions(
+                        client,
+                        "(all tables in a call to putMetadataForTables)",
+                        configManager.getConfig().schemaMutationTimeoutMillis());
             }
+            // Done with actual schema mutation, push the metadata
+            put(AtlasDbConstants.METADATA_TABLE, newMetadata, System.currentTimeMillis());
+            return null;
         });
     }
 
     private void putMetadataWithoutChangingSettings(final TableReference tableRef, final byte[] meta) {
-        put(AtlasDbConstants.METADATA_TABLE, ImmutableMap.of(getMetadataCell(tableRef), meta), System.currentTimeMillis());
+        put(AtlasDbConstants.METADATA_TABLE, ImmutableMap.of(
+                getMetadataCell(tableRef), meta),
+                System.currentTimeMillis());
     }
 
     @Override
@@ -1543,13 +1702,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     @Override
     public Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> cells, long ts) {
         AllTimestampsCollector collector = new AllTimestampsCollector();
-        try {
-            loadWithTs(tableRef, cells, ts, true, collector, deleteConsistency);
-        } catch (UnavailableException e) {
-            throw new InsufficientConsistencyException("Get all timestamps requires all Cassandra nodes to be up and available.", e);
-        } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
-        }
+        loadWithTs(tableRef, cells, ts, true, collector, deleteConsistency);
         return collector.collectedResults;
     }
 
@@ -1565,7 +1718,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         ByteBuffer rowName = ByteBuffer.wrap(e.getKey().getRowName());
                         byte[] contents = e.getValue();
                         long timestamp = AtlasDbConstants.TRANSACTION_TS;
-                        byte[] colName = CassandraKeyValueServices.makeCompositeBuffer(e.getKey().getColumnName(), timestamp).array();
+                        byte[] colName = CassandraKeyValueServices
+                                .makeCompositeBuffer(e.getKey().getColumnName(), timestamp)
+                                .array();
                         Column col = new Column();
                         col.setName(colName);
                         col.setValue(contents);
@@ -1573,12 +1728,13 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         CASResult casResult = run(client, tableRef, () -> client.cas(
                                 rowName,
                                 tableName,
-                                ImmutableList.<Column>of(),
+                                ImmutableList.of(),
                                 ImmutableList.of(col),
                                 ConsistencyLevel.SERIAL,
                                 writeConsistency));
                         if (!casResult.isSuccess()) {
-                            throw new KeyAlreadyExistsException("This transaction row already exists.", ImmutableList.of(e.getKey()));
+                            throw new KeyAlreadyExistsException("This transaction row already exists.",
+                                    ImmutableList.of(e.getKey()));
                         }
                     }
                     return null;
@@ -1628,11 +1784,14 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     @Override
     public void compactInternally(TableReference tableRef) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()), "tableRef:[%s] should not be null or empty.", tableRef);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()),
+                "tableRef:[%s] should not be null or empty.", tableRef);
         CassandraKeyValueServiceConfig config = configManager.getConfig();
         if (!compactionManager.isPresent()) {
-            log.error("No compaction client was configured, but compact was called. If you actually want to clear deleted data immediately " +
-                    "from Cassandra, lower your gc_grace_seconds setting and run `nodetool compact {} {}`.", config.keyspace(), tableRef);
+            log.error("No compaction client was configured, but compact was called."
+                    + " If you actually want to clear deleted data immediately"
+                    + " from Cassandra, lower your gc_grace_seconds setting and"
+                    + " run `nodetool compact {} {}`.", config.keyspace(), tableRef);
             return;
         }
         long timeoutInSeconds = config.jmx().get().compactionTimeoutSeconds();
@@ -1646,21 +1805,37 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         } catch (InterruptedException e) {
             log.error("Compaction for {}.{} was interrupted.", keyspace, tableRef);
         } finally {
-            alterGcAndTombstone(keyspace, tableRef, CassandraConstants.GC_GRACE_SECONDS, CassandraConstants.TOMBSTONE_THRESHOLD_RATIO);
+            alterGcAndTombstone(
+                    keyspace,
+                    tableRef,
+                    CassandraConstants.GC_GRACE_SECONDS,
+                    CassandraConstants.TOMBSTONE_THRESHOLD_RATIO);
         }
     }
 
-    private void alterGcAndTombstone(final String keyspace, final TableReference tableRef, final int gcGraceSeconds, final float tombstoneThresholdRatio) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(keyspace), "keyspace:[%s] should not be null or empty.", keyspace);
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()), "tableRef:[%s] should not be null or empty.", tableRef);
-        Preconditions.checkArgument(gcGraceSeconds >= 0, "gc_grace_seconds:[%s] should not be negative.", gcGraceSeconds);
+    private void alterGcAndTombstone(
+            String keyspace,
+            TableReference tableRef,
+            int gcGraceSeconds,
+            float tombstoneThresholdRatio) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(keyspace),
+                "keyspace:[%s] should not be null or empty.", keyspace);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()),
+                "tableRef:[%s] should not be null or empty.", tableRef);
+        Preconditions.checkArgument(gcGraceSeconds >= 0,
+                "gc_grace_seconds:[%s] should not be negative.", gcGraceSeconds);
         Preconditions.checkArgument(tombstoneThresholdRatio >= 0.0f && tombstoneThresholdRatio <= 1.0f,
                 "tombstone_threshold_ratio:[%s] should be between [0.0, 1.0]", tombstoneThresholdRatio);
 
-        schemaMutationLock.runWithLock(() -> alterGcAndTombstoneWithLock(keyspace, tableRef, gcGraceSeconds, tombstoneThresholdRatio));
+        schemaMutationLock.runWithLock(() ->
+                alterGcAndTombstoneWithLock(keyspace, tableRef, gcGraceSeconds, tombstoneThresholdRatio));
     }
 
-    private void alterGcAndTombstoneWithLock(final String keyspace, final TableReference tableRef, final int gcGraceSeconds, final float tombstoneThresholdRatio) {
+    private void alterGcAndTombstoneWithLock(
+            String keyspace,
+            TableReference tableRef,
+            int gcGraceSeconds,
+            float tombstoneThresholdRatio) {
         try {
             clientPool.runWithRetry((FunctionCheckedException<Client, Void, Exception>) client -> {
                 KsDef ks = client.describe_keyspace(keyspace);
@@ -1668,11 +1843,18 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 for (CfDef cf : cfs) {
                     if (cf.getName().equalsIgnoreCase(internalTableName(tableRef))) {
                         cf.setGc_grace_seconds(gcGraceSeconds);
-                        cf.setCompaction_strategy_options(ImmutableMap.of("tombstone_threshold", String.valueOf(tombstoneThresholdRatio)));
+                        cf.setCompaction_strategy_options(ImmutableMap.of(
+                                "tombstone_threshold",
+                                String.valueOf(tombstoneThresholdRatio)));
                         client.system_update_column_family(cf);
-                        CassandraKeyValueServices.waitForSchemaVersions(client, tableRef.getQualifiedName(), configManager.getConfig().schemaMutationTimeoutMillis());
-                        log.trace("gc_grace_seconds is set to {} for {}.{}", gcGraceSeconds, keyspace, tableRef);
-                        log.trace("tombstone_threshold_ratio is set to {} for {}.{}", tombstoneThresholdRatio, keyspace, tableRef);
+                        CassandraKeyValueServices.waitForSchemaVersions(
+                                client,
+                                tableRef.getQualifiedName(),
+                                configManager.getConfig().schemaMutationTimeoutMillis());
+                        log.trace("gc_grace_seconds is set to {} for {}.{}",
+                                gcGraceSeconds, keyspace, tableRef);
+                        log.trace("tombstone_threshold_ratio is set to {} for {}.{}",
+                                tombstoneThresholdRatio, keyspace, tableRef);
                     }
                 }
                 return null;
@@ -1706,7 +1888,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         return cellsByHost;
     }
 
-    private <V> Map<InetSocketAddress, List<V>> partitionByHost(Iterable<V> iterable, Function<V, byte[]> keyExtractor) {
+    private <V> Map<InetSocketAddress, List<V>> partitionByHost(
+            Iterable<V> iterable,
+            Function<V, byte[]> keyExtractor) {
         // Ensure that the same key goes to the same partition. This is important when writing multiple columns
         // to the same row, since this is a normally a single write in cassandra, whereas splitting the columns
         // into different requests results in multiple writes.
@@ -1756,27 +1940,17 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     }
 
     private static class TableCellAndValue {
+        public static final Function<TableCellAndValue, byte[]> EXTRACT_ROW_NAME_FUNCTION =
+                input -> input.cell.getRowName();
+
+        public static final Function<TableCellAndValue, Long> SIZING_FUNCTION =
+                input -> input.value.length + Cells.getApproxSizeOfCell(input.cell);
+
         private final TableReference tableRef;
         private final Cell cell;
         private final byte[] value;
 
-        public static Function<TableCellAndValue, byte[]> EXTRACT_ROW_NAME_FUNCTION =
-                new Function<TableCellAndValue, byte[]>() {
-                    @Override
-                    public byte[] apply(TableCellAndValue input) {
-                        return input.cell.getRowName();
-                    }
-                };
-
-        public static Function<TableCellAndValue, Long> SIZING_FUNCTION =
-                new Function<CassandraKeyValueService.TableCellAndValue, Long>() {
-                    @Override
-                    public Long apply(TableCellAndValue input) {
-                        return input.value.length + Cells.getApproxSizeOfCell(input.cell);
-                    }
-                };
-
-        public TableCellAndValue(TableReference tableRef, Cell cell, byte[] value) {
+        TableCellAndValue(TableReference tableRef, Cell cell, byte[] value) {
             this.tableRef = tableRef;
             this.cell = cell;
             this.value = value;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -25,13 +25,11 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.cassandra.thrift.Cassandra;
-import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
-import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KeySlice;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,17 +45,22 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.annotation.Output;
-import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.visitor.Visitor;
 import com.palantir.util.Pair;
 
-public class CassandraKeyValueServices {
+public final class CassandraKeyValueServices {
     private static final Logger log = LoggerFactory.getLogger(CassandraKeyValueService.class); // did this on purpose
 
-    private static long INITIAL_SLEEP_TIME = 100;
-    private static long MAX_SLEEP_TIME = 5000;
-    static void waitForSchemaVersions(Cassandra.Client client, String tableName, int schemaTimeoutMillis) throws InvalidRequestException, TException {
+    private static final long INITIAL_SLEEP_TIME = 100;
+    private static final long MAX_SLEEP_TIME = 5000;
+
+    private CassandraKeyValueServices() {
+        // Utility class
+    }
+
+    static void waitForSchemaVersions(Cassandra.Client client, String tableName, int schemaTimeoutMillis)
+            throws TException {
         long start = System.currentTimeMillis();
         long sleepTime = INITIAL_SLEEP_TIME;
         Map<String, List<String>> versions;
@@ -72,39 +75,53 @@ public class CassandraKeyValueServices {
                 throw Throwables.throwUncheckedException(e);
             }
             sleepTime = Math.min(sleepTime * 2, MAX_SLEEP_TIME);
-        } while (System.currentTimeMillis() < start + schemaTimeoutMillis);
+        }
+        while (System.currentTimeMillis() < start + schemaTimeoutMillis);
+
         StringBuilder sb = new StringBuilder();
-        sb.append(String.format("Cassandra cluster cannot come to agreement on schema versions, after attempting to modify table %s.", tableName));
-        for ( Entry<String, List<String>> version : versions.entrySet()) {
+        sb.append(String.format("Cassandra cluster cannot come to agreement on schema versions,"
+                + " after attempting to modify table %s.", tableName));
+        for (Entry<String, List<String>> version : versions.entrySet()) {
             sb.append(String.format("%nAt schema version %s:", version.getKey()));
-            for (String node: version.getValue()) {
+            for (String node : version.getValue()) {
                 sb.append(String.format("%n\tNode: %s", node));
             }
         }
-        sb.append("\nFind the nodes above that diverge from the majority schema " +
-                "(or have schema 'UNKNOWN', which likely means they are down/unresponsive) " +
-                "and examine their logs to determine the issue. Fixing the underlying issue and restarting Cassandra " +
-                "should resolve the problem. You can quick-check this with 'nodetool describecluster'.");
+        sb.append("\nFind the nodes above that diverge from the majority schema")
+                .append(" (or have schema 'UNKNOWN', which likely means they are down/unresponsive)")
+                .append(" and examine their logs to determine the issue.")
+                .append(" Fixing the underlying issue and restarting Cassandra")
+                .append(" should resolve the problem. You can quick-check this with 'nodetool describecluster'.");
         throw new IllegalStateException(sb.toString());
     }
 
     /**
-     * This is a request from pbrown / FDEs; basically it's a pain to do DB surgery to get out of failed patch upgrades, the majority of which requires schema mutations; they would find it preferable to stop before starting the actual patch upgrade / setting APPLYING state.
+     * This is a request from pbrown / FDEs; basically it's a pain to do DB surgery to get out
+     * of failed patch upgrades, the majority of which requires schema mutations; they would find
+     * it preferable to stop before starting the actual patch upgrade / setting APPLYING state.
      */
-    static void failQuickInInitializationIfClusterAlreadyInInconsistentState(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config) {
+    static void failQuickInInitializationIfClusterAlreadyInInconsistentState(
+            CassandraClientPool clientPool,
+            CassandraKeyValueServiceConfig config) {
         if (config.safetyDisabled()) {
-            log.error("Skipped checking the cassandra cluster during initialization, because safety checks are disabled. Please re-enable safety checks when you are outside of your unusual migration period.");
+            log.error("Skipped checking the cassandra cluster during initialization, because safety checks are"
+                    + " disabled. Please re-enable safety checks when you are outside of your unusual"
+                    + " migration period.");
             return;
         }
-        String errorMessage = "While checking the cassandra cluster during initialization, we noticed schema versions could not settle. Failing quickly to avoid getting into harder to fix states (i.e. partially applied patch upgrades, etc). " +
-                "This state is in rare cases the correct one to be in; for instance schema versions will be incapable of settling in a cluster of heterogenous Cassandra 1.2/2.0 nodes. If that is the case, disable safety checks in your Cassandra KVS preferences.";
+        String errorMessage = "While checking the cassandra cluster during initialization, we noticed schema versions"
+                + " could not settle. Failing quickly to avoid getting into harder to fix states (i.e. partially"
+                + " applied patch upgrades, etc). This state is in rare cases the correct one to be in; for"
+                + " instance schema versions will be incapable of settling in a cluster of heterogenous"
+                + " Cassandra 1.2/2.0 nodes. If that is the case, disable safety checks in your Cassandra"
+                + " KVS preferences.";
         try {
-            clientPool.run(new FunctionCheckedException<Cassandra.Client, Void, TException>() {
-                @Override
-                public Void apply(Client client) throws TException {
-                    waitForSchemaVersions(client, "(none, just an initialization check)", config.schemaMutationTimeoutMillis());
-                    return null;
-                }
+            clientPool.run(client -> {
+                waitForSchemaVersions(
+                        client,
+                        "(none, just an initialization check)",
+                        config.schemaMutationTimeoutMillis());
+                return null;
             });
         } catch (TException e) {
             throw new RuntimeException(errorMessage, e);
@@ -117,7 +134,9 @@ public class CassandraKeyValueServices {
     static ByteBuffer makeCompositeBuffer(byte[] colName, long ts) {
         assert colName.length <= 1 << 16 : "Cannot use column names larger than 64KiB, was " + colName.length;
 
-        ByteBuffer buffer = ByteBuffer.allocate(6 /* misc */ + 8 /* timestamp */ + colName.length).order(ByteOrder.BIG_ENDIAN);
+        ByteBuffer buffer = ByteBuffer
+                .allocate(6 /* misc */ + 8 /* timestamp */ + colName.length)
+                .order(ByteOrder.BIG_ENDIAN);
 
         buffer.put((byte) ((colName.length >> 8) & 0xFF));
         buffer.put((byte) (colName.length & 0xFF));
@@ -134,8 +153,8 @@ public class CassandraKeyValueServices {
         return buffer;
     }
 
-    static Pair<byte[], Long> decompose(ByteBuffer composite) {
-        composite = composite.slice().order(ByteOrder.BIG_ENDIAN);
+    static Pair<byte[], Long> decompose(ByteBuffer inputComposite) {
+        ByteBuffer composite = inputComposite.slice().order(ByteOrder.BIG_ENDIAN);
 
         short len = composite.getShort();
         byte[] colName = new byte[len];
@@ -148,7 +167,7 @@ public class CassandraKeyValueServices {
         Validate.isTrue(shouldBe8 == 8);
         long ts = composite.getLong();
 
-        return Pair.create(colName, (~ts));
+        return Pair.create(colName, ~ts);
     }
 
     /**
@@ -188,7 +207,7 @@ public class CassandraKeyValueServices {
     }
 
     // /Obviously/ this is long (internal cassandra timestamp) + long (internal cassandra clock sequence and node id)
-    static String convertCassandraByteBufferUUIDtoString(ByteBuffer uuid) {
+    static String convertCassandraByteBufferUuidToString(ByteBuffer uuid) {
         return new UUID(uuid.getLong(uuid.position()), uuid.getLong(uuid.position() + 8)).toString();
     }
 
@@ -205,8 +224,8 @@ public class CassandraKeyValueServices {
 
 
     static String getFilteredStackTrace(String filter) {
-        Exception e = new Exception();
-        StackTraceElement[] stackTrace = e.getStackTrace();
+        Exception ex = new Exception();
+        StackTraceElement[] stackTrace = ex.getStackTrace();
         StringBuilder sb = new StringBuilder();
         for (StackTraceElement element : stackTrace) {
             if (element.getClassName().contains(filter)) {
@@ -216,7 +235,7 @@ public class CassandraKeyValueServices {
         return sb.toString();
     }
 
-    static interface ThreadSafeResultVisitor extends Visitor<Map<ByteBuffer, List<ColumnOrSuperColumn>>> {
+    interface ThreadSafeResultVisitor extends Visitor<Map<ByteBuffer, List<ColumnOrSuperColumn>>> {
         // marker
     }
 
@@ -225,7 +244,7 @@ public class CassandraKeyValueServices {
         final ValueExtractor extractor = new ValueExtractor(collectedResults);
         final long startTs;
 
-        public StartTsResultsCollector(long startTs) {
+        StartTsResultsCollector(long startTs) {
             this.startTs = startTs;
         }
 
@@ -244,7 +263,7 @@ public class CassandraKeyValueServices {
         }
     }
 
-    static private void extractTimestampResults(@Output Multimap<Cell, Long> ret,
+    private static void extractTimestampResults(@Output Multimap<Cell, Long> ret,
                                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results) {
         for (Entry<ByteBuffer, List<ColumnOrSuperColumn>> result : results.entrySet()) {
             byte[] row = CassandraKeyValueServices.getBytesFromByteBuffer(result.getKey());
@@ -255,32 +274,37 @@ public class CassandraKeyValueServices {
         }
     }
 
-    static protected int convertTtl(final long durationMillis, TimeUnit sourceTimeUnit) {
+    protected static int convertTtl(final long durationMillis, TimeUnit sourceTimeUnit) {
         long ttlSeconds = TimeUnit.SECONDS.convert(durationMillis, sourceTimeUnit);
-        Preconditions.checkArgument((ttlSeconds > 0 && ttlSeconds < Integer.MAX_VALUE), "Expiration time must be between 0 and ~68 years");
+        Preconditions.checkArgument(ttlSeconds > 0 && ttlSeconds < Integer.MAX_VALUE,
+                "Expiration time must be between 0 and ~68 years");
         return (int) ttlSeconds;
     }
 
     // because unfortunately .equals takes into account if fields with defaults are populated or not
-    // also because compression_options after serialization / deserialization comes back as blank for the ones we set 4K chunk on... ?!
-    public static final boolean isMatchingCf(CfDef clientSide, CfDef clusterSide) {
+    // also because compression_options after serialization / deserialization comes back as blank
+    // for the ones we set 4K chunk on... ?!
+    public static boolean isMatchingCf(CfDef clientSide, CfDef clusterSide) {
         String tableName = clientSide.name;
         if (!Objects.equal(clientSide.compaction_strategy_options, clusterSide.compaction_strategy_options)) {
-            log.debug("Found client/server disagreement on compaction strategy options for {}. (client = ({}), server = ({}))",
+            log.debug("Found client/server disagreement on compaction strategy options for {}."
+                    + " (client = ({}), server = ({}))",
                     tableName,
                     clientSide.compaction_strategy_options,
                     clusterSide.compaction_strategy_options);
             return false;
         }
         if (clientSide.gc_grace_seconds != clusterSide.gc_grace_seconds) {
-            log.debug("Found client/server disagreement on gc_grace_seconds for {}. (client = ({}), server = ({}))",
+            log.debug("Found client/server disagreement on gc_grace_seconds for {}."
+                    + " (client = ({}), server = ({}))",
                     tableName,
                     clientSide.gc_grace_seconds,
                     clusterSide.gc_grace_seconds);
             return false;
         }
         if (clientSide.bloom_filter_fp_chance != clusterSide.bloom_filter_fp_chance) {
-            log.debug("Found client/server disagreement on bloom filter false positive chance for {}. (client = ({}), server = ({}))",
+            log.debug("Found client/server disagreement on bloom filter false positive chance for {}."
+                    + " (client = ({}), server = ({}))",
                     tableName,
                     clientSide.bloom_filter_fp_chance,
                     clusterSide.bloom_filter_fp_chance);
@@ -288,21 +312,24 @@ public class CassandraKeyValueServices {
         }
         if (!(clientSide.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY).equals(
                 clusterSide.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY)))) {
-            log.debug("Found client/server disagreement on compression chunk length for {}. (client = ({}), server = ({}))",
+            log.debug("Found client/server disagreement on compression chunk length for {}."
+                    + " (client = ({}), server = ({}))",
                     tableName,
                     clientSide.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY),
                     clusterSide.compression_options.get(CassandraConstants.CFDEF_COMPRESSION_CHUNK_LENGTH_KEY));
             return false;
         }
         if (!Objects.equal(clientSide.compaction_strategy, clusterSide.compaction_strategy)) {
-            log.debug("Found client/server disagreement on compaction_strategy for {}. (client = ({}), server = ({}))",
+            log.debug("Found client/server disagreement on compaction_strategy for {}."
+                    + " (client = ({}), server = ({}))",
                     tableName,
                     clientSide.compaction_strategy,
                     clusterSide.compaction_strategy);
             return false;
         }
         if (clientSide.isSetPopulate_io_cache_on_flush() != clusterSide.isSetPopulate_io_cache_on_flush()) {
-            log.debug("Found client/server disagreement on populate_io_cache_on_flush for {}. (client = ({}), server = ({}))",
+            log.debug("Found client/server disagreement on populate_io_cache_on_flush for {}."
+                    + " (client = ({}), server = ({}))",
                     tableName,
                     clientSide.isSetPopulate_io_cache_on_flush(),
                     clusterSide.isSetPopulate_io_cache_on_flush());
@@ -313,7 +340,9 @@ public class CassandraKeyValueServices {
     }
 
     public static boolean isEmptyOrInvalidMetadata(byte[] metadata) {
-        if (metadata == null || Arrays.equals(metadata, AtlasDbConstants.EMPTY_TABLE_METADATA) || Arrays.equals(metadata, AtlasDbConstants.GENERIC_TABLE_METADATA)) {
+        if (metadata == null
+                || Arrays.equals(metadata, AtlasDbConstants.EMPTY_TABLE_METADATA)
+                || Arrays.equals(metadata, AtlasDbConstants.GENERIC_TABLE_METADATA)) {
             return true;
         }
         return false;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -22,14 +22,12 @@ import java.util.Set;
 
 import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Cassandra.Client;
-import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KsDef;
-import org.apache.cassandra.thrift.SchemaDisagreementException;
 import org.apache.cassandra.thrift.TokenRange;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,30 +47,35 @@ import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientFactory.ClientCrea
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.collect.Maps2;
 
-public class CassandraVerifier {
+public final class CassandraVerifier {
     private static final Logger log = LoggerFactory.getLogger(CassandraVerifier.class);
 
-    static final FunctionCheckedException<Cassandra.Client, Void, Exception> healthCheck = new FunctionCheckedException<Cassandra.Client, Void, Exception>() {
-        @Override
-        public Void apply(Cassandra.Client client) throws Exception {
-            client.describe_version();
-            return null;
-        }
+    private CassandraVerifier() {
+        // Utility class
+    }
+
+    static final FunctionCheckedException<Cassandra.Client, Void, Exception> healthCheck = client -> {
+        client.describe_version();
+        return null;
     };
 
-    static Set<String> sanityCheckDatacenters(Cassandra.Client client, int desiredRf, boolean safetyDisabled) throws InvalidRequestException, TException {
+    static Set<String> sanityCheckDatacenters(Cassandra.Client client, int desiredRf, boolean safetyDisabled)
+            throws TException {
         Set<String> hosts = Sets.newHashSet();
         Multimap<String, String> dataCenterToRack = HashMultimap.create();
 
         List<String> existingKeyspaces = Lists.transform(client.describe_keyspaces(), KsDef::getName);
         if (!existingKeyspaces.contains(CassandraConstants.SIMPLE_RF_TEST_KEYSPACE)) {
             client.system_add_keyspace(
-                    new KsDef(CassandraConstants.SIMPLE_RF_TEST_KEYSPACE, CassandraConstants.SIMPLE_STRATEGY, ImmutableList.<CfDef>of())
-                    .setStrategy_options(ImmutableMap.of(CassandraConstants.REPLICATION_FACTOR_OPTION, "1")));
+                    new KsDef(
+                            CassandraConstants.SIMPLE_RF_TEST_KEYSPACE,
+                            CassandraConstants.SIMPLE_STRATEGY,
+                            ImmutableList.of())
+                            .setStrategy_options(ImmutableMap.of(CassandraConstants.REPLICATION_FACTOR_OPTION, "1")));
         }
         List<TokenRange> ring =  client.describe_ring(CassandraConstants.SIMPLE_RF_TEST_KEYSPACE);
 
-        for (TokenRange tokenRange: ring) {
+        for (TokenRange tokenRange : ring) {
             for (EndpointDetails details : tokenRange.getEndpoint_details()) {
                 dataCenterToRack.put(details.datacenter, details.rack);
                 hosts.add(details.host);
@@ -82,17 +85,19 @@ public class CassandraVerifier {
         if (dataCenterToRack.size() == 1) {
             String dc = dataCenterToRack.keySet().iterator().next();
             String rack = dataCenterToRack.values().iterator().next();
-            if (dc.equals(CassandraConstants.DEFAULT_DC) && rack.equals(CassandraConstants.DEFAULT_RACK) && desiredRf > 1) {
+            if (dc.equals(CassandraConstants.DEFAULT_DC) && rack.equals(CassandraConstants.DEFAULT_RACK)
+                    && desiredRf > 1) {
                 // We don't allow greater than RF=1 because they didn't set up their network.
-                logErrorOrThrow("The cassandra cluster is not set up to be datacenter and rack aware.  " +
-                        "Please set this up before running with a replication factor higher than 1.", safetyDisabled);
+                logErrorOrThrow("The cassandra cluster is not set up to be datacenter and rack aware.  "
+                        + "Please set this up before running with a replication factor higher than 1.", safetyDisabled);
 
             }
             if (dataCenterToRack.values().size() < desiredRf && hosts.size() > desiredRf) {
-                logErrorOrThrow("The cassandra cluster only has one DC, " +
-                        "and is set up with less racks than the desired number of replicas, " +
-                        "and there are more hosts than the replication factor. " +
-                        "It is very likely that your rack configuration is incorrect and replicas would not be placed correctly for the failure tolerance you want.", safetyDisabled);
+                logErrorOrThrow("The cassandra cluster only has one DC, "
+                        + "and is set up with less racks than the desired number of replicas, "
+                        + "and there are more hosts than the replication factor. "
+                        + "It is very likely that your rack configuration is incorrect and replicas "
+                        + "would not be placed correctly for the failure tolerance you want.", safetyDisabled);
             }
         }
 
@@ -107,7 +112,8 @@ public class CassandraVerifier {
     }
 
     static void logErrorOrThrow(String errorMessage, boolean safetyDisabled) {
-        String safetyMessage = " This would have normally resulted in Palantir exiting, however safety checks have been disabled.";
+        String safetyMessage = " This would have normally resulted in Palantir exiting,"
+                + " however safety checks have been disabled.";
         if (safetyDisabled) {
             log.error(errorMessage + safetyMessage);
         } else {
@@ -126,35 +132,54 @@ public class CassandraVerifier {
         }
     }
 
-    static void ensureKeyspaceExistsAndIsUpToDate(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config) throws InvalidRequestException, TException, SchemaDisagreementException {
+    static void ensureKeyspaceExistsAndIsUpToDate(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config)
+            throws TException {
         try {
             clientPool.run(new FunctionCheckedException<Cassandra.Client, Void, TException>() {
                 @Override
                 public Void apply(Cassandra.Client client) throws TException {
                     KsDef originalKsDef = client.describe_keyspace(config.keyspace());
                     KsDef modifiedKsDef = originalKsDef.deepCopy();
-                    CassandraVerifier.checkAndSetReplicationFactor(client, modifiedKsDef, false, config.replicationFactor(), config.safetyDisabled());
+                    CassandraVerifier.checkAndSetReplicationFactor(
+                            client,
+                            modifiedKsDef,
+                            false,
+                            config.replicationFactor(),
+                            config.safetyDisabled());
 
                     if (!modifiedKsDef.equals(originalKsDef)) {
-                        modifiedKsDef.setCf_defs(ImmutableList.<CfDef>of()); // Can't call system_update_keyspace to update replication factor if CfDefs are set
+                        // Can't call system_update_keyspace to update replication factor if CfDefs are set
+                        modifiedKsDef.setCf_defs(ImmutableList.of());
                         client.system_update_keyspace(modifiedKsDef);
-                        CassandraKeyValueServices.waitForSchemaVersions(client, "(updating the existing keyspace)", config.schemaMutationTimeoutMillis());
+                        CassandraKeyValueServices.waitForSchemaVersions(
+                                client,
+                                "(updating the existing keyspace)",
+                                config.schemaMutationTimeoutMillis());
                     }
 
                     return null;
                 }
             });
-        } catch (ClientCreationFailedException e) { // We can't use the pool yet because it does things like setting the keyspace of that connection for us
+        } catch (ClientCreationFailedException e) {
+            // We can't use the pool yet because it does things like setting the keyspace of that connection for us
             boolean someHostWasAbleToCreateTheKeyspace = false;
             for (InetSocketAddress host : config.servers()) { // try until we find a server that works
                 try {
                     Client client = CassandraClientFactory.getClientInternal(host, config);
-                    KsDef ks = new KsDef(config.keyspace(), CassandraConstants.NETWORK_STRATEGY, ImmutableList.<CfDef>of());
-                    CassandraVerifier.checkAndSetReplicationFactor(client, ks, true, config.replicationFactor(), config.safetyDisabled());
+                    KsDef ks = new KsDef(config.keyspace(), CassandraConstants.NETWORK_STRATEGY, ImmutableList.of());
+                    CassandraVerifier.checkAndSetReplicationFactor(
+                            client,
+                            ks,
+                            true,
+                            config.replicationFactor(),
+                            config.safetyDisabled());
                     ks.setDurable_writes(true);
                     log.info("Creating keyspace: {}", config.keyspace());
                     client.system_add_keyspace(ks);
-                    CassandraKeyValueServices.waitForSchemaVersions(client, "(adding the initial empty keyspace)", config.schemaMutationTimeoutMillis());
+                    CassandraKeyValueServices.waitForSchemaVersions(
+                            client,
+                            "(adding the initial empty keyspace)",
+                            config.schemaMutationTimeoutMillis());
 
                     // if we got this far, we're done, no need to continue on other hosts
                     someHostWasAbleToCreateTheKeyspace = true;
@@ -170,21 +195,20 @@ public class CassandraVerifier {
                         throw ire;
                     }
                 } catch (Exception f) {
-                    log.error("Couldn't use host {} to create keyspace, it returned exception \"{}\" during the attempt.", host, f.toString(), f);
+                    log.error("Couldn't use host {} to create keyspace, it returned exception \"{}\" during"
+                            + " the attempt.", host, f.toString(), f);
                 }
             }
-            if (someHostWasAbleToCreateTheKeyspace) {
-                return;
-            } else {
+            if (!someHostWasAbleToCreateTheKeyspace) {
                 throw new TException("No host tried was able to create the keyspace requested.");
             }
         }
     }
 
-    private static boolean attemptedToCreateKeyspaceTwice(InvalidRequestException e) {
-        String exceptionString = e.toString();
+    private static boolean attemptedToCreateKeyspaceTwice(InvalidRequestException ex) {
+        String exceptionString = ex.toString();
         if (exceptionString.contains("case-insensitively unique")) {
-            String[] keyspaceNames = StringUtils.substringsBetween(exceptionString , "\"", "\"");
+            String[] keyspaceNames = StringUtils.substringsBetween(exceptionString, "\"", "\"");
             if (keyspaceNames.length == 2 && keyspaceNames[0].equals(keyspaceNames[1])) {
                 return true;
             }
@@ -192,8 +216,12 @@ public class CassandraVerifier {
         return false;
     }
 
-    static void checkAndSetReplicationFactor(Cassandra.Client client, KsDef ks, boolean freshInstance, int desiredRf, boolean safetyDisabled)
-            throws InvalidRequestException, SchemaDisagreementException, TException {
+    static void checkAndSetReplicationFactor(
+            Cassandra.Client client,
+            KsDef ks,
+            boolean freshInstance,
+            int desiredRf,
+            boolean safetyDisabled) throws TException {
         if (freshInstance) {
             Set<String> dcs = CassandraVerifier.sanityCheckDatacenters(client, desiredRf, safetyDisabled);
             // If RF exceeds # hosts, then Cassandra will reject writes
@@ -203,13 +231,14 @@ public class CassandraVerifier {
 
         final Set<String> dcs;
         if (CassandraConstants.SIMPLE_STRATEGY.equals(ks.getStrategy_class())) {
-            int currentRF = Integer.parseInt(ks.getStrategy_options().get(CassandraConstants.REPLICATION_FACTOR_OPTION));
-            String errorMessage = "This cassandra cluster is running using the simple partitioning strategy.  " +
-                    "This partitioner is not rack aware and is not intended for use on prod.  " +
-                    "This will have to be fixed by manually configuring to the network partitioner " +
-                    "and running the appropriate repairs.  " +
-                    "Contact the AtlasDB team to perform these steps.";
-            if (currentRF != 1) {
+            int currentRf = Integer.parseInt(ks.getStrategy_options().get(
+                    CassandraConstants.REPLICATION_FACTOR_OPTION));
+            String errorMessage = "This cassandra cluster is running using the simple partitioning strategy."
+                    + " This partitioner is not rack aware and is not intended for use on prod."
+                    + " This will have to be fixed by manually configuring to the network partitioner"
+                    + " and running the appropriate repairs."
+                    + " Contact the AtlasDB team to perform these steps.";
+            if (currentRf != 1) {
                 logErrorOrThrow(errorMessage, safetyDisabled);
             }
             // Automatically convert RF=1 to look like network partitioner.
@@ -228,35 +257,33 @@ public class CassandraVerifier {
         Map<String, String> strategyOptions = Maps.newHashMap(ks.getStrategy_options());
         for (String dc : dcs) {
             if (strategyOptions.get(dc) == null) {
-                logErrorOrThrow("The datacenter for this cassandra cluster is invalid. " +
-                        " failed dc: " + dc +
-                        "  strategyOptions: " + strategyOptions, safetyDisabled);
+                logErrorOrThrow("The datacenter for this cassandra cluster is invalid. "
+                        + " failed dc: " + dc
+                        + "  strategyOptions: " + strategyOptions, safetyDisabled);
             }
         }
 
         String dc = dcs.iterator().next();
 
-        int currentRF = Integer.parseInt(strategyOptions.get(dc));
+        int currentRf = Integer.parseInt(strategyOptions.get(dc));
 
         // We need to worry about user not running repair and user skipping replication levels.
-        if (currentRF != desiredRf) {
-            throw new UnsupportedOperationException("Your current Cassandra keyspace (" + ks.getName() +
-                    ") has a replication factor not matching your Atlas Cassandra configuration. " +
-                    "Change them to match, but be mindful of what steps you'll need to " +
-                    "take to correctly repair or cleanup existing data in your cluster.");
+        if (currentRf != desiredRf) {
+            throw new UnsupportedOperationException("Your current Cassandra keyspace (" + ks.getName()
+                    + ") has a replication factor not matching your Atlas Cassandra configuration."
+                    + " Change them to match, but be mindful of what steps you'll need to"
+                    + " take to correctly repair or cleanup existing data in your cluster.");
         }
     }
 
-    final static FunctionCheckedException<Cassandra.Client, Boolean, UnsupportedOperationException> underlyingCassandraClusterSupportsCASOperations = new FunctionCheckedException<Client, Boolean, UnsupportedOperationException>() {
-        @Override
-        public Boolean apply(Client client) throws UnsupportedOperationException {
-            try {
-                CassandraApiVersion serverVersion = new CassandraApiVersion(client.describe_version());
-                return serverVersion.supportsCheckAndSet();
-            } catch (TException e) {
-                throw new UnsupportedOperationException("Couldn't determine underlying cassandra version; received an exception while checking the thrift version.", e);
-            }
-        }
-    };
-
+    static final FunctionCheckedException<Cassandra.Client, Boolean, UnsupportedOperationException>
+            underlyingCassandraClusterSupportsCASOperations = client -> {
+                try {
+                    CassandraApiVersion serverVersion = new CassandraApiVersion(client.describe_version());
+                    return serverVersion.supportsCheckAndSet();
+                } catch (TException ex) {
+                    throw new UnsupportedOperationException("Couldn't determine underlying cassandra version;"
+                            + " received an exception while checking the thrift version.", ex);
+                }
+            };
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
@@ -27,6 +27,7 @@ public class HiddenTables {
             AtlasDbConstants.METADATA_TABLE);
 
     public boolean isHidden(TableReference tableReference) {
-        return HIDDEN_TABLES.contains(tableReference) || tableReference.getTablename().startsWith(SchemaMutationLockTables.LOCK_TABLE_PREFIX);
+        return HIDDEN_TABLES.contains(tableReference)
+                || tableReference.getTablename().startsWith(SchemaMutationLockTables.LOCK_TABLE_PREFIX);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HistoryExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HistoryExtractor.java
@@ -36,7 +36,7 @@ class HistoryExtractor extends ResultsExtractor<SetMultimap<Cell, Value>, Set<Va
         }
     };
 
-    public HistoryExtractor(SetMultimap<Cell, Value> collector) {
+    HistoryExtractor(SetMultimap<Cell, Value> collector) {
         super(collector);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ManyHostPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ManyHostPoolingContainer.java
@@ -22,8 +22,9 @@ import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.pooling.PoolingContainer;
 
 public interface ManyHostPoolingContainer<T> extends PoolingContainer<T> {
-    <V, K extends Exception> V runWithPooledResourceOnHost(InetAddress host,
-                                                           FunctionCheckedException<T, V, K> f) throws K;
+    <V, K extends Exception> V runWithPooledResourceOnHost(
+            InetAddress host,
+            FunctionCheckedException<T, V, K> fn) throws K;
 
-    <V> V runWithPooledResourceOnHost(InetAddress host, Function<T, V> f);
+    <V> V runWithPooledResourceOnHost(InetAddress host, Function<T, V> fn);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java
@@ -38,13 +38,14 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 abstract class ResultsExtractor<T, U> {
     protected final T collector;
 
-    public ResultsExtractor(T collector) {
+    ResultsExtractor(T collector) {
         this.collector = collector;
     }
 
-    public final byte[] extractResults(Map<ByteBuffer, List<ColumnOrSuperColumn>> colsByKey,
-                                       long startTs,
-                                       ColumnSelection selection) {
+    public final byte[] extractResults(
+            Map<ByteBuffer, List<ColumnOrSuperColumn>> colsByKey,
+            long startTs,
+            ColumnSelection selection) {
         byte[] maxRow = null;
         for (Entry<ByteBuffer, List<ColumnOrSuperColumn>> colEntry : colsByKey.entrySet()) {
             byte[] row = CassandraKeyValueServices.getBytesFromByteBuffer(colEntry.getKey());
@@ -72,17 +73,19 @@ abstract class ResultsExtractor<T, U> {
         return getRowResults(endExclusive, lastRow, resultsByRow);
     }
 
-    public static <T> TokenBackedBasicResultsPage<RowResult<T>, byte[]> getRowResults(final byte[] endExclusive,
-                                                                                      byte[] lastRow, SortedMap<byte[], SortedMap<byte[], T>> resultsByRow) {
+    public static <T> TokenBackedBasicResultsPage<RowResult<T>, byte[]> getRowResults(
+            byte[] endExclusive,
+            byte[] lastRow,
+            SortedMap<byte[], SortedMap<byte[], T>> resultsByRow) {
         SortedMap<byte[], RowResult<T>> ret = RowResults.viewOfSortedMap(resultsByRow);
         if (lastRow == null || RangeRequests.isLastRowName(lastRow)) {
-            return new SimpleTokenBackedResultsPage<RowResult<T>, byte[]>(endExclusive, ret.values(), false);
+            return new SimpleTokenBackedResultsPage<>(endExclusive, ret.values(), false);
         }
         byte[] nextStart = RangeRequests.nextLexicographicName(lastRow);
         if (Arrays.equals(nextStart, endExclusive)) {
-            return new SimpleTokenBackedResultsPage<RowResult<T>, byte[]>(endExclusive, ret.values(), false);
+            return new SimpleTokenBackedResultsPage<>(endExclusive, ret.values(), false);
         }
-        return new SimpleTokenBackedResultsPage<RowResult<T>, byte[]>(nextStart, ret.values(), true);
+        return new SimpleTokenBackedResultsPage<>(nextStart, ret.values(), true);
     }
 
     public abstract void internalExtractResult(long startTs,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -37,10 +37,11 @@ class RowColumnRangeExtractor {
         private final Set<byte[]> emptyRows;
         private final Map<byte[], Integer> rowsToRawColumnCount;
 
-        public RowColumnRangeResult(Map<byte[], LinkedHashMap<Cell, Value>> results,
-                                    Map<byte[], Column> rowsToLastCompositeColumns,
-                                    Set<byte[]> emptyRows,
-                                    Map<byte[], Integer> rowsToRawColumnCount) {
+        RowColumnRangeResult(
+                Map<byte[], LinkedHashMap<Cell, Value>> results,
+                Map<byte[], Column> rowsToLastCompositeColumns,
+                Set<byte[]> emptyRows,
+                Map<byte[], Integer> rowsToRawColumnCount) {
             this.results = results;
             this.rowsToLastCompositeColumns = rowsToLastCompositeColumns;
             this.emptyRows = emptyRows;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -240,7 +241,7 @@ public class SchemaMutationLock {
     private Column lockColumnWithValue(byte[] value) {
         return new Column()
                 .setName(CassandraKeyValueServices.makeCompositeBuffer(
-                        CassandraConstants.GLOBAL_DDL_LOCK_COLUMN_NAME.getBytes(),
+                        CassandraConstants.GLOBAL_DDL_LOCK_COLUMN_NAME.getBytes(StandardCharsets.UTF_8),
                         AtlasDbConstants.TRANSACTION_TS).array())
                 .setValue(value) // expected previous
                 .setTimestamp(AtlasDbConstants.TRANSACTION_TS);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -66,12 +66,17 @@ public class SchemaMutationLockTables {
 
     private String getUniqueSuffix() {
         // We replace '-' with '_' as hyphens are forbidden in Cassandra table names.
-        return UUID.randomUUID().toString().replace('-','_');
+        return UUID.randomUUID().toString().replace('-', '_');
     }
 
     private void createTableInternal(Cassandra.Client client, TableReference tableRef) throws TException {
-        CfDef cf = CassandraConstants.getStandardCfDef(config.keyspace(), CassandraKeyValueService.internalTableName(tableRef));
+        CfDef cf = CassandraConstants.getStandardCfDef(
+                config.keyspace(),
+                CassandraKeyValueService.internalTableName(tableRef));
         client.system_add_column_family(cf);
-        CassandraKeyValueServices.waitForSchemaVersions(client, tableRef.getQualifiedName(), config.schemaMutationTimeoutMillis());
+        CassandraKeyValueServices.waitForSchemaVersions(
+                client,
+                tableRef.getQualifiedName(),
+                config.schemaMutationTimeoutMillis());
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TimestampExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TimestampExtractor.java
@@ -35,7 +35,7 @@ class TimestampExtractor extends ResultsExtractor<SetMultimap<Cell, Long>, Set<L
         }
     };
 
-    public TimestampExtractor(SetMultimap<Cell, Long> collector) {
+    TimestampExtractor(SetMultimap<Cell, Long> collector) {
         super(collector);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTable.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTable.java
@@ -29,6 +29,8 @@ import com.palantir.atlasdb.config.LockLeader;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.common.base.Throwables;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class UniqueSchemaMutationLockTable {
     private static final Logger log = LoggerFactory.getLogger(UniqueSchemaMutationLockTable.class);
     private final SchemaMutationLockTables schemaMutationLockTables;
@@ -55,6 +57,7 @@ public class UniqueSchemaMutationLockTable {
         }
     }
 
+    @SuppressFBWarnings("SWL_SLEEP_WITH_LOCK_HELD")
     private synchronized TableReference waitForSomeoneElseToCreateLockTable() throws TException {
         while (schemaMutationLockTables.getAllLockTables().isEmpty()) {
             try {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTable.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UniqueSchemaMutationLockTable.java
@@ -47,7 +47,8 @@ public class UniqueSchemaMutationLockTable {
                 case SOMEONE_ELSE_IS_THE_LOCK_LEADER:
                     return waitForSomeoneElseToCreateLockTable();
                 default:
-                    throw new RuntimeException("We encountered an unknown lock leader status, please contact the AtlasDB team");
+                    throw new RuntimeException(
+                            "We encountered an unknown lock leader status, please contact the AtlasDB team");
             }
         } catch (TException e) {
             throw Throwables.rewrapAndThrowUncheckedException(e);
@@ -80,15 +81,13 @@ public class UniqueSchemaMutationLockTable {
         Set<TableReference> lockTables = schemaMutationLockTables.getAllLockTables();
 
         if (lockTables.size() > 1) {
-            throw new IllegalStateException(
-                    "Multiple schema mutation lock tables have been created.\n" +
-                            "This happens when multiple nodes have themselves as lockLeader in the configuration.\n" +
-                            "Please ensure the lockLeader is the same for each node, stop all Atlas clients using " +
-                            "this keyspace, restart your cassandra cluster and delete all created schema mutation lock tables.\n" +
-                            "The tables that clashed were: " + lockTables);
+            throw new IllegalStateException("Multiple schema mutation lock tables have been created.\n"
+                    + "This happens when multiple nodes have themselves as lockLeader in the configuration.\n"
+                    + "Please ensure the lockLeader is the same for each node, stop all Atlas clients using this "
+                    + "keyspace, restart your cassandra cluster and delete all created schema mutation lock tables.\n"
+                    + "The tables that clashed were: " + lockTables);
         }
 
         return Iterables.getOnlyElement(lockTables);
     }
-
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ValueExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ValueExtractor.java
@@ -33,7 +33,7 @@ class ValueExtractor extends ResultsExtractor<Map<Cell, Value>, Value> {
         }
     };
 
-    public ValueExtractor(Map<Cell, Value> collector) {
+    ValueExtractor(Map<Cell, Value> collector) {
         super(collector);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxBeanFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxBeanFactory.java
@@ -30,20 +30,18 @@ public class CassandraJmxBeanFactory {
     private final JMXConnector jmxConnector;
 
     public CassandraJmxBeanFactory(JMXConnector jmxConnector) {
-        this.jmxConnector = Preconditions.checkNotNull(jmxConnector);
+        this.jmxConnector = Preconditions.checkNotNull(jmxConnector, "jmxConnector cannot be null");
     }
 
     public <T> T create(String name, Class<T> interfaceClass) {
-        MBeanServerConnection mBeanServerConnection = null;
+        MBeanServerConnection jmxBeanServerConnection = null;
         ObjectName objectName = null;
         try {
-            mBeanServerConnection = jmxConnector.getMBeanServerConnection();
+            jmxBeanServerConnection = jmxConnector.getMBeanServerConnection();
             objectName = new ObjectName(name);
-        } catch (MalformedObjectNameException e) {
-            Throwables.propagate(e);
-        } catch (IOException e) {
+        } catch (MalformedObjectNameException | IOException e) {
             Throwables.propagate(e);
         }
-        return JMX.newMBeanProxy(mBeanServerConnection, objectName, interfaceClass);
+        return JMX.newMBeanProxy(jmxBeanServerConnection, objectName, interfaceClass);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompaction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompaction.java
@@ -39,16 +39,17 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
 
-public class CassandraJmxCompaction {
+public final class CassandraJmxCompaction {
     private static final Logger log = LoggerFactory.getLogger(CassandraJmxCompaction.class);
     private final CassandraKeyValueServiceConfig config;
 
     private CassandraJmxCompaction(CassandraKeyValueServiceConfig config) {
-        this.config = Preconditions.checkNotNull(config);
+        this.config = Preconditions.checkNotNull(config, "config cannot be null");
     }
 
-    public static Optional<CassandraJmxCompactionManager> createJmxCompactionManager(CassandraKeyValueServiceConfigManager configManager) {
-        Preconditions.checkNotNull(configManager);
+    public static Optional<CassandraJmxCompactionManager> createJmxCompactionManager(
+            CassandraKeyValueServiceConfigManager configManager) {
+        Preconditions.checkNotNull(configManager, "configManager cannot be null");
         CassandraKeyValueServiceConfig config = configManager.getConfig();
         CassandraJmxCompaction jmxCompaction = new CassandraJmxCompaction(config);
 
@@ -90,29 +91,47 @@ public class CassandraJmxCompaction {
     }
 
     /**
-     * return an empty set if no client can be created
+     * Return an empty set if no client can be created.
      */
     private ImmutableSet<CassandraJmxCompactionClient> createCompactionClients(CassandraJmxCompactionConfig jmxConfig) {
         Set<CassandraJmxCompactionClient> clients = Sets.newHashSet();
         Set<InetSocketAddress> servers = config.servers();
         int jmxPort = jmxConfig.port();
         for (InetSocketAddress addr : servers) {
-            CassandraJmxCompactionClient client = createCompactionClient(addr.getHostString(), jmxPort, jmxConfig.username(), jmxConfig.password());
+            CassandraJmxCompactionClient client =
+                    createCompactionClient(addr.getHostString(), jmxPort, jmxConfig.username(), jmxConfig.password());
             clients.add(client);
         }
 
         return ImmutableSet.copyOf(clients);
     }
 
-    private CassandraJmxCompactionClient createCompactionClient(String host, int port, String username, String password) {
-        CassandraJmxConnectorFactory jmxConnectorFactory = new CassandraJmxConnectorFactory(host, port, username, password);
+    private CassandraJmxCompactionClient createCompactionClient(
+            String host,
+            int port,
+            String username,
+            String password) {
+        CassandraJmxConnectorFactory jmxConnectorFactory =
+                new CassandraJmxConnectorFactory(host, port, username, password);
         JMXConnector jmxConnector = jmxConnectorFactory.create();
 
         CassandraJmxBeanFactory jmxBeanFactory = new CassandraJmxBeanFactory(jmxConnector);
-        StorageServiceMBean storageServiceProxy = jmxBeanFactory.create(CassandraConstants.STORAGE_SERVICE_OBJECT_NAME, StorageServiceMBean.class);
-        HintedHandOffManagerMBean hintedHandoffProxy = jmxBeanFactory.create(CassandraConstants.HINTED_HANDOFF_MANAGER_OBJECT_NAME, HintedHandOffManagerMBean.class);
-        CompactionManagerMBean compactionManagerProxy = jmxBeanFactory.create(CassandraConstants.COMPACTION_MANAGER_OBJECT_NAME, CompactionManagerMBean.class);
+        StorageServiceMBean storageServiceProxy = jmxBeanFactory.create(
+                CassandraConstants.STORAGE_SERVICE_OBJECT_NAME,
+                StorageServiceMBean.class);
+        HintedHandOffManagerMBean hintedHandoffProxy = jmxBeanFactory.create(
+                CassandraConstants.HINTED_HANDOFF_MANAGER_OBJECT_NAME,
+                HintedHandOffManagerMBean.class);
+        CompactionManagerMBean compactionManagerProxy = jmxBeanFactory.create(
+                CassandraConstants.COMPACTION_MANAGER_OBJECT_NAME,
+                CompactionManagerMBean.class);
 
-        return CassandraJmxCompactionClient.create(host, port, jmxConnector, storageServiceProxy, hintedHandoffProxy, compactionManagerProxy);
+        return CassandraJmxCompactionClient.create(
+                host,
+                port,
+                jmxConnector,
+                storageServiceProxy,
+                hintedHandoffProxy,
+                compactionManagerProxy);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/TombstoneCompactionTask.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/TombstoneCompactionTask.java
@@ -34,7 +34,7 @@ public class TombstoneCompactionTask implements Callable<Void> {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(keyspace));
         Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()));
 
-        this.client = Preconditions.checkNotNull(client);
+        this.client = Preconditions.checkNotNull(client, "client cannot be null");
         this.keyspace = keyspace;
         this.tableRef = tableRef;
     }

--- a/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/HintedHandOffManagerMBean.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/HintedHandOffManagerMBean.java
@@ -1,13 +1,11 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+/**
+ * Copyright 2016 Palantir Technologies
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,28 +19,33 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-public interface HintedHandOffManagerMBean
-{
+public interface HintedHandOffManagerMBean {
     /**
      * Nuke all hints from this node to `ep`.
+     *
      * @param host String rep. of endpoint address to delete hints for, either ip address ("127.0.0.1") or hostname
      */
-    public void deleteHintsForEndpoint(final String host);
+    void deleteHintsForEndpoint(final String host);
 
     /**
-     *  Truncate all the hints
+     *  Truncate all the hints.
      */
-    public void truncateAllHints() throws ExecutionException, InterruptedException;
+    void truncateAllHints() throws ExecutionException, InterruptedException;
 
     /**
      * List all the endpoints that this node has hints for.
+     *
      * @return set of endpoints; as Strings
      */
-    public List<String> listEndpointsPendingHints();
+    List<String> listEndpointsPendingHints();
 
-    /** force hint delivery to an endpoint **/
-    public void scheduleHintDelivery(String host) throws UnknownHostException;
+    /**
+     * Force hint delivery to an endpoint.
+     */
+    void scheduleHintDelivery(String host) throws UnknownHostException;
 
-    /** pause hints delivery process **/
-    public void pauseHintsDelivery(boolean b);
+    /**
+     * Pause hints delivery process.
+     */
+    void pauseHintsDelivery(boolean pauseHintsDelivery);
 }

--- a/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/compaction/CompactionManagerMBean.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/compaction/CompactionManagerMBean.java
@@ -1,13 +1,11 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+/**
+ * Copyright 2016 Palantir Technologies
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,16 +20,21 @@ import java.util.Map;
 
 import javax.management.openmbean.TabularData;
 
-public interface CompactionManagerMBean
-{
-    /** List of running compaction objects. */
-    public List<Map<String, String>> getCompactions();
+public interface CompactionManagerMBean {
+    /**
+     * List of running compaction objects.
+     */
+    List<Map<String, String>> getCompactions();
 
-    /** List of running compaction summary strings. */
-    public List<String> getCompactionSummary();
+    /**
+     * List of running compaction summary strings.
+     */
+    List<String> getCompactionSummary();
 
-    /** compaction history **/
-    public TabularData getCompactionHistory();
+    /**
+     * Get the compaction history.
+     */
+    TabularData getCompactionHistory();
 
     /**
      * Triggers the compaction of user specified sstables.
@@ -42,7 +45,7 @@ public interface CompactionManagerMBean
      * @param dataFiles a comma separated list of sstable file to compact.
      *                  must contain keyspace and columnfamily name in path(for 2.1+) or file name itself.
      */
-    public void forceUserDefinedCompaction(String dataFiles);
+    void forceUserDefinedCompaction(String dataFiles);
 
     /**
      * Stop all running compaction-like tasks having the provided {@code type}.
@@ -53,56 +56,59 @@ public interface CompactionManagerMBean
      *   - SCRUB
      *   - INDEX_BUILD
      */
-    public void stopCompaction(String type);
+    void stopCompaction(String type);
 
     /**
      * Stop an individual running compaction using the compactionId.
+     *
      * @param compactionId Compaction ID of compaction to stop. Such IDs can be found in
      *                     the compactions_in_progress table of the system keyspace.
      */
-    public void stopCompactionById(String compactionId);
+    void stopCompactionById(String compactionId);
 
     /**
-     * Returns core size of compaction thread pool
+     * Returns core size of compaction thread pool.
      */
-    public int getCoreCompactorThreads();
-
-    /**
-     * Allows user to resize maximum size of the compaction thread pool.
-     * @param number New maximum of compaction threads
-     */
-    public void setCoreCompactorThreads(int number);
-
-    /**
-     * Returns maximum size of compaction thread pool
-     */
-    public int getMaximumCompactorThreads();
+    int getCoreCompactorThreads();
 
     /**
      * Allows user to resize maximum size of the compaction thread pool.
      * @param number New maximum of compaction threads
      */
-    public void setMaximumCompactorThreads(int number);
+    void setCoreCompactorThreads(int number);
 
     /**
-     * Returns core size of validation thread pool
+     * Returns maximum size of compaction thread pool.
      */
-    public int getCoreValidationThreads();
+    int getMaximumCompactorThreads();
 
     /**
      * Allows user to resize maximum size of the compaction thread pool.
+     *
      * @param number New maximum of compaction threads
      */
-    public void setCoreValidationThreads(int number);
+    void setMaximumCompactorThreads(int number);
 
     /**
-     * Returns size of validator thread pool
+     * Returns core size of validation thread pool.
      */
-    public int getMaximumValidatorThreads();
+    int getCoreValidationThreads();
+
+    /**
+     * Allows user to resize maximum size of the compaction thread pool.
+     *
+     * @param number New maximum of compaction threads
+     */
+    void setCoreValidationThreads(int number);
+
+    /**
+     * Returns size of validator thread pool.
+     */
+    int getMaximumValidatorThreads();
 
     /**
      * Allows user to resize maximum size of the validator thread pool.
      * @param number New maximum of validator threads
      */
-    public void setMaximumValidatorThreads(int number);
+    void setMaximumValidatorThreads(int number);
 }

--- a/atlasdb-cassandra/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -95,7 +95,6 @@ public interface StorageServiceMBean extends NotificationEmitter {
      */
     String getSchemaVersion();
 
-
     /**
      * Get the list of all data file locations from conf.
      *
@@ -660,6 +659,7 @@ public interface StorageServiceMBean extends NotificationEmitter {
      * Returns the threshold for abandoning queries with many tombstones.
      */
     int getTombstoneFailureThreshold();
+
     /**
      * Sets the threshold for abandoning queries with many tombstones.
      */
@@ -669,6 +669,7 @@ public interface StorageServiceMBean extends NotificationEmitter {
      * Returns the threshold for rejecting queries due to a large batch size.
      */
     int getBatchSizeFailureThreshold();
+
     /**
      * Sets the threshold for rejecting queries due to a large batch size.
      */

--- a/atlasdb-cassandra/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -1,13 +1,11 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+/**
+ * Copyright 2015 Palantir Technologies
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,15 +28,14 @@ import java.util.concurrent.TimeoutException;
 import javax.management.NotificationEmitter;
 import javax.management.openmbean.TabularData;
 
-public interface StorageServiceMBean extends NotificationEmitter
-{
+public interface StorageServiceMBean extends NotificationEmitter {
     /**
      * Retrieve the list of live nodes in the cluster, where "liveness" is
      * determined by the failure detector of the node being queried.
      *
      * @return set of IP addresses, as Strings
      */
-    public List<String> getLiveNodes();
+    List<String> getLiveNodes();
 
     /**
      * Retrieve the list of unreachable nodes in the cluster, as determined
@@ -46,35 +43,35 @@ public interface StorageServiceMBean extends NotificationEmitter
      *
      * @return set of IP addresses, as Strings
      */
-    public List<String> getUnreachableNodes();
+    List<String> getUnreachableNodes();
 
     /**
      * Retrieve the list of nodes currently bootstrapping into the ring.
      *
      * @return set of IP addresses, as Strings
      */
-    public List<String> getJoiningNodes();
+    List<String> getJoiningNodes();
 
     /**
      * Retrieve the list of nodes currently leaving the ring.
      *
      * @return set of IP addresses, as Strings
      */
-    public List<String> getLeavingNodes();
+    List<String> getLeavingNodes();
 
     /**
      * Retrieve the list of nodes currently moving in the ring.
      *
      * @return set of IP addresses, as Strings
      */
-    public List<String> getMovingNodes();
+    List<String> getMovingNodes();
 
     /**
      * Fetch string representations of the tokens for this node.
      *
      * @return a collection of tokens formatted as strings
      */
-    public List<String> getTokens();
+    List<String> getTokens();
 
     /**
      * Fetch string representations of the tokens for a specified node.
@@ -82,38 +79,43 @@ public interface StorageServiceMBean extends NotificationEmitter
      * @param endpoint string representation of an node
      * @return a collection of tokens formatted as strings
      */
-    public List<String> getTokens(String endpoint) throws UnknownHostException;
+    List<String> getTokens(String endpoint) throws UnknownHostException;
 
     /**
      * Fetch a string representation of the Cassandra version.
-     * @return A string representation of the Cassandra version.
+     *
+     * @return A string representation of the Cassandra version
      */
-    public String getReleaseVersion();
+    String getReleaseVersion();
 
     /**
      * Fetch a string representation of the current Schema version.
-     * @return A string representation of the Schema version.
+     *
+     * @return A string representation of the Schema version
      */
-    public String getSchemaVersion();
+    String getSchemaVersion();
 
 
     /**
-     * Get the list of all data file locations from conf
+     * Get the list of all data file locations from conf.
+     *
      * @return String array of all locations
      */
-    public String[] getAllDataFileLocations();
+    String[] getAllDataFileLocations();
 
     /**
-     * Get location of the commit log
+     * Get location of the commit log.
+     *
      * @return a string path
      */
-    public String getCommitLogLocation();
+    String getCommitLogLocation();
 
     /**
-     * Get location of the saved caches dir
+     * Get location of the saved caches dir.
+     *
      * @return a string path
      */
-    public String getSavedCachesLocation();
+    String getSavedCachesLocation();
 
     /**
      * Retrieve a map of range to end points that describe the ring topology
@@ -121,7 +123,7 @@ public interface StorageServiceMBean extends NotificationEmitter
      *
      * @return mapping of ranges to end points
      */
-    public Map<List<String>, List<String>> getRangeToEndpointMap(String keyspace);
+    Map<List<String>, List<String>> getRangeToEndpointMap(String keyspace);
 
     /**
      * Retrieve a map of range to rpc addresses that describe the ring topology
@@ -129,23 +131,24 @@ public interface StorageServiceMBean extends NotificationEmitter
      *
      * @return mapping of ranges to rpc addresses
      */
-    public Map<List<String>, List<String>> getRangeToRpcaddressMap(String keyspace);
+    Map<List<String>, List<String>> getRangeToRpcaddressMap(String keyspace);
 
     /**
-     * The same as {@code describeRing(String)} but converts TokenRange to the String for JMX compatibility
+     * The same as {@code describeRing(String)} but converts TokenRange to the String for JMX compatibility.
      *
      * @param keyspace The keyspace to fetch information about
      *
      * @return a List of TokenRange(s) converted to String for the given keyspace
      */
-    public List <String> describeRingJMX(String keyspace) throws IOException;
+    List<String> describeRingJMX(String keyspace) throws IOException;
 
     /**
-     * Retrieve a map of pending ranges to endpoints that describe the ring topology
+     * Retrieve a map of pending ranges to endpoints that describe the ring topology.
+     *
      * @param keyspace the keyspace to get the pending range map for.
      * @return a map of pending ranges to endpoints
      */
-    public Map<List<String>, List<String>> getPendingRangeToEndpointMap(String keyspace);
+    Map<List<String>, List<String>> getPendingRangeToEndpointMap(String keyspace);
 
     /**
      * Retrieve a map of tokens to endpoints, including the bootstrapping
@@ -153,38 +156,45 @@ public interface StorageServiceMBean extends NotificationEmitter
      *
      * @return a map of tokens to endpoints in ascending order
      */
-    public Map<String, String> getTokenToEndpointMap();
-
-    /** Retrieve this hosts unique ID */
-    public String getLocalHostId();
-
-    /** Retrieve the mapping of endpoint to host ID */
-    public Map<String, String> getHostIdMap();
-
-    /** Human-readable load value */
-    public String getLoadString();
-
-    /** Human-readable load value.  Keys are IP addresses. */
-    public Map<String, String> getLoadMap();
+    Map<String, String> getTokenToEndpointMap();
 
     /**
-     * Return the generation value for this node.
+     *  Retrieve this hosts unique ID.
+     */
+    String getLocalHostId();
+
+    /**
+     * Retrieve the mapping of endpoint to host ID.
+     */
+    Map<String, String> getHostIdMap();
+
+    /**
+     * Human-readable load value.
+     */
+    String getLoadString();
+
+    /**
+     * Human-readable load value.  Keys are IP addresses.
+     */
+    Map<String, String> getLoadMap();
+
+    /**
+     * Returns the generation value for this node.
      *
      * @return generation number
      */
-    public int getCurrentGenerationNumber();
+    int getCurrentGenerationNumber();
 
     /**
-     * This method returns the N endpoints that are responsible for storing the
-     * specified key i.e for replication.
+     * Returns the N endpoints that are responsible for storing the specified key i.e for replication.
      *
      * @param keyspaceName keyspace name
      * @param cf Column family name
      * @param key - key for which we need to find the endpoint return value -
      * the endpoint responsible for this key
      */
-    public List<InetAddress> getNaturalEndpoints(String keyspaceName, String cf, String key);
-    public List<InetAddress> getNaturalEndpoints(String keyspaceName, ByteBuffer key);
+    List<InetAddress> getNaturalEndpoints(String keyspaceName, String cf, String key);
+    List<InetAddress> getNaturalEndpoints(String keyspaceName, ByteBuffer key);
 
     /**
      * Takes the snapshot for the given keyspaces. A snapshot name must be specified.
@@ -192,7 +202,7 @@ public interface StorageServiceMBean extends NotificationEmitter
      * @param tag the tag given to the snapshot; may not be null or empty
      * @param keyspaceNames the name of the keyspaces to snapshot; empty means "all."
      */
-    public void takeSnapshot(String tag, String... keyspaceNames) throws IOException;
+    void takeSnapshot(String tag, String... keyspaceNames) throws IOException;
 
     /**
      * Takes the snapshot of a specific column family. A snapshot name must be specified.
@@ -201,7 +211,7 @@ public interface StorageServiceMBean extends NotificationEmitter
      * @param columnFamilyName the column family to snapshot
      * @param tag the tag given to the snapshot; may not be null or empty
      */
-    public void takeColumnFamilySnapshot(String keyspaceName, String columnFamilyName, String tag) throws IOException;
+    void takeColumnFamilySnapshot(String keyspaceName, String columnFamilyName, String tag) throws IOException;
 
     /**
      * Takes the snapshot of a multiple column family from different keyspaces. A snapshot name must be specified.
@@ -211,68 +221,85 @@ public interface StorageServiceMBean extends NotificationEmitter
      * @param columnFamilyList
      *            list of columnfamily from different keyspace in the form of ks1.cf1 ks2.cf2
      */
-    public void takeMultipleColumnFamilySnapshot(String tag, String... columnFamilyList) throws IOException;
+    void takeMultipleColumnFamilySnapshot(String tag, String... columnFamilyList) throws IOException;
 
     /**
      * Remove the snapshot with the given name from the given keyspaces.
      * If no tag is specified we will remove all snapshots.
      */
-    public void clearSnapshot(String tag, String... keyspaceNames) throws IOException;
+    void clearSnapshot(String tag, String... keyspaceNames) throws IOException;
 
     /**
-     *  Get the details of all the snapshot
-     * @return A map of snapshotName to all its details in Tabular form.
+     * Get the details of all the snapshot.
+     *
+     * @return A map of snapshotName to all its details in Tabular form
      */
-    public Map<String, TabularData> getSnapshotDetails();
+    Map<String, TabularData> getSnapshotDetails();
 
     /**
      * Get the true size taken by all snapshots across all keyspaces.
-     * @return True size taken by all the snapshots.
+     *
+     * @return True size taken by all the snapshots
      */
-    public long trueSnapshotsSize();
+    long trueSnapshotsSize();
 
     /**
-     * Forces major compaction of a single keyspace
+     * Forces major compaction of a single keyspace.
      */
-    public void forceKeyspaceCompaction(boolean splitOutput, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+    void forceKeyspaceCompaction(boolean splitOutput, String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
 
     /**
-     * Trigger a cleanup of keys on a single keyspace
+     * Trigger a cleanup of keys on a single keyspace.
      */
-    public int forceKeyspaceCleanup(String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+    int forceKeyspaceCleanup(String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
+     * See {@link #scrub(boolean, boolean, boolean, String, String...)}.
+     *
+     * @deprecated Use {@link #scrub(boolean, boolean, boolean, String, String...)} instead.
+     */
+    @Deprecated
+    int scrub(boolean disableSnapshot, boolean skipCorrupted, String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
 
     /**
      * Scrub (deserialize + reserialize at the latest version, skipping bad rows if any) the given keyspace.
      * If columnFamilies array is empty, all CFs are scrubbed.
      *
-     * Scrubbed CFs will be snapshotted first, if disableSnapshot is false
+     * Scrubbed CFs will be snapshotted first, if disableSnapshot is false.
      */
-    @Deprecated
-    public int scrub(boolean disableSnapshot, boolean skipCorrupted, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
-    public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+    int scrub(
+            boolean disableSnapshot,
+            boolean skipCorrupted,
+            boolean checkData,
+            String keyspaceName,
+            String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
 
     /**
      * Verify (checksums of) the given keyspace.
      * If columnFamilies array is empty, all CFs are verified.
      *
-     * The entire sstable will be read to ensure each cell validates if extendedVerify is true
+     * The entire sstable will be read to ensure each cell validates if extendedVerify is true.
      */
-    public int verify(boolean extendedVerify, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+    int verify(boolean extendedVerify, String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
 
     /**
      * Rewrite all sstables to the latest version.
      * Unlike scrub, it doesn't skip bad rows and do not snapshot sstables first.
      */
-    public int upgradeSSTables(String keyspaceName, boolean excludeCurrentVersion, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+    int upgradeSSTables(String keyspaceName, boolean excludeCurrentVersion, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
 
     /**
      * Flush all memtables for the given column families, or all columnfamilies for the given keyspace
      * if none are explicitly listed.
-     * @param keyspaceName
-     * @param columnFamilies
-     * @throws IOException
      */
-    public void forceKeyspaceFlush(String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+    void forceKeyspaceFlush(String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
 
     /**
      * Invoke repair asynchronously.
@@ -285,10 +312,22 @@ public interface StorageServiceMBean extends NotificationEmitter
      * @param options repair option.
      * @return Repair command number, or 0 if nothing to repair
      */
-    public int repairAsync(String keyspace, Map<String, String> options);
+    int repairAsync(String keyspace, Map<String, String> options);
 
+    /**
+     * Invoke repair asynchronously.
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
     @Deprecated
-    public int forceRepairAsync(String keyspace, boolean isSequential, Collection<String> dataCenters, Collection<String> hosts,  boolean primaryRange, boolean repairedAt, String... columnFamilies) throws IOException;
+    int forceRepairAsync(
+            String keyspace,
+            boolean isSequential,
+            Collection<String> dataCenters,
+            Collection<String> hosts,
+            boolean primaryRange,
+            boolean repairedAt,
+            String... columnFamilies) throws IOException;
 
     /**
      * Invoke repair asynchronously.
@@ -299,87 +338,152 @@ public interface StorageServiceMBean extends NotificationEmitter
      *
      * @param parallelismDegree 0: sequential, 1: parallel, 2: DC parallel
      * @return Repair command number, or 0 if nothing to repair
+     *
+     * @deprecated Use {@link #repairAsync} instead.
      */
     @Deprecated
-    public int forceRepairAsync(String keyspace, int parallelismDegree, Collection<String> dataCenters, Collection<String> hosts, boolean primaryRange, boolean fullRepair, String... columnFamilies);
-
-    @Deprecated
-    public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, boolean isSequential, Collection<String> dataCenters, Collection<String> hosts, boolean repairedAt, String... columnFamilies) throws IOException;
+    int forceRepairAsync(
+            String keyspace,
+            int parallelismDegree,
+            Collection<String> dataCenters,
+            Collection<String> hosts,
+            boolean primaryRange,
+            boolean fullRepair,
+            String... columnFamilies);
 
     /**
-     * Same as forceRepairAsync, but handles a specified range
+     * Invoke repair asynchronously.
      *
-     * @param parallelismDegree 0: sequential, 1: parallel, 2: DC parallel
+     * @deprecated Use {@link #repairAsync} instead.
      */
     @Deprecated
-    public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, int parallelismDegree, Collection<String> dataCenters, Collection<String> hosts, boolean fullRepair, String... columnFamilies);
+    int forceRepairAsync(
+            String keyspace,
+            boolean isSequential,
+            boolean isLocal,
+            boolean primaryRange,
+            boolean fullRepair,
+            String... columnFamilies);
 
+    /**
+     * Same as {@link #forceRepairAsync}, but handles a specified range.
+     *
+     * @param parallelismDegree 0: sequential, 1: parallel, 2: DC parallel
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
     @Deprecated
-    public int forceRepairAsync(String keyspace, boolean isSequential, boolean isLocal, boolean primaryRange, boolean fullRepair, String... columnFamilies);
+    int forceRepairRangeAsync(
+            String beginToken,
+            String endToken,
+            String keyspaceName,
+            int parallelismDegree,
+            Collection<String> dataCenters,
+            Collection<String> hosts,
+            boolean fullRepair,
+            String... columnFamilies);
 
+    /**
+     * Invoke repair asynchronously.
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
     @Deprecated
-    public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, boolean isSequential, boolean isLocal, boolean repairedAt, String... columnFamilies);
+    int forceRepairRangeAsync(
+            String beginToken,
+            String endToken,
+            String keyspaceName,
+            boolean isSequential,
+            Collection<String> dataCenters,
+            Collection<String> hosts,
+            boolean repairedAt,
+            String... columnFamilies) throws IOException;
 
-    public void forceTerminateAllRepairSessions();
+    /**
+     * Invoke repair asynchronously.
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
+    @Deprecated
+    int forceRepairRangeAsync(
+            String beginToken,
+            String endToken,
+            String keyspaceName,
+            boolean isSequential,
+            boolean isLocal,
+            boolean repairedAt,
+            String... columnFamilies);
+
+    void forceTerminateAllRepairSessions();
 
     /**
      * transfer this node's data to other machines and remove it from service.
      */
-    public void decommission() throws InterruptedException;
+    void decommission() throws InterruptedException;
 
     /**
-     * @param newToken token to move this node to.
      * This node will unload its data onto its neighbors, and bootstrap to the new token.
+     *
+     * @param newToken token to move this node to.
      */
-    public void move(String newToken) throws IOException;
+    void move(String newToken) throws IOException;
 
     /**
-     * removeToken removes token (and all data associated with
-     * enpoint that had it) from the ring
+     * removeNode removes the token (and all data associated with the endpoint that had it) from the ring.
      */
-    public void removeNode(String token);
+    void removeNode(String token);
 
     /**
      * Get the status of a token removal.
      */
-    public String getRemovalStatus();
+    String getRemovalStatus();
 
     /**
      * Force a remove operation to finish.
      */
-    public void forceRemoveCompletion();
+    void forceRemoveCompletion();
 
     /**
      * set the logging level at runtime<br>
      * <br>
      * If both classQualifer and level are empty/null, it will reload the configuration to reset.<br>
-     * If classQualifer is not empty but level is empty/null, it will set the level to null for the defined classQualifer<br>
+     * If classQualifier is not empty but level is empty/null, it will set the level to null for
+     * the defined classQualifier<br>
      * If level cannot be parsed, then the level will be defaulted to DEBUG<br>
      * <br>
      * The logback configuration should have < jmxConfigurator /> set
      *
      * @param classQualifier The logger's classQualifer
      * @param level The log level
-     * @throws Exception
      *
-     *  @see ch.qos.logback.classic.Level#toLevel(String)
+     * @see ch.qos.logback.classic.Level#toLevel(String)
      */
-    public void setLoggingLevel(String classQualifier, String level) throws Exception;
+    void setLoggingLevel(String classQualifier, String level) throws Exception;
 
-    /** get the runtime logging levels */
-    public Map<String,String> getLoggingLevels();
+    /**
+     *  Get the runtime logging levels.
+     */
+    Map<String, String> getLoggingLevels();
 
-    /** get the operational mode (leaving, joining, normal, decommissioned, client) **/
-    public String getOperationMode();
+    /**
+     * Get the operational mode (leaving, joining, normal, decommissioned, client).
+     */
+    String getOperationMode();
 
-    /** Returns whether the storage service is starting or not */
-    public boolean isStarting();
+    /**
+     * Returns whether the storage service is starting or not.
+     */
+    boolean isStarting();
 
-    /** get the progress of a drain operation */
-    public String getDrainProgress();
+    /**
+     * Get the progress of a drain operation.
+     */
+    String getDrainProgress();
 
-    /** makes node unavailable for writes, flushes memtables and replays commitlog. */
-    public void drain() throws IOException, InterruptedException, ExecutionException;
+    /**
+     * makes node unavailable for writes, flushes memtables and replays commitlog.
+     */
+    void drain() throws IOException, InterruptedException, ExecutionException;
 
     /**
      * Truncates (deletes) the given columnFamily from the provided keyspace.
@@ -391,13 +495,14 @@ public interface StorageServiceMBean extends NotificationEmitter
      * @param keyspace The keyspace to delete from
      * @param columnFamily The column family to delete data from.
      */
-    public void truncate(String keyspace, String columnFamily)throws TimeoutException, IOException;
+    void truncate(String keyspace, String columnFamily) throws TimeoutException, IOException;
 
     /**
-     * given a list of tokens (representing the nodes in the cluster), returns
-     *   a mapping from "token -> %age of cluster owned by that token"
+     * Gets the percentage of the cluster owned per token.
+     *
+     * @return A mapping from "token -> %age of cluster owned by that token"
      */
-    public Map<InetAddress, Float> getOwnership();
+    Map<InetAddress, Float> getOwnership();
 
     /**
      * Effective ownership is % of the data each node owns given the keyspace
@@ -406,62 +511,68 @@ public interface StorageServiceMBean extends NotificationEmitter
      * in the cluster have the same replication strategies and if yes then we will
      * use the first else a empty Map is returned.
      */
-    public Map<InetAddress, Float> effectiveOwnership(String keyspace) throws IllegalStateException;
+    Map<InetAddress, Float> effectiveOwnership(String keyspace) throws IllegalStateException;
 
-    public List<String> getKeyspaces();
+    List<String> getKeyspaces();
 
-    public List<String> getNonSystemKeyspaces();
+    List<String> getNonSystemKeyspaces();
 
     /**
-     * Change endpointsnitch class and dynamic-ness (and dynamic attributes) at runtime
+     * Change endpointsnitch class and dynamic-ness (and dynamic attributes) at runtime.
+     *
      * @param epSnitchClassName        the canonical path name for a class implementing IEndpointSnitch
      * @param dynamic                  boolean that decides whether dynamicsnitch is used or not
      * @param dynamicUpdateInterval    integer, in ms (default 100)
      * @param dynamicResetInterval     integer, in ms (default 600,000)
      * @param dynamicBadnessThreshold  double, (default 0.0)
      */
-    public void updateSnitch(String epSnitchClassName, Boolean dynamic, Integer dynamicUpdateInterval, Integer dynamicResetInterval, Double dynamicBadnessThreshold) throws ClassNotFoundException;
+    void updateSnitch(
+            String epSnitchClassName,
+            Boolean dynamic,
+            Integer dynamicUpdateInterval,
+            Integer dynamicResetInterval,
+            Double dynamicBadnessThreshold) throws ClassNotFoundException;
 
     // allows a user to forcibly 'kill' a sick node
-    public void stopGossiping();
+    void stopGossiping();
 
     // allows a user to recover a forcibly 'killed' node
-    public void startGossiping();
+    void startGossiping();
 
     // allows a user to see whether gossip is running or not
-    public boolean isGossipRunning();
+    boolean isGossipRunning();
 
     // allows a user to forcibly completely stop cassandra
-    public void stopDaemon();
+    void stopDaemon();
 
     // to determine if gossip is disabled
-    public boolean isInitialized();
+    boolean isInitialized();
 
     // allows a user to disable thrift
-    public void stopRPCServer();
+    void stopRPCServer();
 
     // allows a user to reenable thrift
-    public void startRPCServer();
+    void startRPCServer();
 
     // to determine if thrift is running
-    public boolean isRPCServerRunning();
+    boolean isRPCServerRunning();
 
-    public void stopNativeTransport();
-    public void startNativeTransport();
-    public boolean isNativeTransportRunning();
+    void stopNativeTransport();
+    void startNativeTransport();
+    boolean isNativeTransportRunning();
 
     // allows a node that have been started without joining the ring to join it
-    public void joinRing() throws IOException;
-    public boolean isJoined();
+    void joinRing() throws IOException;
+    boolean isJoined();
 
-    public void setStreamThroughputMbPerSec(int value);
-    public int getStreamThroughputMbPerSec();
+    void setStreamThroughputMbPerSec(int value);
+    int getStreamThroughputMbPerSec();
 
-    public int getCompactionThroughputMbPerSec();
-    public void setCompactionThroughputMbPerSec(int value);
+    int getCompactionThroughputMbPerSec();
+    void setCompactionThroughputMbPerSec(int value);
 
-    public boolean isIncrementalBackupsEnabled();
-    public void setIncrementalBackupsEnabled(boolean value);
+    boolean isIncrementalBackupsEnabled();
+    void setIncrementalBackupsEnabled(boolean value);
 
     /**
      * Initiate a process of streaming data for which we are responsible from other nodes. It is similar to bootstrap
@@ -470,26 +581,26 @@ public interface StorageServiceMBean extends NotificationEmitter
      *
      * @param sourceDc Name of DC from which to select sources for streaming or null to pick any node
      */
-    public void rebuild(String sourceDc);
+    void rebuild(String sourceDc);
 
     /** Starts a bulk load and blocks until it completes. */
-    public void bulkLoad(String directory);
+    void bulkLoad(String directory);
 
     /**
      * Starts a bulk load asynchronously and returns the String representation of the planID for the new
      * streaming session.
      */
-    public String bulkLoadAsync(String directory);
+    String bulkLoadAsync(String directory);
 
-    public void rescheduleFailedDeletions();
+    void rescheduleFailedDeletions();
 
     /**
-     * Load new SSTables to the given keyspace/columnFamily
+     * Load new SSTables to the given keyspace/columnFamily.
      *
      * @param ksName The parent keyspace name
      * @param cfName The ColumnFamily name where SSTables belong
      */
-    public void loadNewSSTables(String ksName, String cfName);
+    void loadNewSSTables(String ksName, String cfName);
 
     /**
      * Return a List of Tokens representing a sample of keys across all ColumnFamilyStores.
@@ -499,14 +610,14 @@ public interface StorageServiceMBean extends NotificationEmitter
      *
      * @return set of Tokens as Strings
      */
-    public List<String> sampleKeyRange();
+    List<String> sampleKeyRange();
 
     /**
-     * rebuild the specified indexes
+     * Rebuild the specified indexes.
      */
-    public void rebuildSecondaryIndex(String ksName, String cfName, String... idxNames);
+    void rebuildSecondaryIndex(String ksName, String cfName, String... idxNames);
 
-    public void resetLocalSchema() throws IOException;
+    void resetLocalSchema() throws IOException;
 
     /**
      * Enables/Disables tracing for the whole system. Only thrift requests can start tracing currently.
@@ -515,46 +626,63 @@ public interface StorageServiceMBean extends NotificationEmitter
      *            ]0,1[ will enable tracing on a partial number of requests with the provided probability. 0 will
      *            disable tracing and 1 will enable tracing for all requests (which mich severely cripple the system)
      */
-    public void setTraceProbability(double probability);
+    void setTraceProbability(double probability);
 
     /**
      * Returns the configured tracing probability.
      */
-    public double getTraceProbability();
+    double getTraceProbability();
 
     void disableAutoCompaction(String ks, String ... columnFamilies) throws IOException;
     void enableAutoCompaction(String ks, String ... columnFamilies) throws IOException;
 
-    public void deliverHints(String host) throws UnknownHostException;
+    void deliverHints(String host) throws UnknownHostException;
 
-    /** Returns the name of the cluster */
-    public String getClusterName();
-    /** Returns the cluster partitioner */
-    public String getPartitionerName();
+    /**
+     * Returns the name of the cluster.
+     */
+    String getClusterName();
+    /**
+     * Returns the cluster partitioner.
+     */
+    String getPartitionerName();
 
-    /** Returns the threshold for warning of queries with many tombstones */
-    public int getTombstoneWarnThreshold();
-    /** Sets the threshold for warning queries with many tombstones */
-    public void setTombstoneWarnThreshold(int tombstoneDebugThreshold);
+    /**
+     * Returns the threshold for warning of queries with many tombstones.
+     */
+    int getTombstoneWarnThreshold();
+    /**
+     * Sets the threshold for warning queries with many tombstones.
+     */
+    void setTombstoneWarnThreshold(int tombstoneDebugThreshold);
 
-    /** Returns the threshold for abandoning queries with many tombstones */
-    public int getTombstoneFailureThreshold();
-    /** Sets the threshold for abandoning queries with many tombstones */
-    public void setTombstoneFailureThreshold(int tombstoneDebugThreshold);
+    /**
+     * Returns the threshold for abandoning queries with many tombstones.
+     */
+    int getTombstoneFailureThreshold();
+    /**
+     * Sets the threshold for abandoning queries with many tombstones.
+     */
+    void setTombstoneFailureThreshold(int tombstoneDebugThreshold);
 
-    /** Returns the threshold for rejecting queries due to a large batch size */
-    public int getBatchSizeFailureThreshold();
-    /** Sets the threshold for rejecting queries due to a large batch size */
-    public void setBatchSizeFailureThreshold(int batchSizeDebugThreshold);
+    /**
+     * Returns the threshold for rejecting queries due to a large batch size.
+     */
+    int getBatchSizeFailureThreshold();
+    /**
+     * Sets the threshold for rejecting queries due to a large batch size.
+     */
+    void setBatchSizeFailureThreshold(int batchSizeDebugThreshold);
 
-    /** Sets the hinted handoff throttle in kb per second, per delivery thread. */
-    public void setHintedHandoffThrottleInKB(int throttleInKB);
+    /**
+     * Sets the hinted handoff throttle in kb per second, per delivery thread.
+     */
+    void setHintedHandoffThrottleInKB(int throttleInKB);
 
     /**
      * Resume bootstrap streaming when there is failed data streaming.
      *
-     *
      * @return true if the node successfully starts resuming. (this does not mean bootstrap streaming was success.)
      */
-    public boolean resumeBootstrap();
+    boolean resumeBootstrap();
 }

--- a/gradle/baseline.gradle
+++ b/gradle/baseline.gradle
@@ -1,5 +1,4 @@
 List<String> blacklistedBaselineProjects = [
-        'atlasdb-cassandra',
         'atlasdb-cassandra-tests',
         'atlasdb-cli',
         'atlasdb-client',


### PR DESCRIPTION
Changes:
  - Mainly cosmetic to match baseline style
  - A few changes are for efficiency reasons found by findbugs.
    - We were iterating over `keySet`, then using `Map#get`.

Looking through by commit is probably easier.

| Project | Checkstyle main bugs | Checkstyle test bugs |
| --- | --- | --- |
| atlasdb-cassandra | 843 | 0 |

**Baseline modifications**
  - Checkstyle
    - Suppress abbreviations in files that match `CQL.*KeyValueServices?|CQLStatementCache|StorageServiceMBean`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/780)
<!-- Reviewable:end -->
