### PR TITLE
bypass a schema lock on startup if table exists; fixes #989

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -40,17 +40,6 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 @Path("/keyvalue")
 public interface KeyValueService extends AutoCloseable {
     /**
-     * Performs any initialization that must be done on a fresh instance of the key-value store,
-     * such as creating the metadata table.
-     *
-     * This method should be called when the key-value store is first created. Further calls in the
-     * lifetime of the key-value store should be silently ignored.
-     */
-    @POST
-    @Path("initialize")
-    void initializeFromFreshInstance();
-
-    /**
      * Performs non-destructive cleanup when the KVS is no longer needed.
      */
     @POST

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -54,7 +54,6 @@ public class CassandraClientPoolIntegrationTest {
         kv = CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG),
                 CassandraTestSuite.LEADER_CONFIG);
-        kv.initializeFromFreshInstance();
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
@@ -60,6 +60,7 @@ public class CassandraConnectionIntegrationTest {
         assert true; // getting here implies authentication succeeded
     }
 
+    // Don't worry about failing this test if you're running against a local Cassandra that isn't setup with auth magic
     @Test
     public void testAuthMissing() {
         try {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -148,4 +148,32 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
         existingMetadata = kvs.getMetadataForTable(missingMetadataTable);
         assertThat(initialMetadata, is(existingMetadata));
     }
+
+    @Test
+    public void testGetMetadataCaseInsensitive() {
+        // Make two casewise-different references to the "same" table
+        TableReference caseSensitiveTable = TableReference.createFromFullyQualifiedName("test.cased_table");
+        TableReference wackyCasedTable = TableReference.createFromFullyQualifiedName("test.CaSeD_TaBlE");
+
+        byte[] initialMetadata = new TableDefinition() {{
+            rowName();
+            rowComponent("blob", ValueType.BLOB);
+            columns();
+            column("bar", "b", ValueType.BLOB);
+            conflictHandler(ConflictHandler.IGNORE_ALL);
+            sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING);
+        }}.toTableMetadata().persistToBytes();
+
+        kvs.createTable(caseSensitiveTable, initialMetadata);
+
+        // retrieve the metadata and see that it's the same as what we just put in
+        byte[] existingMetadata = kvs.getMetadataForTable(caseSensitiveTable);
+        assertThat(initialMetadata, is(existingMetadata));
+
+        // retrieve same metadata with a wacky cased version of the "same" name
+        existingMetadata = kvs.getMetadataForTable(wackyCasedTable);
+        assertThat(initialMetadata, is(existingMetadata));
+
+        kvs.dropTable(caseSensitiveTable);
+    }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -32,7 +32,6 @@ public class CassandraTimestampIntegrationTest {
     public void setUp() {
         kv = CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.CASSANDRA_KVS_CONFIG), CassandraTestSuite.LEADER_CONFIG);
-        kv.initializeFromFreshInstance();
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
@@ -258,11 +258,6 @@ public class CQLKeyValueService extends AbstractKeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        // we already did our init in our factory method
-    }
-
-    @Override
     public void close() {
         log.info("Closing CQLKeyValueService");
         session.close();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -136,7 +136,6 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
  * and these inactive nodes will be removed afterwards.
  */
 public class CassandraKeyValueService extends AbstractKeyValueService {
-
     private final Logger log;
 
     private static final Function<Entry<Cell, Value>, Long> ENTRY_SIZING_FUNCTION = input ->
@@ -236,11 +235,6 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         CassandraKeyValueServices.failQuickInInitializationIfClusterAlreadyInInconsistentState(
                 clientPool,
                 configManager.getConfig());
-    }
-
-    @Override
-    public void initializeFromFreshInstance() {
-        // we already did our init in our factory method
     }
 
     private void upgradeFromOlderInternalSchema() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -51,12 +51,6 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        delegate1.initializeFromFreshInstance();
-        delegate2.initializeFromFreshInstance();
-    }
-
-    @Override
     public void close() {
         delegate1.close();
         delegate2.close();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
@@ -46,11 +46,6 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        delegate().initializeFromFreshInstance();
-    }
-
-    @Override
     public void close() {
         delegate().close();
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -86,11 +86,6 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        // All initialization is done in the constructor and initializers above
-    }
-
-    @Override
     public Map<Cell, Value> getRows(TableReference tableRef, Iterable<byte[]> rows,
                                     ColumnSelection columnSelection, long timestamp) {
         Map<Cell, Value> result = Maps.newHashMap();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -316,17 +316,6 @@ public class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        if (log.isTraceEnabled()) {
-            Stopwatch stopwatch = Stopwatch.createStarted();
-            delegate.initializeFromFreshInstance();
-            logTime("initializeFromFreshInstance", stopwatch);
-        } else {
-            delegate.initializeFromFreshInstance();
-        }
-    }
-
-    @Override
     public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp) {
         if (log.isTraceEnabled()) {
             Stopwatch stopwatch = Stopwatch.createStarted();

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -150,13 +150,6 @@ public class DbKvs extends AbstractKeyValueService {
             }
         });
     }
