### PR TITLE
add build number to published snapshots

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-buildInfo.build.number = System.getenv('CIRCLE_BUILD_NUM')

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -22,7 +22,7 @@ publishing {
             artifact(testJar) {
                 classifier 'tests'
             }
-            version project.version.replaceAll(/-\d+.*/, '-SNAPSHOT')
+            version project.version.replaceAll(/-\d+.*/, (circleBuildNum ? '.b' + circleBuildNum : '') + '-SNAPSHOT')
             pom.withXml {
                 def scm = asNode().appendNode('scm')
                 scm.appendNode('url', 'https://github.com/palantir/atlasdb')
@@ -49,7 +49,8 @@ bintray {
 }
 
 ext {
-  releaseVersionRegex = /\d+\.\d+\.\d+(-alpha|-beta)?(\+\d{3})?/
+    releaseVersionRegex = /\d+\.\d+\.\d+(-alpha|-beta)?(\+\d{3})?/
+    circleBuildNum = System.getenv('CIRCLE_BUILD_NUM')
 }
 
 bintrayUpload.onlyIf {


### PR DESCRIPTION
This makes each snapshot have a unique and consistent version number,
which means that using snapshot dependencies should be more reliable
(since a specific snapshot should never be effectively overwritten by
another).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/988)
<!-- Reviewable:end -->
