### PR TITLE
don't attempt to grab schema lock for no-op mutations

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -1342,6 +1342,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
      */
     @Override
     public void dropTables(final Set<TableReference> tablesToDrop) {
+        if (tablesToDrop.isEmpty()) {
+            return;
+        }
         schemaMutationLock.runWithLock(() -> dropTablesWithLock(tablesToDrop));
     }
 
@@ -1393,6 +1396,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
      */
     @Override
     public void createTables(final Map<TableReference, byte[]> tableNamesToTableMetadata) {
+        if (tableNamesToTableMetadata.isEmpty()) {
+            return;
+        }
         schemaMutationLock.runWithLock(() -> createTablesWithLock(tableNamesToTableMetadata));
         internalPutMetadataForTables(tableNamesToTableMetadata, false);
     }


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Simply make sure there are actually tables we want to create/drop before attempting to grab the schema mutation lock.

There's much more work that can be done here around checking if the things we want to drop exist / the things we want to create don't exist as well, but is better handled in scope with #841.

CC @ashrayjain @clockfort

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/914)
<!-- Reviewable:end -->
