### PR TITLE
Allow running entire test suite or single test from IDEs

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSerializableTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSerializableTransactionIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import org.junit.ClassRule;
 import org.junit.Ignore;
 
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
@@ -23,6 +24,9 @@ import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest
 
 public class CQLKeyValueServiceSerializableTransactionIntegrationTest extends
         AbstractSerializableTransactionTest {
+
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
 
     @Override
     protected KeyValueService getKeyValueService() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSerializableTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSerializableTransactionIntegrationTest.java
@@ -26,7 +26,7 @@ public class CQLKeyValueServiceSerializableTransactionIntegrationTest extends
         AbstractSerializableTransactionTest {
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Override
     protected KeyValueService getKeyValueService() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSweeperIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSweeperIntegrationTest.java
@@ -15,11 +15,17 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import org.junit.ClassRule;
+
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.sweep.AbstractSweeperTest;
 
 public class CQLKeyValueServiceSweeperIntegrationTest extends AbstractSweeperTest {
+
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Override
     protected KeyValueService getKeyValueService() {
         return CQLKeyValueService.create(

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSweeperIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceSweeperIntegrationTest.java
@@ -24,7 +24,7 @@ import com.palantir.atlasdb.sweep.AbstractSweeperTest;
 public class CQLKeyValueServiceSweeperIntegrationTest extends AbstractSweeperTest {
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Override
     protected KeyValueService getKeyValueService() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceTransactionIntegrationTest.java
@@ -24,7 +24,7 @@ import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 public class CQLKeyValueServiceTransactionIntegrationTest extends AbstractTransactionTest {
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Override
     protected KeyValueService getKeyValueService() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueServiceTransactionIntegrationTest.java
@@ -15,11 +15,16 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import org.junit.ClassRule;
+
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 
 public class CQLKeyValueServiceTransactionIntegrationTest extends AbstractTransactionTest {
+
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
 
     @Override
     protected KeyValueService getKeyValueService() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -33,6 +33,7 @@ import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -49,11 +50,14 @@ import com.palantir.common.base.FunctionCheckedException;
 public class CassandraClientPoolIntegrationTest {
     private CassandraKeyValueService kv;
 
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Before
     public void setUp() {
         kv = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG),
-                CassandraTestSuite.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG),
+                cassandraResources.LEADER_CONFIG);
         kv.initializeFromFreshInstance();
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -51,13 +51,13 @@ public class CassandraClientPoolIntegrationTest {
     private CassandraKeyValueService kv;
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Before
     public void setUp() {
         kv = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG),
-                cassandraResources.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraResources.CASSANDRA_KVS_CONFIG),
+                CassandraResources.LEADER_CONFIG);
         kv.initializeFromFreshInstance();
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
@@ -32,11 +32,11 @@ import com.palantir.atlasdb.config.LeaderConfig;
 public class CassandraConnectionIntegrationTest {
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     private static final CassandraKeyValueServiceConfig NO_CREDS_CKVS_CONFIG = ImmutableCassandraKeyValueServiceConfig
             .builder()
-            .addServers(cassandraResources.CASSANDRA_THRIFT_ADDRESS)
+            .addServers(CassandraResources.CASSANDRA_THRIFT_ADDRESS)
             .poolSize(20)
             .keyspace("atlasdb")
             .credentials(Optional.absent())
@@ -59,7 +59,7 @@ public class CassandraConnectionIntegrationTest {
     @Test
     public void testAuthProvided() {
         CassandraKeyValueService kv = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG), LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraResources.CASSANDRA_KVS_CONFIG), LEADER_CONFIG);
         kv.teardown();
         assert true; // getting here implies authentication succeeded
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import static org.junit.Assert.fail;
 
 import org.apache.cassandra.thrift.InvalidRequestException;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.google.common.base.Optional;
@@ -30,9 +31,12 @@ import com.palantir.atlasdb.config.LeaderConfig;
 
 public class CassandraConnectionIntegrationTest {
 
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     private static final CassandraKeyValueServiceConfig NO_CREDS_CKVS_CONFIG = ImmutableCassandraKeyValueServiceConfig
             .builder()
-            .addServers(CassandraTestSuite.CASSANDRA_THRIFT_ADDRESS)
+            .addServers(cassandraResources.CASSANDRA_THRIFT_ADDRESS)
             .poolSize(20)
             .keyspace("atlasdb")
             .credentials(Optional.absent())
@@ -55,7 +59,7 @@ public class CassandraConnectionIntegrationTest {
     @Test
     public void testAuthProvided() {
         CassandraKeyValueService kv = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG), LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG), LEADER_CONFIG);
         kv.teardown();
         assert true; // getting here implies authentication succeeded
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -32,6 +32,7 @@ import org.apache.thrift.TException;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -54,6 +55,9 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractAtlasDbKeyV
     private ExecutorService executorService;
     private Logger logger = mock(Logger.class);
 
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Before
     public void setupKVS() {
         keyValueService = getKeyValueService();
@@ -68,7 +72,9 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractAtlasDbKeyV
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG), CassandraTestSuite.LEADER_CONFIG, logger);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG),
+                cassandraResources.LEADER_CONFIG,
+                logger);
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -56,7 +56,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractAtlasDbKeyV
     private Logger logger = mock(Logger.class);
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Before
     public void setupKVS() {
@@ -72,8 +72,8 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractAtlasDbKeyV
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG),
-                cassandraResources.LEADER_CONFIG,
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraResources.CASSANDRA_KVS_CONFIG),
+                CassandraResources.LEADER_CONFIG,
                 logger);
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSerializableTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSerializableTransactionIntegrationTest.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import org.junit.ClassRule;
+
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
@@ -22,10 +24,13 @@ import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest
 public class CassandraKeyValueServiceSerializableTransactionIntegrationTest extends
         AbstractSerializableTransactionTest {
 
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG), CassandraTestSuite.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG), cassandraResources.LEADER_CONFIG);
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSerializableTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSerializableTransactionIntegrationTest.java
@@ -25,12 +25,12 @@ public class CassandraKeyValueServiceSerializableTransactionIntegrationTest exte
         AbstractSerializableTransactionTest {
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG), cassandraResources.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraResources.CASSANDRA_KVS_CONFIG), CassandraResources.LEADER_CONFIG);
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweeperIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweeperIntegrationTest.java
@@ -39,7 +39,7 @@ import com.palantir.atlasdb.sweep.AbstractSweeperTest;
 public class CassandraKeyValueServiceSweeperIntegrationTest extends AbstractSweeperTest {
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Parameterized.Parameter
     public boolean useColumnBatchSize;
@@ -53,11 +53,11 @@ public class CassandraKeyValueServiceSweeperIntegrationTest extends AbstractSwee
     @Override
     protected KeyValueService getKeyValueService() {
         ImmutableCassandraKeyValueServiceConfig config = useColumnBatchSize
-                ? cassandraResources.CASSANDRA_KVS_CONFIG.withTimestampsGetterBatchSize(Optional.of(10))
-                : cassandraResources.CASSANDRA_KVS_CONFIG;
+                ? CassandraResources.CASSANDRA_KVS_CONFIG.withTimestampsGetterBatchSize(Optional.of(10))
+                : CassandraResources.CASSANDRA_KVS_CONFIG;
 
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(config), cassandraResources.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(config), CassandraResources.LEADER_CONFIG);
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweeperIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweeperIntegrationTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assume;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,6 +37,10 @@ import com.palantir.atlasdb.sweep.AbstractSweeperTest;
 
 @RunWith(Parameterized.class)
 public class CassandraKeyValueServiceSweeperIntegrationTest extends AbstractSweeperTest {
+
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Parameterized.Parameter
     public boolean useColumnBatchSize;
 
@@ -48,11 +53,11 @@ public class CassandraKeyValueServiceSweeperIntegrationTest extends AbstractSwee
     @Override
     protected KeyValueService getKeyValueService() {
         ImmutableCassandraKeyValueServiceConfig config = useColumnBatchSize
-                ? CassandraTestSuite.CASSANDRA_KVS_CONFIG.withTimestampsGetterBatchSize(Optional.of(10))
-                : CassandraTestSuite.CASSANDRA_KVS_CONFIG;
+                ? cassandraResources.CASSANDRA_KVS_CONFIG.withTimestampsGetterBatchSize(Optional.of(10))
+                : cassandraResources.CASSANDRA_KVS_CONFIG;
 
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(config), CassandraTestSuite.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(config), cassandraResources.LEADER_CONFIG);
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -54,19 +54,19 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
     protected CassandraKeyValueService slowTimeoutKvs;
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Before
     public void setUp() {
-        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = cassandraResources.CASSANDRA_KVS_CONFIG
+        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = CassandraResources.CASSANDRA_KVS_CONFIG
                 .withSchemaMutationTimeoutMillis(500);
         kvs = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig), cassandraResources.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig), CassandraResources.LEADER_CONFIG);
 
