### PR TITLE
Docs/port sweep docs

### DIFF
--- a/docs/source/cluster_management/clis.rst
+++ b/docs/source/cluster_management/clis.rst
@@ -37,7 +37,10 @@ The following useful commands come with the vanilla atlasdb-cli.
 sweep
 -----
 
-Sweep old table rows. This can be useful for improving performance if having too many dead cells is impacting read times.  The command allows you to specify a namespace or a specific set of tables. Run ``./bin/atlasdb help sweep`` for more information.
+Sweep old table rows.
+This can be useful for improving performance if having too many dead cells is impacting read times.
+The command allows you to specify a namespace or a specific set of tables.
+Run ``./bin/atlasdb help sweep`` for more information, or check out :ref:`the sweep CLI documentation <atlas_sweep_cli>`.
 
 
 timestamp

--- a/docs/source/cluster_management/clis.rst
+++ b/docs/source/cluster_management/clis.rst
@@ -40,7 +40,7 @@ sweep
 Sweep old table rows.
 This can be useful for improving performance if having too many dead cells is impacting read times.
 The command allows you to specify a namespace or a specific set of tables.
-Run ``./bin/atlasdb help sweep`` for more information, or check out :ref:`the sweep CLI documentation <atlas_sweep_cli>`.
+For more information, check out :ref:`the sweep CLI documentation <atlas_sweep_cli>`, or run ``./bin/atlasdb help sweep``.
 
 
 timestamp

--- a/docs/source/cluster_management/index.rst
+++ b/docs/source/cluster_management/index.rst
@@ -10,3 +10,4 @@ Cluster Management
    clis
    console
    dropwizard-bundle
+   sweep

--- a/docs/source/cluster_management/sweep.rst
+++ b/docs/source/cluster_management/sweep.rst
@@ -46,10 +46,9 @@ Targeted Sweep
 If there are specific tables that have built up over time to a large size, you might consider running the targeted sweep job.
 For more information about how to do this, check out our documentation on the :ref:`atlas_sweep_cli`.
 
-For more information:
----------------------
-
 .. toctree::
     :maxdepth: 1
+    :hidden:
 
+    sweep/background-sweep
     sweep/sweep-cli

--- a/docs/source/cluster_management/sweep.rst
+++ b/docs/source/cluster_management/sweep.rst
@@ -39,16 +39,12 @@ Targeted Sweep
 --------------
 
 If there are specific tables that have built up over time to a large size, you might consider running the targeted sweep job.
-For more information about how to do this, check out our documentation on the atlas_sweep_cli (TODO PORT).
+For more information about how to do this, check out our documentation on the :ref:`atlas_sweep_cli`.
 
-.. :ref:`atlas_sweep_cli`.
+For more information:
+---------------------
 
-..  For more information:
-.. #---------------------
-.. #
-.. #.. toctree::
-.. #:maxdepth: 1
-.. #
-.. #       pages/configuration
-.. #       pages/monitoring
-.. #       pages/atlasSweepCli
+.. toctree::
+    :maxdepth: 1
+
+    sweep/sweep-cli

--- a/docs/source/cluster_management/sweep.rst
+++ b/docs/source/cluster_management/sweep.rst
@@ -35,6 +35,11 @@ The sweep job is intended to regularly delete unused data from AtlasDB, reducing
 Older AtlasDB instances with high data scale and months/years of user activity will likely have a large number of accumulated cells that are eligible for sweeping (i.e. a lot of unused data in AtlasDB that has never been swept).
 In this case, manually sweeping specific tables may be required to reduce the number of unused cells that have accumulated over time.
 
+Background Sweep
+----------------
+
+For more information on how to set up a regular sweep job on your system, check out the :ref:`background_sweep` documentation.
+
 Targeted Sweep
 --------------
 

