### PR TITLE
Remove / from ATLASDB_CONFIG_ROOT in yml files

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
@@ -33,7 +33,7 @@ import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 
 public final class AtlasDbConfigs {
 
-    public static final String ATLASDB_CONFIG_ROOT = "/atlasdb";
+    public static final String ATLASDB_CONFIG_ROOT = "atlasdb";
 
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory()
             .disable(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID)


### PR DESCRIPTION
All yml files have "atlasdb" as the config root
instead of "/atlasdb".  Remove the leading /.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/909)
<!-- Reviewable:end -->
