### PR TITLE
refactor C* keyspace creation and improve degraded node startup

### DIFF
--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -99,10 +99,10 @@ public class DegradedClusterInitializationTest {
     private static boolean startupChecksPass() {
         CassandraKeyValueServiceConfigManager manager = CassandraKeyValueServiceConfigManager.createSimpleManager(
                 ThreeNodeCassandraCluster.KVS_CONFIG);
-        CassandraClientPool pool = new CassandraClientPool(manager.getConfig());
         try {
-            pool.runOneTimeStartupChecks();
-        } catch (RuntimeException e) {
+            // startup checks are done implicitly in the constructor
+            new CassandraClientPool(manager.getConfig());
+        } catch (Exception e) {
             return false;
         }
         return true;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -211,8 +211,6 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     + " an existing correctness bug with semi-complex column selections");
         }
 
-        clientPool.runOneTimeStartupChecks();
-
         boolean supportsCas = !configManager.getConfig().scyllaDb()
                 && clientPool.runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -125,7 +125,7 @@ public final class CassandraKeyValueServices {
     static void warnUserInInitializationIfClusterAlreadyInInconsistentState(
             CassandraClientPool clientPool,
             CassandraKeyValueServiceConfig config) {
-        String errorMessage = "While checking the cassandra cluster during initialization, we noticed schema versions"
+        String warnMessage = "While checking the cassandra cluster during initialization, we noticed schema versions"
                 + " could not settle. Be aware that some operations will not work while you are in your current"
                 + " cluster status.";
         try {
@@ -137,8 +137,8 @@ public final class CassandraKeyValueServices {
                         true);
                 return null;
             });
-        } catch (TException e) {
-            throw new RuntimeException(errorMessage, e);
+        } catch (Exception e) {
+            log.warn("Failed to retrieve current Cassandra cluster schema status.", e);
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -43,7 +43,6 @@ import com.google.common.collect.Sets;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientFactory.ClientCreationFailedException;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.collect.Maps2;
 
@@ -134,79 +133,93 @@ public final class CassandraVerifier {
 
     static void ensureKeyspaceExistsAndIsUpToDate(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config)
             throws TException {
-        try {
-            clientPool.run(new FunctionCheckedException<Cassandra.Client, Void, TException>() {
-                @Override
-                public Void apply(Cassandra.Client client) throws TException {
-                    KsDef originalKsDef = client.describe_keyspace(config.keyspace());
-                    KsDef modifiedKsDef = originalKsDef.deepCopy();
-                    CassandraVerifier.checkAndSetReplicationFactor(
-                            client,
-                            modifiedKsDef,
-                            false,
-                            config.replicationFactor(),
-                            config.safetyDisabled());
+        createKeyspace(config);
+        updateExistingKeyspace(clientPool, config);
+    }
 
-                    if (!modifiedKsDef.equals(originalKsDef)) {
-                        // Can't call system_update_keyspace to update replication factor if CfDefs are set
-                        modifiedKsDef.setCf_defs(ImmutableList.of());
-                        client.system_update_keyspace(modifiedKsDef);
-                        CassandraKeyValueServices.waitForSchemaVersions(
-                                client,
-                                "(updating the existing keyspace)",
-                                config.schemaMutationTimeoutMillis());
-                    }
+    private static void updateExistingKeyspace(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config)
+            throws TException {
+        clientPool.run(new FunctionCheckedException<Cassandra.Client, Void, TException>() {
+            @Override
+            public Void apply(Cassandra.Client client) throws TException {
+                KsDef originalKsDef = client.describe_keyspace(config.keyspace());
+                // there was an existing keyspace
+                // check and make sure it's definition is up to date with our config
+                KsDef modifiedKsDef = originalKsDef.deepCopy();
+                CassandraVerifier.checkAndSetReplicationFactor(
+                        client,
+                        modifiedKsDef,
+                        false,
+                        config.replicationFactor(),
+                        config.safetyDisabled());
 
-                    return null;
-                }
-            });
-        } catch (ClientCreationFailedException e) {
-            // We can't use the pool yet because it does things like setting the keyspace of that connection for us
-            boolean someHostWasAbleToCreateTheKeyspace = false;
-            for (InetSocketAddress host : config.servers()) { // try until we find a server that works
-                try {
-                    Client client = CassandraClientFactory.getClientInternal(host, config);
-                    KsDef ks = new KsDef(config.keyspace(), CassandraConstants.NETWORK_STRATEGY, ImmutableList.of());
-                    CassandraVerifier.checkAndSetReplicationFactor(
-                            client,
-                            ks,
-                            true,
-                            config.replicationFactor(),
-                            config.safetyDisabled());
-                    ks.setDurable_writes(true);
-                    log.info("Creating keyspace: {}", config.keyspace());
-                    client.system_add_keyspace(ks);
+                if (!modifiedKsDef.equals(originalKsDef)) {
+                    // Can't call system_update_keyspace to update replication factor if CfDefs are set
+                    modifiedKsDef.setCf_defs(ImmutableList.of());
+                    client.system_update_keyspace(modifiedKsDef);
                     CassandraKeyValueServices.waitForSchemaVersions(
                             client,
-                            "(adding the initial empty keyspace)",
+                            "(updating the existing keyspace)",
                             config.schemaMutationTimeoutMillis());
+                }
 
+
+                return null;
+            }
+        });
+    }
+
+    private static void createKeyspace(CassandraKeyValueServiceConfig config) throws TException {
+        // We can't use the pool yet because it does things like setting the connection's keyspace for us
+        boolean someHostWasAbleToCreateTheKeyspace = false;
+        for (InetSocketAddress host : config.servers()) { // try until we find a server that works
+            try {
+                attemptToCreateKeyspaceOnHost(host, config);
+
+                // if we got this far, we're done, no need to continue on other hosts
+                someHostWasAbleToCreateTheKeyspace = true;
+                break;
+            } catch (InvalidRequestException ire) {
+                if (attemptedToCreateKeyspaceTwice(ire)) {
                     // if we got this far, we're done, no need to continue on other hosts
                     someHostWasAbleToCreateTheKeyspace = true;
                     break;
-                } catch (InvalidRequestException ire) {
-                    if (attemptedToCreateKeyspaceTwice(ire)) {
-                        log.info("Attempted to create keyspace {} on multiple hosts at once", config.keyspace());
-
-                        // if we got this far, we're done, no need to continue on other hosts
-                        someHostWasAbleToCreateTheKeyspace = true;
-                        break;
-                    } else {
-                        throw ire;
-                    }
-                } catch (Exception f) {
-                    log.warn("Couldn't use host {} to create keyspace."
-                            + " It returned exception \"{}\" during the attempt."
-                            + " We will retry on other nodes, so this shouldn't be a problem unless all nodes failed."
-                            + " See the debug-level log for the stack trace.", host, f.toString(), f);
-                    log.debug("Specifically, creating the keyspace failed with the following stack trace", f);
+                } else {
+                    throw ire;
                 }
-            }
-            if (!someHostWasAbleToCreateTheKeyspace) {
-                throw new TException("No host tried was able to create the keyspace requested.");
+            } catch (Exception f) {
+                log.warn("Couldn't use host {} to create keyspace."
+                        + " It returned exception \"{}\" during the attempt."
+                        + " We will retry on other nodes, so this shouldn't be a problem unless all nodes failed."
+                        + " See the debug-level log for the stack trace.", host, f.toString(), f);
+                log.debug("Specifically, creating the keyspace failed with the following stack trace", f);
             }
         }
+        if (!someHostWasAbleToCreateTheKeyspace) {
+            throw new TException("No host tried was able to create the keyspace requested.");
+        }
     }
+
+    private static void attemptToCreateKeyspaceOnHost(InetSocketAddress host, CassandraKeyValueServiceConfig config)
+            throws TException {
+        Client client = CassandraClientFactory.getClientInternal(host, config);
+        KsDef ks = new KsDef(config.keyspace(), CassandraConstants.NETWORK_STRATEGY,
+                ImmutableList.of());
+        CassandraVerifier.checkAndSetReplicationFactor(
+                client,
+                ks,
+                true,
+                config.replicationFactor(),
+                config.safetyDisabled());
+        ks.setDurable_writes(true);
+        client.system_add_keyspace(ks);
+        log.info("Created keyspace: {}", config.keyspace());
+        CassandraKeyValueServices.waitForSchemaVersions(
+                client,
+                "(adding the initial empty keyspace)",
+                config.schemaMutationTimeoutMillis());
+    }
+
 
     private static boolean attemptedToCreateKeyspaceTwice(InvalidRequestException ex) {
         String exceptionString = ex.toString();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -54,7 +54,7 @@ public class SchemaMutationLockTables {
     }
 
     public TableReference createLockTable() throws TException {
-        return clientPool.run(this::createLockTable);
+        return clientPool.runWithRetry(this::createLockTable);
     }
 
     private TableReference createLockTable(Cassandra.Client client) throws TException {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -205,7 +205,7 @@ public class CassandraClientPoolTest {
         when(config.poolRefreshIntervalSeconds()).thenReturn(POOL_REFRESH_INTERVAL_SECONDS);
         when(config.servers()).thenReturn(servers);
 
-        CassandraClientPool cassandraClientPool = CassandraClientPool.createForTesting(config);
+        CassandraClientPool cassandraClientPool = CassandraClientPool.createWithoutChecksForTesting(config);
 
         cassandraClientPool.currentPools = serversInPool.stream()
                 .collect(Collectors.toMap(Function.identity(),

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -205,7 +205,8 @@ public class CassandraClientPoolTest {
         when(config.poolRefreshIntervalSeconds()).thenReturn(POOL_REFRESH_INTERVAL_SECONDS);
         when(config.servers()).thenReturn(servers);
 
-        CassandraClientPool cassandraClientPool = new CassandraClientPool(config);
+        CassandraClientPool cassandraClientPool = CassandraClientPool.createForTesting(config);
+
         cassandraClientPool.currentPools = serversInPool.stream()
                 .collect(Collectors.toMap(Function.identity(),
                         address -> getMockPoolingContainerForHost(address, failureMode)));

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,10 @@ v0.23.0
          - Removed spurious error logging during first-time startup against a brand new Cassandra cluster.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1033>`__)
 
+    *    - |improved|
+         - Improved the reliability of starting up against a degraded Cassandra cluster.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1033>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -85,6 +85,10 @@ v0.23.0
          - AtlasDB clients can start when a single Cassandra node is unreachable.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1045>`__).
 
+    *    - |improved|
+         - Removed spurious error logging during first-time startup against a brand new Cassandra cluster.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1033>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
refactor C\* keyspace creation; fixes #1028 and as a bonus breaks up a large method

Made a tiny manual test class against a local C\* 3.9 instance.

```
package com.palantir.atlasdb.keyvalue.cassandra;

import java.net.InetSocketAddress;

import com.google.common.base.Optional;
import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;

public class TestLogOutput {
    public static void main(String[] args) {
        CassandraKeyValueService.create(
                CassandraKeyValueServiceConfigManager.createSimpleManager(
                        ImmutableCassandraKeyValueServiceConfig.builder()
                                .addServers(new InetSocketAddress("localhost", 9160))
                                .keyspace("atlas")
                                .ssl(false)
                                .replicationFactor(1)
                                .build()),
                Optional.absent()).close();
    }
}
```

First run now logs:

```
15:17:36.863 [main] INFO  c.p.a.k.c.jmx.CassandraJmxCompaction - Jmx compaction is not enabled.
15:17:37.225 [main] INFO  c.p.a.k.cassandra.CassandraVerifier - Created keyspace: atlas
15:17:37.444 [main calling cassandra host localhost/127.0.0.1:9160 started at 2016-10-05T22:17:37.443Z - 4] INFO  c.p.a.k.c.CassandraApiVersion - Your cassandra api version (20.1.0) supports check and set.
15:17:38.562 [main calling cassandra host localhost/127.0.0.1:9160 started at 2016-10-05T22:17:37.537Z - 8] INFO  c.p.a.k.cassandra.SchemaMutationLock - Successfully acquired schema mutation lock.
15:17:38.642 [main calling cassandra host localhost/127.0.0.1:9160 started at 2016-10-05T22:17:38.637Z - 15] INFO  c.p.a.k.cassandra.SchemaMutationLock - Successfully released schema mutation lock.

Process finished with exit code 0
```

Subsequent runs now log:

```
15:16:49.758 [main] INFO  c.p.a.k.c.jmx.CassandraJmxCompaction - Jmx compaction is not enabled.
15:16:50.268 [main calling cassandra host localhost/127.0.0.1:9160 started at 2016-10-05T22:16:50.267Z - 4] INFO  c.p.a.k.c.CassandraApiVersion - Your cassandra api version (20.1.0) supports check and set.
15:16:50.299 [main calling cassandra host localhost/127.0.0.1:9160 started at 2016-10-05T22:16:50.280Z - 7] INFO  c.p.a.k.cassandra.SchemaMutationLock - Successfully acquired schema mutation lock.
15:16:50.318 [main calling cassandra host localhost/127.0.0.1:9160 started at 2016-10-05T22:16:50.312Z - 12] INFO  c.p.a.k.cassandra.SchemaMutationLock - Successfully released schema mutation lock.

Process finished with exit code 0
```

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1033)

<!-- Reviewable:end -->
