### PR TITLE
re-add removed api as deprecated for back-compat

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -53,6 +53,7 @@ public final class Leaders {
      * registers appropriate endpoints for that service.
      */
     public static LeaderElectionService create(
+            Optional<SSLSocketFactory> sslSocketFactory,
             Environment env,
             LeaderConfig config) {
 
@@ -61,9 +62,6 @@ public final class Leaders {
 
         Set<String> remoteLeaderUris = Sets.newHashSet(config.leaders());
         remoteLeaderUris.remove(config.localServer());
-
-        Optional<SSLSocketFactory> sslSocketFactory =
-                TransactionManagers.createSslSocketFactory(config.sslConfiguration());
 
         List<PaxosLearner> learners =
                 AtlasDbHttpClients.createProxies(sslSocketFactory, remoteLeaderUris, PaxosLearner.class);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -24,7 +24,6 @@ import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -36,7 +35,6 @@ import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
-import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.NamespacedKeyValueServices;
@@ -67,6 +65,7 @@ import com.palantir.lock.LockClient;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.client.LockRefreshingRemoteLockService;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.remoting.ssl.SslConfiguration;
 import com.palantir.remoting.ssl.SslSocketFactories;
 import com.palantir.timestamp.TimestampService;
 
@@ -98,7 +97,7 @@ public final class TransactionManagers {
      * {@link SSLSocketFactory}, {@link Schema}, and an environment in which to
      * register HTTP server endpoints.
      *
-     * This method is deprecated in favor of specifying the ssl configuration for
+     * @deprecated Consumers should instead specify the ssl configuration for
      * client-side leader connections via {@link LeaderConfig}'s sslConfiguration
      * and not through the sslSocketFactory argument.
      */
@@ -128,7 +127,7 @@ public final class TransactionManagers {
      * Create a {@link SerializableTransactionManager} with provided configuration, {@link SSLSocketFactory}, a set of
      * {@link Schema}s, and an environment in which to register HTTP server endpoints.
      *
-     * This method is deprecated in favor of specifying the ssl configuration for
+     * @deprecated Consumers should instead specify the ssl configuration for
      * client-side leader connections via {@link LeaderConfig}'s sslConfiguration
      * and not through the sslSocketFactory argument.
      */
@@ -139,14 +138,13 @@ public final class TransactionManagers {
             Set<Schema> schemas,
             Environment env,
             boolean allowHiddenTableAccess) {
-        Optional<SSLSocketFactory> canonicalSslSocketFactory = getSslSocketFactory(config, sslSocketFactory);
         ServiceDiscoveringAtlasSupplier atlasFactory =
                 new ServiceDiscoveringAtlasSupplier(config.keyValueService(), config.leader());
         KeyValueService rawKvs = atlasFactory.getKeyValueService();
 
         LockAndTimestampServices lts = createLockAndTimestampServices(
                 config,
-                canonicalSslSocketFactory,
+                sslSocketFactory,
                 env,
                 LockServiceImpl::create,
                 atlasFactory::getTimestampService);
@@ -252,7 +250,9 @@ public final class TransactionManagers {
             Supplier<RemoteLockService> lock,
             Supplier<TimestampService> time) {
         if (config.leader().isPresent()) {
-            LeaderElectionService leader = Leaders.create(sslSocketFactory, env, config.leader().get());
+            Optional<SSLSocketFactory> leaderSslSocketFactory = getSslSocketFactory(
+                    config.leader().get().sslConfiguration(), sslSocketFactory);
+            LeaderElectionService leader = Leaders.create(leaderSslSocketFactory, env, config.leader().get());
             env.register(AwaitingLeadershipProxy.newProxyInstance(RemoteLockService.class, lock, leader));
             env.register(AwaitingLeadershipProxy.newProxyInstance(TimestampService.class, time, leader));
 
@@ -262,24 +262,34 @@ public final class TransactionManagers {
                     "Ignoring timestamp server configuration because leadership election is enabled");
 
             return ImmutableLockAndTimestampServices.builder()
-                    .lock(createService(sslSocketFactory, config.leader().get().leaders(), RemoteLockService.class))
-                    .time(createService(sslSocketFactory, config.leader().get().leaders(), TimestampService.class))
+                    .lock(createService(
+                            leaderSslSocketFactory, config.leader().get().leaders(), RemoteLockService.class))
+                    .time(createService(
+                            leaderSslSocketFactory, config.leader().get().leaders(), TimestampService.class))
                     .build();
         } else {
             warnIf(config.lock().isPresent() != config.timestamp().isPresent(),
                     "Using embedded instances for one (but not both) of lock and timestamp services");
 
-            RemoteLockService lockService = config.lock()
-                    .transform(new ServiceCreator<>(sslSocketFactory, RemoteLockService.class))
-                    .or(lock);
-            TimestampService timeService = config.timestamp()
-                    .transform(new ServiceCreator<>(sslSocketFactory, TimestampService.class))
-                    .or(time);
-
-            if (!config.lock().isPresent()) {
+            RemoteLockService lockService;
+            if (config.lock().isPresent()) {
+                Optional<SSLSocketFactory> lockSslSocketFactory = getSslSocketFactory(
+                        config.lock().get().sslConfiguration(), sslSocketFactory);
+                lockService = createService(
+                        lockSslSocketFactory, config.lock().get().servers(), RemoteLockService.class);
+            } else {
+                lockService = lock.get();
                 env.register(lockService);
             }
-            if (!config.timestamp().isPresent()) {
+
+            TimestampService timeService;
+            if (config.timestamp().isPresent()) {
+                Optional<SSLSocketFactory> timeSslSocketFactory = getSslSocketFactory(
+                        config.timestamp().get().sslConfiguration(), sslSocketFactory);
+                timeService = createService(
+                        timeSslSocketFactory, config.timestamp().get().servers(), TimestampService.class);
+            } else {
+                timeService = time.get();
                 env.register(timeService);
             }
 
@@ -296,13 +306,11 @@ public final class TransactionManagers {
         }
     }
 
-    private static Optional<SSLSocketFactory> getSslSocketFactory(AtlasDbConfig config, Optional<SSLSocketFactory> sslSocketFactory) {
-        return config.leader().transform(leader -> {
-                return leader.sslConfiguration()
-                        .transform(sslConfig -> SslSocketFactories.createSslSocketFactory(sslConfig))
-                        .or(sslSocketFactory);
-                })
-                .or(sslSocketFactory);
+    private static Optional<SSLSocketFactory> getSslSocketFactory(
+            Optional<SslConfiguration> provided, Optional<SSLSocketFactory> fallback) {
+        return provided
+                .transform(sslConfig -> SslSocketFactories.createSslSocketFactory(sslConfig))
+                .or(fallback);
     }
 
     private static <T> T createService(
@@ -310,21 +318,6 @@ public final class TransactionManagers {
             Set<String> uris,
             Class<T> serviceClass) {
         return AtlasDbHttpClients.createProxyWithFailover(sslSocketFactory, uris, serviceClass);
-    }
-
-    private static class ServiceCreator<T> implements Function<ServerListConfig, T> {
-        private Optional<SSLSocketFactory> sslSocketFactory;
-        private Class<T> serviceClass;
-
-        ServiceCreator(Optional<SSLSocketFactory> sslSocketFactory, Class<T> serviceClass) {
-            this.sslSocketFactory = sslSocketFactory;
-            this.serviceClass = serviceClass;
-        }
-
-        @Override
-        public T apply(ServerListConfig input) {
-            return createService(sslSocketFactory, input.servers(), serviceClass);
-        }
     }
 
     @Value.Immutable

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -15,11 +15,8 @@
  */
 package com.palantir.atlasdb.console.module
 
-import groovy.json.JsonBuilder
-import groovy.json.JsonOutput
-import groovy.transform.CompileStatic
-
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.base.Optional
 import com.google.common.collect.ImmutableSet
 import com.palantir.atlasdb.api.AtlasDbService
 import com.palantir.atlasdb.api.TransactionToken
@@ -35,6 +32,11 @@ import com.palantir.atlasdb.impl.TableMetadataCache
 import com.palantir.atlasdb.jackson.AtlasJacksonModule
 import com.palantir.atlasdb.table.description.Schema
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager
+import groovy.json.JsonBuilder
+import groovy.json.JsonOutput
+import groovy.transform.CompileStatic
+
+import javax.net.ssl.SSLSocketFactory
 
 /**
  * Public methods that clients can call within AtlasConsole.
@@ -141,7 +143,7 @@ class AtlasCoreModule implements AtlasConsoleModule {
     }
 
     private setupConnection(AtlasDbConfig config) {
-        SerializableTransactionManager tm = TransactionManagers.create(config, ImmutableSet.<Schema>of(),
+        SerializableTransactionManager tm = TransactionManagers.create(config, Optional.<SSLSocketFactory>absent(), ImmutableSet.<Schema>of(),
                 new com.palantir.atlasdb.factory.TransactionManagers.Environment() {
                     @Override
                     public void register(Object resource) {

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/LockAndTimestampModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/LockAndTimestampModule.java
@@ -34,6 +34,7 @@ public class LockAndTimestampModule {
     public TransactionManagers.LockAndTimestampServices provideLockAndTimestampServices(ServicesConfig config) {
         return TransactionManagers.createLockAndTimestampServices(
                 config.atlasDbConfig(),
+                config.sslSocketFactory(),
                 resource -> { },
                 LockServiceImpl::create,
                 () -> config.atlasDbSupplier().getTimestampService());

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/AtlasDbConfigurationProvider.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/AtlasDbConfigurationProvider.java
@@ -15,8 +15,14 @@
  */
 package com.palantir.atlasdb.dropwizard;
 
+import com.google.common.base.Optional;
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.remoting.ssl.SslConfiguration;
 
 public interface AtlasDbConfigurationProvider {
+
     AtlasDbConfig getAtlasDbConfig();
+
+    Optional<SslConfiguration> getLeaderSslConfiguration();
+
 }

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCliCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCliCommand.java
@@ -111,7 +111,7 @@ public class AtlasDbCliCommand<T extends Configuration & AtlasDbConfigurationPro
     @Override
     protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws Exception {
         AtlasDbConfig cliConfiguration = AtlasDbCommandUtils.convertServerConfigToClientConfig(
-                configuration.getAtlasDbConfig());
+                configuration.getAtlasDbConfig(), configuration.getLeaderSslConfiguration());
 
         Map<String, OptionType> optionTypes = getCliOptionTypes();
 

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommandUtils.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommandUtils.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.config.ServerListConfig;
+import com.palantir.remoting.ssl.SslConfiguration;
 
 public final class AtlasDbCommandUtils {
     public static final Object ZERO_ARITY_ARG_CONSTANT = "<ZERO ARITY ARG CONSTANT>";
@@ -37,13 +38,15 @@ public final class AtlasDbCommandUtils {
         // Static utility class
     }
 
-    public static AtlasDbConfig convertServerConfigToClientConfig(AtlasDbConfig serverConfig) {
+    public static AtlasDbConfig convertServerConfigToClientConfig(AtlasDbConfig serverConfig,
+            Optional<SslConfiguration> sslConfig) {
         Preconditions.checkArgument(serverConfig.leader().isPresent(),
                 "Only server configurations with a leader block can be converted to client configurations");
 
         ServerListConfig leaders = ImmutableServerListConfig.builder()
                 .servers(serverConfig.leader().get().leaders())
-                .sslConfiguration(serverConfig.leader().get().sslConfiguration())
+                .sslConfiguration(serverConfig.leader().get().sslConfiguration()
+                        .or(sslConfig))
                 .build();
 
         return ImmutableAtlasDbConfig.builder()

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommand.java
@@ -63,7 +63,7 @@ public class AtlasDbConsoleCommand<T extends Configuration & AtlasDbConfiguratio
     @Override
     protected void run(Bootstrap<T> bootstrap, Namespace namespace, T configuration) throws JsonProcessingException {
         AtlasDbConfig cliConfiguration = AtlasDbCommandUtils.convertServerConfigToClientConfig(
-                configuration.getAtlasDbConfig());
+                configuration.getAtlasDbConfig(), configuration.getLeaderSslConfiguration());
 
         // We do this here because there's no flag to connect to an offline
         // cluster in atlasdb-console (since this is passed in through bind)

--- a/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommandUtilsTest.java
+++ b/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommandUtilsTest.java
@@ -56,28 +56,32 @@ public class AtlasDbCommandUtilsTest {
 
     @Test
     public void leaderBlockNoLongerExistsAfterConvertingConfig() {
-        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG, NO_SSL);
+        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(
+                MINIMAL_LEADER_CONFIG, NO_SSL);
 
         assertThat(clientConfig.leader().isPresent()).isFalse();
     }
 
     @Test
     public void timestampBlockExistsAfterConvertingConfig() {
-        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG, NO_SSL);
+        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(
+                MINIMAL_LEADER_CONFIG, NO_SSL);
 
         assertThat(clientConfig.timestamp().isPresent()).isTrue();
     }
 
     @Test
     public void timestampBlockContainsLeadersAfterConvertingConfig() {
-        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG, NO_SSL);
+        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(
+                MINIMAL_LEADER_CONFIG, NO_SSL);
 
         assertThat(clientConfig.timestamp().get().servers()).containsExactly(LOCAL_SERVER_NAME);
     }
 
     @Test
     public void lockBlockExistsAfterConvertingConfig() {
-        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG, NO_SSL);
+        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(
+                MINIMAL_LEADER_CONFIG, NO_SSL);
 
         assertThat(clientConfig.lock().get().servers()).containsExactly(LOCAL_SERVER_NAME);
     }

--- a/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommandUtilsTest.java
+++ b/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommandUtilsTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -51,38 +52,39 @@ public class AtlasDbCommandUtilsTest {
     private static final AtlasDbConfig MINIMAL_EMBEDDED_CONFIG = ImmutableAtlasDbConfig.builder()
             .keyValueService(mock(KeyValueServiceConfig.class))
             .build();
+    private static final Optional<SslConfiguration> NO_SSL = Optional.absent();
 
     @Test
     public void leaderBlockNoLongerExistsAfterConvertingConfig() {
-        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG);
+        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG, NO_SSL);
 
         assertThat(clientConfig.leader().isPresent()).isFalse();
     }
 
     @Test
     public void timestampBlockExistsAfterConvertingConfig() {
-        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG);
+        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG, NO_SSL);
 
         assertThat(clientConfig.timestamp().isPresent()).isTrue();
     }
 
     @Test
     public void timestampBlockContainsLeadersAfterConvertingConfig() {
-        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG);
+        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG, NO_SSL);
 
         assertThat(clientConfig.timestamp().get().servers()).containsExactly(LOCAL_SERVER_NAME);
     }
 
     @Test
     public void lockBlockExistsAfterConvertingConfig() {
-        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG);
+        AtlasDbConfig clientConfig = AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_LEADER_CONFIG, NO_SSL);
 
         assertThat(clientConfig.lock().get().servers()).containsExactly(LOCAL_SERVER_NAME);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void conversionFailsWhenUsingEmbeddedServerConfig() {
-        AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_EMBEDDED_CONFIG);
+        AtlasDbCommandUtils.convertServerConfigToClientConfig(MINIMAL_EMBEDDED_CONFIG, NO_SSL);
     }
 
     @Test

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteConfiguration.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteConfiguration.java
@@ -16,8 +16,10 @@
 package com.palantir.atlasdb;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Optional;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.dropwizard.AtlasDbConfigurationProvider;
+import com.palantir.remoting.ssl.SslConfiguration;
 
 import io.dropwizard.Configuration;
 
@@ -31,5 +33,10 @@ public class AtlasDbEteConfiguration extends Configuration implements AtlasDbCon
     @Override
     public AtlasDbConfig getAtlasDbConfig() {
         return atlasdb;
+    }
+
+    @Override
+    public Optional<SslConfiguration> getLeaderSslConfiguration() {
+        return Optional.absent();
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -17,6 +17,9 @@ package com.palantir.atlasdb;
 
 import java.util.Set;
 
+import javax.net.ssl.SSLSocketFactory;
+
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cas.CheckAndSetClient;
 import com.palantir.atlasdb.cas.CheckAndSetSchema;
@@ -37,6 +40,7 @@ import io.dropwizard.setup.Environment;
 
 public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
     private static final boolean DONT_SHOW_HIDDEN_TABLES = false;
+    private static final Optional<SSLSocketFactory> NO_SSL = Optional.absent();
     private static final Set<Schema> ETE_SCHEMAS = ImmutableSet.of(
             CheckAndSetSchema.getSchema(),
             TodoSchema.getSchema());
@@ -53,7 +57,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
 
     @Override
     public void run(AtlasDbEteConfiguration config, final Environment environment) throws Exception {
-        TransactionManager transactionManager = TransactionManagers.create(config.getAtlasDbConfig(), ETE_SCHEMAS, environment.jersey()::register, DONT_SHOW_HIDDEN_TABLES);
+        TransactionManager transactionManager = TransactionManagers.create(config.getAtlasDbConfig(), NO_SSL, ETE_SCHEMAS, environment.jersey()::register, DONT_SHOW_HIDDEN_TABLES);
         environment.jersey().register(new SimpleTodoResource(new TodoClient(transactionManager)));
         environment.jersey().register(new SimpleCheckAndSetResource(new CheckAndSetClient(transactionManager)));
     }

--- a/atlasdb-service-server/src/main/java/com/palantir/atlasdb/server/AtlasDbServiceServer.java
+++ b/atlasdb-service-server/src/main/java/com/palantir/atlasdb/server/AtlasDbServiceServer.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.server;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.impl.AtlasDbServiceImpl;
@@ -35,6 +36,7 @@ public class AtlasDbServiceServer extends Application<AtlasDbServiceServerConfig
     public void run(AtlasDbServiceServerConfiguration config, final Environment environment) throws Exception {
         SerializableTransactionManager tm = TransactionManagers.create(
                 config.getConfig(),
+                Optional.absent(),
                 ImmutableSet.of(),
                 environment.jersey()::register,
                 false);


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

@gsheasby and @markelliot for SA.

Brought back the the old TMs.create method and just marked it as deprecated.  Kept the ability to specify ssl via configuration.  If both are present it uses the config, but I'm happy to swap the logic there to prefer the arg.

The docs / release-notes / and javadoc probably need sprucing up.

I didn't touch the atladb bundle and passing the ssl stuff through it yet, but will.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/898)
<!-- Reviewable:end -->