-
-    @Override
-    public void initializeFromFreshInstance() {
-        // do nothing
-    }
-
-    @Override
     public void close() {
         super.close();
         dbTables.close();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/NamespacedKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/NamespacedKeyValueService.java
@@ -42,8 +42,6 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 public interface NamespacedKeyValueService {
     Collection<? extends KeyValueService> getDelegates();
 
-    void initializeFromFreshInstance();
-
     void close();
 
     void teardown();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespaceMappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespaceMappingKeyValueService.java
@@ -210,11 +210,6 @@ public class NamespaceMappingKeyValueService extends ForwardingObject implements
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        delegate().initializeFromFreshInstance();
-    }
-
-    @Override
     public void close() {
         delegate().close();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -246,11 +246,6 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        delegate.initializeFromFreshInstance();
-    }
-
-    @Override
     public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable,
                          long timestamp) {
         delegate().multiPut(tableMapper.mapToShortTableNames(valuesByTable), timestamp);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -274,13 +274,6 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        for (KeyValueService delegate : delegates) {
-            delegate.initializeFromFreshInstance();
-        }
-    }
-
-    @Override
     public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp) {
         Map<KeyValueService, Map<TableReference, Map<Cell, byte[]>>> mapByDelegate = Maps.newHashMap();
         for (Entry<TableReference, ? extends Map<Cell, byte[]>> e : valuesByTable.entrySet()) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/ThrowingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/ThrowingKeyValueService.java
@@ -58,11 +58,6 @@ public class ThrowingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        // do nothing
-    }
-
-    @Override
     public void close() {
         // do nothing
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TieredKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TieredKeyValueService.java
@@ -126,12 +126,6 @@ public final class TieredKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        primary.initializeFromFreshInstance();
-        secondary.initializeFromFreshInstance();
-    }
-
-    @Override
     public void close() {
         primary.close();
         secondary.close();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/partition/PartitionedKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/partition/PartitionedKeyValueService.java
@@ -768,19 +768,6 @@ public class PartitionedKeyValueService extends PartitionMapProvider implements 
         });
     }
 
-    @Override
-    public void initializeFromFreshInstance() {
-        runWithPartitionMapRetryable(new Function<DynamicPartitionMap, Void>() {
-            @Override
-            public Void apply(@Nullable DynamicPartitionMap input) {
-                for (KeyValueService kvs : input.getDelegates()) {
-                    kvs.initializeFromFreshInstance();
-                }
-                return null;
-            }
-        });
-    }
-
     // *** Creation *******************************************************************************
     protected PartitionedKeyValueService(ExecutorService executor, QuorumParameters quorumParameters,
             ImmutableList<PartitionMapService> partitionMapProviders, int partitionMapProvidersReadFactor) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/partition/server/EndpointServer.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/partition/server/EndpointServer.java
@@ -122,17 +122,6 @@ public class EndpointServer implements PartitionMapService, KeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        runPartitionMapReadOperation(new Function<Void, Void>() {
-            @Override
-            public Void apply(Void input) {
-                kvs().initializeFromFreshInstance();
-                return null;
-            }
-        });
-    }
-
-    @Override
     public void close() {
         runPartitionMapReadOperation(new Function<Void, Void>() {
             @Override

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -184,11 +184,6 @@ public class JdbcKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        // do nothing
-    }
-
-    @Override
     public Collection<? extends KeyValueService> getDelegates() {
         return ImmutableList.of();
     }

--- a/atlasdb-rocksdb/src/main/java/com/palantir/atlasdb/keyvalue/rocksdb/impl/RocksDbKeyValueService.java
+++ b/atlasdb-rocksdb/src/main/java/com/palantir/atlasdb/keyvalue/rocksdb/impl/RocksDbKeyValueService.java
@@ -265,11 +265,6 @@ public class RocksDbKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void initializeFromFreshInstance() {
-        // nothing
-    }
-
-    @Override
     public void close() {
         if (!closed) {
             try {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -84,7 +84,6 @@ public abstract class TransactionTestSetup {
     public void setUp() throws Exception {
         keyValueService = getKeyValueService();
         timestampService = new InMemoryTimestampService();
-        keyValueService.initializeFromFreshInstance();
         keyValueService.createTables(ImmutableMap.of(
                 TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA,
                 TransactionConstants.TRANSACTION_TABLE, TransactionConstants.TRANSACTION_TABLE_METADATA.persistToBytes()));

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -93,7 +93,6 @@ public class AtlasDbTestCase {
         KeyValueService kvs = getBaseKeyValueService();
         keyValueServiceWithStats = new StatsTrackingKeyValueService(kvs);
         keyValueService = new TrackingKeyValueService(keyValueServiceWithStats);
-        keyValueService.initializeFromFreshInstance();
         TransactionTables.createTables(kvs);
         transactionService = TransactionServices.createTransactionService(kvs);
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,6 +41,11 @@ v0.19.0
     *    - Type
          - Change
 
+    *    - |fixed|
+         - In Cassandra KVS, We now no longer take out the schema mutation lock in calls to `createTables` if tables already exist.
+           This fixes the issue that prevented the `clean-cass-locks-state` CLI from running correctly.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/991>`__)
+
     *    - |breaking|
          - Removed the following classes that appeared to be unused - ``ManyHostPoolingContainer``, ``CloseShieldedKeyValueService``, ``RowWrapper``, ``BatchRowVisitor``,
            ``MapCollector``, ``DBMgrConfigurationException``, and ``SqlStackLogWrapper``.  Please reach out to us if you are adversly affected by these removals.


### PR DESCRIPTION
In general this would have been automatically prevented if we had a core internal atlas schema, and the metadata / timestamp / sweep / ??? tables lived in that.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/991)
<!-- Reviewable:end -->