--- a/docs/source/cluster_management/sweep.rst
+++ b/docs/source/cluster_management/sweep.rst
@@ -1,0 +1,54 @@
+.. _sweep:
+
+AtlasDB Sweep Job
+=================
+
+.. warning::
+
+   AtlasDB sweep is currently an experimental feature, and is disabled by default. If you are interested in testing it, please contact the AtlasDB team.
+
+.. warning::
+
+   Running the Sweep Job while taking a Backup can cause **SEVERE DATA CORRUPTION** to your Backup.
+
+
+Under normal usage, the data written to the key value service backing AtlasDB is never updated or deleted.
+When a row in AtlasDB is "updated", a new version of the row with a higher timestamp is written.
+The old row is left untouched. When that row is later read, only the version with the higher timestamp is returned.
+Deletions in AtlasDB are similar; in practice they are the same as updates with an empty value.
+
+To prevent an AtlasDB database from growing in size indefinitely, old versions of rows can be deleted through a process called sweeping.
+At a high level, this works by periodically scanning the database for rows with multiple versions and deleting the older versions from the database.
+
+
+Reasons to Sweep
+----------------
+
+1. Freeing up Disk Space
+    - Putting large amounts of data into cells that are updated creates tables that hold onto data that isn't used. These tables are good candidates to sweep if you want to reclaim disk space.
+
+2. Improving Performance
+    - Making many edits to the same row will leave behind many tombstoned entries, so it's advantageous to sweep these tables to increase performance.
+
+Under normal use, the sweep job is intended to run at a constant interval as a background process that does not consume significant system resources.
+The sweep job is intended to regularly delete unused data from AtlasDB, reducing disk usage, and improving performance for certain queries.
+Older AtlasDB instances with high data scale and months/years of user activity will likely have a large number of accumulated cells that are eligible for sweeping (i.e. a lot of unused data in AtlasDB that has never been swept).
+In this case, manually sweeping specific tables may be required to reduce the number of unused cells that have accumulated over time.
+
+Targeted Sweep
+--------------
+
+If there are specific tables that have built up over time to a large size, you might consider running the targeted sweep job.
+For more information about how to do this, check out our documentation on the atlas_sweep_cli (TODO PORT).
+
+.. :ref:`atlas_sweep_cli`.
+
+..  For more information:
+.. #---------------------
+.. #
+.. #.. toctree::
+.. #:maxdepth: 1
+.. #
+.. #       pages/configuration
+.. #       pages/monitoring
+.. #       pages/atlasSweepCli

--- a/docs/source/cluster_management/sweep.rst
+++ b/docs/source/cluster_management/sweep.rst
@@ -30,18 +30,20 @@ Reasons to Sweep
 2. Improving Performance
     - Making many edits to the same row will leave behind many tombstoned entries, so it's advantageous to sweep these tables to increase performance.
 
+Ways to Sweep
+-------------
+
 Under normal use, the sweep job is intended to run at a constant interval as a background process that does not consume significant system resources.
-The sweep job is intended to regularly delete unused data from AtlasDB, reducing disk usage, and improving performance for certain queries.
 Older AtlasDB instances with high data scale and months/years of user activity will likely have a large number of accumulated cells that are eligible for sweeping (i.e. a lot of unused data in AtlasDB that has never been swept).
-In this case, manually sweeping specific tables may be required to reduce the number of unused cells that have accumulated over time.
+In this case, consider manually sweeping specific tables to reduce the number of unused cells that have accumulated over time.
 
 Background Sweep
-----------------
+~~~~~~~~~~~~~~~~
 
 For more information on how to set up a regular sweep job on your system, check out the :ref:`background_sweep` documentation.
 
 Targeted Sweep
---------------
+~~~~~~~~~~~~~~
 
 If there are specific tables that have built up over time to a large size, you might consider running the targeted sweep job.
 For more information about how to do this, check out our documentation on the :ref:`atlas_sweep_cli`.

