### PR TITLE
Add unit tests for CassandraClientPool

### DIFF
--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolUnitTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolUnitTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+
+public class CassandraClientPoolUnitTest {
+    public static final int POOL_REFRESH_INTERVAL_SECONDS = 10;
+    public static final int DEFAULT_PORT = 5000;
+    public static final int OTHER_PORT = 6000;
+    public static final String HOST_1 = "1.0.0.0";
+    public static final String HOST_2 = "2.0.0.0";
+    public static final String HOST_3 = "3.0.0.0";
+
+    @Test
+    public void shouldReturnAddressForSingleHostInPool() throws UnknownHostException {
+        InetSocketAddress host = new InetSocketAddress(HOST_1, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(host));
+
+        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(host.getHostName());
+
+        assertThat(resolvedHost, equalTo(host));
+    }
+
+    @Test
+    public void shouldReturnAddressForSingleServer() throws UnknownHostException {
+        InetSocketAddress host = new InetSocketAddress(HOST_1, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool = clientPoolWithServers(ImmutableSet.of(host));
+
+        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(host.getHostName());
+
+        assertThat(resolvedHost, equalTo(host));
+    }
+
+    @Test
+    public void shouldUseCommonPortIfThereIsOnlyOneAndNoAddressMatches() throws UnknownHostException {
+        InetSocketAddress host1 = new InetSocketAddress(HOST_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOST_2, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool = clientPoolWithServers(ImmutableSet.of(host1, host2));
+
+        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(HOST_3);
+
+        assertThat(resolvedHost, equalTo(new InetSocketAddress(HOST_3, DEFAULT_PORT)));
+    }
+
+
+    @Test(expected = UnknownHostException.class)
+    public void shouldThrowIfPortsAreNotTheSameAddressDoesNotMatch() throws UnknownHostException {
+        InetSocketAddress host1 = new InetSocketAddress(HOST_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOST_2, OTHER_PORT);
+
+        CassandraClientPool cassandraClientPool = clientPoolWithServers(ImmutableSet.of(host1, host2));
+
+        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(HOST_3);
+
+        assertThat(resolvedHost, equalTo(host1));
+    }
+
+    private CassandraClientPool clientPoolWithServers(ImmutableSet<InetSocketAddress> servers) {
+        return clientPoolWith(servers, ImmutableSet.of());
+    }
+
+    private CassandraClientPool clientPoolWithServersInCurrentPool(ImmutableSet<InetSocketAddress> servers) {
+        return clientPoolWith(ImmutableSet.of(), servers);
+    }
+
+    private CassandraClientPool clientPoolWith(
+            ImmutableSet<InetSocketAddress> servers,
+            ImmutableSet<InetSocketAddress> serversInPool) {
+        CassandraKeyValueServiceConfig config = mock(CassandraKeyValueServiceConfig.class);
+        when(config.poolRefreshIntervalSeconds()).thenReturn(POOL_REFRESH_INTERVAL_SECONDS);
+        when(config.servers()).thenReturn(servers);
+
+        CassandraClientPool cassandraClientPool = new CassandraClientPool(config);
+        cassandraClientPool.currentPools = serversInPool.stream()
+                .collect(Collectors.toMap(Function.identity(), address -> mock(CassandraClientPoolingContainer.class)));
+        return cassandraClientPool;
+    }
+}

--- a/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolUnitTest.java
+++ b/atlasdb-cassandra-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolUnitTest.java
@@ -34,52 +34,50 @@ public class CassandraClientPoolUnitTest {
     public static final int POOL_REFRESH_INTERVAL_SECONDS = 10;
     public static final int DEFAULT_PORT = 5000;
     public static final int OTHER_PORT = 6000;
-    public static final String HOST_1 = "1.0.0.0";
-    public static final String HOST_2 = "2.0.0.0";
-    public static final String HOST_3 = "3.0.0.0";
+    public static final String HOSTNAME_1 = "1.0.0.0";
+    public static final String HOSTNAME_2 = "2.0.0.0";
+    public static final String HOSTNAME_3 = "3.0.0.0";
 
     @Test
     public void shouldReturnAddressForSingleHostInPool() throws UnknownHostException {
-        InetSocketAddress host = new InetSocketAddress(HOST_1, DEFAULT_PORT);
+        InetSocketAddress host = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
         CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(host));
 
-        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(host.getHostName());
+        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(HOSTNAME_1);
 
         assertThat(resolvedHost, equalTo(host));
     }
 
     @Test
     public void shouldReturnAddressForSingleServer() throws UnknownHostException {
-        InetSocketAddress host = new InetSocketAddress(HOST_1, DEFAULT_PORT);
+        InetSocketAddress host = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
         CassandraClientPool cassandraClientPool = clientPoolWithServers(ImmutableSet.of(host));
 
-        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(host.getHostName());
+        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(HOSTNAME_1);
 
         assertThat(resolvedHost, equalTo(host));
     }
 
     @Test
     public void shouldUseCommonPortIfThereIsOnlyOneAndNoAddressMatches() throws UnknownHostException {
-        InetSocketAddress host1 = new InetSocketAddress(HOST_1, DEFAULT_PORT);
-        InetSocketAddress host2 = new InetSocketAddress(HOST_2, DEFAULT_PORT);
+        InetSocketAddress host1 = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
         CassandraClientPool cassandraClientPool = clientPoolWithServers(ImmutableSet.of(host1, host2));
 
-        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(HOST_3);
+        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(HOSTNAME_3);
 
-        assertThat(resolvedHost, equalTo(new InetSocketAddress(HOST_3, DEFAULT_PORT)));
+        assertThat(resolvedHost, equalTo(new InetSocketAddress(HOSTNAME_3, DEFAULT_PORT)));
     }
 
 
     @Test(expected = UnknownHostException.class)
     public void shouldThrowIfPortsAreNotTheSameAddressDoesNotMatch() throws UnknownHostException {
-        InetSocketAddress host1 = new InetSocketAddress(HOST_1, DEFAULT_PORT);
-        InetSocketAddress host2 = new InetSocketAddress(HOST_2, OTHER_PORT);
+        InetSocketAddress host1 = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOSTNAME_2, OTHER_PORT);
 
         CassandraClientPool cassandraClientPool = clientPoolWithServers(ImmutableSet.of(host1, host2));
 
-        InetSocketAddress resolvedHost = cassandraClientPool.getAddressForHost(HOST_3);
-
-        assertThat(resolvedHost, equalTo(host1));
+        cassandraClientPool.getAddressForHost(HOSTNAME_3);
     }
 
     private CassandraClientPool clientPoolWithServers(ImmutableSet<InetSocketAddress> servers) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -380,7 +380,7 @@ public class CassandraClientPool {
         }
     }
 
