### PR TITLE
Handle old (non-heartbeat) lock values after upgrades

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -15,9 +15,9 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -56,7 +56,7 @@ import com.palantir.common.exception.PalantirRuntimeException;
 @RunWith(Parameterized.class)
 public class SchemaMutationLockIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(SchemaMutationLockIntegrationTest.class);
-    private static final SchemaMutationLock.Action DO_NOTHING = () -> {};
+    private static final SchemaMutationLock.Action DO_NOTHING = () -> { };
 
     private SchemaMutationLock schemaMutationLock;
     private HeartbeatService heartbeatService;
@@ -107,7 +107,7 @@ public class SchemaMutationLockIntegrationTest {
 
     @Test
     public void testLockAndUnlockWithoutContention() {
-        schemaMutationLock.runWithLock(() -> {});
+        schemaMutationLock.runWithLock(() -> { });
     }
 
     @Test
@@ -117,7 +117,7 @@ public class SchemaMutationLockIntegrationTest {
                     executorService,
                     () -> schemaMutationLock.runWithLock(DO_NOTHING));
 
-            Thread.sleep(3*1000);
+            Thread.sleep(3 * 1000);
 
             CassandraTestTools.assertThatFutureDidNotSucceedYet(getLockAgain);
         });
@@ -141,7 +141,9 @@ public class SchemaMutationLockIntegrationTest {
         expectedException.expect(PalantirRuntimeException.class);
         expectedException.expectCause(is(error));
 
-        schemaMutationLock.runWithLock(() -> { throw error; });
+        schemaMutationLock.runWithLock(() -> {
+            throw error;
+        });
     }
 
     @Test
@@ -199,14 +201,17 @@ public class SchemaMutationLockIntegrationTest {
     }
 
     private CqlResult createNonHeartbeatClearedLockEntry(Cassandra.Client client) throws TException {
-        String lockValue= CassandraKeyValueServices.encodeAsHex(Longs.toByteArray(Long.MAX_VALUE));
+        String lockValue = CassandraKeyValueServices.encodeAsHex(Longs.toByteArray(Long.MAX_VALUE));
         String lockRowName = CassandraKeyValueServices.encodeAsHex(
                 CassandraConstants.GLOBAL_DDL_LOCK_ROW_NAME.getBytes(StandardCharsets.UTF_8));
         String lockColName = CassandraKeyValueServices.encodeAsHex(
                 CassandraConstants.GLOBAL_DDL_LOCK_COLUMN_NAME.getBytes(StandardCharsets.UTF_8));
         String createCql = String.format(
                 "UPDATE \"%s\" SET value = %s WHERE key = %s AND column1 = %s AND column2 = -1;",
-                lockTable.getOnlyTable().getQualifiedName(), lockValue, lockRowName, lockColName);
+                lockTable.getOnlyTable().getQualifiedName(),
+                lockValue,
+                lockRowName,
+                lockColName);
         ByteBuffer queryBuffer = ByteBuffer.wrap(createCql.getBytes(StandardCharsets.UTF_8));
         return client.execute_cql3_query(queryBuffer, Compression.NONE, writeConsistency);
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
@@ -148,7 +148,7 @@ final class SchemaMutationLock {
 
                 CASResult casResult = writeDdlLockWithCas(client, expected, ourUpdate);
 
-                Column lastSeenValue = null;
+                Column lastSeenColumn = null;
                 int timesAttempted = 0;
 
                 // We use schemaMutationTimeoutMillis to wait for schema mutations to agree as well as
@@ -164,27 +164,21 @@ final class SchemaMutationLock {
                         // this becomes analogous to putUnlessExists now
                         expected = ImmutableList.of();
                     } else {
-                        Column existingValue = Iterables.getOnlyElement(casResult.getCurrent_values(), null);
-                        if (existingValue == null) {
+                        Column existingColumn = Iterables.getOnlyElement(casResult.getCurrent_values(), null);
+                        if (existingColumn == null) {
                             throw new IllegalStateException("Something is wrong with underlying locks."
                                     + " Contact support for guidance on manually examining and clearing"
                                     + " locks from " + lockTable.getOnlyTable() + " table.");
                         }
-                        if (lastSeenValue == null || !existingValue.equals(lastSeenValue)) {
+                        if (lastSeenColumn == null || !existingColumn.equals(lastSeenColumn)) {
                             LOGGER.debug("Heartbeat alive, will retry.");
-                            lastSeenValue = existingValue;
+                            lastSeenColumn = existingColumn;
                         } else {
                             // dead heartbeat
                             throw Throwables.rewrapAndThrowUncheckedException(generateDeadHeartbeatException());
                         }
 
-                        // handle old (pre-heartbeat) cleared lock values encountered during migrations
-                        if (Longs.fromByteArray(existingValue.getValue()) == GLOBAL_DDL_LOCK_CLEARED_ID) {
-                            expected = ImmutableList.of(lockColumnWithValue(
-                                    Longs.toByteArray(GLOBAL_DDL_LOCK_CLEARED_ID)));
-                        } else {
-                            expected = ImmutableList.of(lockColumnWithValue(GLOBAL_DDL_LOCK_CLEARED_VALUE));
-                        }
+                        expected = getExpectedCasResult(existingColumn);
                     }
 
                     // lock holder taking unreasonable amount of time, signal something's wrong
@@ -211,6 +205,16 @@ final class SchemaMutationLock {
             throw Throwables.throwUncheckedException(e);
         }
         return perOperationNodeId;
+    }
+
+    private List<Column> getExpectedCasResult(Column existingColumn) {
+        // handle old (pre-heartbeat) cleared lock values encountered during migrations
+        if (Longs.fromByteArray(existingColumn.getValue()) == GLOBAL_DDL_LOCK_CLEARED_ID) {
+            return ImmutableList.of(lockColumnWithValue(
+                    Longs.toByteArray(GLOBAL_DDL_LOCK_CLEARED_ID)));
+        } else {
+            return ImmutableList.of(lockColumnWithValue(GLOBAL_DDL_LOCK_CLEARED_VALUE));
+        }
     }
 
     private RuntimeException generateDeadHeartbeatException() {


### PR DESCRIPTION
So I think I figured out why we are seeing all those dead heartbeat exceptions with people upgrading Multipass. This seems to be happening because the lock entry format changed with the heartbeat addition. Previously we used a simple `long` value but now we use `long_heartbeat`. Consequently, our "Cleared" value also changed which made us fail when people upgraded and tried to grab the lock on startup.

Added a test too but feel free to remove it if you feel its not needed here (since this is happens as a one off case when upgrading from pre-heartbeat atlas)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1016)
<!-- Reviewable:end -->
