### PR TITLE
Add Truncate cli tests

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -178,14 +178,16 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractAtlasDbKeyV
                 new SchemaMutationLockTables(ckvs.clientPool, CassandraTestSuite.cassandraKvsConfig),
                 LockLeader.I_AM_THE_LOCK_LEADER);
         SchemaMutationLockTestTools lockTestTools = new SchemaMutationLockTestTools(ckvs.clientPool, lockTable);
-
-        // grab lock
-        lockTestTools.setLocksTableValue(LOCK_ID, 0);
+        grabLock(lockTestTools);
 
         ckvs.cleanUpSchemaMutationLockTablesState();
 
         CqlResult result = lockTestTools.readLocksTable();
         assertThat(result.getRows(), is(empty()));
+    }
+
+    private void grabLock(SchemaMutationLockTestTools lockTestTools) throws TException {
+        lockTestTools.setLocksTableValue(LOCK_ID, 0);
     }
 
     private static int getAmountOfGarbageInMetadataTable(KeyValueService keyValueService, TableReference tableRef) {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -59,7 +59,6 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 
 public class CassandraKeyValueServiceIntegrationTest extends AbstractAtlasDbKeyValueServiceTest {
-
     private static final long LOCK_ID = 123456789;
 
     private KeyValueService keyValueService;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestTools.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestTools.java
@@ -110,8 +110,8 @@ public final class CassandraTestTools {
         });
     }
 
-    public static String getHexEncodedBytes(String s) {
-        return CassandraKeyValueServices.encodeAsHex(s.getBytes(StandardCharsets.UTF_8));
+    public static String getHexEncodedBytes(String str) {
+        return CassandraKeyValueServices.encodeAsHex(str.getBytes(StandardCharsets.UTF_8));
     }
 
     public static long readLockIdFromLocksTable(CassandraClientPool clientPool, UniqueSchemaMutationLockTable lockTable)
@@ -121,8 +121,8 @@ public final class CassandraTestTools {
         return SchemaMutationLock.getLockIdFromColumn(resultColumn);
     }
 
-    public static long readHeartbeatCountFromLocksTable(CassandraClientPool clientPool, UniqueSchemaMutationLockTable lockTable)
-            throws TException {
+    public static long readHeartbeatCountFromLocksTable(CassandraClientPool clientPool,
+            UniqueSchemaMutationLockTable lockTable) throws TException {
         CqlResult result = CassandraTestTools.readLocksTable(clientPool, lockTable);
         Column resultColumn = getColumnFromCqlResult(result);
         return SchemaMutationLock.getHeartbeatCountFromColumn(resultColumn);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HeartbeatServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HeartbeatServiceIntegrationTest.java
@@ -45,6 +45,7 @@ public class HeartbeatServiceIntegrationTest {
     private CassandraClientPool clientPool;
     private ConsistencyLevel writeConsistency;
     private UniqueSchemaMutationLockTable lockTable;
+    private SchemaMutationLockTestTools lockTestTools;
 
     private final long lockId = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE - 2);
 
@@ -67,22 +68,23 @@ public class HeartbeatServiceIntegrationTest {
                                                 heartbeatTimePeriodMillis,
                                                 lockTable.getOnlyTable(),
                                                 writeConsistency);
-        CassandraTestTools.setLocksTableValue(clientPool, lockTable, lockId, 0, writeConsistency);
+        lockTestTools = new SchemaMutationLockTestTools(clientPool, lockTable);
+        lockTestTools.setLocksTableValue(lockId, 0);
     }
 
     @After
     public void cleanUp() throws TException {
         heartbeatService.stopBeating();
-        CassandraTestTools.truncateLocksTable(clientPool, lockTable);
+        lockTestTools.truncateLocksTable();
     }
 
     @Test
     public void testNormalStartStopBeatingSequence() throws TException, InterruptedException {
-        assertThat(CassandraTestTools.readHeartbeatCountFromLocksTable(clientPool, lockTable), is(0));
+        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(0));
         heartbeatService.startBeatingForLock(lockId);
         Thread.sleep(10 * heartbeatTimePeriodMillis);
         heartbeatService.stopBeating();
-        assertThat(CassandraTestTools.readHeartbeatCountFromLocksTable(clientPool, lockTable), not(0));
+        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), not(0));
     }
 
     @Test
