### PR TITLE
Fix the dropwizard console by properly checking for the --offline flag

### DIFF
--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCliCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCliCommand.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.dropwizard.commands;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -130,10 +129,7 @@ public class AtlasDbCliCommand<T extends Configuration & AtlasDbConfigurationPro
         Iterable<String> groups = Iterables.limit(namespace.getList(COMMAND_NAME_ATTR), 1);
         Iterable<String> commands = Iterables.skip(namespace.getList(COMMAND_NAME_ATTR), 1);
 
-        List<String> offlineArg =
-                Objects.equals(namespace.getString("runCliOffline"), AtlasDbCommandUtils.ZERO_ARITY_ARG_CONSTANT)
-                        ? ImmutableList.of("--offline")
-                        : ImmutableList.of();
+        List<String> offlineArg = isCliRunningOffline(namespace) ? ImmutableList.of("--offline") : ImmutableList.of();
 
         List<String> allArgs = ImmutableList.<String>builder()
                 .addAll(offlineArg)

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCommand.java
@@ -15,11 +15,14 @@
  */
 package com.palantir.atlasdb.dropwizard.commands;
 
+import java.util.Objects;
+
 import com.palantir.atlasdb.dropwizard.AtlasDbConfigurationProvider;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.cli.ConfiguredCommand;
 import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
 public abstract class AtlasDbCommand<T extends Configuration & AtlasDbConfigurationProvider>
@@ -47,5 +50,9 @@ public abstract class AtlasDbCommand<T extends Configuration & AtlasDbConfigurat
                 .required(false)
                 .action(Arguments.storeConst())
                 .setConst(AtlasDbCommandUtils.ZERO_ARITY_ARG_CONSTANT);
+    }
+
+    protected boolean isCliRunningOffline(Namespace namespace) {
+        return Objects.equals(namespace.getString("runCliOffline"), AtlasDbCommandUtils.ZERO_ARITY_ARG_CONSTANT);
     }
 }

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommand.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.dropwizard.commands;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 
 import org.apache.commons.cli.Option;
 import org.slf4j.Logger;
@@ -72,7 +71,7 @@ public class AtlasDbConsoleCommand<T extends Configuration & AtlasDbConfiguratio
 
         // We do this here because there's no flag to connect to an offline
         // cluster in atlasdb-console (since this is passed in through bind)
