### PR TITLE
Make message a warning instead of error, move stacktrace to debug

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -195,8 +195,11 @@ public final class CassandraVerifier {
                         throw ire;
                     }
                 } catch (Exception f) {
-                    log.error("Couldn't use host {} to create keyspace, it returned exception \"{}\" during"
-                            + " the attempt.", host, f.toString(), f);
+                    log.warn("Couldn't use host {} to create keyspace."
+                            + " It returned exception \"{}\" during the attempt."
+                            + " We will retry on other nodes, so this shouldn't be a problem unless all nodes failed."
+                            + " See the debug-level log for the stack trace.", host, f.toString(), f);
+                    log.debug("Specifically, creating the keyspace failed with the following stack trace", f);
                 }
             }
             if (!someHostWasAbleToCreateTheKeyspace) {


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Fixes #800. 

The error should be a warning, and the stacktrace can be logged at the debug level. Also, adds a short explanation why this is not an error. 

This change does not require a docs update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/832)
<!-- Reviewable:end -->
