### PR TITLE
Backup lock

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasCli.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasCli.java
@@ -20,8 +20,10 @@ import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.atlasdb.cli.command.BackupLockCommand;
 import com.palantir.atlasdb.cli.command.CleanCassLocksStateCommand;
 import com.palantir.atlasdb.cli.command.KvsMigrationCommand;
+import com.palantir.atlasdb.cli.command.PersistentLockCommand;
 import com.palantir.atlasdb.cli.command.SweepCommand;
 import com.palantir.atlasdb.cli.command.timestamp.CleanTransactionRange;
 import com.palantir.atlasdb.cli.command.timestamp.FastForwardTimestamp;
@@ -42,7 +44,9 @@ public class AtlasCli {
                         Help.class,
                         SweepCommand.class,
                         KvsMigrationCommand.class,
-                        CleanCassLocksStateCommand.class);
+                        CleanCassLocksStateCommand.class,
+                        BackupLockCommand.class,
+                        PersistentLockCommand.class);
 
         builder.withGroup("timestamp")
                 .withDescription("Timestamp-centric commands")

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/BackupLockCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/BackupLockCommand.java
@@ -47,7 +47,10 @@ public class BackupLockCommand extends SingleBackendCommand {
         DeletionLock deletionLock = new DeletionLock(keyValueService);
 
         try {
-            deletionLock.runWithLock(() -> blockOnConsoleInput(console), "Backup lock CLI");
+            deletionLock.runWithLock(() -> {
+                blockOnConsoleInput(console);
+                return null;
+            }, "Backup lock CLI");
             return 0;
         } catch (PersistentLockIsTakenException e) {
             log.error("Another process is performing deletes. "

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/BackupLockCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/BackupLockCommand.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.cli.command;
+
+import java.io.Console;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.persistentlock.DeletionLock;
+import com.palantir.atlasdb.persistentlock.PersistentLockIsTakenException;
+import com.palantir.atlasdb.services.AtlasDbServices;
+
+import io.airlift.airline.Command;
+
+@Command(name = "backup-lock", description = "Prevent deletions during a backup")
+public class BackupLockCommand extends SingleBackendCommand {
+    private static final Logger log = LoggerFactory.getLogger(BackupLockCommand.class);
+
+    @Override
+    public boolean isOnlineRunSupported() {
+        return true;
+    }
+
+    @Override
+	public int execute(final AtlasDbServices services) {
+        Console console = System.console();
+        Preconditions.checkNotNull(console,
+                "This CLI must be run inside an interactive console. Pipelines are not supported");
+
+        KeyValueService keyValueService = services.getKeyValueService();
+        DeletionLock deletionLock = new DeletionLock(keyValueService);
+
+        try {
+            deletionLock.runWithLock(() -> blockOnConsoleInput(console), "Backup lock CLI");
+            return 0;
+        } catch (PersistentLockIsTakenException e) {
+            log.error("Another process is performing deletes. "
+                    + "It is not safe to take a backup now, as it may become corrupted", e);
+            return 1;
+        }
+    }
+
+    private void blockOnConsoleInput(Console console) {
+        log.info("Successfully acquired the lock. "
+                + "When your backup is complete, press ENTER to release it");
+        console.readLine();
+        log.info("Will now release the lock");
+    }
+}

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/PersistentLockCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/PersistentLockCommand.java
@@ -93,7 +93,7 @@ public class PersistentLockCommand extends SingleBackendCommand {
 
     private int releaseLock(PersistentLock persistentLock, String lockName, long lockId) {
         LockEntry lockToRelease = LockEntry.of(PersistentLockName.of(lockName), lockId);
-        persistentLock.unlock(lockToRelease);
+        persistentLock.releaseLock(lockToRelease);
         log.info("This persistent lock is now released: " + lockToRelease);
         return 0;
     }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/PersistentLockCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/PersistentLockCommand.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.cli.command;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.persistentlock.LockEntry;
+import com.palantir.atlasdb.persistentlock.PersistentLock;
+import com.palantir.atlasdb.persistentlock.PersistentLockIsTakenException;
+import com.palantir.atlasdb.persistentlock.PersistentLockName;
+import com.palantir.atlasdb.services.AtlasDbServices;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+@Command(name = "persistent-lock", description = "Manipulate persistent locks - use with caution!")
+public class PersistentLockCommand extends SingleBackendCommand {
+    private static final Logger log = LoggerFactory.getLogger(PersistentLockCommand.class);
+
+    @Option(name = {"-l", "--list"},
+            description = "List all the persistent locks currently taken")
+    boolean listLocks;
+
+    @Option(name = {"-a", "--acquire"},
+            description = "Name of the lock to acquire")
+    String acquireLockName;
+
+    @Option(name = {"-r", "--release"},
+            description = "Name of the lock to release")
+    String releaseLockName;
+
+    @Option(name = {"-i", "--lockId"},
+            description = "Long ID of the lock to release")
+    String releaseLockId;
+
+    @Override
+    public boolean isOnlineRunSupported() {
+        return true;
+    }
+
+    @Override
+    public int execute(final AtlasDbServices services) {
+        KeyValueService keyValueService = services.getKeyValueService();
+        PersistentLock persistentLock = new PersistentLock(keyValueService);
+
+        System.out.println("keyValueService = " + keyValueService);
+
+        if (acquireLockName != null) {
+            return acquireLock(persistentLock, acquireLockName);
+        } else if (releaseLockName != null) {
+            if (releaseLockId != null) {
+                return releaseLock(persistentLock, releaseLockName, Long.parseLong(releaseLockId));
+            } else {
+                log.error("To release a lock, you must specify its lockId");
+                return 1;
+            }
+        } else if (listLocks) {
+            return printLockList(persistentLock);
+        } else {
+            log.error("See the help page for instructions on how to use this CLI");
+            return 1;
+        }
+    }
+
+    private int acquireLock(PersistentLock persistentLock, String lockName) {
+        try {
+            LockEntry acquiredLock = persistentLock.acquireLock(
+                    PersistentLockName.of(lockName), "PersistentLock CLI command");
+            log.info("Successfully acquired persistent lock " + acquiredLock);
+            return 0;
+        } catch (PersistentLockIsTakenException e) {
+            log.error("Could not acquire the lock because it was already taken", e);
+            return 1;
+        }
+    }
+
+    private int releaseLock(PersistentLock persistentLock, String lockName, long lockId) {
+        LockEntry lockToRelease = LockEntry.of(PersistentLockName.of(lockName), lockId);
+        persistentLock.unlock(lockToRelease);
+        log.info("This persistent lock is now released: " + lockToRelease);
+        return 0;
+    }
+
+    private int printLockList(PersistentLock persistentLock) {
+        List<LockEntry> allLockEntries = persistentLock.allLockEntries();
+        log.info("The following persistent locks are currently taken out (total " + allLockEntries.size() + ")");
+        for (LockEntry lockEntry : allLockEntries) {
+            log.info(lockEntry.toString());
+        }
+        return 0;
+    }
+}

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/PersistentLockCommandTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/PersistentLockCommandTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.cli.command;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.palantir.atlasdb.cli.runner.InMemoryTestRunner;
+import com.palantir.atlasdb.cli.runner.SingleBackendCliTestRunner;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.persistentlock.PersistentLock;
+import com.palantir.atlasdb.persistentlock.PersistentLockIsTakenException;
+import com.palantir.atlasdb.persistentlock.PersistentLockName;
+import com.palantir.atlasdb.services.AtlasDbServicesFactory;
+import com.palantir.atlasdb.services.ServicesConfigModule;
+import com.palantir.atlasdb.services.test.DaggerTestAtlasDbServices;
+import com.palantir.atlasdb.services.test.TestAtlasDbServices;
+
+import io.airlift.airline.Command;
+
+public class PersistentLockCommandTest {
+    private static final String LOCK_COMMAND_NAME = PersistentLockCommand.class.getAnnotation(Command.class).name();
+    private static final PersistentLockName LOCK_NAME = PersistentLockName.of("someLockName");
+
+    private static AtlasDbServicesFactory moduleFactory;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        moduleFactory = new AtlasDbServicesFactory() {
+            @Override
+            public TestAtlasDbServices connect(ServicesConfigModule servicesConfigModule) {
+                return DaggerTestAtlasDbServices.builder()
+                        .servicesConfigModule(servicesConfigModule)
+                        .build();
+            }
+        };
+    }
+
+    private InMemoryTestRunner makeRunner(String... args) {
+        return new InMemoryTestRunner(PersistentLockCommand.class, args);
+    }
+
+    @Test
+    public void acquireLock() throws Exception {
+        try (SingleBackendCliTestRunner runner = makeRunner(LOCK_COMMAND_NAME, "--acquire", LOCK_NAME.name())) {
+            TestAtlasDbServices services = runner.connect(moduleFactory);
+
+            runner.run();
+
+            List<PersistentLockName> lockNames = getAllLockNames(services.getKeyValueService());
+            assertThat(lockNames, contains(LOCK_NAME));
+        }
+    }
+
+    @Test
+    public void listLocks() throws Exception {
+        try (SingleBackendCliTestRunner runner = makeRunner(LOCK_COMMAND_NAME, "--list")) {
+            TestAtlasDbServices services = runner.connect(moduleFactory);
+            writeLock(services.getKeyValueService());
+
+            String stdout = runner.run();
+
+            assertThat(stdout, containsString(LOCK_NAME.name()));
+        }
+    }
+
+    private List<PersistentLockName> getAllLockNames(KeyValueService keyValueService) {
+        PersistentLock persistentLock = new PersistentLock(keyValueService);
+
+        return persistentLock.allLockEntries().stream()
+                .map(lockEntry -> lockEntry.lockName())
+                .collect(Collectors.toList());
+    }
+
+    private void writeLock(KeyValueService keyValueService) throws PersistentLockIsTakenException {
+        PersistentLock persistentLock = new PersistentLock(keyValueService);
+        persistentLock.acquireLock(LOCK_NAME, "Some reason");
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -34,6 +34,8 @@ public class AtlasDbConstants {
     public static final TableReference NAMESPACE_TABLE = TableReference.createWithEmptyNamespace("_namespace");
     public static final TableReference TIMESTAMP_TABLE = TableReference.createWithEmptyNamespace("_timestamp");
     public static final TableReference METADATA_TABLE = TableReference.createWithEmptyNamespace("_metadata");
+    public static final TableReference PERSISTED_LOCKS_TABLE =
+            TableReference.createWithEmptyNamespace("_persisted_locks");
     public static final String NAMESPACE_PREFIX = "_n_";
     public static final String NAMESPACE_SHORT_COLUMN_NAME = "s";
     public static final byte[] NAMESPACE_SHORT_COLUMN_BYTES = PtBytes.toBytes(NAMESPACE_SHORT_COLUMN_NAME);
@@ -58,7 +60,8 @@ public class AtlasDbConstants {
             PUNCH_TABLE,
             SCRUB_TABLE,
             NAMESPACE_TABLE,
-            PARTITION_MAP_TABLE);
+            PARTITION_MAP_TABLE,
+            PERSISTED_LOCKS_TABLE);
     public static final Set<TableReference> SKIP_POSTFILTER_TABLES = ImmutableSet.of(TransactionConstants.TRANSACTION_TABLE,
             NAMESPACE_TABLE);
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -43,6 +43,7 @@ import com.palantir.atlasdb.keyvalue.impl.NamespacedKeyValueServices;
 import com.palantir.atlasdb.keyvalue.impl.ProfilingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.ValidatingQueryRewritingKeyValueService;
+import com.palantir.atlasdb.persistentlock.DeletionLock;
 import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
@@ -160,9 +161,11 @@ public final class TransactionManagers {
                 cleaner,
                 allowHiddenTableAccess);
 
+        DeletionLock deletionLock = new DeletionLock(kvs);
         SweepTaskRunner sweepRunner = new SweepTaskRunnerImpl(
                 transactionManager,
                 kvs,
+                deletionLock,
                 getUnreadableTsSupplier(transactionManager),
                 getImmutableTsSupplier(transactionManager),
                 transactionService,

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/SweeperModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/SweeperModule.java
@@ -21,6 +21,7 @@ import javax.inject.Singleton;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.persistentlock.DeletionLock;
 import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.sweep.SweepTaskRunnerImpl;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -43,6 +44,7 @@ public class SweeperModule {
         return new SweepTaskRunnerImpl(
                 txm,
                 kvs,
+                new DeletionLock(kvs),
                 txm::getUnreadableTimestamp,
                 txm::getImmutableTimestamp,
                 transactionService,

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestSweeperModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestSweeperModule.java
@@ -23,6 +23,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.persistentlock.DeletionLock;
 import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.sweep.SweepTaskRunnerImpl;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -65,9 +66,11 @@ public class TestSweeperModule {
                                                   Follower follower) {
         Supplier<Long> unreadable = unreadableTs.isPresent() ? unreadableTs.get() : txm::getUnreadableTimestamp;
         Supplier<Long> immutable = immutableTs.isPresent() ? immutableTs.get() : txm::getImmutableTimestamp;
+        DeletionLock deletionLock = new DeletionLock(kvs);
         return new SweepTaskRunnerImpl(
                 txm,
                 kvs,
+                deletionLock,
                 unreadable,
                 immutable,
                 transactionService,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.persistentlock.DeletionLock;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.time.Clock;
 import com.palantir.lock.LockClient;
@@ -109,8 +110,10 @@ public class DefaultCleanerBuilder {
     private Scrubber buildScrubber(Supplier<Long> unreadableTimestampSupplier,
                                    Supplier<Long> immutableTimestampSupplier) {
         ScrubberStore scrubberStore = KeyValueServiceScrubberStore.create(keyValueService);
+        DeletionLock deletionLock = new DeletionLock(keyValueService);
         return Scrubber.create(
                 keyValueService,
+                deletionLock,
                 scrubberStore,
                 Suppliers.ofInstance(backgroundScrubFrequencyMillis),
                 Suppliers.ofInstance(true),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -523,7 +523,7 @@ public final class Scrubber {
             long scrubTimestamp,
             Transaction.TransactionType transactionType) {
         try {
-            deletionLock.runWithLock(
+            deletionLock.runWithLockNonExclusively(
                     () -> scrubCellsInternal(txManager, tableNameToCells, scrubTimestamp, transactionType),
                     "Scrub");
         } catch (PersistentLockIsTakenException e) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -523,9 +523,10 @@ public final class Scrubber {
             long scrubTimestamp,
             Transaction.TransactionType transactionType) {
         try {
-            deletionLock.runWithLockNonExclusively(
-                    () -> scrubCellsInternal(txManager, tableNameToCells, scrubTimestamp, transactionType),
-                    "Scrub");
+            deletionLock.runWithLockNonExclusively(() -> {
+                scrubCellsInternal(txManager, tableNameToCells, scrubTimestamp, transactionType);
+                return null;
+            }, "Scrub");
         } catch (PersistentLockIsTakenException e) {
             throw new RuntimeException(e);
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/DeletionLock.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/DeletionLock.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.persistentlock;
+
+import com.google.common.base.Supplier;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+
+public class DeletionLock {
+
+    private final PersistentLock persistentLock;
+    private PersistentLockName lockName = PersistentLockName.of("DeletionLock");
+
+    public DeletionLock(KeyValueService keyValueService) {
+        this.persistentLock = new PersistentLock(keyValueService);
+    }
+
+    public <T> T runWithLock(Supplier<T> supplier, String reason) throws PersistentLockIsTakenException {
+        return persistentLock.runWithLock(supplier, lockName, reason);
+    }
+
+    public void runWithLock(PersistentLock.Action action, String reason) throws PersistentLockIsTakenException {
+        persistentLock.runWithLock(action, lockName, reason);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/DeletionLock.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/DeletionLock.java
@@ -15,11 +15,11 @@
  */
 package com.palantir.atlasdb.persistentlock;
 
-import com.google.common.base.Supplier;
+import java.util.function.Supplier;
+
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 
 public class DeletionLock {
-
     private final PersistentLock persistentLock;
     private PersistentLockName lockName = PersistentLockName.of("DeletionLock");
 
@@ -28,20 +28,10 @@ public class DeletionLock {
     }
 
     public <T> T runWithLock(Supplier<T> supplier, String reason) throws PersistentLockIsTakenException {
-        return persistentLock.runWithLock(supplier, lockName, reason);
-    }
-
-    public void runWithLock(PersistentLock.Action action, String reason) throws PersistentLockIsTakenException {
-        persistentLock.runWithLock(action, lockName, reason);
+        return persistentLock.runWithExclusiveLock(supplier, lockName, reason);
     }
 
     public <T> T  runWithLockNonExclusively(Supplier<T> supplier, String reason) throws PersistentLockIsTakenException {
-        return persistentLock.runWithLockNonExclusively(supplier, lockName, reason);
+        return persistentLock.runWithNonExclusiveLock(supplier, lockName, reason);
     }
-
-    public void runWithLockNonExclusively(
-            PersistentLock.Action action, String reason) throws PersistentLockIsTakenException {
-        persistentLock.runWithLockNonExclusively(action, lockName, reason);
-    }
-
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/DeletionLock.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/DeletionLock.java
@@ -34,4 +34,14 @@ public class DeletionLock {
     public void runWithLock(PersistentLock.Action action, String reason) throws PersistentLockIsTakenException {
         persistentLock.runWithLock(action, lockName, reason);
     }
+
+    public <T> T  runWithLockNonExclusively(Supplier<T> supplier, String reason) throws PersistentLockIsTakenException {
+        return persistentLock.runWithLockNonExclusively(supplier, lockName, reason);
+    }
+
+    public void runWithLockNonExclusively(
+            PersistentLock.Action action, String reason) throws PersistentLockIsTakenException {
+        persistentLock.runWithLockNonExclusively(action, lockName, reason);
+    }
+
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockEntry.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockEntry.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.persistentlock;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 
 import org.immutables.value.Value;
 
@@ -66,7 +65,9 @@ public abstract class LockEntry {
         return ImmutableLockEntry.of(extractLockName(rowName), extractLockId(rowName), reason, exclusive);
     }
 
-    public static String valueOfColumnInRow(String columnName, RowResult<com.palantir.atlasdb.keyvalue.api.Value> rowResult) {
+    public static String valueOfColumnInRow(
+            String columnName,
+            RowResult<com.palantir.atlasdb.keyvalue.api.Value> rowResult) {
         Cell columnCell = rowResult.getCellSet().stream()
                 .filter(cell -> Arrays.equals(cell.getColumnName(), asUtf8Bytes(columnName)))
                 .findFirst()

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockEntry.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockEntry.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.persistentlock;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.immutables.value.Value;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+
+@Value.Immutable
+public abstract class LockEntry {
+    public static final String DELIMITER = "_";
+
+    @Value.Parameter
+    public abstract PersistentLockName lockName();
+
+    @Value.Parameter
+    public abstract long lockId();
+
+    @Value.Parameter
+    public abstract String reason();
+
+    public static LockEntry of(PersistentLockName lockName, long lockId, String reason) {
+        return ImmutableLockEntry.of(lockName, lockId, reason);
+    }
+
+    public static LockEntry of(PersistentLockName lockName, long lockId) {
+        return ImmutableLockEntry.of(lockName, lockId, "");
+    }
+
+    public static LockEntry fromRowResult(RowResult<com.palantir.atlasdb.keyvalue.api.Value> rowResult) {
+        String rowName = new String(rowResult.getRowName(), StandardCharsets.UTF_8);
+        String reason = new String(rowResult.getOnlyColumnValue().getContents(), StandardCharsets.UTF_8);
+
+        return ImmutableLockEntry.of(extractLockName(rowName), extractLockId(rowName), reason);
+    }
+
+    public Map<Cell, byte[]> insertionMap() {
+        return ImmutableMap.of(lockTableCell(), asUtf8(reason()));
+    }
+
+    public Multimap<Cell, Long> deletionMapWithTimestamp(long timestamp) {
+        return ImmutableMultimap.of(lockTableCell(), timestamp);
+    }
+
+    private Cell lockTableCell() {
+        byte[] rowName = makeLockRowName(lockName(), lockId());
+        byte[] columnName = asUtf8("reasonForLock");
+        return Cell.create(rowName, columnName);
+    }
+
+    private byte[] makeLockRowName(PersistentLockName lock, long thisId) {
+        return asUtf8(lock.name() + DELIMITER + thisId);
+    }
+
+    private byte[] asUtf8(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static PersistentLockName extractLockName(String rowName) {
+        String[] rowNameParts = rowName.split(DELIMITER);
+        return PersistentLockName.of(rowNameParts[0]);
+    }
+
+    private static long extractLockId(String rowName) {
+        String[] rowNameParts = rowName.split(DELIMITER);
+        return Long.parseLong(rowNameParts[1]);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLock.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLock.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.persistentlock;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.common.base.Throwables;
+
+public class PersistentLock {
+    public static final long LOCKS_TIMESTAMP = 0L;
+
+    private static final Logger log = LoggerFactory.getLogger(PersistentLock.class);
+
+    private final KeyValueService keyValueService;
+
+    public PersistentLock(KeyValueService keyValueService) {
+        this.keyValueService = keyValueService;
+
+        createPersistedLocksTableIfNotExists();
+    }
+
+    public interface Action {
+        void execute() throws Exception;
+    }
+
+    public <T> T runWithLock(
+            Supplier<T> supplier,
+            PersistentLockName lock, String reason) throws PersistentLockIsTakenException {
+        LockEntry acquiredLock = acquireLock(lock, reason);
+
+        try {
+            return supplier.get();
+        } catch (Exception e) {
+            throw Throwables.throwUncheckedException(e);
+        } finally {
+            unlock(acquiredLock);
+        }
+    }
+
+    public void runWithLock(
+            Action action, PersistentLockName lock,
+            String reason) throws PersistentLockIsTakenException {
+        runWithLock(() -> {
+            try {
+                action.execute();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        }, lock, reason);
+    }
+
+    private LockEntry acquireLock(PersistentLockName lockName, String reason) throws PersistentLockIsTakenException {
+        long thisId = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+        LockEntry lockEntry = LockEntry.of(lockName, thisId, reason);
+
+        insertLockEntry(lockEntry);
+
+        return verifyLockWasSuccessfullyAcquired(lockEntry);
+    }
+
+    private LockEntry verifyLockWasSuccessfullyAcquired(LockEntry lockEntry) throws PersistentLockIsTakenException {
+        List<LockEntry> relevantLocks = allRelevantLockRows(lockEntry.lockName());
+        if (onlyLockIsOurs(lockEntry, relevantLocks)) {
+            log.debug("Acquired persistent lock " + lockEntry);
+            return lockEntry;
+        } else {
+            log.debug("Failed to acquire persistent lock " + lockEntry);
+            unlock(lockEntry);
+
+            Optional<LockEntry> otherLock = relevantLocks.stream()
+                    .filter(otherLockEntry -> otherLockEntry.lockId() != lockEntry.lockId())
+                    .findFirst();
+
+            throw new PersistentLockIsTakenException(otherLock);
+        }
+    }
+
+    private void unlock(LockEntry lock) {
+        log.info("Releasing persistent lock " + lock);
+        keyValueService.delete(AtlasDbConstants.PERSISTED_LOCKS_TABLE, lock.deletionMapWithTimestamp(LOCKS_TIMESTAMP));
+    }
+
+    private void insertLockEntry(LockEntry lockEntry) {
+        log.debug("Attempting to acquire persistent lock " + lockEntry);
+        keyValueService.put(AtlasDbConstants.PERSISTED_LOCKS_TABLE, lockEntry.insertionMap(), LOCKS_TIMESTAMP);
+    }
+
+    private boolean onlyLockIsOurs(LockEntry ourLock, List<LockEntry> relevantLocks) {
+        return relevantLocks.size() == 1 && relevantLocks.get(0).equals(ourLock);
+    }
+
+    private List<LockEntry> allRelevantLockRows(PersistentLockName lock) {
+        ImmutableList<RowResult<Value>> allLocks = ImmutableList.copyOf(keyValueService.getRange(
+                AtlasDbConstants.PERSISTED_LOCKS_TABLE, RangeRequest.all(), LOCKS_TIMESTAMP + 1));
+
+        return allLocks.stream()
+                .map(LockEntry::fromRowResult)
+                .filter(lockEntry -> lockEntry.lockName().equals(lock))
+                .collect(Collectors.toList());
+    }
+
+    private void createPersistedLocksTableIfNotExists() {
+        if (!keyValueService.getAllTableNames().contains(AtlasDbConstants.PERSISTED_LOCKS_TABLE)) {
+            keyValueService.createTable(
+                    AtlasDbConstants.PERSISTED_LOCKS_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLockIsTakenException.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLockIsTakenException.java
@@ -15,24 +15,18 @@
  */
 package com.palantir.atlasdb.persistentlock;
 
-import java.util.Optional;
+import java.util.List;
 
 public class PersistentLockIsTakenException extends Exception {
-    private final Optional<LockEntry> otherLock;
+    private final List<LockEntry> conflictingLocks;
 
-    public PersistentLockIsTakenException(Optional<LockEntry> otherLock) {
-        this.otherLock = otherLock;
+    public PersistentLockIsTakenException(List<LockEntry> conflictingLocks) {
+        this.conflictingLocks = conflictingLocks;
     }
 
     @Override
     public String getMessage() {
-        if (otherLock.isPresent()) {
-            LockEntry otherLockEntry = otherLock.get();
-            return "Lock " + otherLockEntry.lockName().name()
-                    + " with id=" + otherLockEntry.lockId()
-                    + " was already taken: " + otherLockEntry.reason();
-        } else {
-            return "Could not register lock";
-        }
+        return "Could not acquire the requested lock because it conflicts with the following other lock(s): "
+                + conflictingLocks;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLockIsTakenException.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLockIsTakenException.java
@@ -27,7 +27,10 @@ public class PersistentLockIsTakenException extends Exception {
     @Override
     public String getMessage() {
         if (otherLock.isPresent()) {
-            return "Lock " + otherLock.get().lockName() + "was already taken: " + otherLock.get().reason();
+            LockEntry otherLockEntry = otherLock.get();
+            return "Lock " + otherLockEntry.lockName().name()
+                    + " with id=" + otherLockEntry.lockId()
+                    + " was already taken: " + otherLockEntry.reason();
         } else {
             return "Could not register lock";
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLockIsTakenException.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLockIsTakenException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.persistentlock;
+
+import java.util.Optional;
+
+public class PersistentLockIsTakenException extends Exception {
+    private final Optional<LockEntry> otherLock;
+
+    public PersistentLockIsTakenException(Optional<LockEntry> otherLock) {
+        this.otherLock = otherLock;
+    }
+
+    @Override
+    public String getMessage() {
+        if (otherLock.isPresent()) {
+            return "Lock " + otherLock.get().lockName() + "was already taken: " + otherLock.get().reason();
+        } else {
+            return "Could not register lock";
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLockName.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/PersistentLockName.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.persistentlock;
+
+import org.immutables.value.Value;
+
+import com.google.common.base.Preconditions;
+
+@Value.Immutable
+public abstract class PersistentLockName {
+    @Value.Parameter
+    public abstract String name();
+
+    @Value.Check
+    public void check() {
+        boolean isValidName = !name().contains(LockEntry.DELIMITER);
+        Preconditions.checkArgument(isValidName, "Lock names cannot contain '" + LockEntry.DELIMITER + "'");
+    }
+
+    public static PersistentLockName of(String lockName) {
+        return ImmutablePersistentLockName.builder().name(lockName).build();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImpl.java
@@ -124,7 +124,9 @@ public class SweepTaskRunnerImpl implements SweepTaskRunner {
 
         try {
             String reason = "Sweep for " + tableRef;
-            return deletionLock.runWithLock(() -> runSweepInternal(tableRef, batchSize, nullableStartRow), reason);
+            return deletionLock.runWithLockNonExclusively(
+                    () -> runSweepInternal(tableRef, batchSize, nullableStartRow),
+                    reason);
         } catch (PersistentLockIsTakenException e) {
             throw new RuntimeException(e);
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImpl.java
@@ -83,16 +83,20 @@ public class SweepTaskRunnerImpl implements SweepTaskRunner {
     private final TransactionService transactionService;
     private final SweepStrategyManager sweepStrategyManager;
     private final Collection<Follower> followers;
+    private final DeletionLock deletionLock;
 
-    public SweepTaskRunnerImpl(TransactionManager txManager,
-                           KeyValueService keyValueService,
-                           Supplier<Long> unreadableTimestampSupplier,
-                           Supplier<Long> immutableTimestampSupplier,
-                           TransactionService transactionService,
-                           SweepStrategyManager sweepStrategyManager,
-                           Collection<Follower> followers) {
+    public SweepTaskRunnerImpl(
+            TransactionManager txManager,
+            KeyValueService keyValueService,
+            DeletionLock deletionLock,
+            Supplier<Long> unreadableTimestampSupplier,
+            Supplier<Long> immutableTimestampSupplier,
+            TransactionService transactionService,
+            SweepStrategyManager sweepStrategyManager,
+            Collection<Follower> followers) {
         this.txManager = txManager;
         this.keyValueService = keyValueService;
+        this.deletionLock = deletionLock;
         this.unreadableTimestampSupplier = unreadableTimestampSupplier;
         this.immutableTimestampSupplier = immutableTimestampSupplier;
         this.transactionService = transactionService;
@@ -118,7 +122,6 @@ public class SweepTaskRunnerImpl implements SweepTaskRunner {
             return SweepResults.createEmptySweepResult(0L);
         }
 
-        DeletionLock deletionLock = new DeletionLock(keyValueService);
         try {
             String reason = "Sweep for " + tableRef;
             return deletionLock.runWithLock(() -> runSweepInternal(tableRef, batchSize, nullableStartRow), reason);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/PersistentLockNameShould.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/PersistentLockNameShould.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.persistentlock;
+
+import org.junit.Test;
+
+public class PersistentLockNameShould {
+
+    @Test (expected = IllegalArgumentException.class)
+    public void notAllowDelimiterInName() {
+        PersistentLockName.of("someName" + LockEntry.DELIMITER);
+    }
+
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/PersistentLocksShould.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/PersistentLocksShould.java
@@ -130,7 +130,7 @@ public class PersistentLocksShould {
         persistentLock.runWithLock(NO_ACTION, deletionLock, REASON);
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void forbidTwoProcessesFromRunningConcurrently()
             throws InterruptedException, ExecutionException, BrokenBarrierException {
         KeyValueService keyValueService = new InMemoryKeyValueService(false);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/PersistentLocksShould.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/PersistentLocksShould.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.persistentlock;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+
+public class PersistentLocksShould {
+    private static final String REASON = "for testing";
+
+    private static final PersistentLock.Action NO_ACTION = () -> { };
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void createPersistedLocksTable() {
+        KeyValueService keyValueService = mock(KeyValueService.class);
+        when(keyValueService.getAllTableNames()).thenReturn(ImmutableSet.of());
+
+        new PersistentLock(keyValueService);
+
+        verify(keyValueService).createTable(eq(AtlasDbConstants.PERSISTED_LOCKS_TABLE), any(byte[].class));
+    }
+
+    @Test
+    public void notCreatePersistedLocksTableIfItAlreadyExists() {
+        KeyValueService keyValueService = mock(KeyValueService.class);
+        when(keyValueService.getAllTableNames()).thenReturn(ImmutableSet.of(AtlasDbConstants.PERSISTED_LOCKS_TABLE));
+
+        new PersistentLock(keyValueService);
+
+        verify(keyValueService, times(0)).createTable(any(TableReference.class), any(byte[].class));
+    }
+
+    @Test
+    public void createAndReleaseLockIfNotAlreadyLocked() throws PersistentLockIsTakenException {
+        KeyValueService keyValueService = spy(new InMemoryKeyValueService(false));
+        PersistentLock persistentLock = new PersistentLock(keyValueService);
+
+        persistentLock.runWithLock(NO_ACTION, PersistentLockName.of("deletionLock"), REASON);
+
+        verify(keyValueService).put(eq(AtlasDbConstants.PERSISTED_LOCKS_TABLE), anyMap(), anyLong());
+        verify(keyValueService).delete(eq(AtlasDbConstants.PERSISTED_LOCKS_TABLE), any(Multimap.class));
+    }
+
+    @Test
+    public void successfullyGrabLockAfterItWasReleased() throws PersistentLockIsTakenException {
+        KeyValueService keyValueService = spy(new InMemoryKeyValueService(false));
+        PersistentLock persistentLock = new PersistentLock(keyValueService);
+
+        persistentLock.runWithLock(NO_ACTION, PersistentLockName.of("deletionLock"), REASON);
+        persistentLock.runWithLock(NO_ACTION, PersistentLockName.of("deletionLock"), REASON);
+    }
+
+    @Test
+    public void runActionWhileLockIsHeld() throws PersistentLockIsTakenException {
+        KeyValueService keyValueService = new InMemoryKeyValueService(false);
+        PersistentLock persistentLock = new PersistentLock(keyValueService);
+
+        persistentLock.runWithLock(
+                () -> {
+                    ImmutableList<RowResult<Value>> rowResults = ImmutableList.copyOf(
+                            keyValueService.getRange(AtlasDbConstants.PERSISTED_LOCKS_TABLE, RangeRequest.all(), 1));
+                    assertThat(rowResults.size(), equalTo(1));
+                },
+                PersistentLockName.of("deletionLock"),
+                REASON
+        );
+    }
+
+    @Test
+    public void throwIfLockAlreadyExists() throws PersistentLockIsTakenException {
+        KeyValueService keyValueService = spy(new InMemoryKeyValueService(false));
+        PersistentLock persistentLock = new PersistentLock(keyValueService);
+        PersistentLockName deletionLock = PersistentLockName.of("deletionLock");
+        LockEntry existingLock = LockEntry.of(PersistentLockName.of("deletionLock"), 4321, REASON);
+        keyValueService.put(AtlasDbConstants.PERSISTED_LOCKS_TABLE, existingLock.insertionMap(), 0);
+
+        expectedException.expect(PersistentLockIsTakenException.class);
+        expectedException.expectMessage(containsString("deletionLock"));
+        expectedException.expectMessage(containsString(REASON));
+        persistentLock.runWithLock(NO_ACTION, deletionLock, REASON);
+    }
+
+    @Test
+    public void forbidTwoProcessesFromRunningConcurrently()
+            throws InterruptedException, ExecutionException, BrokenBarrierException {
+        KeyValueService keyValueService = spy(new InMemoryKeyValueService(false));
+        PersistentLock persistentLock = new PersistentLock(keyValueService);
+        PersistentLockName deletionLock = PersistentLockName.of("deletionLock");
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        Semaphore semaphore = new Semaphore(0);
+
+        Future<Void> keepLockForever = executorService.submit(() -> {
+            persistentLock.runWithLock(() -> {
+                barrier.await();
+                semaphore.acquire();
+            }, deletionLock, REASON);
+            return null;
+        });
+
+        barrier.await();
+        Future<Void> task = executorService.submit(() -> {
+            persistentLock.runWithLock(NO_ACTION, deletionLock, REASON);
+            return null;
+        });
+
+        expectedException.expect(ExecutionException.class);
+        expectedException.expectCause(instanceOf(PersistentLockIsTakenException.class));
+        task.get();
+
+        semaphore.release();
+        keepLockForever.get();
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImplTest.java
@@ -330,7 +330,7 @@ public class SweepTaskRunnerImplTest {
     public void throwIfDeletionLockIsTaken() throws PersistentLockIsTakenException {
         TableReference tableReference = TableReference.createWithEmptyNamespace("someTable");
         int batchSize = 10;
-        when(mockDeletionLock.runWithLockNonExclusively(any(Supplier.class), anyString())).thenThrow(
+        when(mockDeletionLock.runWithLockNonExclusively(any(), anyString())).thenThrow(
                 new PersistentLockIsTakenException(ImmutableList.of()));
         when(mockKvs.getMetadataForTable(tableReference)).thenReturn(new byte[1]);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImplTest.java
@@ -332,7 +332,7 @@ public class SweepTaskRunnerImplTest {
         TableReference tableReference = TableReference.createWithEmptyNamespace("someTable");
         int batchSize = 10;
         when(mockDeletionLock.runWithLock(any(Supplier.class), anyString())).thenThrow(
-                new PersistentLockIsTakenException(Optional.empty()));
+                new PersistentLockIsTakenException(ImmutableList.of()));
         when(mockKvs.getMetadataForTable(tableReference)).thenReturn(new byte[1]);
 
         expectedException.expect(RuntimeException.class);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepTaskRunnerImplTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import org.junit.Rule;
@@ -331,7 +330,7 @@ public class SweepTaskRunnerImplTest {
     public void throwIfDeletionLockIsTaken() throws PersistentLockIsTakenException {
         TableReference tableReference = TableReference.createWithEmptyNamespace("someTable");
         int batchSize = 10;
-        when(mockDeletionLock.runWithLock(any(Supplier.class), anyString())).thenThrow(
+        when(mockDeletionLock.runWithLockNonExclusively(any(Supplier.class), anyString())).thenThrow(
                 new PersistentLockIsTakenException(ImmutableList.of()));
         when(mockKvs.getMetadataForTable(tableReference)).thenReturn(new byte[1]);
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweeperTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweeperTest.java
@@ -40,6 +40,7 @@ import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
+import com.palantir.atlasdb.persistentlock.DeletionLock;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.schema.generated.SweepPriorityTable;
@@ -96,7 +97,8 @@ public abstract class AbstractSweeperTest {
         txManager = new SerializableTransactionManager(kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false);
         setupTables(kvs);
         Supplier<Long> tsSupplier = sweepTimestamp::get;
-        sweepRunner = new SweepTaskRunnerImpl(txManager, kvs, tsSupplier, tsSupplier, txService, ssm, ImmutableList.<Follower>of());
+        DeletionLock deletionLock = new DeletionLock(kvs);
+        sweepRunner = new SweepTaskRunnerImpl(txManager, kvs, deletionLock, tsSupplier, tsSupplier, txService, ssm, ImmutableList.<Follower>of());
         setupBackgroundSweeper(DEFAULT_BATCH_SIZE);
     }
 


### PR DESCRIPTION
Beginning of work on #852 ; enables sweep to run safely alongside backups

Users of AtlasDB need to coordinate sweep and backup jobs, because running a sweep during a backup can corrupt that backup. This PR adds coordination via a KVS-persisted deletion lock. 

This PR adds a KVS-persisted deletion lock, which sweep and scrub acquire before running. The PR also adds CLIs to manipulate these locks, which can be used to acquire the deletion lock in preparation for a backup. The locks can be exclusive or non-exclusive (similar to read-write locks) - sweep and scrub take a non-exclusive deletion lock (so that sweep and scrub can run simultaneously), while the backup CLI takes an exclusive lock. 

Still need: 

- [ ] Docs and release notes
- [ ] Consider protecting truncates and schema mutations.
- [ ] Support for suppressing the sweep timestamp (to enable partial sweep/scrub during a backup).  Will do this as part of a separate PR. 