-        if (Objects.equals(namespace.getString("runCliOffline"), AtlasDbCommandUtils.ZERO_ARITY_ARG_CONSTANT)) {
+        if (isCliRunningOffline(namespace)) {
             cliConfiguration = ImmutableAtlasDbConfig.builder()
                     .from(cliConfiguration)
                     .leader(Optional.absent())

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommand.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.dropwizard.commands;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.cli.Option;
 import org.slf4j.Logger;
@@ -71,7 +72,7 @@ public class AtlasDbConsoleCommand<T extends Configuration & AtlasDbConfiguratio
 
         // We do this here because there's no flag to connect to an offline
         // cluster in atlasdb-console (since this is passed in through bind)
-        if (namespace.getAttrs().containsKey("runCliOffline")) {
+        if (Objects.equals(namespace.getString("runCliOffline"), AtlasDbCommandUtils.ZERO_ARITY_ARG_CONSTANT)) {
             cliConfiguration = ImmutableAtlasDbConfig.builder()
                     .from(cliConfiguration)
                     .leader(Optional.absent())

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommand.java
@@ -89,6 +89,10 @@ public class AtlasDbConsoleCommand<T extends Configuration & AtlasDbConfiguratio
                 .addAll(AtlasDbCommandUtils.gatherPassedInArguments(namespace.getAttrs()))
                 .build();
 
+        runAtlasDbConsole(allArgs);
+    }
+
+    protected void runAtlasDbConsole(List<String> allArgs) {
         try {
             AtlasConsoleMain.main(allArgs.toArray(new String[] {}));
         } catch (Throwable e) {

--- a/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommandTest.java
+++ b/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommandTest.java
@@ -59,16 +59,16 @@ public class AtlasDbConsoleCommandTest {
     public void lockAndTimestampFieldsShouldBeSetWhenRunningOnline() throws JsonProcessingException {
         AtlasDbConfig cliConfig = getConfigFromConsoleCommand(ONLINE_PARAMS, MINIMAL_LEADER_CONFIG);
 
-        assertThat(cliConfig.lock().isPresent()).describedAs("Lock block is missing").isTrue();
-        assertThat(cliConfig.timestamp().isPresent()).describedAs("Timestamp block is missing").isTrue();
+        assertThat(cliConfig.lock().isPresent()).describedAs("Lock block must be present").isTrue();
+        assertThat(cliConfig.timestamp().isPresent()).describedAs("Timestamp block must be present").isTrue();
     }
 
     @Test
     public void lockAndTimestampFieldsShouldBeEmptyWhenRunningOffline() throws JsonProcessingException {
         AtlasDbConfig cliConfig = getConfigFromConsoleCommand(OFFLINE_PARAMS, MINIMAL_LEADER_CONFIG);
 
-        assertThat(cliConfig.lock().isPresent()).describedAs("Lock block is present").isFalse();
-        assertThat(cliConfig.timestamp().isPresent()).describedAs("Timestamp block is present").isFalse();
+        assertThat(cliConfig.lock().isPresent()).describedAs("Lock block must be absent").isFalse();
+        assertThat(cliConfig.timestamp().isPresent()).describedAs("Timestamp block must be absent").isFalse();
     }
 
     private AtlasDbConfig getConfigFromConsoleCommand(Map<String, Object> params, AtlasDbConfig config)

--- a/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommandTest.java
+++ b/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommandTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.dropwizard.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Throwables;
+import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.AtlasDbConfigs;
+import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
+import com.palantir.atlasdb.config.ImmutableLeaderConfig;
+import com.palantir.atlasdb.dropwizard.AtlasDbConfigurationProvider;
+import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+public class AtlasDbConsoleCommandTest {
+    private static final String LOCAL_SERVER_NAME = "Local Server";
+    private static final AtlasDbConfig MINIMAL_LEADER_CONFIG = ImmutableAtlasDbConfig.builder()
+            .leader(ImmutableLeaderConfig.builder()
+                    .quorumSize(1)
+                    .addLeaders(LOCAL_SERVER_NAME)
+                    .localServer(LOCAL_SERVER_NAME)
+                    .build())
+            .keyValueService(new InMemoryAtlasDbConfig())
+            .build();
+
+    private static final Map<String, Object> ONLINE_PARAMS = Collections
+            .singletonMap("runCliOffline", null);
+    private static final Map<String, Object> OFFLINE_PARAMS = Collections
+            .singletonMap("runCliOffline", AtlasDbCommandUtils.ZERO_ARITY_ARG_CONSTANT);
+
+    @Test
+    public void lockAndTimestampFieldsShouldBeSetWhenRunningOnline() throws JsonProcessingException {
+        AtlasDbConfig cliConfig = getConfigFromConsoleCommand(ONLINE_PARAMS, MINIMAL_LEADER_CONFIG);
+
+        assertThat(cliConfig.lock().isPresent()).describedAs("Lock block is missing").isTrue();
+        assertThat(cliConfig.timestamp().isPresent()).describedAs("Timestamp block is missing").isTrue();
+    }
+
+    @Test
+    public void lockAndTimestampFieldsShouldBeEmptyWhenRunningOffline() throws JsonProcessingException {
+        AtlasDbConfig cliConfig = getConfigFromConsoleCommand(OFFLINE_PARAMS, MINIMAL_LEADER_CONFIG);
+
+        assertThat(cliConfig.lock().isPresent()).describedAs("Lock block is present").isFalse();
+        assertThat(cliConfig.timestamp().isPresent()).describedAs("Timestamp block is present").isFalse();
+    }
+
+    private AtlasDbConfig getConfigFromConsoleCommand(Map<String, Object> params, AtlasDbConfig config)
+            throws JsonProcessingException {
+        AtomicReference<AtlasDbConfig> cliConfig = new AtomicReference<>();
+
+        new AtlasDbConsoleCommand<AtlasDbDropwizardConfig>(AtlasDbDropwizardConfig.class) {
+            @Override
+            protected void runAtlasDbConsole(List<String> allArgs) {
+                try {
+                    cliConfig.set(AtlasDbConfigs.loadFromString(allArgs.get(2), null));
+                } catch (IOException e) {
+                    throw Throwables.propagate(e);
+                }
+            }
+        }.run(mock(Bootstrap.class), new Namespace(params), new AtlasDbDropwizardConfig(config));
+
+        return cliConfig.get();
+    }
+
+    private class AtlasDbDropwizardConfig extends Configuration implements AtlasDbConfigurationProvider {
+        private final AtlasDbConfig atlasDbConfig;
+
+        AtlasDbDropwizardConfig(AtlasDbConfig atlasDbConfig) {
+            this.atlasDbConfig = atlasDbConfig;
+        }
+
+        @Override
+        public AtlasDbConfig getAtlasDbConfig() {
+            return atlasDbConfig;
+        }
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -31,6 +31,24 @@ Changelog
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
+v0.20.0
+=======
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |fixed|
+         - The dropwizard console no longer always starts up embedded timestamp and lock services.
+           This fixes the issue where running the console would cause the ``MultipleRunningTimestampServiceError``
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1063>`__).
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
 v0.19.0
 =======
 


### PR DESCRIPTION
## The bug:
Dropwizard inserts `null` for `"runCliOffline"` meaning that `containsKey` returns `true`. Now we check whether it is the correct value or `null`.

## Temporary workaround (before this version is used):

So, given you have your config with the leader block:
```
atlas:
  leader:
    quorumSize: 1
    localServer: https://host:8101/api
    leaders:
    - https://host:8101/api
    sslConfiguration:
      trustStorePath: var/security/truststore.jks
  keyValueService:
    type: cassandra
    ...
<rest of your config>
```

You need to create one other config to start the console with:
```
atlas:
  leader:
    quorumSize: 1
    localServer: https://host:8101/api
    leaders:
    - https://host:8101/api
    sslConfiguration:
      trustStorePath: var/security/truststore.jks
  keyValueService:
    type: memory
<rest of your config>
```

It should look exactly the same apart from the `keyValueService` block should contain only `type: memory`

You then need to start the console using the command:
```service/bin/application-name atlasdb console var/conf/application-name.yml.console```

and run the two commands:
```
dropwizardAtlasDb = com.palantir.atlasdb.config.AtlasDbConfigs.OBJECT_MAPPER.writeValueAsString(com.palantir.atlasdb.dropwizard.commands.AtlasDbCommandUtils.convertServerConfigToClientConfig(com.palantir.atlasdb.config.AtlasDbConfigs.load(new File("var/conf/application-name.yml"), "/atlas")))
connectInline dropwizardAtlasDb
```

This should connect you successfully to the database.

The configuration you use for starting the console should contain the config with the in-memory KVS, and the config used within the two commands to run, should be the proper config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1063)
<!-- Reviewable:end -->
