### PR TITLE
Publish shadowed jar correctly

### DIFF
--- a/atlasdb-dagger/build.gradle
+++ b/atlasdb-dagger/build.gradle
@@ -28,3 +28,6 @@ shadowJar {
     include dependency(group: 'com.google.dagger', name: 'dagger', version: libVersions.dagger)
   }
 }
+
+jar.dependsOn shadowJar
+jar.onlyIf { false }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -15,7 +15,7 @@ task testJar(type: Jar) {
 publishing {
     publications {
         artifactory(MavenPublication) {
-            from components.hasProperty('shadow') ? components.shadow : components.java          
+            from components.hasProperty('shadow') ? components.shadow : components.java
             artifact(sourceJar) {
                 classifier 'sources'
             }


### PR DESCRIPTION
The dropwizard bundle was failing to work when someone pulls in a later version of dagger. It was supposedly fixed by PR #926 but that only worked when publishing locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1065)
<!-- Reviewable:end -->