@@ -101,7 +103,7 @@ public class HeartbeatServiceIntegrationTest {
         Heartbeat heartbeat = new Heartbeat(clientPool, queryRunner,
                 lockTable.getOnlyTable(), writeConsistency, lockId);
         heartbeat.run();
-        assertThat(CassandraTestTools.readHeartbeatCountFromLocksTable(clientPool, lockTable), is(1));
+        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(1));
     }
 
     @Test
@@ -111,6 +113,6 @@ public class HeartbeatServiceIntegrationTest {
                 writeConsistency, invalidLockId);
         heartbeat.run();
         // value should not be updated because an IllegalStateException will be thrown and caught
-        assertThat(CassandraTestTools.readHeartbeatCountFromLocksTable(clientPool, lockTable), is(0));
+        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(0));
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HeartbeatServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HeartbeatServiceIntegrationTest.java
@@ -80,11 +80,11 @@ public class HeartbeatServiceIntegrationTest {
 
     @Test
     public void testNormalStartStopBeatingSequence() throws TException, InterruptedException {
-        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(0));
+        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(0L));
         heartbeatService.startBeatingForLock(lockId);
         Thread.sleep(10 * heartbeatTimePeriodMillis);
         heartbeatService.stopBeating();
-        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), not(0));
+        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(not(0L)));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class HeartbeatServiceIntegrationTest {
         Heartbeat heartbeat = new Heartbeat(clientPool, queryRunner,
                 lockTable.getOnlyTable(), writeConsistency, lockId);
         heartbeat.run();
-        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(1));
+        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(1L));
     }
 
     @Test
@@ -113,6 +113,6 @@ public class HeartbeatServiceIntegrationTest {
                 writeConsistency, invalidLockId);
         heartbeat.run();
         // value should not be updated because an IllegalStateException will be thrown and caught
-        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(0));
+        assertThat(lockTestTools.readHeartbeatCountFromLocksTable(), is(0L));
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -198,12 +198,12 @@ public class SchemaMutationLockIntegrationTest {
     }
 
     @Test