--- a/docs/source/cluster_management/sweep/background-sweep.rst
+++ b/docs/source/cluster_management/sweep/background-sweep.rst
@@ -1,0 +1,66 @@
+.. _background_sweep:
+
+Background Sweep
+================
+
+.. warning::
+
+   Background sweep is currently considered to be an experimental feature, and is disabled by default.
+   If you are interested in trialling background sweep, please contact the AtlasDB team.
+
+
+How Background Sweep Works
+--------------------------
+
+The Background Sweep Job works by sweeping one table at a time.
+The Background Sweep Job determines which table to sweep by estimating which would be most beneficial based on I/O activity and frequency, considering the following criteria:
+
+- The number of cells written to a table since it was last swept.
+- The number of cells that were deleted the last time a table was swept.
+- The number of cells that were not deleted the last time a table was swept.
+- The amount of time that has passed since the it was last swept.
+
+
+Additional logging for Background Sweep
+---------------------------------------
+
+By default, the background sweeper only logs errors. If you'd like to watch the background sweeper's progress, add the following in ``atlasdb.log.properties``:
+
+  ::
+
+    #--------------------------------------------------------------------------------
+    # Sweep Logging
+    #--------------------------------------------------------------------------------
+
+    # enable background sweep logging by setting this to 'debug', to get more logging use 'info', disable with 'off'
+    log4j.logger.com.palantir.atlasdb.sweep.BackgroundSweeperImpl=debug, sweepAppend
+
+    # set additivity to false to make these logs only show up in <redacted>.log
+    log4j.additivity.com.palantir.atlasdb.sweep.BackgroundSweeperImpl=false
+
+    # configure a basic file appender
+    log4j.appender.sweepAppend.layout=com.palantir.monitoring.logging.log4j.PalantirPatternLayout
+    log4j.appender.sweepAppend.layout.ConversionPattern=%m%n
+    log4j.appender.sweepAppend=com.palantir.util.logging.ArchivedDailyRollingFileAppender
+    log4j.appender.sweepAppend.threshold=debug
+    log4j.appender.sweepAppend.file=log/background-sweeper.log
+    log4j.appender.sweepAppend.datePattern='.'yyyy-MM-dd
+    log4j.appender.sweepAppend.maxArchivesToKeep=90
+
+This will create a log file ``log/background-sweeper.log`` where sweep information will be logged.
+
+Querying the Sweep Metadata Tables
+----------------------------------
+
+You can also query the Atlas table ``sweep.progress`` using Atlas Console.
+``sweep.progress`` contains at most a single row detailing information for the current table the background sweeper is sweeping.
+You can also query ``sweep.priority`` to get a breakdown per table of:
+
+- ``write_count`` - Approximate number of writes to this table since the last time it was swept.
+
+- ``last_sweep_time`` - Wall clock time the last time this table was swept.
+
+- ``cells_deleted`` - The numbers of cells deleted last time this table was swept.
+
+- ``cells_examined`` - The number of cells in the table total the last time this table was swept.
+

--- a/docs/source/cluster_management/sweep/background-sweep.rst
+++ b/docs/source/cluster_management/sweep/background-sweep.rst
@@ -35,7 +35,7 @@ By default, the background sweeper only logs errors. If you'd like to watch the 
     # enable background sweep logging by setting this to 'debug', to get more logging use 'info', disable with 'off'
     log4j.logger.com.palantir.atlasdb.sweep.BackgroundSweeperImpl=debug, sweepAppend
 
-    # set additivity to false to make these logs only show up in <redacted>.log
+    # set additivity to false to make these logs only show up in background-sweeper.log
     log4j.additivity.com.palantir.atlasdb.sweep.BackgroundSweeperImpl=false
 
     # configure a basic file appender

--- a/docs/source/cluster_management/sweep/background-sweep.rst
+++ b/docs/source/cluster_management/sweep/background-sweep.rst
@@ -32,7 +32,7 @@ By default, the background sweeper only logs errors. If you'd like to watch the 
     # Sweep Logging
     #--------------------------------------------------------------------------------
 
