### PR TITLE
Split up cassandra integration test suite to enable faster build times

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -17,6 +17,5 @@ dependencies {
 test {
     maxHeapSize = "1024m"
     exclude '**/*IntegrationTest*'
-    maxParallelForks 2
     dependsOn ':atlasdb-ete-test-utils:buildCassandraImage'
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -57,8 +57,8 @@ public class CassandraClientPoolIntegrationTest {
     @Before
     public void setUp() {
         kv = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.cassandraKvsConfig),
-                CassandraTestSuite.leaderConfig);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuiteUtils.cassandraKvsConfig),
+                CassandraTestSuiteUtils.leaderConfig);
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraConnectionIntegrationTest.java
@@ -33,7 +33,7 @@ public class CassandraConnectionIntegrationTest {
 
     private static final CassandraKeyValueServiceConfig NO_CREDS_CKVS_CONFIG = ImmutableCassandraKeyValueServiceConfig
             .builder()
-            .addServers(CassandraTestSuite.cassandraThriftAddress)
+            .addServers(CassandraTestSuiteUtils.cassandraThriftAddress)
             .poolSize(20)
             .keyspace("atlasdb")
             .credentials(Optional.absent())
@@ -56,7 +56,7 @@ public class CassandraConnectionIntegrationTest {
     @Test
     public void testAuthProvided() {
         CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.cassandraKvsConfig),
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuiteUtils.cassandraKvsConfig),
                 LEADER_CONFIG).close();
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -90,8 +90,8 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractAtlasDbKeyV
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.cassandraKvsConfig),
-                CassandraTestSuite.leaderConfig,
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuiteUtils.cassandraKvsConfig),
+                CassandraTestSuiteUtils.leaderConfig,
                 logger);
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSerializableTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSerializableTransactionIntegrationTest.java
@@ -25,8 +25,8 @@ public class CassandraKeyValueServiceSerializableTransactionIntegrationTest exte
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.cassandraKvsConfig),
-                CassandraTestSuite.leaderConfig);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuiteUtils.cassandraKvsConfig),
+                CassandraTestSuiteUtils.leaderConfig);
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweeperIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweeperIntegrationTest.java
@@ -52,7 +52,8 @@ public class CassandraKeyValueServiceSweeperIntegrationTest extends AbstractSwee
                 : CassandraTestSuiteUtils.cassandraKvsConfig;
 
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(config), CassandraTestSuiteUtils.leaderConfig);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(config),
+                CassandraTestSuiteUtils.leaderConfig);
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweeperIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweeperIntegrationTest.java
@@ -48,11 +48,11 @@ public class CassandraKeyValueServiceSweeperIntegrationTest extends AbstractSwee
     @Override
     protected KeyValueService getKeyValueService() {
         ImmutableCassandraKeyValueServiceConfig config = useColumnBatchSize
-                ? CassandraTestSuite.cassandraKvsConfig.withTimestampsGetterBatchSize(Optional.of(10))
-                : CassandraTestSuite.cassandraKvsConfig;
+                ? CassandraTestSuiteUtils.cassandraKvsConfig.withTimestampsGetterBatchSize(Optional.of(10))
+                : CassandraTestSuiteUtils.cassandraKvsConfig;
 
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(config), CassandraTestSuite.leaderConfig);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(config), CassandraTestSuiteUtils.leaderConfig);
     }
 
     @Test

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -53,17 +53,17 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
 
     @Before
     public void setUp() {
-        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = CassandraTestSuite.cassandraKvsConfig
+        ImmutableCassandraKeyValueServiceConfig quickTimeoutConfig = CassandraTestSuiteUtils.cassandraKvsConfig
                 .withSchemaMutationTimeoutMillis(500);
         kvs = CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig),
-                CassandraTestSuite.leaderConfig);
+                CassandraTestSuiteUtils.leaderConfig);
 
-        ImmutableCassandraKeyValueServiceConfig slowTimeoutConfig = CassandraTestSuite.cassandraKvsConfig
+        ImmutableCassandraKeyValueServiceConfig slowTimeoutConfig = CassandraTestSuiteUtils.cassandraKvsConfig
                 .withSchemaMutationTimeoutMillis(6 * 1000);
         slowTimeoutKvs = CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(slowTimeoutConfig),
-                CassandraTestSuite.leaderConfig);
+                CassandraTestSuiteUtils.leaderConfig);
 
         kvs.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -24,8 +24,8 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
     @Override
     protected KeyValueService getKeyValueService() {
         return CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.cassandraKvsConfig),
