### PR TITLE
load config from streams to fix internal tests

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
@@ -68,7 +68,8 @@ public final class AtlasDbConfigs {
         return OBJECT_MAPPER.treeToValue(rootNode, AtlasDbConfig.class);
     }
 
-    public static AtlasDbConfig loadFromStream(InputStream configStream, @Nullable String configRoot) throws IOException {
+    public static AtlasDbConfig loadFromStream(InputStream configStream, @Nullable String configRoot)
+            throws IOException {
         JsonNode rootNode = getConfigNode(configStream, configRoot);
         return OBJECT_MAPPER.treeToValue(rootNode, AtlasDbConfig.class);
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 import javax.annotation.Nullable;
 
@@ -53,6 +54,10 @@ public final class AtlasDbConfigs {
         return load(configFile, ATLASDB_CONFIG_ROOT);
     }
 
+    public static AtlasDbConfig load(InputStream configStream) throws IOException {
+        return loadFromStream(configStream, ATLASDB_CONFIG_ROOT);
+    }
+
     public static AtlasDbConfig load(File configFile, @Nullable String configRoot) throws IOException {
         JsonNode rootNode = getConfigNode(configFile, configRoot);
         return OBJECT_MAPPER.treeToValue(rootNode, AtlasDbConfig.class);
@@ -60,6 +65,11 @@ public final class AtlasDbConfigs {
 
     public static AtlasDbConfig loadFromString(String fileContents, @Nullable String configRoot) throws IOException {
         JsonNode rootNode = getConfigNode(fileContents, configRoot);
+        return OBJECT_MAPPER.treeToValue(rootNode, AtlasDbConfig.class);
+    }
+
+    public static AtlasDbConfig loadFromStream(InputStream configStream, @Nullable String configRoot) throws IOException {
+        JsonNode rootNode = getConfigNode(configStream, configRoot);
         return OBJECT_MAPPER.treeToValue(rootNode, AtlasDbConfig.class);
     }
 
@@ -80,6 +90,17 @@ public final class AtlasDbConfigs {
 
         if (configNode == null) {
             throw new IllegalArgumentException("Could not find " + configRoot + " in given string");
+        }
+
+        return configNode;
+    }
+
+    private static JsonNode getConfigNode(InputStream configStream, @Nullable String configRoot) throws IOException {
+        JsonNode node = OBJECT_MAPPER.readTree(configStream);
+        JsonNode configNode = findRoot(node, configRoot);
+
+        if (configNode == null) {
+            throw new IllegalArgumentException("Could not find " + configRoot + " in given stream");
         }
 
         return configNode;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
@@ -59,44 +59,29 @@ public final class AtlasDbConfigs {
     }
 
     public static AtlasDbConfig load(File configFile, @Nullable String configRoot) throws IOException {
-        JsonNode rootNode = getConfigNode(configFile, configRoot);
-        return OBJECT_MAPPER.treeToValue(rootNode, AtlasDbConfig.class);
+        JsonNode node = OBJECT_MAPPER.readTree(configFile);
+        return getConfig(node, configRoot);
     }
 
     public static AtlasDbConfig loadFromString(String fileContents, @Nullable String configRoot) throws IOException {
-        JsonNode rootNode = getConfigNode(fileContents, configRoot);
-        return OBJECT_MAPPER.treeToValue(rootNode, AtlasDbConfig.class);
+        JsonNode node = OBJECT_MAPPER.readTree(fileContents);
+        return getConfig(node, configRoot);
     }
 
     public static AtlasDbConfig loadFromStream(InputStream configStream, @Nullable String configRoot)
             throws IOException {
-        JsonNode rootNode = getConfigNode(configStream, configRoot);
-        return OBJECT_MAPPER.treeToValue(rootNode, AtlasDbConfig.class);
-    }
-
-    private static JsonNode getConfigNode(File configFile, @Nullable String configRoot) throws IOException {
-        JsonNode node = OBJECT_MAPPER.readTree(configFile);
-        return getConfigNode(node, configRoot);
-    }
-
-    private static JsonNode getConfigNode(String fileContents, @Nullable String configRoot) throws IOException {
-        JsonNode node = OBJECT_MAPPER.readTree(fileContents);
-        return getConfigNode(node, configRoot);
-    }
-
-    private static JsonNode getConfigNode(InputStream configStream, @Nullable String configRoot) throws IOException {
         JsonNode node = OBJECT_MAPPER.readTree(configStream);
-        return getConfigNode(node, configRoot);
+        return getConfig(node, configRoot);
     }
 
-    private static JsonNode getConfigNode(JsonNode node, @Nullable String configRoot) {
+    private static AtlasDbConfig getConfig(JsonNode node, @Nullable String configRoot) throws IOException {
         JsonNode configNode = findRoot(node, configRoot);
 
         if (configNode == null) {
             throw new IllegalArgumentException("Could not find " + configRoot + " in input");
         }
 
-        return configNode;
+        return OBJECT_MAPPER.treeToValue(configNode, AtlasDbConfig.class);
     }
 
     private static JsonNode findRoot(JsonNode node, @Nullable String configRoot) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
@@ -76,32 +76,24 @@ public final class AtlasDbConfigs {
 
     private static JsonNode getConfigNode(File configFile, @Nullable String configRoot) throws IOException {
         JsonNode node = OBJECT_MAPPER.readTree(configFile);
-        JsonNode configNode = findRoot(node, configRoot);
-
-        if (configNode == null) {
-            throw new IllegalArgumentException("Could not find " + configRoot + " in yaml file " + configFile);
-        }
-
-        return configNode;
+        return getConfigNode(node, configRoot);
     }
 
     private static JsonNode getConfigNode(String fileContents, @Nullable String configRoot) throws IOException {
         JsonNode node = OBJECT_MAPPER.readTree(fileContents);
-        JsonNode configNode = findRoot(node, configRoot);
-
-        if (configNode == null) {
-            throw new IllegalArgumentException("Could not find " + configRoot + " in given string");
-        }
-
-        return configNode;
+        return getConfigNode(node, configRoot);
     }
 
     private static JsonNode getConfigNode(InputStream configStream, @Nullable String configRoot) throws IOException {
         JsonNode node = OBJECT_MAPPER.readTree(configStream);
+        return getConfigNode(node, configRoot);
+    }
+
+    private static JsonNode getConfigNode(JsonNode node, @Nullable String configRoot) {
         JsonNode configNode = findRoot(node, configRoot);
 
         if (configNode == null) {
-            throw new IllegalArgumentException("Could not find " + configRoot + " in given stream");
+            throw new IllegalArgumentException("Could not find " + configRoot + " in input");
         }
 
         return configNode;

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
@@ -36,11 +36,7 @@ import com.palantir.nexus.db.pool.config.ConnectionConfig;
 public class TestConfigLoading {
     @Test
     public void testLoadingConfig() throws IOException {
-        // Palantir internal runs this test from the jar rather than from source. This means that the resource
-        // cannot be loaded as a file. Instead it must be loaded as a stream.
-        try (InputStream stream = getClass().getClassLoader().getResourceAsStream("postgresTestConfig.yml")) {
-            AtlasDbConfigs.load(stream);
-        }
+        getPostgresTestConfig();
     }
 
     @Test
@@ -82,15 +78,18 @@ public class TestConfigLoading {
     }
 
     private ConnectionConfig getConnectionConfig() throws IOException {
-        final AtlasDbConfig config;
-        // Palantir internal runs this test from the jar rather than from source. This means that the resource
-        // cannot be loaded as a file. Instead it must be loaded as a stream.
-        try (InputStream stream = getClass().getClassLoader().getResourceAsStream("postgresTestConfig.yml")) {
-            config = AtlasDbConfigs.load(stream);
-        }
+        AtlasDbConfig config = getPostgresTestConfig();
         KeyValueServiceConfig keyValueServiceConfig = config.keyValueService();
         DbKeyValueServiceConfig dbkvsConfig = (DbKeyValueServiceConfig) keyValueServiceConfig;
         return dbkvsConfig.connection();
+    }
+
+    private AtlasDbConfig getPostgresTestConfig() throws IOException {
+        // Palantir internal runs this test from the jar rather than from source. This means that the resource
+        // cannot be loaded as a file. Instead it must be loaded as a stream.
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream("postgresTestConfig.yml")) {
+            return AtlasDbConfigs.load(stream);
+        }
     }
 
     private void verifyHikariProperty(ConnectionConfig connectionConfig, String property, int expectedValueSeconds) {

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TestConfigLoading.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -36,7 +37,11 @@ import com.palantir.nexus.db.pool.config.ConnectionConfig;
 public class TestConfigLoading {
     @Test
     public void testLoadingConfig() throws IOException {
-        AtlasDbConfigs.load(new File(getClass().getClassLoader().getResource("postgresTestConfig.yml").getFile()));
+        // Palantir internal runs this test from the jar rather than from source. This means that the resource
+        // cannot be loaded as a file. Instead it must be loaded as a stream.
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream("postgresTestConfig.yml")) {
+            AtlasDbConfigs.load(stream);
+        }
     }
 
     @Test
@@ -78,8 +83,12 @@ public class TestConfigLoading {
     }
 
     private ConnectionConfig getConnectionConfig() throws IOException {
-        AtlasDbConfig config = AtlasDbConfigs.load(
-                new File(getClass().getClassLoader().getResource("postgresTestConfig.yml").getFile()));
+        final AtlasDbConfig config;
+        // Palantir internal runs this test from the jar rather than from source. This means that the resource
+        // cannot be loaded as a file. Instead it must be loaded as a stream.
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream("postgresTestConfig.yml")) {
+            config = AtlasDbConfigs.load(stream);
+        }
         KeyValueServiceConfig keyValueServiceConfig = config.keyValueService();
         DbKeyValueServiceConfig dbkvsConfig = (DbKeyValueServiceConfig) keyValueServiceConfig;
         return dbkvsConfig.connection();


### PR DESCRIPTION
Palantir internal runs unit tests from the compiled jars rather than the
sources. This means that in a test, resources cannot be loaded as files.
They must be loaded as streams instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/900)
<!-- Reviewable:end -->