-    # enable background sweep logging by setting this to 'debug', to get more logging use 'info', disable with 'off'
+    # enable background sweep logging by setting this to 'debug'; for less verbose logging, use 'error'.
     log4j.logger.com.palantir.atlasdb.sweep.BackgroundSweeperImpl=debug, sweepAppend
 
     # set additivity to false to make these logs only show up in background-sweeper.log

--- a/docs/source/cluster_management/sweep/sweep-cli.rst
+++ b/docs/source/cluster_management/sweep/sweep-cli.rst
@@ -1,0 +1,37 @@
+.. _atlas_sweep_cli:
+
+AtlasDB Sweep Cli
+=================
+
+If you ever need to force a particular table to be swept immediately, you can run the cli ``./bin/atlasdb sweep`` with the following options:
+
+- -n, ---namespace <namespace name>
+
+  A namespace name to sweep, for instance ``--namespace product``
+
+- -t, ---table <table name>
+
+  A fully qualified table name to sweep. For example, to sweep the accounts table in the bank namespace, you would use ``--table bank.accounts``.
+
+- -a, ---all
+  Sweep all tables.
+
+- -r, ---row <row name>
+
+  A row name encoded in hexadecimal to stat sweeping from. The cli prints out row names as it runs, so you can use this to easily resume a manual sweep job without unnecessarily processing rows that have already been recently swept. If this option is omitted, sweeping will process all rows of the table.
+
+
+Configuration options
+---------------------
+
+- sweepBatchSize
+  If you have extremely large rows, you may want to set a lower batch size. If you have extremely small rows, you may want to up the batch size. (Default: 1000)
+
+- sweepPauseMillis
+  If you want take less shared DB resources during user-facing hours, you can specify a wait time in between batches. (Default: 0 ms)
+
+- keyValueService/cassandra/timestampsGetterBatchSize
+  (Cassandra KVS only): For really, really large rows, you can set a batch size for the number of columns to fetch in a single database query. (Default: null, meaning fetch all columns per row)
+
+Be aware that manual sweeping will ignore all conditions that factor into determining whether background sweepers should run, and that the background sweeper will also be affected by system property changes.
+

--- a/docs/source/cluster_management/sweep/sweep-cli.rst
+++ b/docs/source/cluster_management/sweep/sweep-cli.rst
@@ -5,18 +5,18 @@ AtlasDB Sweep Cli
 
 If you ever need to force a particular table to be swept immediately, you can run the cli ``./bin/atlasdb sweep`` with the following options:
 
-- -n, ---namespace <namespace name>
+- ``-n``, ``--namespace <namespace name>``
 
   A namespace name to sweep, for instance ``--namespace product``
 
-- -t, ---table <table name>
+- ``-t``, ``--table <table name>``
 
   A fully qualified table name to sweep. For example, to sweep the accounts table in the bank namespace, you would use ``--table bank.accounts``.
 
-- -a, ---all
+- ``-a``, ``--all``
   Sweep all tables.
 
-- -r, ---row <row name>
+- ``-r``, ``--row <row name>``
 
   A row name encoded in hexadecimal to stat sweeping from. The cli prints out row names as it runs, so you can use this to easily resume a manual sweep job without unnecessarily processing rows that have already been recently swept. If this option is omitted, sweeping will process all rows of the table.
 
@@ -24,13 +24,13 @@ If you ever need to force a particular table to be swept immediately, you can ru
 Configuration options
 ---------------------
 
-- sweepBatchSize
+- ``sweepBatchSize``
   If you have extremely large rows, you may want to set a lower batch size. If you have extremely small rows, you may want to up the batch size. (Default: 1000)
 
-- sweepPauseMillis
+- ``sweepPauseMillis``
   If you want take less shared DB resources during user-facing hours, you can specify a wait time in between batches. (Default: 0 ms)
 
