### PR TITLE
change release note new -> improved

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,7 +41,7 @@ v0.17.0
     *    - Type
          - Change
 
-    *    - |new|
+    *    - |improved|
          - The schema mutation lock holder now writes a "heartbeat" to the database to indicate that it is still responsive.
            Other processes that are waiting for the schema mutation lock will now be able to see this heartbeat, infer that the lock holder is still working, and wait for longer.
            This should reduce the need to manually truncate the locks table.


### PR DESCRIPTION
I think this release note entry should actually be improved rather than new. We're doing something new by adding in the heartbeat, but there isn't new functionality exposed to users, and the overall process of "waiting on schema mutations" has been "improved".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1007)
<!-- Reviewable:end -->
