### PR TITLE
making leader configs for CLIs more clear

### DIFF
--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommandUtils.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommandUtils.java
@@ -39,7 +39,8 @@ public final class AtlasDbCommandUtils {
 
     public static AtlasDbConfig convertServerConfigToClientConfig(AtlasDbConfig serverConfig) {
         Preconditions.checkArgument(serverConfig.leader().isPresent(),
-                "Only server configurations with a leader block can be converted to client configurations");
+                "Your server configuration file must have a leader block. For instructions on how to do this, see the "
+                        + "documentation: http://palantir.github.io/atlasdb/html/configuration/leader_config.html");
 
         ServerListConfig leaders = ImmutableServerListConfig.builder()
                 .servers(serverConfig.leader().get().leaders())

--- a/docs/source/configuration/leader_config.rst
+++ b/docs/source/configuration/leader_config.rst
@@ -125,10 +125,13 @@ Failure to specify a leader configuration could lead to data corruption.
         sslConfiguration:
           trustStorePath: var/security/truststore.jks
 
-Single AtlasDB Client with Leader Block
----------------------------------------
+.. _leader-config-single-client-with-leader:
+
+Single AtlasDB Client or Offline CLI with Leader Block 
+------------------------------------------------------
 
 Similar to the above configuration, but with only a single leader specified in ``leaders``.
+To run an :ref:`offline CLI <offline-clis`, you also need to specify a leader block.
 
 .. code-block:: yaml
 
@@ -179,11 +182,12 @@ An example configuration is below.
 
       # no leader block
 
-No leader (CLI Only)
---------------------
+No leader (Online CLI Only)
+---------------------------
 
-When you are running a client that can't be a leader, for instance a CLI, it is necessary to specify a remote lock and timestamp service running on your AtlasDB clients.
+When you are running a client that can't be a leader, for instance an online CLI, it is necessary to specify a remote lock and timestamp service running on your AtlasDB clients.
 If you are running multiple AtlasDB clients, ensure your CLI is pointing at the correct hosts and ports for the service you wish to interact with.
+If you are running an :ref:`offline CLI <offline-clis>` then you must specify a leader block as noted above in the :ref:`Single AtlasDB Client with Leader Block <leader-config-single-client-with-leader>` section.
 
 .. code-block:: yaml
 

--- a/docs/source/configuration/leader_config.rst
+++ b/docs/source/configuration/leader_config.rst
@@ -127,11 +127,11 @@ Failure to specify a leader configuration could lead to data corruption.
 
 .. _leader-config-single-client-with-leader:
 
-Single AtlasDB Client or Offline CLI with Leader Block 
+Single AtlasDB Client or Offline CLI with Leader Block
 ------------------------------------------------------
 
 Similar to the above configuration, but with only a single leader specified in ``leaders``.
-To run an :ref:`offline CLI <offline-clis`, you also need to specify a leader block.
+To run an :ref:`offline CLI <offline-clis>`, you also need to specify a leader block.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Making it clear that online CLIs shouldn't have a leader block, and offline CLIs should have a single client leader block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1013)
<!-- Reviewable:end -->
