### PR TITLE
Tweak Circle setup

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -19,4 +19,8 @@ test {
     exclude '**/*IntegrationTest*'
     maxParallelForks 2
     dependsOn ':atlasdb-ete-test-utils:buildCassandraImage'
+
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }

--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -19,8 +19,4 @@ test {
     exclude '**/*IntegrationTest*'
     maxParallelForks 2
     dependsOn ':atlasdb-ete-test-utils:buildCassandraImage'
-
-    testLogging {
-        events "passed", "skipped", "failed"
-    }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ test:
     - ./scripts/circle-ci/run-circle-tests.sh:
         parallel: true
   post:
-    - ./gradlew jacocoFullReport:
+    - ./gradlew jacocoFullReport -x classes:
         parallel: true
     - bash <(curl -s https://codecov.io/bash):
         parallel: true

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -77,3 +77,14 @@ afterEvaluate {
         }
     }
 }
+
+test {
+    testLogging {
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+
+        events "started", "passed", "skipped", "failed"
+    }
+}

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -14,11 +14,11 @@ CONTAINER_1=(':atlasdb-cassandra-integration-tests:check')
 CONTAINER_2=(':atlasdb-ete-tests:check')
 
 #Container 3
-CONTAINER_3=(':atlasdb-timelock-ete:check' ':lock-impl:check' ':atlasdb-dbkvs-tests:check' ':atlasdb-tests-shared:check' ':atlasdb-ete-test-utils:check')
+CONTAINER_3=(':atlasdb-timelock-ete:check' ':lock-impl:check' ':atlasdb-dbkvs-tests:check' ':atlasdb-tests-shared:check' ':atlasdb-ete-test-utils:check' ':atlasdb-cassandra:check' ':atlasdb-api:check')
 
 CONTAINER_4=(':atlasdb-dropwizard-tests:check')
 
-CONTAINER_5=(':atlasdb-dbkvs:check' ':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check')
+CONTAINER_5=(':atlasdb-dbkvs:check' ':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check' ':atlasdb-dropwizard-bundle:check')
 
 # Container 0 - runs tasks not found in the below containers
 CONTAINER_0_EXCLUDE=("${CONTAINER_1[@]}" "${CONTAINER_2[@]}" "${CONTAINER_3[@]}" "${CONTAINER_4[@]}"  "${CONTAINER_5[@]}")


### PR DESCRIPTION
Make Circle tests run a little better. : 

* Speed: Move some projects out of CONTAINER_0 to get a more even distribution
* Speed: Exclude 'classes' from jacocoFullReport, shaves ~30s from build. 
* Stability: Stop Circle from timing out on `atlasdb-cassandra-integration-tests` (CONTAINER_1). This project takes ~10min to run, and previously produced no output in the meantime causing Circle to time out. For example, [build 3058](https://circleci.com/gh/palantir/atlasdb/3058#tests/containers/1) probably failed for this reason. This PR outputs success after every individual test, to avoid timing out due to stdout being silent. The longer term fix is to make this suite faster (or parallelize it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1018)
<!-- Reviewable:end -->
