### PR TITLE
use built-in postgres function for sequence batched gets

### DIFF
--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/id/DbSequenceBackedIdGenerator.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/id/DbSequenceBackedIdGenerator.java
@@ -155,7 +155,5 @@ public class DbSequenceBackedIdGenerator implements IdGenerator {
 
     // constants for selecting top id from a sequence
     private static final String ORACLE_TOP_MANY_ID_SQL = "SELECT %s.nextval from dual_n where rownum <= ?"; //$NON-NLS-1$
-    // TODO: this only grabs one at a time. need to add a plpgsql function to really make this work
-    private static final String POSTGRESQL_TOP_MANY_ID_SQL = "SELECT * FROM nextvals_%s( ? );"; //$NON-NLS-1$
-
+    private static final String POSTGRESQL_TOP_MANY_ID_SQL = "SELECT nextval( lower('%s') ) from generate_series(1, ?)"; //$NON-NLS-1$
 }


### PR DESCRIPTION
This isn't functionality that AtlasDB uses, it's used in our internal product.
I'm making it simpler / less special-snowflake because of some issues I found at a customer site.
Previously we preloaded a "nextvals_$sequence(n)" function for each of our sequences to have an ability to correctly / concurrent-safely grab batches of n globally unique values from the sequence; this new version keeps the same guarantees but instead uses postgres built-in functions that I confirmed work on postgres 8+, which is already farther back than I care about supporting.

I have run this code through our internal test suites before pushing it here ( Change-Id: Ic34a701a1ff5325c004436e9b3ea1adf40630d3f internally, if you care ) and these tests pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/829)
<!-- Reviewable:end -->