-                CassandraTestSuite.leaderConfig);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuiteUtils.cassandraKvsConfig),
+                CassandraTestSuiteUtils.leaderConfig);
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraSuite.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraSuite.java
@@ -34,13 +34,17 @@ import org.junit.runners.Suite;
         HeartbeatServiceIntegrationTest.class,
         SchemaMutationLockIntegrationTest.class,
         SchemaMutationLockTablesIntegrationTest.class
-})
-public class CassandraSuite {
+        })
+public final class CassandraSuite {
     @ClassRule
     public static final RuleChain CASSANDRA_DOCKER_SET_UP = CassandraTestSuiteUtils.CASSANDRA_DOCKER_SET_UP;
 
     @BeforeClass
     public static void beforeClass() throws IOException, InterruptedException {
         CassandraTestSuiteUtils.waitUntilCassandraIsUp();
+    }
+
+    private CassandraSuite() {
+        // Hidden constructor
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraSuite.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraSuite.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        CassandraClientPoolIntegrationTest.class,
+        CassandraConnectionIntegrationTest.class,
+        CassandraKeyValueServiceTableCreationIntegrationTest.class,
+        CassandraKeyValueServiceSweeperIntegrationTest.class,
+        CassandraTimestampIntegrationTest.class,
+        CassandraKeyValueServiceIntegrationTest.class,
+        HeartbeatServiceIntegrationTest.class,
+        SchemaMutationLockIntegrationTest.class,
+        SchemaMutationLockTablesIntegrationTest.class
+})
+public class CassandraSuite {
+    @ClassRule
+    public static final RuleChain CASSANDRA_DOCKER_SET_UP = CassandraTestSuiteUtils.CASSANDRA_DOCKER_SET_UP;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException, InterruptedException {
+        CassandraTestSuiteUtils.waitUntilCassandraIsUp();
+    }
+}

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuiteUtils.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuiteUtils.java
@@ -56,7 +56,7 @@ import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
         SchemaMutationLockIntegrationTest.class,
         SchemaMutationLockTablesIntegrationTest.class
         })
