### PR TITLE
provide timings for each benchmark

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -19,10 +19,7 @@ package com.palantir.atlasdb.performance.benchmarks;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -32,10 +29,6 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.performance.benchmarks.table.RegeneratingTable;
 
 @State(Scope.Benchmark)
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class KvsDeleteBenchmarks {
 
     private Object doDelete(RegeneratingTable<Multimap<Cell, Long>> table) {
@@ -44,11 +37,15 @@ public class KvsDeleteBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object singleDelete(RegeneratingTable.KvsRowRegeneratingTable table) {
         return doDelete(table);
     }
 
     @Benchmark
+    @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public Object batchDelete(RegeneratingTable.KvsBatchRegeneratingTable table) {
         return doDelete(table);
     }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
@@ -24,10 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -47,13 +44,11 @@ import com.palantir.atlasdb.performance.benchmarks.table.WideRowTable;
  *
  */
 @State(Scope.Benchmark)
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class KvsGetDynamicBenchmarks {
 
     @Benchmark
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsExplicitly(WideRowTable table) {
         Map<Cell, Value> result = table.getKvs().get(table.getTableRef(), table.getAllCellsAtMaxTimestamp());
         Benchmarks.validate(result.size() == WideRowTable.NUM_COLS,
@@ -62,6 +57,8 @@ public class KvsGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsImplicitly(WideRowTable table) throws UnsupportedEncodingException {
         Map<Cell, Value> result = table.getKvs().getRows(
                 table.getTableRef(),
@@ -74,6 +71,8 @@ public class KvsGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitly(WideRowTable table) {
         Map<Cell, Value> result = table.getKvs().get(table.getTableRef(), table.getFirstCellAtMaxTimestampAsMap());
         Benchmarks.validate(result.size() == 1, "Should be %s column, but were: %s", 1, result.size());
@@ -83,6 +82,8 @@ public class KvsGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitlyGetRows(WideRowTable table) throws UnsupportedEncodingException {
         Map<Cell, Value> result = table.getKvs()
                 .getRows(table.getTableRef(), Collections.singleton(Tables.ROW_BYTES.array()),

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRangeBenchmarks.java
@@ -23,10 +23,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.collect.Iterables;
@@ -39,10 +38,7 @@ import com.palantir.atlasdb.performance.benchmarks.table.ConsecutiveNarrowTable;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
 public class KvsGetRangeBenchmarks {
 
     private Object getSingleRangeInner(ConsecutiveNarrowTable table, int sliceSize) {
@@ -88,49 +84,46 @@ public class KvsGetRangeBenchmarks {
 
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getSingleRange(ConsecutiveNarrowTable.CleanNarrowTable table) {
         return getSingleRangeInner(table, 1);
     }
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getSingleRangeDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
         return getSingleRangeInner(table, 1);
     }
 
-    @Benchmark
-    public Object getSingleRangeVeryDirty(ConsecutiveNarrowTable.VeryDirtyNarrowTable table) {
-        return getSingleRangeInner(table, 1);
-    }
-
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getSingleLargeRange(ConsecutiveNarrowTable.CleanNarrowTable table) {
         return getSingleRangeInner(table, (int) (0.1 * table.getNumRows()));
     }
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getSingleLargeRangeDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
         return getSingleRangeInner(table, (int) (0.1 * table.getNumRows()));
     }
 
-    @Benchmark
-    public Object getSingleLargeRangeVeryDirty(ConsecutiveNarrowTable.VeryDirtyNarrowTable table) {
-        return getSingleRangeInner(table, (int) (0.1 * table.getNumRows()));
-    }
-
 
     @Benchmark
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
     public Object getMultiRange(ConsecutiveNarrowTable.CleanNarrowTable table) {
         return getMultiRangeInner(table);
     }
 
     @Benchmark
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
     public Object getMultiRangeDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
-        return getMultiRangeInner(table);
-    }
-
-    @Benchmark
-    public Object getMultiRangeVeryDirty(ConsecutiveNarrowTable.VeryDirtyNarrowTable table) {
         return getMultiRangeInner(table);
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsPutBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsPutBenchmarks.java
@@ -21,10 +21,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -40,16 +37,14 @@ import com.palantir.atlasdb.performance.benchmarks.table.EmptyTables;
  * @author mwakerman
  */
 @State(Scope.Benchmark)
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class KvsPutBenchmarks {
 
     private static final long DUMMY_TIMESTAMP = 1L;
     private static final int BATCH_SIZE = 250;
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object singleRandomPut(EmptyTables tables) {
         Map<Cell, byte[]> batch = tables.generateBatchToInsert(1);
         tables.getKvs().put(tables.getFirstTableRef(), batch, DUMMY_TIMESTAMP);
@@ -57,6 +52,8 @@ public class KvsPutBenchmarks {
     }
 
     @Benchmark
+    @Warmup(iterations = 1, time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 1, time = 10, timeUnit = TimeUnit.SECONDS)
     public Object batchRandomPut(EmptyTables tables) {
         Map<Cell, byte[]> batch = tables.generateBatchToInsert(BATCH_SIZE);
         tables.getKvs().put(tables.getFirstTableRef(), batch, DUMMY_TIMESTAMP);
@@ -64,6 +61,8 @@ public class KvsPutBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object batchRandomMultiPut(EmptyTables tables) {
         Map<TableReference, Map<Cell, byte[]>> multiPutMap = Maps.newHashMap();
         multiPutMap.put(tables.getFirstTableRef(), tables.generateBatchToInsert(BATCH_SIZE));

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionDeleteBenchmarks.java
@@ -20,10 +20,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -32,10 +29,6 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.performance.benchmarks.table.RegeneratingTable;
 
 @State(Scope.Benchmark)
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class TransactionDeleteBenchmarks {
 
     private Object doDelete(RegeneratingTable<Set<Cell>> table) {
@@ -46,11 +39,15 @@ public class TransactionDeleteBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public Object singleDelete(RegeneratingTable.TransactionRowRegeneratingTable table) {
         return doDelete(table);
     }
 
     @Benchmark
+    @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public Object batchDelete(RegeneratingTable.TransactionBatchRegeneratingTable table) {
         return doDelete(table);
     }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetBenchmarks.java
@@ -22,10 +22,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -40,10 +37,6 @@ import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
 
 @State(Scope.Benchmark)
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class TransactionGetBenchmarks {
 
     private static final int RANGES_SINGLE_REQUEST_SIZE = 1;
@@ -114,84 +107,77 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getCells(ConsecutiveNarrowTable.CleanNarrowTable table) {
         return getCellsInner(table);
     }
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getCellsDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
         return getCellsInner(table);
     }
 
-    @Benchmark
-    public Object getCellsVeryDirty(ConsecutiveNarrowTable.VeryDirtyNarrowTable table) {
-        return getCellsInner(table);
-    }
-
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getSingleRowWithRangeQuery(ConsecutiveNarrowTable.CleanNarrowTable table) {
         return getSingleRowWithRangeQueryInner(table);
     }
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getSingleRowWithRangeQueryDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
         return getSingleRowWithRangeQueryInner(table);
     }
 
-    @Benchmark
-    public Object getSingleRowWithRangeQueryVeryDirty(
-            ConsecutiveNarrowTable.VeryDirtyNarrowTable table) {
-        return getSingleRowWithRangeQueryInner(table);
-    }
-
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getRange(ConsecutiveNarrowTable.CleanNarrowTable table) {
         return getRangeInner(table);
     }
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getRangeDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
         return getRangeInner(table);
     }
 
-    @Benchmark
-    public Object getRangeVeryDirty(ConsecutiveNarrowTable.VeryDirtyNarrowTable table) {
-        return getRangeInner(table);
-    }
-
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getSingleCell(ConsecutiveNarrowTable.CleanNarrowTable table) {
         return getSingleCellInner(table);
     }
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getSingleCellDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
         return getSingleCellInner(table);
     }
 
-    @Benchmark
-    public Object getSingleCellVeryDirty(ConsecutiveNarrowTable.VeryDirtyNarrowTable table) {
-        return getSingleCellInner(table);
-    }
-
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getRanges(ConsecutiveNarrowTable.CleanNarrowTable table) {
         return getRangesInner(table);
     }
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getRangesDirty(
             ConsecutiveNarrowTable.DirtyNarrowTable table) {
-        return getRangesInner(table);
-    }
-
-    @Benchmark
-    public Object getRangesVeryDirty(
-            ConsecutiveNarrowTable.VeryDirtyNarrowTable table) {
         return getRangesInner(table);
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
@@ -23,10 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -46,13 +43,11 @@ import com.palantir.atlasdb.performance.benchmarks.table.WideRowTable;
  *
  */
 @State(Scope.Benchmark)
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class TransactionGetDynamicBenchmarks {
 
     @Benchmark
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsExplicitly(WideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Map<Cell, byte[]> result = txn.get(table.getTableRef(), table.getAllCells());
@@ -63,6 +58,8 @@ public class TransactionGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsImplicitly(WideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             SortedMap<byte[], RowResult<byte[]>> result = txn.getRows(table.getTableRef(),
@@ -76,6 +73,8 @@ public class TransactionGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitly(WideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Map<Cell, byte[]> result = txn.get(table.getTableRef(), table.getFirstCellAsSet());
@@ -88,6 +87,8 @@ public class TransactionGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitlyGetRows(WideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             SortedMap<byte[], RowResult<byte[]>> result = txn.getRows(table.getTableRef(),

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionPutBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionPutBenchmarks.java
@@ -20,10 +20,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -37,15 +34,13 @@ import com.palantir.atlasdb.performance.benchmarks.table.EmptyTables;
  * @author mwakerman
  */
 @State(Scope.Benchmark)
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 1, time = 5, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 30, timeUnit = TimeUnit.SECONDS)
 public class TransactionPutBenchmarks {
 
     private static final int BATCH_SIZE = 250;
 
     @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object singleRandomPut(EmptyTables tables) {
         return tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Map<Cell, byte[]> batch = tables.generateBatchToInsert(1);
@@ -55,6 +50,8 @@ public class TransactionPutBenchmarks {
     }
 
     @Benchmark
+    @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object batchRandomPut(EmptyTables tables) {
         return tables.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Map<Cell, byte[]> batch = tables.generateBatchToInsert(BATCH_SIZE);

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -103,19 +103,7 @@ public abstract class ConsecutiveNarrowTable {
     public static class DirtyNarrowTable extends ConsecutiveNarrowTable {
         @Override
         protected void setupData() {
-            storeDataInTable(this, 10);
-        }
-    }
-
-    @State(Scope.Benchmark)
-    public static class VeryDirtyNarrowTable extends ConsecutiveNarrowTable {
-        @Override
-        protected void setupData() {
-            storeDataInTable(this, 1000);
-        }
-        @Override
-        public int getNumRows() {
-            return 10;
+            storeDataInTable(this, 100);
         }
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/cli/AtlasDbPerfCli.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/cli/AtlasDbPerfCli.java
@@ -22,11 +22,13 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
@@ -105,6 +107,10 @@ public class AtlasDbPerfCli {
         ChainedOptionsBuilder optBuilder = new OptionsBuilder()
                 .forks(1)
                 .threads(1)
+                .warmupIterations(1)
+                .measurementIterations(1)
+                .mode(Mode.SampleTime)
+                .timeUnit(TimeUnit.MICROSECONDS)
                 .param(BenchmarkParam.BACKEND.getKey(), getBackends(cli.backends));
         if (cli.logFile != null) {
             optBuilder.output(cli.logFile);


### PR DESCRIPTION
- these were adjust to allow the tests to run around 100-2500 times
- also eliminate one of the two unswept rows flavors