### PR TITLE
Attempt to fix LazyClosableIteratorTest flake

### DIFF
--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/LazyClosableIteratorTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/LazyClosableIteratorTest.java
@@ -41,20 +41,19 @@ import com.palantir.exception.PalantirInterruptedException;
 
 public class LazyClosableIteratorTest {
 
-    @Test
+    @Test // QA-89231
     public void testInterruptsDontCauseLeaksMultiple() throws Exception {
         for (int i = 1; i <= 100; i++) {
             try {
                 // Because race conditions are hard...
-                testInterruptsDontCauseLeaks();
+                assertInterruptsDontCauseLeaks();
             } catch (Throwable e) {
                 throw new RuntimeException("Failure during run " + i, e);
             }
         }
     }
 
-    @Test // QA-89231
-    public void testInterruptsDontCauseLeaks() throws Exception {
+    private void assertInterruptsDontCauseLeaks() throws Exception {
         Set<Integer> opened = Sets.newConcurrentHashSet();
         Set<Integer> closed = Sets.newConcurrentHashSet();
         List<FutureTask<ClosableIterator<String>>> tasks = Lists.newArrayList();

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/LazyClosableIteratorTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/LazyClosableIteratorTest.java
@@ -103,7 +103,7 @@ public class LazyClosableIteratorTest {
             } catch (InterruptedException e) {
                 closed.add(-1);
             }
-            throw new RuntimeException();
+            throw new IllegalStateException("Interrupt was not triggered fast enough");
         });
     }
 

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/LazyClosableIteratorTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/LazyClosableIteratorTest.java
@@ -99,7 +99,7 @@ public class LazyClosableIteratorTest {
             opened.add(-1);
             curThread.interrupt();
             try {
-                Thread.sleep(1000);
+                Thread.sleep(5000);
             } catch (InterruptedException e) {
                 closed.add(-1);
             }


### PR DESCRIPTION
Attempt to fix #935 

The flake might be caused by a timeout. This PR adds a small amount of cleanup and an increased timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1020)
<!-- Reviewable:end -->
