### PR TITLE
Move release notes for #907 to 0.15.0

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,6 +41,11 @@ v0.15.0
     *    - Type
          - Change
 
+    *    - |breaking|
+         - All TransactionManagers are now AutoCloseable and implement a close method that will free up the underlying resources.
+           No operations can be performed using the TransactionManager once it is closed.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/907>`__)
+
     *    - |new|
          - ``CassandraKeyValueServiceConfiguration`` now supports :ref:`column paging <cassandra-sweep-config>`
            via the ``timestampsGetterBatchSize`` parameter.
@@ -96,11 +101,6 @@ v0.14.0
            AtlasDB will now fail to start if your configuration is invalid with a sensible message, per `#790 <https://github.com/palantir/atlasdb/issues/790>`__, rather than potentially breaking in unexpected ways.
            Please refer to :ref:`Example Leader Configurations <leader-config-examples>` for guidance on valid configurations.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/854>`__)
-
-    *    - |breaking|
-         - All TransactionManagers are now AutoCloseable and implement a close method that will free up the underlying resources.
-           No operations can be performed using the TransactionManager once it is closed.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/907>`__)
 
     *    - |fixed|
          - Fixed and standardized serialization and deserialization of AtlasDBConfig.


### PR DESCRIPTION
We merged #907 today, in time for 0.15.0, not 0.14.0.