### PR TITLE
do fewer transactions when populating perf tables

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -150,15 +150,15 @@ public abstract class ConsecutiveNarrowTable {
 
     private static void storeDataInTable(ConsecutiveNarrowTable table, int numOverwrites) {
         int numRows = table.getNumRows();
-        IntStream.range(0, numOverwrites + 1).forEach($ -> {
-            for (int i = 0; i < numRows; i += PUT_BATCH_SIZE) {
-                final Map<Cell, byte[]> values =
-                        Tables.generateContinuousBatch(table.getRandom(), i, Math.min(PUT_BATCH_SIZE, numRows - i));
-                table.getTransactionManager().runTaskThrowOnConflict(txn -> {
+        table.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            IntStream.range(0, numOverwrites + 1).forEach($ -> {
+                for (int i = 0; i < numRows; i += PUT_BATCH_SIZE) {
+                    final Map<Cell, byte[]> values =
+                            Tables.generateContinuousBatch(table.getRandom(), i, Math.min(PUT_BATCH_SIZE, numRows - i));
                     txn.put(table.getTableRef(), values);
-                    return null;
-                });
-            }
+                }
+            });
+            return null;
         });
     }
 


### PR DESCRIPTION
Probably can also remove the batching code (since this is already buffered in memory in the transaction)?  In the name of doing less change, I'm happy with this (which I've succeeding in running remotely).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/881)
<!-- Reviewable:end -->