-- keyValueService/cassandra/timestampsGetterBatchSize
+- ``keyValueService/cassandra/timestampsGetterBatchSize``
   (Cassandra KVS only): For really, really large rows, you can set a batch size for the number of columns to fetch in a single database query. (Default: null, meaning fetch all columns per row)
 
 Be aware that manual sweeping will ignore all conditions that factor into determining whether background sweepers should run, and that the background sweeper will also be affected by system property changes.

--- a/docs/source/cluster_management/sweep/sweep-cli.rst
+++ b/docs/source/cluster_management/sweep/sweep-cli.rst
@@ -3,7 +3,7 @@
 AtlasDB Sweep Cli
 =================
 
-If you ever need to force a particular table to be swept immediately, you can run the cli ``./bin/atlasdb sweep`` with the following options:
+If you ever need to force a particular table to be swept immediately, you can run the CLI ``./bin/atlasdb sweep`` with the following options:
 
 - ``-n``, ``--namespace <namespace name>``
 
@@ -18,7 +18,7 @@ If you ever need to force a particular table to be swept immediately, you can ru
 
 - ``-r``, ``--row <row name>``
 
-  A row name encoded in hexadecimal to stat sweeping from. The cli prints out row names as it runs, so you can use this to easily resume a manual sweep job without unnecessarily processing rows that have already been recently swept. If this option is omitted, sweeping will process all rows of the table.
+  A row name encoded in hexadecimal to start sweeping from. The CLI prints out row names as it runs, so you can use this to easily resume a manual sweep job without unnecessarily processing rows that have already been recently swept. If this option is omitted, sweeping will process all rows of the table.
 
 
 Configuration options
@@ -28,7 +28,7 @@ Configuration options
   If you have extremely large rows, you may want to set a lower batch size. If you have extremely small rows, you may want to up the batch size. (Default: 1000)
 
 - ``sweepPauseMillis``
-  If you want take less shared DB resources during user-facing hours, you can specify a wait time in between batches. (Default: 0 ms)
+  If you want to use less shared DB resources during user-facing hours, you can specify a wait time in between batches. (Default: 0 ms)
 
 - ``keyValueService/cassandra/timestampsGetterBatchSize``
   (Cassandra KVS only): For really, really large rows, you can set a batch size for the number of columns to fetch in a single database query. (Default: null, meaning fetch all columns per row)

--- a/docs/source/cluster_management/sweep/sweep-cli.rst
+++ b/docs/source/cluster_management/sweep/sweep-cli.rst
@@ -3,26 +3,23 @@
 AtlasDB Sweep Cli
 =================
 
-If you ever need to force a particular table to be swept immediately, you can run the CLI ``./bin/atlasdb sweep`` with the following options:
+If you ever need to force a particular table or namespace to be swept immediately, you can run the CLI ``./bin/atlasdb sweep``, which has the following arguments:
 
-- ``-n``, ``--namespace <namespace name>``
+.. csv-table::
+   :header: "Short option", "Long option", "Description"
+   :widths: 20, 40, 200
 
-  A namespace name to sweep, for instance ``--namespace product``
+   ``-a``, ``--all``, Sweep all tables.
+   ``-n``, ``--namespace <namespace name>``, "A namespace name to sweep, for instance ``-n product``"
+   ``-t``, ``--table <table name>``, "A fully qualified table name to sweep. For example, to sweep the accounts table in the bank namespace, you would use ``-t bank.accounts``."
+   ``-r``, ``--row <row name>``, "A row name encoded in hexadecimal to start sweeping from. The CLI prints out row names as it runs, so you can use this to easily resume a manual sweep job without unnecessarily processing rows that have already been recently swept. If this option is omitted, sweeping will process all rows of the table."
 
-- ``-t``, ``--table <table name>``
-
-  A fully qualified table name to sweep. For example, to sweep the accounts table in the bank namespace, you would use ``--table bank.accounts``.
-
-- ``-a``, ``--all``
-  Sweep all tables.
-
-- ``-r``, ``--row <row name>``
-
-  A row name encoded in hexadecimal to start sweeping from. The CLI prints out row names as it runs, so you can use this to easily resume a manual sweep job without unnecessarily processing rows that have already been recently swept. If this option is omitted, sweeping will process all rows of the table.
-
+You can use exactly one of ``-a``, ``-n``, and ``-t``. If giving a row name, you must also provide the table name.
 
 Configuration options
 ---------------------
