### PR TITLE
Give a decent error message when the bundle is called with no config

### DIFF
--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommand.java
@@ -39,7 +39,9 @@ public abstract class AtlasDbCommand<T extends Configuration & AtlasDbConfigurat
 
     @Override
     public void configure(Subparser subparser) {
-        super.configure(subparser);
+        subparser.addArgument("file")
+                .nargs(1)
+                .help("application configuration file");
 
         subparser.addArgument("--offline")
                 .help("run this cli offline")


### PR DESCRIPTION
If we want a decent error message, this will make it so the `file` argument is compulsory. Dropwizard applications without a config file will not be able to run the CLIs though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/869)
<!-- Reviewable:end -->
