### PR TITLE
add deletes to 'put' performance tests

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsPutBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsPutBenchmarks.java
@@ -30,6 +30,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.performance.benchmarks.table.EmptyTables;
@@ -53,6 +54,8 @@ public class KvsPutBenchmarks {
     public Map<Cell, byte[]> singleRandomPut(EmptyTables tables) {
         Map<Cell, byte[]> batch = tables.generateBatchToInsert(1);
         tables.getKvs().put(EmptyTables.TABLE_REF_1, batch, DUMMY_TIMESTAMP);
+        tables.getKvs().delete(EmptyTables.TABLE_REF_1,
+                Multimaps.forMap(Maps.transformValues(batch, $ -> DUMMY_TIMESTAMP)));
         return batch;
     }
 
@@ -60,6 +63,8 @@ public class KvsPutBenchmarks {
     public Map<Cell, byte[]> batchRandomPut(EmptyTables tables) {
         Map<Cell, byte[]> batch = tables.generateBatchToInsert(BATCH_SIZE);
         tables.getKvs().put(EmptyTables.TABLE_REF_1, batch, DUMMY_TIMESTAMP);
+        tables.getKvs().delete(EmptyTables.TABLE_REF_1,
+                Multimaps.forMap(Maps.transformValues(batch, $ -> DUMMY_TIMESTAMP)));
         return batch;
     }
 
@@ -69,6 +74,10 @@ public class KvsPutBenchmarks {
         multiPutMap.put(EmptyTables.TABLE_REF_1, tables.generateBatchToInsert(BATCH_SIZE));
         multiPutMap.put(EmptyTables.TABLE_REF_2, tables.generateBatchToInsert(BATCH_SIZE));
         tables.getKvs().multiPut(multiPutMap, DUMMY_TIMESTAMP);
+        tables.getKvs().delete(EmptyTables.TABLE_REF_1,
+                Multimaps.forMap(Maps.transformValues(multiPutMap.get(EmptyTables.TABLE_REF_1), $ -> DUMMY_TIMESTAMP)));
+        tables.getKvs().delete(EmptyTables.TABLE_REF_2,
+                Multimaps.forMap(Maps.transformValues(multiPutMap.get(EmptyTables.TABLE_REF_2), $ -> DUMMY_TIMESTAMP)));
         return multiPutMap;
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionPutBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionPutBenchmarks.java
@@ -47,18 +47,26 @@ public class TransactionPutBenchmarks {
 
     @Benchmark
     public Map<Cell, byte[]> singleRandomPut(EmptyTables tables) {
-        return tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
-            Map<Cell, byte[]> batch = tables.generateBatchToInsert(1);
+        Map<Cell, byte[]> batch = tables.generateBatchToInsert(1);
+        tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
             txn.put(EmptyTables.TABLE_REF_1, batch);
+            return batch;
+        });
+        return tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            txn.delete(EmptyTables.TABLE_REF_1, batch.keySet());
             return batch;
         });
     }
 
     @Benchmark
     public Map<Cell, byte[]> batchRandomPut(EmptyTables tables) {
-        return tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
-            Map<Cell, byte[]> batch = tables.generateBatchToInsert(BATCH_SIZE);
+        Map<Cell, byte[]> batch = tables.generateBatchToInsert(BATCH_SIZE);
+        tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
             txn.put(EmptyTables.TABLE_REF_1, batch);
+            return batch;
+        });
+        return tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            txn.delete(EmptyTables.TABLE_REF_1, batch.keySet());
             return batch;
         });
     }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionPutBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionPutBenchmarks.java
@@ -21,11 +21,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -52,10 +54,11 @@ public class TransactionPutBenchmarks {
             txn.put(EmptyTables.TABLE_REF_1, batch);
             return batch;
         });
-        return tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
+        tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
             txn.delete(EmptyTables.TABLE_REF_1, batch.keySet());
             return batch;
         });
+        return batch;
     }
 
     @Benchmark
@@ -65,10 +68,23 @@ public class TransactionPutBenchmarks {
             txn.put(EmptyTables.TABLE_REF_1, batch);
             return batch;
         });
-        return tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
+        tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
             txn.delete(EmptyTables.TABLE_REF_1, batch.keySet());
             return batch;
         });
+        return batch;
+    }
+
+    /**
+     * Justification for using the potentially dangerous Level.Invocation:
+     * (a) It prevents DB polution after each invocation.
+     * (b) Each invocation takes over 1ms
+     * (c) Truncating takes about as long as the test does and so it would cloud the result output
+     *     if encapsulated in the test.
+     */
+    @TearDown(Level.Invocation)
+    public void truncateTable(EmptyTables tables) {
+        tables.getKvs().truncateTable(EmptyTables.TABLE_REF_1);
     }
 
 }


### PR DESCRIPTION
This is definitely a good idea for the put tests since it cleans up the data the test produces. For the transaction tests this is a fine way to test both put and delete (since they take about the same order of magnitude time), but it doesn't actually cleanup the db.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/865)
<!-- Reviewable:end -->