-        ImmutableCassandraKeyValueServiceConfig slowTimeoutConfig = cassandraResources.CASSANDRA_KVS_CONFIG
+        ImmutableCassandraKeyValueServiceConfig slowTimeoutConfig = CassandraResources.CASSANDRA_KVS_CONFIG
                 .withSchemaMutationTimeoutMillis(6 * 1000);
         slowTimeoutKvs = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(slowTimeoutConfig), cassandraResources.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(slowTimeoutConfig), CassandraResources.LEADER_CONFIG);
 
         kvs.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.google.common.base.Preconditions;
@@ -52,17 +53,20 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
     protected CassandraKeyValueService kvs;
     protected CassandraKeyValueService slowTimeoutKvs;
 
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Before
     public void setUp() {
-        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = CassandraTestSuite.CASSANDRA_KVS_CONFIG
+        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = cassandraResources.CASSANDRA_KVS_CONFIG
                 .withSchemaMutationTimeoutMillis(500);
         kvs = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig), CassandraTestSuite.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig), cassandraResources.LEADER_CONFIG);
 
-        ImmutableCassandraKeyValueServiceConfig slowTimeoutConfig = CassandraTestSuite.CASSANDRA_KVS_CONFIG
+        ImmutableCassandraKeyValueServiceConfig slowTimeoutConfig = cassandraResources.CASSANDRA_KVS_CONFIG
                 .withSchemaMutationTimeoutMillis(6 * 1000);
         slowTimeoutKvs = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(slowTimeoutConfig), CassandraTestSuite.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(slowTimeoutConfig), cassandraResources.LEADER_CONFIG);
 
         kvs.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -24,12 +24,12 @@ import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 public class CassandraKeyValueServiceTransactionIntegrationTest extends AbstractTransactionTest {
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG), cassandraResources.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraResources.CASSANDRA_KVS_CONFIG), CassandraResources.LEADER_CONFIG);
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -15,16 +15,21 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import org.junit.ClassRule;
+
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 
 public class CassandraKeyValueServiceTransactionIntegrationTest extends AbstractTransactionTest {
 
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG), CassandraTestSuite.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG), cassandraResources.LEADER_CONFIG);
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraResources.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraResources.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.Callable;
+
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.Duration;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
+import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
+import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.config.ImmutableLeaderConfig;
+import com.palantir.atlasdb.config.LeaderConfig;
+import com.palantir.atlasdb.ete.Gradle;
+import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.connection.DockerPort;
+import com.palantir.docker.compose.connection.waiting.HealthCheck;
+import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
+
+class CassandraResources extends ExternalResource {
+
+    private static final Logger log = LoggerFactory.getLogger(CassandraResources.class);
+    private static final int THRIFT_PORT_NUMBER = 9160;
+    private static final Gradle GRADLE_PREPARE_TASK = Gradle.ensureTaskHasRun(
+            ":atlasdb-ete-test-utils:buildCassandraImage");
+    private static final DockerComposeRule docker = DockerComposeRule.builder()
+            .file("src/test/resources/docker-compose.yml")
+            .waitingForHostNetworkedPort(THRIFT_PORT_NUMBER, toBeOpen())
+            .saveLogsTo("container-logs")
+            .build();
+
+    private static RuleChain CASSANDRA_DOCKER_SET_UP = RuleChain.outerRule(GRADLE_PREPARE_TASK).around(docker);
+    private static int refCount = 0;
+    private static CassandraResources currentInstance;
+
+    static InetSocketAddress CASSANDRA_THRIFT_ADDRESS;
+    static ImmutableCassandraKeyValueServiceConfig CASSANDRA_KVS_CONFIG;
+    static Optional<LeaderConfig> LEADER_CONFIG;
+
+    static CassandraResources getCassandraResource() {
+        if (refCount == 0) {
+            // currentInstance either hasn't been created yet, or after was called on it - create a new one
+            currentInstance = new CassandraResources();
+        }
+        return currentInstance;
+    }
+
+    private CassandraResources() {
+        // nothing to initialize
+    }
+
+    @Override
+    protected void before() {
+        try {
+            if (refCount == 0) {
+                try {
+                    waitUntilCassandraIsUp();
+                } catch (Throwable e) {
+                    log.error("Exception: {}", e);
+                }
+            }
+        }
+        finally {
+            refCount++;
+        }
+    }
+
+    @Override
+    protected void after() {
+        Preconditions.checkState(refCount > 0, "No more references to kill");
+        refCount--;
+        if (refCount == 0) {
+            log.info("Killed all refs to Cassandra resources");
+        }
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        Statement cassandraResources = super.apply(base, description);
+        return refCount == 0 ? CASSANDRA_DOCKER_SET_UP.apply(cassandraResources, description) : cassandraResources;
+    }
+
+    private static void waitUntilCassandraIsUp() throws IOException, InterruptedException {
+        DockerPort port = docker.hostNetworkedPort(THRIFT_PORT_NUMBER);
+        String hostname = port.getIp();
+        CASSANDRA_THRIFT_ADDRESS = new InetSocketAddress(hostname, port.getExternalPort());
+
+        CASSANDRA_KVS_CONFIG = ImmutableCassandraKeyValueServiceConfig.builder()
+                .addServers(CASSANDRA_THRIFT_ADDRESS)
+                .poolSize(20)
+                .keyspace("atlasdb")
+                .credentials(ImmutableCassandraCredentialsConfig.builder()
+                        .username("cassandra")
+                        .password("cassandra")
+                        .build())
+                .ssl(false)
+                .replicationFactor(1)
+                .mutationBatchCount(10000)
+                .mutationBatchSizeBytes(10000000)
+                .fetchBatchCount(1000)
+                .safetyDisabled(false)
+                .autoRefreshNodes(false)
+                .build();
+
+        LEADER_CONFIG = Optional.of(ImmutableLeaderConfig
+                .builder()
+                .quorumSize(1)
+                .localServer(hostname)
+                .leaders(ImmutableSet.of(hostname))
+                .build());
+
+        Awaitility.await()
+                .atMost(Duration.ONE_MINUTE)
+                .pollInterval(Duration.ONE_SECOND)
+                .until(canCreateKeyValueService());
+    }
+
+    private static Callable<Boolean> canCreateKeyValueService() {
+        return () -> {
+            try {
+                CassandraKeyValueService.create(CassandraKeyValueServiceConfigManager.createSimpleManager(CASSANDRA_KVS_CONFIG), LEADER_CONFIG);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        };
+    }
+
+    private static HealthCheck<DockerPort> toBeOpen() {
+        return port -> SuccessOrFailure.fromBoolean(port.isListeningNow(), "" + "" + port + " was not open");
+    }
+
+}

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuite.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuite.java
@@ -15,31 +15,10 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.concurrent.Callable;
-
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableSet;
-import com.jayway.awaitility.Awaitility;
-import com.jayway.awaitility.Duration;
-import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
-import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
-import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.config.ImmutableLeaderConfig;
-import com.palantir.atlasdb.config.LeaderConfig;
-import com.palantir.atlasdb.ete.Gradle;
-import com.palantir.docker.compose.DockerComposeRule;
-import com.palantir.docker.compose.connection.DockerPort;
-import com.palantir.docker.compose.connection.waiting.HealthCheck;
-import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -56,75 +35,7 @@ import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 })
 public class CassandraTestSuite {
 
-    public static final int THRIFT_PORT_NUMBER = 9160;
-    public static final DockerComposeRule docker = DockerComposeRule.builder()
-            .file("src/test/resources/docker-compose.yml")
-            .waitingForHostNetworkedPort(THRIFT_PORT_NUMBER, toBeOpen())
-            .saveLogsTo("container-logs")
-            .build();
-
-    public static final Gradle GRADLE_PREPARE_TASK = Gradle.ensureTaskHasRun(":atlasdb-ete-test-utils:buildCassandraImage");
-
     @ClassRule
-    public static final RuleChain CASSANDRA_DOCKER_SET_UP = RuleChain.outerRule(GRADLE_PREPARE_TASK).around(docker);
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
 
-    static InetSocketAddress CASSANDRA_THRIFT_ADDRESS;
-
-    static ImmutableCassandraKeyValueServiceConfig CASSANDRA_KVS_CONFIG;
-
-    static Optional<LeaderConfig> LEADER_CONFIG;
-
-    @BeforeClass
-    public static void waitUntilCassandraIsUp() throws IOException, InterruptedException {
-        DockerPort port = docker.hostNetworkedPort(THRIFT_PORT_NUMBER);
-        String hostname = port.getIp();
-        CASSANDRA_THRIFT_ADDRESS = new InetSocketAddress(hostname, port.getExternalPort());
-
-        CASSANDRA_KVS_CONFIG = ImmutableCassandraKeyValueServiceConfig.builder()
-                .addServers(CASSANDRA_THRIFT_ADDRESS)
-                .poolSize(20)
-                .keyspace("atlasdb")
-                .credentials(ImmutableCassandraCredentialsConfig.builder()
-                        .username("cassandra")
-                        .password("cassandra")
-                        .build())
-                .ssl(false)
-                .replicationFactor(1)
-                .mutationBatchCount(10000)
-                .mutationBatchSizeBytes(10000000)
-                .fetchBatchCount(1000)
-                .safetyDisabled(false)
-                .autoRefreshNodes(false)
-                .build();
-
-        LEADER_CONFIG = Optional.of(ImmutableLeaderConfig
-                .builder()
-                .quorumSize(1)
-                .localServer(hostname)
-                .leaders(ImmutableSet.of(hostname))
-                .build());
-
-        Awaitility.await()
-                .atMost(Duration.ONE_MINUTE)
-                .pollInterval(Duration.ONE_SECOND)
-                .until(canCreateKeyValueService());
-    }
-
-    private static Callable<Boolean> canCreateKeyValueService() {
-        return new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                try {
-                    CassandraKeyValueService.create(CassandraKeyValueServiceConfigManager.createSimpleManager(CASSANDRA_KVS_CONFIG), LEADER_CONFIG);
-                    return true;
-                } catch (Exception e) {
-                    return false;
-                }
-            }
-        };
-    }
-
-    private static HealthCheck<DockerPort> toBeOpen() {
-        return port -> SuccessOrFailure.fromBoolean(port.isListeningNow(), "" + "" + port + " was not open");
-    }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuite.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuite.java
@@ -36,6 +36,6 @@ import org.junit.runners.Suite.SuiteClasses;
 public class CassandraTestSuite {
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -28,10 +29,13 @@ import com.palantir.timestamp.TimestampBoundStore;
 public class CassandraTimestampIntegrationTest {
     private CassandraKeyValueService kv;
 
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Before
     public void setUp() {
         kv = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG), CassandraTestSuite.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG), cassandraResources.LEADER_CONFIG);
         kv.initializeFromFreshInstance();
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -30,12 +30,12 @@ public class CassandraTimestampIntegrationTest {
     private CassandraKeyValueService kv;
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Before
     public void setUp() {
         kv = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(cassandraResources.CASSANDRA_KVS_CONFIG), cassandraResources.LEADER_CONFIG);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraResources.CASSANDRA_KVS_CONFIG), CassandraResources.LEADER_CONFIG);
         kv.initializeFromFreshInstance();
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -46,6 +47,9 @@ public class SchemaMutationLockIntegrationTest {
     public static final SchemaMutationLock.Action DO_NOTHING = () -> {};
     protected SchemaMutationLock schemaMutationLock;
     private final ExecutorService executorService = Executors.newFixedThreadPool(4);
+
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
 
     @Parameterized.Parameter(value = 0)
     public boolean casEnabled;
@@ -69,7 +73,7 @@ public class SchemaMutationLockIntegrationTest {
     }
 
     protected void setUpWithCasSupportSetTo(boolean supportsCas) throws Exception {
-        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = CassandraTestSuite.CASSANDRA_KVS_CONFIG
+        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = cassandraResources.CASSANDRA_KVS_CONFIG
                 .withSchemaMutationTimeoutMillis(500);
         CassandraKeyValueServiceConfigManager simpleManager = CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig);
         ConsistencyLevel writeConsistency = ConsistencyLevel.EACH_QUORUM;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -49,7 +49,7 @@ public class SchemaMutationLockIntegrationTest {
     private final ExecutorService executorService = Executors.newFixedThreadPool(4);
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Parameterized.Parameter(value = 0)
     public boolean casEnabled;
@@ -73,7 +73,7 @@ public class SchemaMutationLockIntegrationTest {
     }
 
     protected void setUpWithCasSupportSetTo(boolean supportsCas) throws Exception {
-        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = cassandraResources.CASSANDRA_KVS_CONFIG
+        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = CassandraResources.CASSANDRA_KVS_CONFIG
                 .withSchemaMutationTimeoutMillis(500);
         CassandraKeyValueServiceConfigManager simpleManager = CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig);
         ConsistencyLevel writeConsistency = ConsistencyLevel.EACH_QUORUM;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesIntegrationTest.java
@@ -49,11 +49,11 @@ public class SchemaMutationLockTablesIntegrationTest {
     private CassandraClientPool clientPool;
 
     @ClassRule
-    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+    public static CassandraResources cassandraResources = CassandraResources.getCassandraResource();
 
     @Before
     public void setupKVS() throws TException, InterruptedException {
-        config = cassandraResources.CASSANDRA_KVS_CONFIG
+        config = CassandraResources.CASSANDRA_KVS_CONFIG
                 .withKeyspace(UUID.randomUUID().toString().replace('-', '_')); // Hyphens not allowed in C* schema
         clientPool = new CassandraClientPool(config);
         clientPool.runOneTimeStartupChecks();

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesIntegrationTest.java
@@ -36,6 +36,7 @@ import java.util.function.IntConsumer;
 
 import org.apache.thrift.TException;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.google.common.collect.Iterables;
@@ -47,9 +48,12 @@ public class SchemaMutationLockTablesIntegrationTest {
     private CassandraKeyValueServiceConfig config;
     private CassandraClientPool clientPool;
 
+    @ClassRule
+    public static CassandraResources cassandraResources= CassandraResources.getCassandraResource();
+
     @Before
     public void setupKVS() throws TException, InterruptedException {
-        config = CassandraTestSuite.CASSANDRA_KVS_CONFIG
+        config = cassandraResources.CASSANDRA_KVS_CONFIG
                 .withKeyspace(UUID.randomUUID().toString().replace('-', '_')); // Hyphens not allowed in C* schema
         clientPool = new CassandraClientPool(config);
         clientPool.runOneTimeStartupChecks();


### PR DESCRIPTION
This improves dev workflow by allowing individual test runs or the running the entire test suite from the IDE, without any code changes.

Previous workflow was to comment out other tests when running a single test or a subset of tests and then uncommenting once done. This makes that unnecessary.

It works by ensuring that the Cassandra and Gradle setup tasks or only run once regardless of how many times they are referenced.

Note: Only works for Cassandra integration tests atm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/974)
<!-- Reviewable:end -->
