### PR TITLE
transaction get benchmarks

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/AtlasDbServicesConnector.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/AtlasDbServicesConnector.java
@@ -58,7 +58,7 @@ public class AtlasDbServicesConnector {
 
     public void close() throws Exception {
         if (services != null) {
-            services.getKeyValueService().close();
+            services.close();
         }
         if (store != null) {
             store.close();

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/Benchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/Benchmarks.java
@@ -29,9 +29,9 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 /**
  * Static utilities class for common performance test procedures.
  */
-public final class KvsBenchmarks {
+public final class Benchmarks {
 
-    private KvsBenchmarks() {
+    private Benchmarks() {
         // uninstantiable
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
@@ -80,7 +80,7 @@ public class KvsGetDynamicBenchmarks {
     public void setup(AtlasDbServicesConnector conn) throws UnsupportedEncodingException {
         this.connector = conn;
         kvs = conn.connect().getKeyValueService();
-        tableRef1 = KvsBenchmarks.createTableWithDynamicColumns(kvs, TABLE_NAME_1, ROW_COMPONENT, COLUMN_COMPONENT);
+        tableRef1 = Benchmarks.createTableWithDynamicColumns(kvs, TABLE_NAME_1, ROW_COMPONENT, COLUMN_COMPONENT);
         byte[] rowBytes = ROW_COMPONENT.getBytes(StandardCharsets.UTF_8);
         Map<Cell, byte[]> values = Maps.newHashMap();
         allCells2ReadTimestamp = Maps.newHashMap();
@@ -104,7 +104,7 @@ public class KvsGetDynamicBenchmarks {
     @Benchmark
     public Map<Cell, Value> getAllColumnsExplicitly() {
         Map<Cell, Value> result = kvs.get(tableRef1, allCells2ReadTimestamp);
-        KvsBenchmarks.validate(result.size() == NUM_COLS,
+        Benchmarks.validate(result.size() == NUM_COLS,
                 "Should be %s columns, but were: %s", NUM_COLS, result.size());
         return result;
     }
@@ -116,7 +116,7 @@ public class KvsGetDynamicBenchmarks {
                 Collections.singleton(ROW_COMPONENT.getBytes("UTF-8")),
                 ColumnSelection.all(),
                 READ_TIMESTAMP);
-        KvsBenchmarks.validate(result.size() == NUM_COLS,
+        Benchmarks.validate(result.size() == NUM_COLS,
                 "Should be %s columns, but were: %s", NUM_COLS, result.size());
         return result;
     }
@@ -125,9 +125,9 @@ public class KvsGetDynamicBenchmarks {
     @Benchmark
     public Map<Cell, Value> getFirstColumnExplicitly() {
         Map<Cell, Value> result = kvs.get(tableRef1, firstCell2ReadTimestamp);
-        KvsBenchmarks.validate(result.size() == 1, "Should be %s column, but were: %s", 1, result.size());
+        Benchmarks.validate(result.size() == 1, "Should be %s column, but were: %s", 1, result.size());
         int value = Ints.fromByteArray(Iterables.getOnlyElement(result.values()).getContents());
-        KvsBenchmarks.validate(value == 0, "Value should be %s but is %s", 0,  value);
+        Benchmarks.validate(value == 0, "Value should be %s but is %s", 0,  value);
         return result;
     }
 
@@ -139,9 +139,9 @@ public class KvsGetDynamicBenchmarks {
                         firstCell2ReadTimestamp.keySet().stream().map(Cell::getColumnName).collect(Collectors.toList())
                 ),
                 READ_TIMESTAMP);
-        KvsBenchmarks.validate(result.size() == 1, "Should be %s column, but were: %s", 1, result.size());
+        Benchmarks.validate(result.size() == 1, "Should be %s column, but were: %s", 1, result.size());
         int value = Ints.fromByteArray(Iterables.getOnlyElement(result.values()).getContents());
-        KvsBenchmarks.validate(value == 0, "Value should be %s but is %s", 0,  value);
+        Benchmarks.validate(value == 0, "Value should be %s but is %s", 0,  value);
         return result;
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRangeBenchmarks.java
@@ -85,7 +85,7 @@ public class KvsGetRangeBenchmarks {
     public void setup(AtlasDbServicesConnector conn) {
         this.connector = conn;
         this.kvs = conn.connect().getKeyValueService();
-        this.tableRef1 = KvsBenchmarks.createTable(kvs, TABLE_NAME_1, ROW_COMPONENT, COLUMN_NAME);
+        this.tableRef1 = Benchmarks.createTable(kvs, TABLE_NAME_1, ROW_COMPONENT, COLUMN_NAME);
         storeData();
     }
 
@@ -137,7 +137,7 @@ public class KvsGetRangeBenchmarks {
         ArrayList<RowResult<Value>> list = Lists.newArrayList(result);
         byte[] rowName = Iterables.getOnlyElement(list).getRowName();
         int rowNumber = Ints.fromByteArray(rowName);
-        KvsBenchmarks.validate(rowNumber == startRow, "Start Row %s, row number %s", startRow, rowNumber);
+        Benchmarks.validate(rowNumber == startRow, "Start Row %s, row number %s", startRow, rowNumber);
     }
 
     private Iterable<RangeRequest> getRangeRequests(int numRequests) {
@@ -168,17 +168,17 @@ public class KvsGetRangeBenchmarks {
 
         int numRequests = Iterables.size(requests);
 
-        KvsBenchmarks.validate(numRequests == results.size(),
+        Benchmarks.validate(numRequests == results.size(),
                 "Got %s requests and %s results, requests %s, results %s",
                 numRequests, results.size(), requests, results);
 
         results.forEach((request, result) -> {
-            KvsBenchmarks.validate(1 == result.getResults().size(), "Key %s, List size is %s",
+            Benchmarks.validate(1 == result.getResults().size(), "Key %s, List size is %s",
                     Ints.fromByteArray(request.getStartInclusive()), result.getResults().size());
-            KvsBenchmarks.validate(!result.moreResultsAvailable(), "Key %s, result.moreResultsAvailable() %s",
+            Benchmarks.validate(!result.moreResultsAvailable(), "Key %s, result.moreResultsAvailable() %s",
                     Ints.fromByteArray(request.getStartInclusive()), result.moreResultsAvailable());
             RowResult<Value> row = Iterables.getOnlyElement(result.getResults());
-            KvsBenchmarks.validate(Arrays.equals(request.getStartInclusive(), row.getRowName()),
+            Benchmarks.validate(Arrays.equals(request.getStartInclusive(), row.getRowName()),
                     "Request row is %s, result is %s",
                     Ints.fromByteArray(request.getStartInclusive()),
                     Ints.fromByteArray(row.getRowName()));

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsPutBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsPutBenchmarks.java
@@ -76,8 +76,8 @@ public class KvsPutBenchmarks {
     public void setup(AtlasDbServicesConnector conn) {
         this.connector = conn;
         this.kvs = conn.connect().getKeyValueService();
-        this.tableRef1 = KvsBenchmarks.createTable(kvs, TABLE_NAME_1, ROW_COMPONENT, COLUMN_NAME);
-        this.tableRef2 = KvsBenchmarks.createTable(kvs, TABLE_NAME_2, ROW_COMPONENT, COLUMN_NAME);
+        this.tableRef1 = Benchmarks.createTable(kvs, TABLE_NAME_1, ROW_COMPONENT, COLUMN_NAME);
+        this.tableRef2 = Benchmarks.createTable(kvs, TABLE_NAME_2, ROW_COMPONENT, COLUMN_NAME);
     }
 
     @TearDown

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetBenchmarks.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.performance.benchmarks;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.Validate;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.performance.backend.AtlasDbServicesConnector;
+import com.palantir.atlasdb.services.AtlasDbServices;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitables;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
+public class TransactionGetBenchmarks {
+
+    private static final String TABLE_NAME = "performance.table";
+    private static final String ROW_COMPONENT = "key";
+    private static final String COLUMN_NAME = "value";
+    private static final byte [] COLUMN_NAME_IN_BYTES = COLUMN_NAME.getBytes(StandardCharsets.UTF_8);
+
+    private static final int VALUE_BYTE_ARRAY_SIZE = 100;
+    private static final long VALUE_SEED = 279L;
+
+
+    private static final int NUM_ROWS = 10000;
+    private static final int PUT_BATCH_SIZE = 1000;
+
+    private static final int GET_CELLS_SIZE = 500;
+    private static final int RANGE_REQUEST_SIZE = 500;
+
+    private static final int NUM_RANGE_REQUESTS = 50;
+    private static final int RANGES_SINGLE_REQUEST_SIZE = 10;
+
+    private Random random = new Random(VALUE_SEED);
+
+    private AtlasDbServicesConnector connector;
+    private AtlasDbServices services;
+    private TableReference tableRef;
+
+    @Setup(Level.Trial)
+    public void setup(AtlasDbServicesConnector conn) {
+        this.connector = conn;
+        this.services = conn.connect();
+        this.tableRef = Benchmarks.createTable(services.getKeyValueService(), TABLE_NAME, ROW_COMPONENT, COLUMN_NAME);
+        storeData();
+    }
+
+    private void storeData() {
+        Validate.isTrue(NUM_ROWS % PUT_BATCH_SIZE  == 0);
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            for (int i = 0; i < NUM_ROWS; i += PUT_BATCH_SIZE) {
+                Map<Cell, byte[]> putMap = generateBatch(i, PUT_BATCH_SIZE);
+                txn.put(tableRef, putMap);
+            }
+            return null;
+        });
+    }
+
+    private byte[] generateValue() {
+        byte[] value = new byte[VALUE_BYTE_ARRAY_SIZE];
+        random.nextBytes(value);
+        return value;
+    }
+
+    private Map<Cell, byte[]> generateBatch(int startKey, int size) {
+        Map<Cell, byte[]> map = Maps.newHashMapWithExpectedSize(size);
+        for (int j = 0; j < size; j++) {
+            byte[] value = generateValue();
+            map.put(cell(startKey + j), value);
+        }
+        return map;
+    }
+
+    private Cell cell(int i) {
+        byte[] key = Ints.toByteArray(i);
+        return Cell.create(key, COLUMN_NAME_IN_BYTES);
+    }
+
+    private int rowNumber(byte[] row) {
+        return Ints.fromByteArray(row);
+    }
+
+    @TearDown(Level.Trial)
+    public void cleanup() throws Exception {
+        this.services.getKeyValueService().dropTables(Sets.newHashSet(tableRef));
+        this.connector.close();
+        this.tableRef = null;
+    }
+
+
+    private Set<Cell> getCellsRequest(int numberOfCellsToRequest) {
+        Set<Cell> ret = Sets.newHashSet();
+        while (ret.size() < numberOfCellsToRequest) {
+            ret.add(cell(random.nextInt(NUM_ROWS)));
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public void getSingleCell() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Set<Cell> request = getCellsRequest(1);
+            Map<Cell, byte[]> result = txn.get(this.tableRef, request);
+            byte[] rowName = Iterables.getOnlyElement(result.entrySet()).getKey().getRowName();
+            int rowNumber = Ints.fromByteArray(rowName);
+            int expectRowNumber = rowNumber(Iterables.getOnlyElement(request).getRowName());
+            Benchmarks.validate(rowNumber == expectRowNumber,
+                    "Start Row %s, row number %s", expectRowNumber, rowNumber);
+            return null;
+        });
+    }
+
+    @Benchmark
+    public void getCells() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Set<Cell> request = getCellsRequest(GET_CELLS_SIZE);
+            Map<Cell, byte[]> result = txn.get(this.tableRef, request);
+            Benchmarks.validate(result.size() == GET_CELLS_SIZE,
+                    "expected %s cells, found %s cells", GET_CELLS_SIZE, result.size());
+            return null;
+        });
+    }
+
+    private RangeRequest getRangeRequest(int numberOfRowsToRequest) {
+        int startRow = random.nextInt(NUM_ROWS - numberOfRowsToRequest + 1);
+        int endRow = startRow + numberOfRowsToRequest;
+        return RangeRequest.builder()
+                .batchHint(1)
+                .startRowInclusive(Ints.toByteArray(startRow))
+                .endRowExclusive(Ints.toByteArray(endRow))
+                .build();
+    }
+
+    @Benchmark
+    public void getSingleCellWithRangeQuery() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            RangeRequest request = getRangeRequest(1);
+            List<RowResult<byte[]>> result = BatchingVisitables.copyToList(txn.getRange(this.tableRef, request));
+            byte[] rowName = Iterables.getOnlyElement(result).getRowName();
+            int rowNumber = rowNumber(rowName);
+            int expectedRowNumber = rowNumber(request.getStartInclusive());
+            Benchmarks.validate(rowNumber == expectedRowNumber,
+                    "Start Row %s, row number %s", expectedRowNumber, rowNumber);
+            return null;
+        });
+    }
+
+    @Benchmark
+    public void getRange() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            RangeRequest request = getRangeRequest(RANGE_REQUEST_SIZE);
+            List<RowResult<byte[]>> results = BatchingVisitables.copyToList(txn.getRange(this.tableRef, request));
+            Benchmarks.validate(results.size() == RANGE_REQUEST_SIZE,
+                    "Expected %s rows, found %s rows", RANGE_REQUEST_SIZE, results.size());
+            return null;
+        });
+    }
+
+    @Benchmark
+    public void getRanges() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            List<RangeRequest> requests = Stream
+                    .generate(() -> getRangeRequest(RANGES_SINGLE_REQUEST_SIZE))
+                    .limit(NUM_RANGE_REQUESTS)
+                    .collect(Collectors.toList());
+            Iterable<BatchingVisitable<RowResult<byte[]>>> results = txn.getRanges(this.tableRef, requests);
+            results.forEach(bvs -> {
+                List<RowResult<byte[]>> result = BatchingVisitables.copyToList(bvs);
+                Benchmarks.validate(result.size() == RANGES_SINGLE_REQUEST_SIZE,
+                        "Expected %s rows, found %s rows", RANGES_SINGLE_REQUEST_SIZE, result.size());
+            });
+            return null;
+        });
+    }
+
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetBenchmarks.java
@@ -142,8 +142,8 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
-    public void getSingleCell() {
-        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+    public Map<Cell, byte[]> getSingleCell() {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Set<Cell> request = getCellsRequest(1);
             Map<Cell, byte[]> result = txn.get(this.tableRef, request);
             byte[] rowName = Iterables.getOnlyElement(result.entrySet()).getKey().getRowName();
@@ -151,18 +151,18 @@ public class TransactionGetBenchmarks {
             int expectRowNumber = rowNumber(Iterables.getOnlyElement(request).getRowName());
             Benchmarks.validate(rowNumber == expectRowNumber,
                     "Start Row %s, row number %s", expectRowNumber, rowNumber);
-            return null;
+            return result;
         });
     }
 
     @Benchmark
-    public void getCells() {
-        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+    public Map<Cell, byte[]> getCells() {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Set<Cell> request = getCellsRequest(GET_CELLS_SIZE);
             Map<Cell, byte[]> result = txn.get(this.tableRef, request);
             Benchmarks.validate(result.size() == GET_CELLS_SIZE,
                     "expected %s cells, found %s cells", GET_CELLS_SIZE, result.size());
-            return null;
+            return result;
         });
     }
 
@@ -177,8 +177,8 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
-    public void getSingleCellWithRangeQuery() {
-        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+    public  List<RowResult<byte[]>> getSingleCellWithRangeQuery() {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
             RangeRequest request = getRangeRequest(1);
             List<RowResult<byte[]>> result = BatchingVisitables.copyToList(txn.getRange(this.tableRef, request));
             byte[] rowName = Iterables.getOnlyElement(result).getRowName();
@@ -186,24 +186,24 @@ public class TransactionGetBenchmarks {
             int expectedRowNumber = rowNumber(request.getStartInclusive());
             Benchmarks.validate(rowNumber == expectedRowNumber,
                     "Start Row %s, row number %s", expectedRowNumber, rowNumber);
-            return null;
+            return result;
         });
     }
 
     @Benchmark
-    public void getRange() {
-        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+    public List<RowResult<byte[]>> getRange() {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
             RangeRequest request = getRangeRequest(RANGE_REQUEST_SIZE);
             List<RowResult<byte[]>> results = BatchingVisitables.copyToList(txn.getRange(this.tableRef, request));
             Benchmarks.validate(results.size() == RANGE_REQUEST_SIZE,
                     "Expected %s rows, found %s rows", RANGE_REQUEST_SIZE, results.size());
-            return null;
+            return results;
         });
     }
 
     @Benchmark
-    public void getRanges() {
-        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+    public Iterable<BatchingVisitable<RowResult<byte[]>>> getRanges() {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
             List<RangeRequest> requests = Stream
                     .generate(() -> getRangeRequest(RANGES_SINGLE_REQUEST_SIZE))
                     .limit(NUM_RANGE_REQUESTS)
@@ -214,7 +214,7 @@ public class TransactionGetBenchmarks {
                 Benchmarks.validate(result.size() == RANGES_SINGLE_REQUEST_SIZE,
                         "Expected %s rows, found %s rows", RANGES_SINGLE_REQUEST_SIZE, result.size());
             });
-            return null;
+            return results;
         });
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.performance.benchmarks;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.performance.backend.AtlasDbServicesConnector;
+import com.palantir.atlasdb.services.AtlasDbServices;
+
+/**
+ * Performance benchmarks for KVS get with dynamic columns.
+ *
+ * @author coda
+ *
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
+public class TransactionGetDynamicBenchmarks {
+
+    private static final String TABLE_NAME = "performance.table";
+    private static final String ROW_COMPONENT = "BIG_ROW_OF_INTS";
+    private static final String COLUMN_COMPONENT = "col";
+    private static final byte[] ROW_BYTES = ROW_COMPONENT.getBytes(StandardCharsets.UTF_8);
+
+    private static final int NUM_COLS = 50000;
+
+    private AtlasDbServicesConnector connector;
+    private AtlasDbServices services;
+
+    private TableReference tableRef;
+
+    private Set<Cell> allCells;
+    private Set<Cell> firstCell;
+
+    @Setup
+    public void setup(AtlasDbServicesConnector conn) throws UnsupportedEncodingException {
+        this.connector = conn;
+        services = conn.connect();
+        tableRef = Benchmarks.createTableWithDynamicColumns(
+                services.getKeyValueService(), TABLE_NAME, ROW_COMPONENT, COLUMN_COMPONENT);
+        storeData();
+    }
+
+    private void storeData() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Map<Cell, byte[]> values = Maps.newHashMap();
+            allCells = Sets.newHashSet();
+            firstCell = Sets.newHashSet(cell(0));
+            for (int i = 0; i < NUM_COLS; i++) {
+                values.put(cell(i), Ints.toByteArray(i));
+            }
+            allCells = values.keySet();
+            txn.put(this.tableRef, values);
+            return null;
+        });
+    }
+
+    private Cell cell(int i) {
+        return Cell.create(ROW_BYTES, ("col_" + i).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @TearDown
+    public void cleanup() throws Exception {
+        services.getKeyValueService().dropTables(Sets.newHashSet(tableRef));
+        connector.close();
+    }
+
+    @Benchmark
+    public Map<Cell, byte[]> getAllColumnsExplicitly() {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Map<Cell, byte[]> result = txn.get(this.tableRef, allCells);
+            Benchmarks.validate(result.values().size() == NUM_COLS,
+                    "Should be %s columns, but were: %s", NUM_COLS, result.values().size());
+            return result;
+        });
+    }
+
+    @Benchmark
+    public SortedMap<byte[], RowResult<byte[]>> getAllColumnsImplicitly() throws UnsupportedEncodingException {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            SortedMap<byte[], RowResult<byte[]>> result = txn.getRows(this.tableRef,
+                    Collections.singleton(ROW_BYTES),
+                    ColumnSelection.all());
+            int count = Iterables.getOnlyElement(result.values()).getColumns().size();
+            Benchmarks.validate(count == NUM_COLS, "Should be %s columns, but were: %s", NUM_COLS, count);
+            return result;
+        });
+    }
+
+    @Benchmark
+    public Map<Cell, byte[]> getFirstColumnExplicitly() {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Map<Cell, byte[]> result = txn.get(this.tableRef, firstCell);
+            Benchmarks.validate(result.values().size() == 1,
+                    "Should be %s column, but were: %s", 1, result.values().size());
+            int value = Ints.fromByteArray(Iterables.getOnlyElement(result.values()));
+            Benchmarks.validate(value == 0, "Value should be %s but is %s", 0,  value);
+            return result;
+        });
+    }
+
+    @Benchmark
+    public SortedMap<byte[], RowResult<byte[]>> getFirstColumnExplicitlyGetRows() throws UnsupportedEncodingException {
+        return services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            SortedMap<byte[], RowResult<byte[]>> result = txn.getRows(this.tableRef,
+                    Collections.singleton(ROW_BYTES),
+                    ColumnSelection.create(
+                            firstCell.stream().map(Cell::getColumnName).collect(Collectors.toList())
+                    ));
+            int count = Iterables.getOnlyElement(result.values()).getColumns().size();
+            Benchmarks.validate(count == 1, "Should be %s column, but were: %s", 1, count);
+            int value = Ints.fromByteArray(
+                    Iterables.getOnlyElement(
+                            Iterables.getOnlyElement(result.values()).getColumns().entrySet()
+                    ).getValue());
+            Benchmarks.validate(value == 0, "Value should be %s but is %s", 0,  value);
+            return result;
+        });
+    }
+
+}


### PR DESCRIPTION
These tests are structured just like the KVS tests.  It would be nice to have all the repeated code be shared, but may be a little tricky to do this without adding overhead inside the tests (not great for jmh).  I'll look into this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/830)
<!-- Reviewable:end -->