-public final class CassandraTestSuite {
+public final class CassandraTestSuiteUtils {
     public static final int THRIFT_PORT_NUMBER = 9160;
 
     private static final DockerComposeRule docker = DockerComposeRule.builder()

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuiteUtils.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestSuiteUtils.java
@@ -19,12 +19,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Callable;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
@@ -42,20 +37,6 @@ import com.palantir.docker.compose.connection.waiting.HealthCheck;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
-@RunWith(Suite.class)
-@SuiteClasses({
-        CassandraKeyValueServiceTransactionIntegrationTest.class,
-        CassandraClientPoolIntegrationTest.class,
-        CassandraConnectionIntegrationTest.class,
-        CassandraKeyValueServiceTableCreationIntegrationTest.class,
-        CassandraKeyValueServiceSerializableTransactionIntegrationTest.class,
-        CassandraKeyValueServiceSweeperIntegrationTest.class,
-        CassandraTimestampIntegrationTest.class,
-        CassandraKeyValueServiceIntegrationTest.class,
-        HeartbeatServiceIntegrationTest.class,
-        SchemaMutationLockIntegrationTest.class,
-        SchemaMutationLockTablesIntegrationTest.class
-        })
 public final class CassandraTestSuiteUtils {
     public static final int THRIFT_PORT_NUMBER = 9160;
 
@@ -67,7 +48,6 @@ public final class CassandraTestSuiteUtils {
     private static final Gradle GRADLE_PREPARE_TASK =
             Gradle.ensureTaskHasRun(":atlasdb-ete-test-utils:buildCassandraImage");
 
-    @ClassRule
     public static final RuleChain CASSANDRA_DOCKER_SET_UP = RuleChain.outerRule(GRADLE_PREPARE_TASK)
             .around(docker);
 
@@ -77,7 +57,6 @@ public final class CassandraTestSuiteUtils {
 
     static Optional<LeaderConfig> leaderConfig;
 
-    @BeforeClass
     public static void waitUntilCassandraIsUp() throws IOException, InterruptedException {
         DockerPort port = docker.hostNetworkedPort(THRIFT_PORT_NUMBER);
         String hostname = port.getIp();

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -31,8 +31,8 @@ public class CassandraTimestampIntegrationTest {
     @Before
     public void setUp() {
         kv = CassandraKeyValueService.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.cassandraKvsConfig),
-                CassandraTestSuite.leaderConfig);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuiteUtils.cassandraKvsConfig),
+                CassandraTestSuiteUtils.leaderConfig);
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTransactionsSuite.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTransactionsSuite.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        CassandraKeyValueServiceTransactionIntegrationTest.class,
+        CassandraKeyValueServiceSerializableTransactionIntegrationTest.class
+})
+public class CassandraTransactionsSuite {
+    @ClassRule
+    public static final RuleChain CASSANDRA_DOCKER_SET_UP = CassandraTestSuiteUtils.CASSANDRA_DOCKER_SET_UP;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException, InterruptedException {
+        CassandraTestSuiteUtils.waitUntilCassandraIsUp();
+    }
+}

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTransactionsSuite.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTransactionsSuite.java
@@ -27,13 +27,17 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
         CassandraKeyValueServiceTransactionIntegrationTest.class,
         CassandraKeyValueServiceSerializableTransactionIntegrationTest.class
-})
-public class CassandraTransactionsSuite {
+        })
+public final class CassandraTransactionsSuite {
     @ClassRule
     public static final RuleChain CASSANDRA_DOCKER_SET_UP = CassandraTestSuiteUtils.CASSANDRA_DOCKER_SET_UP;
 
     @BeforeClass
     public static void beforeClass() throws IOException, InterruptedException {
         CassandraTestSuiteUtils.waitUntilCassandraIsUp();
+    }
+
+    private CassandraTransactionsSuite() {
+        //Hidden constructor
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HeartbeatServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HeartbeatServiceIntegrationTest.java
@@ -61,13 +61,13 @@ public class HeartbeatServiceIntegrationTest {
     @Before
     public void setUp() throws TException {
         CassandraKeyValueServiceConfigManager simpleManager = CassandraKeyValueServiceConfigManager.createSimpleManager(
-                CassandraTestSuite.cassandraKvsConfig);
+                CassandraTestSuiteUtils.cassandraKvsConfig);
         queryRunner = new TracingQueryRunner(log, TracingPrefsConfig.create());
 
         writeConsistency = ConsistencyLevel.EACH_QUORUM;
         clientPool = new CassandraClientPool(simpleManager.getConfig());
         lockTable = new UniqueSchemaMutationLockTable(
-                new SchemaMutationLockTables(clientPool, CassandraTestSuite.cassandraKvsConfig),
+                new SchemaMutationLockTables(clientPool, CassandraTestSuiteUtils.cassandraKvsConfig),
                 LockLeader.I_AM_THE_LOCK_LEADER);
         heartbeatService = new HeartbeatService(clientPool,
                                                 queryRunner,

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockIntegrationTest.java
@@ -90,7 +90,7 @@ public class SchemaMutationLockIntegrationTest {
     }
 
     private void setUpWithCasSupportSetTo(boolean supportsCas) throws Exception {
-        quickTimeoutConfig = CassandraTestSuite.cassandraKvsConfig
+        quickTimeoutConfig = CassandraTestSuiteUtils.cassandraKvsConfig
                 .withSchemaMutationTimeoutMillis(500);
         CassandraKeyValueServiceConfigManager simpleManager =
                 CassandraKeyValueServiceConfigManager.createSimpleManager(quickTimeoutConfig);
@@ -212,7 +212,7 @@ public class SchemaMutationLockIntegrationTest {
 
     private SchemaMutationLock createQuickHeartbeatTimeoutLock() {
         CassandraKeyValueServiceConfigManager configManager =
-                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuite.cassandraKvsConfig);
+                CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraTestSuiteUtils.cassandraKvsConfig);
         TracingQueryRunner queryRunner = new TracingQueryRunner(log, TracingPrefsConfig.create());
         return new SchemaMutationLock(true, configManager, clientPool, queryRunner, writeConsistency, lockTable,
                 heartbeatService, 2000);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesIntegrationTest.java
@@ -48,7 +48,7 @@ public class SchemaMutationLockTablesIntegrationTest {
 
     @Before
     public void setupKvs() throws TException, InterruptedException {
-        config = CassandraTestSuite.cassandraKvsConfig
+        config = CassandraTestSuiteUtils.cassandraKvsConfig
                 .withKeyspace(UUID.randomUUID().toString().replace('-', '_')); // Hyphens not allowed in C* schema
         clientPool = new CassandraClientPool(config);
         clientPool.runOneTimeStartupChecks();


### PR DESCRIPTION
Just split into two Suites for now; we can do the actual rebalancing in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1079)
<!-- Reviewable:end -->