-    public void testNonHeartbeatClearedLockPostMigration() throws TException {
+    public void testLegacyClearedLockPostMigration() throws TException {
         // only run this test with cas
         Assume.assumeTrue(casEnabled);
 
-        // set up pre heartbeat old style cleared lock
-        lockTestTools.setOldStyleNonHeartbeatLocksTableValue(Long.MAX_VALUE);
+        // set up pre heartbeat legacy cleared lock
+        lockTestTools.setLegacyLocksTableValue(Long.MAX_VALUE);
 
         schemaMutationLock.runWithLock(DO_NOTHING);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -19,8 +19,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
@@ -31,10 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.cassandra.thrift.Cassandra;
-import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
-import org.apache.cassandra.thrift.CqlResult;
 import org.apache.thrift.TException;
 import org.junit.Assume;
 import org.junit.Before;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -219,22 +219,7 @@ public class SchemaMutationLockIntegrationTest {
     }
 
     private void setUpWithNonHeartbeatClearedLock() throws TException {
-        clientPool.runWithRetry(this::createNonHeartbeatClearedLockEntry);
-    }
-
-    private CqlResult createNonHeartbeatClearedLockEntry(Cassandra.Client client) throws TException {
         String lockValue = CassandraKeyValueServices.encodeAsHex(Longs.toByteArray(Long.MAX_VALUE));
-        String lockRowName = CassandraKeyValueServices.encodeAsHex(
-                CassandraConstants.GLOBAL_DDL_LOCK_ROW_NAME.getBytes(StandardCharsets.UTF_8));
-        String lockColName = CassandraKeyValueServices.encodeAsHex(
-                CassandraConstants.GLOBAL_DDL_LOCK_COLUMN_NAME.getBytes(StandardCharsets.UTF_8));
-        String createCql = String.format(
-                "UPDATE \"%s\" SET value = %s WHERE key = %s AND column1 = %s AND column2 = -1;",
-                lockTable.getOnlyTable().getQualifiedName(),
-                lockValue,
-                lockRowName,
-                lockColName);
-        ByteBuffer queryBuffer = ByteBuffer.wrap(createCql.getBytes(StandardCharsets.UTF_8));
-        return client.execute_cql3_query(queryBuffer, Compression.NONE, writeConsistency);
+        CassandraTestTools.setLocksTableValue(clientPool, lockTable, lockValue, writeConsistency);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -41,7 +41,6 @@ import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.primitives.Longs;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.config.LockLeader;
@@ -214,7 +213,6 @@ public class SchemaMutationLockIntegrationTest {
     }
 
     private void setUpWithNonHeartbeatClearedLock() throws TException {
-        String lockValue = CassandraKeyValueServices.encodeAsHex(Longs.toByteArray(Long.MAX_VALUE));
-        CassandraTestTools.setLocksTableValue(clientPool, lockTable, lockValue, writeConsistency);
+        CassandraTestTools.setLocksTableValue(clientPool, lockTable, Long.MAX_VALUE, writeConsistency);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -203,7 +203,7 @@ public class SchemaMutationLockIntegrationTest {
         Assume.assumeTrue(casEnabled);
 
         // set up pre heartbeat old style cleared lock
-        lockTestTools.setLocksTableValue(Long.MAX_VALUE);
+        lockTestTools.setOldStyleNonHeartbeatLocksTableValue(Long.MAX_VALUE);
 
         schemaMutationLock.runWithLock(DO_NOTHING);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -202,8 +202,7 @@ public class SchemaMutationLockIntegrationTest {
         // only run this test with cas
         Assume.assumeTrue(casEnabled);
 
-        // set up pre heartbeat legacy cleared lock
-        lockTestTools.setLegacyLocksTableValue(Long.MAX_VALUE);
+        lockTestTools.setLegacyClearedLocksTableValue();
 
         schemaMutationLock.runWithLock(DO_NOTHING);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
@@ -39,8 +39,8 @@ public final class SchemaMutationLockTestTools {
         this.lockTable = lockTable;
     }
 
-    public CqlResult setLegacyLocksTableValue(long lockId) throws TException {
-        String lockValue = CassandraKeyValueServices.encodeAsHex(Longs.toByteArray(lockId));
+    public CqlResult setLegacyClearedLocksTableValue() throws TException {
+        String lockValue = CassandraKeyValueServices.encodeAsHex(Longs.toByteArray(Long.MAX_VALUE));
         return setLocksTableValueInternal(lockValue);
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
@@ -15,10 +15,6 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -43,7 +39,7 @@ public final class SchemaMutationLockTestTools {
         this.lockTable = lockTable;
     }
 
-    public CqlResult setOldStyleNonHeartbeatLocksTableValue(long lockId) throws TException {
+    public CqlResult setLegacyLocksTableValue(long lockId) throws TException {
         String lockValue = CassandraKeyValueServices.encodeAsHex(Longs.toByteArray(lockId));
         return setLocksTableValueInternal(lockValue);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.Column;
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.CqlRow;
+import org.apache.thrift.TException;
+
+import com.google.common.collect.Iterables;
+import com.google.common.primitives.Longs;
+
+public final class SchemaMutationLockTestTools {
+
+    private final CassandraClientPool clientPool;
+    private final UniqueSchemaMutationLockTable lockTable;
+
+    public SchemaMutationLockTestTools(CassandraClientPool clientPool, UniqueSchemaMutationLockTable lockTable) {
+        this.clientPool = clientPool;
+        this.lockTable = lockTable;
+    }
+
+    // for handling old non-heartbeat lock values
+    public CqlResult setLocksTableValue(long lockId) throws TException {
+        String lockValue = CassandraKeyValueServices.encodeAsHex(Longs.toByteArray(lockId));
+        return setLocksTableValueInternal(lockValue);
+    }
+
+    public CqlResult setLocksTableValue(long lockId, int heartbeatCount) throws TException {
+        String lockValue = getHexEncodedBytes(SchemaMutationLock.lockValueFromIdAndHeartbeat(lockId, heartbeatCount));
+        return setLocksTableValueInternal(lockValue);
+    }
+
+    public CqlResult truncateLocksTable()
+            throws TException {
+        return clientPool.run(client -> {
+            String truncateCql = String.format("TRUNCATE \"%s\";", lockTable.getOnlyTable().getQualifiedName());
+            return runCqlQuery(truncateCql, client, ConsistencyLevel.ALL);
+        });
+    }
+
+    public CqlResult readLocksTable() throws TException {
+        return clientPool.run(client -> {
+            String selectCql = "SELECT \"value\" FROM \"%s\" WHERE key = %s AND column1 = %s AND column2 = -1;";
+            String lockRowName = getHexEncodedBytes(CassandraConstants.GLOBAL_DDL_LOCK_ROW_NAME);
+            String lockColName = getHexEncodedBytes(CassandraConstants.GLOBAL_DDL_LOCK_COLUMN_NAME);
+            selectCql = String.format(selectCql, lockTable.getOnlyTable().getQualifiedName(), lockRowName, lockColName);
+            return runCqlQuery(selectCql, client, ConsistencyLevel.LOCAL_QUORUM);
+        });
+    }
+
+    public long readLockIdFromLocksTable() throws TException {
+        CqlResult result = readLocksTable();
+        Column resultColumn = getColumnFromCqlResult(result);
+        return SchemaMutationLock.getLockIdFromColumn(resultColumn);
+    }
+
+    public long readHeartbeatCountFromLocksTable() throws TException {
+        CqlResult result = readLocksTable();
+        Column resultColumn = getColumnFromCqlResult(result);
+        return SchemaMutationLock.getHeartbeatCountFromColumn(resultColumn);
+    }
+
+    private String getHexEncodedBytes(String str) {
+        return CassandraKeyValueServices.encodeAsHex(str.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private CqlResult setLocksTableValueInternal(String hexLockValue) throws TException {
+        return clientPool.run(client -> {
+            String updateCql = "UPDATE \"%s\" SET value = %s WHERE key = %s AND column1 = %s AND column2 = -1;";
+            String lockRowName = getHexEncodedBytes(CassandraConstants.GLOBAL_DDL_LOCK_ROW_NAME);
+            String lockColName = getHexEncodedBytes(CassandraConstants.GLOBAL_DDL_LOCK_COLUMN_NAME);
+            String lockTableName = lockTable.getOnlyTable().getQualifiedName();
+            updateCql = String.format(updateCql, lockTableName, hexLockValue, lockRowName, lockColName);
+            return runCqlQuery(updateCql, client, ConsistencyLevel.EACH_QUORUM);
+        });
+    }
+
+    private Column getColumnFromCqlResult(CqlResult result) {
+        List<CqlRow> resultRows = result.getRows();
+        assertThat(resultRows, hasSize(1));
+        List<Column> resultColumns = Iterables.getOnlyElement(resultRows).getColumns();
+        assertThat(resultColumns, hasSize(1));
+        return Iterables.getOnlyElement(resultColumns);
+    }
+
+    private CqlResult runCqlQuery(String query, Cassandra.Client client, ConsistencyLevel consistency)
+            throws TException {
+        ByteBuffer queryBuffer = ByteBuffer.wrap(query.getBytes(StandardCharsets.UTF_8));
+        return client.execute_cql3_query(queryBuffer, Compression.NONE, consistency);
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
@@ -386,7 +386,8 @@ final class SchemaMutationLock {
         return lockColumnWithValue(strValue.getBytes(StandardCharsets.UTF_8));
     }
 
-    private static long getLockIdFromColumn(Column column) {
+    @VisibleForTesting
+    static long getLockIdFromColumn(Column column) {
         String columnStringValue = new String(column.getValue(), StandardCharsets.UTF_8);
         Matcher columnStringMatcher = GLOBAL_DDL_LOCK_FORMAT_PATTERN.matcher(columnStringValue);
         Preconditions.checkState(columnStringMatcher.matches(), "Invalid format for a lock column");


### PR DESCRIPTION
Attempts to address #1055 

Testing the cli ete proved quite difficult, so this adds a test for the underlying KVS method that the cli calls.
In order to do so, we required something to setup the locks table with a "bad state", which is why some CQL-using utilities that were used by `HeartbeatServiceIntegrationTest` and `SchemaMutationLockIntegrationTest` have also been cleaned up a bit and moved to `CassandraTestTools`

Once we change the semantics of the cli in #1049 (Update with cleared value instead of just dropping everything), this test will also need to change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1074)
<!-- Reviewable:end -->
