### PR TITLE
improve schema lock error message

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
@@ -179,12 +179,15 @@ public class SchemaMutationLock {
     }
 
     private TimeoutException generateSchemaLockTimeoutException(Stopwatch stopwatch) {
-        return new TimeoutException(String.format("We have timed out waiting on the current"
-                        + " schema mutation lock holder. We have tried to grab the lock for %d milliseconds"
-                        + " unsuccessfully. This indicates that the current lock holder has died without"
-                        + " releasing the lock and will require manual intervention. Shut down all AtlasDB"
-                        + " clients and then run the clean-cass-locks-state cli command.",
-                stopwatch.elapsed(TimeUnit.MILLISECONDS)));
+        return new TimeoutException(
+                String.format("We have timed out waiting on the current"
+                                + " schema mutation lock holder. We have tried to grab the lock for %d milliseconds"
+                                + " unsuccessfully. This indicates that the current lock holder has died without"
+                                + " releasing the lock and will require manual intervention. Shut down all AtlasDB"
+                                + " clients operating on the %s keyspace and then run the clean-cass-locks-state"
+                                + " cli command.",
+                        stopwatch.elapsed(TimeUnit.MILLISECONDS),
+                        configManager.getConfig().keyspace()));
     }
 
     private void schemaMutationUnlock(long perOperationNodeIdentifier) {


### PR DESCRIPTION
A user with many different Atlas services wasn't sure which ones she would have to bounce when encountering this error.
This change should make it clearer to future users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/990)
<!-- Reviewable:end -->