-    private InetSocketAddress getAddressForHost(String host) throws UnknownHostException {
+    protected InetSocketAddress getAddressForHost(String host) throws UnknownHostException {
         InetAddress resolvedHost = InetAddress.getByName(host);
 
         for (InetSocketAddress address : Sets.union(currentPools.keySet(), config.servers())) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -55,7 +55,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedBytes;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -279,16 +278,17 @@ public class CassandraClientPool {
 
     public InetSocketAddress getRandomHostForKey(byte[] key) {
         List<InetSocketAddress> hostsForKey = tokenMap.get(new LightweightOppToken(key));
-        SetView<InetSocketAddress> liveOwnerHosts;
 
         if (hostsForKey == null) {
             log.debug("We attempted to route your query to a cassandra host that already contains the relevant data."
                     + " However, the mapping of which host contains which data is not available yet."
                     + " We will choose a random host instead.");
             return getRandomGoodHost().getHost();
-        } else {
-            liveOwnerHosts = Sets.difference(ImmutableSet.copyOf(hostsForKey), blacklistedHosts.keySet());
         }
+
+        Set<InetSocketAddress> liveOwnerHosts = Sets.difference(
+                ImmutableSet.copyOf(hostsForKey),
+                blacklistedHosts.keySet());
 
         if (liveOwnerHosts.isEmpty()) {
             log.warn("Perf / cluster stability issue. Token aware query routing has failed because there are no known "

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -380,7 +380,8 @@ public class CassandraClientPool {
         }
     }
 
-    protected InetSocketAddress getAddressForHost(String host) throws UnknownHostException {
+    @VisibleForTesting
+    InetSocketAddress getAddressForHost(String host) throws UnknownHostException {
         InetAddress resolvedHost = InetAddress.getByName(host);
 
         Set<InetSocketAddress> allKnownHosts = Sets.union(currentPools.keySet(), config.servers());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -383,7 +383,7 @@ public class CassandraClientPool {
     protected InetSocketAddress getAddressForHost(String host) throws UnknownHostException {
         InetAddress resolvedHost = InetAddress.getByName(host);
 
-        SetView<InetSocketAddress> allKnownHosts = Sets.union(currentPools.keySet(), config.servers());
+        Set<InetSocketAddress> allKnownHosts = Sets.union(currentPools.keySet(), config.servers());
         for (InetSocketAddress address : allKnownHosts) {
             if (address.getAddress().equals(resolvedHost)) {
                 return address;
@@ -391,7 +391,7 @@ public class CassandraClientPool {
         }
 
         Set<Integer> allKnownPorts = allKnownHosts.stream()
-                .map(address -> address.getPort())
+                .map(InetSocketAddress::getPort)
                 .collect(Collectors.toSet());
 
         if (allKnownPorts.size() == 1) { // if everyone is on one port, try and use that

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 
-public class CassandraClientPoolUnitTest {
+public class CassandraClientPoolTest {
     public static final int POOL_REFRESH_INTERVAL_SECONDS = 10;
     public static final int DEFAULT_PORT = 5000;
     public static final int OTHER_PORT = 6000;


### PR DESCRIPTION
In particular, tests to ensure we are getting hosts with the correct port.

Possible questions: 

- [ ] Don't really like the class name ending in `UnitTest`.  All the other classes in this package are integration tests, maybe we should just rename those instead. 
- [ ] I don't like this being a protected method.  Maybe it would be cleaner to extract `CassandraClientPool.currentPools` into its own class, and have `getAddressForHost()` live there.  But it's already past lunch time and I wanted to throw something up first :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/894)
<!-- Reviewable:end -->
