### PR TITLE
ignore eclipse generated stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 *.iws
 fix-ivy.py
 .idea
+.checkstyle
 .classpath
 .ecbuild
 .settings/
@@ -22,6 +23,7 @@ docs/build/
 .gradle
 bin/
 userdict.txt
+.apt_generated/
 generated_src/
 generated_testSrc/
 .factorypath


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

I think the baseline stuff made the eclipse task generate more files.  This ignores them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/803)
<!-- Reviewable:end -->
