### PR TITLE
Fix lockCreator selection and add quorum checks

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
@@ -52,10 +52,10 @@ public abstract class LeaderConfig {
     @JsonProperty("lockCreator")
     @Value.Default
     public String lockCreator() {
-        if (leaders().isEmpty()) {
-            throw new IllegalStateException("The leaders block cannot be empty");
-        }
-        return leaders().iterator().next();
+        return leaders().stream()
+                .sorted()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("The leaders block cannot be empty"));
     }
 
     @Value.Default
@@ -75,6 +75,8 @@ public abstract class LeaderConfig {
 
     @Value.Check
     protected final void check() {
+        Preconditions.checkState(quorumSize() > leaders().size() / 2,
+                "The quorumSize '%d' must be over half the amount of the leaders entries %s.", quorumSize(), leaders());
         Preconditions.checkArgument(leaders().contains(localServer()),
                 "The localServer '%s' must included in the leader entries %s.", localServer(), leaders());
         Preconditions.checkArgument(learnerLogDir().exists() || learnerLogDir().mkdirs(),

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
@@ -76,7 +76,7 @@ public abstract class LeaderConfig {
     @Value.Check
     protected final void check() {
         Preconditions.checkState(quorumSize() > leaders().size() / 2,
-                "The quorumSize '%d' must be over half the amount of the leaders entries %s.", quorumSize(), leaders());
+                "The quorumSize '%s' must be over half the amount of the leaders entries %s.", quorumSize(), leaders());
         Preconditions.checkArgument(leaders().contains(localServer()),
                 "The localServer '%s' must included in the leader entries %s.", localServer(), leaders());
         Preconditions.checkArgument(learnerLogDir().exists() || learnerLogDir().mkdirs(),

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderConfig.java
@@ -76,7 +76,11 @@ public abstract class LeaderConfig {
     @Value.Check
     protected final void check() {
         Preconditions.checkState(quorumSize() > leaders().size() / 2,
-                "The quorumSize '%s' must be over half the amount of the leaders entries %s.", quorumSize(), leaders());
+                "The quorumSize '%s' must be over half the amount of leader entries %s.", quorumSize(), leaders());
+        Preconditions.checkState(leaders().size() >= quorumSize(),
+                "The quorumSize '%s' must be less than or equal to the amount of leader entries %s.",
+                quorumSize(), leaders());
+
         Preconditions.checkArgument(leaders().contains(localServer()),
                 "The localServer '%s' must included in the leader entries %s.", localServer(), leaders());
         Preconditions.checkArgument(learnerLogDir().exists() || learnerLogDir().mkdirs(),

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/config/LeaderConfigTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/config/LeaderConfigTest.java
@@ -47,16 +47,15 @@ public class LeaderConfigTest {
         assertThat(config.whoIsTheLockLeader(), is(LockLeader.SOMEONE_ELSE_IS_THE_LOCK_LEADER));
     }
 
-
     @Test
-    public void lockLeaderDefaultsToBeTheFirstLeader() {
+    public void lockLeaderDefaultsToBeTheFirstSortedLeader() {
         ImmutableLeaderConfig config = ImmutableLeaderConfig.builder()
                 .localServer("me")
                 .addLeaders("not me", "me")
                 .quorumSize(2)
                 .build();
 
-        assertThat(config.lockCreator(), is("not me"));
+        assertThat(config.lockCreator(), is("me"));
     }
 
     @Test(expected = IllegalStateException.class)

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/config/LeaderConfigTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/config/LeaderConfigTest.java
@@ -66,4 +66,13 @@ public class LeaderConfigTest {
                 .quorumSize(0)
                 .build();
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void cannotCreateALeaderConfigWithQuorumSizeNotBeingAMajorityOfTheLeaders() {
+        ImmutableLeaderConfig.builder()
+                .localServer("me")
+                .addLeaders("not me", "me")
+                .quorumSize(1)
+                .build();
+    }
 }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/config/LeaderConfigTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/config/LeaderConfigTest.java
@@ -75,4 +75,13 @@ public class LeaderConfigTest {
                 .quorumSize(1)
                 .build();
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void cannotCreateALeaderConfigWithQuorumSizeLargerThanTheAmountOfLeaders() {
+        ImmutableLeaderConfig.builder()
+                .localServer("me")
+                .addLeaders("not me", "me")
+                .quorumSize(3)
+                .build();
+    }
 }

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionTest.java
@@ -47,7 +47,7 @@ public class CassandraConnectionTest {
 
     private static final Optional<LeaderConfig> LEADER_CONFIG = Optional.of(ImmutableLeaderConfig
             .builder()
-            .quorumSize(0)
+            .quorumSize(1)
             .localServer("localhost")
             .leaders(Sets.newHashSet("localhost"))
             .build());

--- a/docs/source/configuration/leader_config.rst
+++ b/docs/source/configuration/leader_config.rst
@@ -38,7 +38,7 @@ Optional parameters:
 
 - ``learnerLogDir`` : Path to the paxos learner logs (defaults to var/data/paxos/learner)
 - ``acceptorLogDir`` : Path to the paxos acceptor logs (defaults to var/data/paxos/acceptor)
-- ``lockCreator`` : The host responsible for creation of the schema mutation lock table. If specified, this must be same across all hosts. (defaults to the first host in the leaders list, the first host must be same across all the hosts for this to work)
+- ``lockCreator`` : The host responsible for creation of the schema mutation lock table. If specified, this must be same across all hosts. (defaults to the first host in the sorted leaders list)
 - ``pingRateMs`` : defaults to 5000
 - ``randomWaitBeforeProposingLeadershipMs`` : defaults to 1000
 - ``leaderPingResponseWaitMs`` : defaults to 5000


### PR DESCRIPTION
This makes lockCreator consistent across different JVMs and checks that it is possible to reach quorum and that quorum will be a majority.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/793)
<!-- Reviewable:end -->
