### PR TITLE
test that re-creating a table can restore lost table metadata

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -15,6 +15,11 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ForkJoinPool;
@@ -24,10 +29,19 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.atlasdb.table.description.TableDefinition;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
 
 public class CassandraKeyValueServiceTableCreationIntegrationTest {
     public static final TableReference GOOD_TABLE = TableReference.createFromFullyQualifiedName("foo.bar");
@@ -90,5 +104,42 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
     @Test
     public void describeVersionBehavesCorrectly() throws Exception {
         kvs.clientPool.runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
+    }
+
+
+    @Test
+    public void testCreateTableCanRestoreLostMetadata() {
+        // setup a basic table
+        TableReference missingMetadataTable = TableReference.createFromFullyQualifiedName("test.metadata_missing");
+        byte[] initialMetadata = new TableDefinition() {{
+            rowName();
+            rowComponent("blob", ValueType.BLOB);
+            columns();
+            column("bar", "b", ValueType.BLOB);
+            conflictHandler(ConflictHandler.IGNORE_ALL);
+            sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING);
+        }}.toTableMetadata().persistToBytes();
+
+        kvs.createTable(missingMetadataTable, initialMetadata);
+
+
+        // retrieve the metadata and see that it's the same as what we just put in
+        byte[] existingMetadata = kvs.getMetadataForTable(missingMetadataTable);
+        assertThat(initialMetadata, is(existingMetadata));
+
+        // Directly get and delete the metadata (`get` necessary to get the fake timestamp putMetadataForTables used)
+        Cell cell = Cell.create(
+                missingMetadataTable.getQualifiedName().getBytes(Charset.defaultCharset()),
+                "m".getBytes(StandardCharsets.UTF_8));
+        Value persistedMetadata = Iterables.getLast(
+                kvs.get(AtlasDbConstants.METADATA_TABLE, ImmutableMap.of(cell, Long.MAX_VALUE)).values());
+        kvs.delete(AtlasDbConstants.METADATA_TABLE, ImmutableMultimap.of(cell, persistedMetadata.getTimestamp()));
+
+        // pretend we started up again and did a createTable() for our existing table, that no longer has metadata
+        kvs.createTable(missingMetadataTable, initialMetadata);
+
+        // retrieve the metadata again and see that it's the same as what we just put in
+        existingMetadata = kvs.getMetadataForTable(missingMetadataTable);
+        assertThat(initialMetadata, is(existingMetadata));
     }
 }


### PR DESCRIPTION
Arose from discussion on our internal chat.
I think there was a bug a long time in the past that could have caused table metadata to not be persisted correctly in certain error edge cases in CassandraKVS, and it looks like some old versions also can't recover from this state, though from a look through the code now it seems like this should work.
I've added a test to confirm and make this a guarantee.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/945)
<!-- Reviewable:end -->
