### PR TITLE
Circle/reduce memory

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,10 @@ dependencies:
     - ~/.m2
 
 test:
+  pre:
+    - ./scripts/circle-ci/track-memory-usage.sh:
+        background: true
+        parallel: true
   override:
     - ./gradlew --profile --continue --parallel compileJava compileTestJava:
         parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,8 @@ dependencies:
 
 test:
   override:
+    - ./gradlew --profile --continue --parallel compileJava compileTestJava:
+        parallel: true
     - ./scripts/circle-ci/run-circle-tests.sh:
         parallel: true
   post:

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -25,8 +25,8 @@ done
 
 case $CIRCLE_NODE_INDEX in
     0) ./gradlew --profile --continue check $CONTAINER_0_EXCLUDE_ARGS ;;
-    1) ./gradlew --profile --continue --parallel ${CONTAINER_1[@]} ;;
-    2) ./gradlew --profile --continue --parallel ${CONTAINER_2[@]} ;;
+    1) ./gradlew --profile --continue ${CONTAINER_1[@]} ;;
+    2) ./gradlew --profile --continue ${CONTAINER_2[@]} ;;
     3) ./gradlew --profile --continue ${CONTAINER_3[@]} && checkDocsBuild ;;
-    4) ./gradlew --profile --continue --parallel ${CONTAINER_4[@]} ;;
+    4) ./gradlew --profile --continue ${CONTAINER_4[@]} ;;
 esac

--- a/scripts/circle-ci/track-memory-usage.sh
+++ b/scripts/circle-ci/track-memory-usage.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+while true; do
+    MEMUSAGE=$(($(ps aux | awk "{{ print \$6 }}" | tr "\n" "+"; echo 0)))
+    echo "Memory usage at $(date): $MEMUSAGE"
+    sleep 1
+done


### PR DESCRIPTION
95% of our builds are OOMing. Hopefully this will fix the majority of them.

Maximum memory that this goes up to is now 3.87GB. Hopefully that's enough for now.

This also adds a script which tracks memory usage during builds. Builds that OOM will not show the output of this script AFAIK though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1071)
<!-- Reviewable:end -->
