### PR TITLE
Fix reads from two overflow tables

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbReadTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbReadTable.java
@@ -24,10 +24,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Queues;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
@@ -249,9 +250,34 @@ public abstract class AbstractDbReadTable implements DbReadTable {
         }
         Queue<Future<ClosableIterator<AgnosticLightResultRow>>> futures = Queues.newArrayDeque();
         for (FullQuery query : queries) {
-            futures.add(submit(MoreExecutors.directExecutor(), query));
+            futures.add(getSupplierFuture(() -> run(query)));
         }
         return new LazyClosableIterator<>(futures);
+    }
+
+    private static <T> Future<T> getSupplierFuture(Supplier<T> supplier) {
+        return new Future<T>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+            @Override
+            public boolean isCancelled() {
+                return false;
+            }
+            @Override
+            public boolean isDone() {
+                return true;
+            }
+            @Override
+            public T get() {
+                return supplier.get();
+            }
+            @Override
+            public T get(long timeout, TimeUnit unit) {
+                return get();
+            }
+        };
     }
 
     private boolean isSingleton(Iterable<?> iterable) {


### PR DESCRIPTION
"Submitting" a task to a directExecutor executes it immediately.
So if we "submit" two tasks, the second one will run in the same
connection and will destroy the result set from the first task.

(cherry picked from commit 2f00bf8258f1ca08a7ac369293c7350bb312901e)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/864)
<!-- Reviewable:end -->