+
+The following options are set as part of your :ref:`AtlasDB configuration <atlas_config>`.
 
 - ``sweepBatchSize``
   If you have extremely large rows, you may want to set a lower batch size. If you have extremely small rows, you may want to up the batch size. (Default: 1000)
@@ -30,7 +27,7 @@ Configuration options
 - ``sweepPauseMillis``
   If you want to use less shared DB resources during user-facing hours, you can specify a wait time in between batches. (Default: 0 ms)
 
-- ``keyValueService/cassandra/timestampsGetterBatchSize``
+- ``keyValueService/timestampsGetterBatchSize``
   (Cassandra KVS only): For really, really large rows, you can set a batch size for the number of columns to fetch in a single database query. (Default: null, meaning fetch all columns per row)
 
 Be aware that manual sweeping will ignore all conditions that factor into determining whether background sweepers should run, and that the background sweeper will also be affected by system property changes.

--- a/docs/source/cluster_management/sweep/sweep-cli.rst
+++ b/docs/source/cluster_management/sweep/sweep-cli.rst
@@ -9,12 +9,12 @@ If you ever need to force a particular table or namespace to be swept immediatel
    :header: "Short option", "Long option", "Description"
    :widths: 20, 40, 200
 
-   ``-a``, ``--all``, Sweep all tables.
+   ``-a``, ``--all``, "Sweep all tables, in all AtlasDB namespaces."
    ``-n``, ``--namespace <namespace name>``, "A namespace name to sweep, for instance ``-n product``"
    ``-t``, ``--table <table name>``, "A fully qualified table name to sweep. For example, to sweep the accounts table in the bank namespace, you would use ``-t bank.accounts``."
    ``-r``, ``--row <row name>``, "A row name encoded in hexadecimal to start sweeping from. The CLI prints out row names as it runs, so you can use this to easily resume a manual sweep job without unnecessarily processing rows that have already been recently swept. If this option is omitted, sweeping will process all rows of the table."
 
-You can use exactly one of ``-a``, ``-n``, and ``-t``. If giving a row name, you must also provide the table name.
+You must specify exactly one of ``-a``, ``-n``, and ``-t``. If you are sweeping a specific table with `-t`, you may additionally specify the start row with ``-r``. This is useful for resuming failed jobs.
 
 Configuration options
 ---------------------
@@ -28,7 +28,7 @@ The following options are set as part of your :ref:`AtlasDB configuration <atlas
   If you want to use less shared DB resources during user-facing hours, you can specify a wait time in between batches. (Default: 0 ms)
 
 - ``keyValueService/timestampsGetterBatchSize``
-  (Cassandra KVS only): For really, really large rows, you can set a batch size for the number of columns to fetch in a single database query. (Default: null, meaning fetch all columns per row)
+  (EXPERIMENTAL - Cassandra KVS only): For really, really large rows, you can set a batch size for the number of columns to fetch in a single database query. See :ref:`Cassandra KVS config <cassandra-configuration>`. (absent by default, meaning fetch all columns per row)
 
 Be aware that manual sweeping will ignore all conditions that factor into determining whether background sweepers should run, and that the background sweeper will also be affected by system property changes.
 

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -1,3 +1,5 @@
+.. _atlas_config:
+
 =============
 Configuration
 =============


### PR DESCRIPTION
Ported the sweep docs over from internal documentation. Apart from removing internal references and minor typo/formatting fixes, it's pretty much word-for-word, i.e. I've assumed that the internal docs were up to date and correct.

I do have a couple of areas where I was uncertain; I'll indicate these now in the comments.

#NoReleaseNotes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/957)
<!-- Reviewable:end -->
