### PR TITLE
Append -dropwizard to log folder names so they are unique

### DIFF
--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/dropwizard/CassandraDropwizardEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/dropwizard/CassandraDropwizardEteTest.java
@@ -22,5 +22,5 @@ import com.palantir.atlasdb.ete.EteSetup;
 
 public class CassandraDropwizardEteTest extends DropwizardEteTest {
     @ClassRule
-    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("cassandra-ha", "docker-compose.cassandra.yml");
+    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("cassandra-ha-dropwizard", "docker-compose.cassandra.yml");
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/dropwizard/CassandraNoLeaderDropwizardEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/dropwizard/CassandraNoLeaderDropwizardEteTest.java
@@ -22,5 +22,5 @@ import com.palantir.atlasdb.ete.EteSetup;
 
 public class CassandraNoLeaderDropwizardEteTest extends DropwizardEteTest {
     @ClassRule
-    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("cassandra-no-leader", "docker-compose.no-leader.cassandra.yml");
+    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("cassandra-no-leader-dropwizard", "docker-compose.no-leader.cassandra.yml");
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/dropwizard/DbKvsDropwizardEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/dropwizard/DbKvsDropwizardEteTest.java
@@ -22,5 +22,5 @@ import com.palantir.atlasdb.ete.EteSetup;
 
 public class DbKvsDropwizardEteTest extends DropwizardEteTest {
     @ClassRule
-    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("dbkvs", "docker-compose.dbkvs.yml");
+    public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition("dbkvs-dropwizard", "docker-compose.dbkvs.yml");
 }


### PR DESCRIPTION
When investigating the flaky tests described in #845, it would be nice to have access to the container logs.  Currently we have two sets of tests overwriting the same container-logs directory, so this information gets lost. 

This PR ensures that each set of started containers writes to a different directory.  This way, we'll have logs next time the problem occurs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/913)
<!-- Reviewable:end -->
