### PR TITLE
Revert "Add jar, shadowJar to publishing for atlasdb-dagger shaded dependencies"

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -15,7 +15,7 @@ task testJar(type: Jar) {
 publishing {
     publications {
         artifactory(MavenPublication) {
-            from components.hasProperty('shadow') ? components.shadow : components.java
+            from components.hasProperty('shadow') ? components.shadow : components.java          
             artifact(sourceJar) {
                 classifier 'sources'
             }
@@ -57,7 +57,7 @@ bintrayUpload.onlyIf {
     System.getenv('BINTRAY_USERNAME') && System.getenv('BINTRAY_PASSWORD') && project.version ==~ releaseVersionRegex
 }
 
-bintrayUpload.dependsOn 'generatePomFileForArtifactoryPublication', 'jar', 'shadowJar', 'sourceJar', 'testJar', 'build'
+bintrayUpload.dependsOn 'generatePomFileForArtifactoryPublication', 'sourceJar', 'testJar', 'build'
 
 artifactory {
     publish {
@@ -78,4 +78,4 @@ artifactory {
 artifactoryPublish.onlyIf {
   System.getenv('ARTIFACTORY_USERNAME') && System.getenv('ARTIFACTORY_PASSWORD') && !(project.version ==~ releaseVersionRegex)
 }
-artifactoryPublish.dependsOn 'generatePomFileForArtifactoryPublication', 'jar', 'shadowJar', 'sourceJar', 'testJar', 'build'
+artifactoryPublish.dependsOn 'generatePomFileForArtifactoryPublication', 'sourceJar', 'testJar', 'build'


### PR DESCRIPTION
Reverts palantir/atlasdb#1057

Testing over. This didn't fix it :(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1064)
<!-- Reviewable:end -->
