### PR TITLE
(Develop) Add trace logging to help track down the MultipleTimestamps issue

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -15,6 +15,9 @@
  */
 package com.palantir.atlasdb.cassandra;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.auto.service.AutoService;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -30,6 +33,7 @@ import com.palantir.timestamp.TimestampService;
 
 @AutoService(AtlasDbFactory.class)
 public class CassandraAtlasDbFactory implements AtlasDbFactory {
+    private static final Logger log = LoggerFactory.getLogger(CassandraAtlasDbFactory.class);
 
     @Override
     public KeyValueService createRawKeyValueService(
@@ -52,6 +56,8 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
 
     @Override
     public TimestampService createTimestampService(KeyValueService rawKvs) {
+        log.trace("Creating timestamp service. This should only happen once.");
+
         AtlasDbVersion.ensureVersionReported();
         Preconditions.checkArgument(rawKvs instanceof CassandraKeyValueService,
                 "TimestampService must be created from an instance of"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -75,11 +75,13 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
     }
 
     private CassandraTimestampBoundStore(CassandraClientPool clientPool) {
+        log.trace("Creating CassandraTimestampBoundStore object. This should only happen once.");
         this.clientPool = Preconditions.checkNotNull(clientPool, "clientPool cannot be null");
     }
 
     @Override
     public synchronized long getUpperLimit() {
+        log.trace("[GET] Getting upper limit");
         return clientPool.runWithRetry(new FunctionCheckedException<Client, Long, RuntimeException>() {
             @Override
             public Long apply(Client client) {
@@ -95,11 +97,13 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                     throw Throwables.throwUncheckedException(e);
                 }
                 if (result == null) {
+                    log.trace("[GET] Null result, setting upper value to {}", INITIAL_VALUE);
                     cas(client, null, INITIAL_VALUE);
                     return INITIAL_VALUE;
                 }
                 Column column = result.getColumn();
                 currentLimit = PtBytes.toLong(column.getValue());
+                log.trace("[GET] Setting cached limit to {}.", currentLimit);
                 return currentLimit;
             }
         });
@@ -107,6 +111,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
 
     @Override
     public synchronized void storeUpperLimit(final long limit) {
+        log.trace("[PUT] Storing upper limit of {}.", limit);
         clientPool.runWithRetry(new FunctionCheckedException<Client, Void, RuntimeException>() {
             @Override
             public Void apply(Client client) {
@@ -120,6 +125,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
     private void cas(Client client, Long oldVal, long newVal) {
         final CASResult result;
         try {
+            log.trace("[CAS] Trying to set from {} to {}.", oldVal, newVal);
             result = client.cas(
                     getRowName(),
                     AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName(),
@@ -128,6 +134,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                     ConsistencyLevel.SERIAL,
                     ConsistencyLevel.EACH_QUORUM);
         } catch (Exception e) {
+            log.error("[CAS] Error trying to set from {} to {}: {}", oldVal, newVal, e.getMessage());
             lastWriteException = e;
             throw Throwables.throwUncheckedException(e);
         }
@@ -142,6 +149,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
             lastWriteException = err;
             throw err;
         } else {
+            log.trace("[CAS] Setting cached limit to {}.", newVal);
             lastWriteException = null;
             currentLimit = newVal;
         }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -57,7 +57,8 @@ public class ServiceDiscoveringAtlasSupplier {
     }
 
     public TimestampService getTimestampService() {
-        log.trace("Fetching timestamp service. This should only happen once.",
+        log.trace("Fetching timestamp service from thread {}. This should only happen once.",
+                Thread.currentThread().getName(),
                 new RuntimeException("Not necessarily exceptional, but here's a stack trace..."));
         return timestampService.get();
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -19,6 +19,9 @@ import java.util.ServiceLoader;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -29,6 +32,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.timestamp.TimestampService;
 
 public class ServiceDiscoveringAtlasSupplier {
+    private static final Logger log = LoggerFactory.getLogger(ServiceDiscoveringAtlasSupplier.class);
     private static final ServiceLoader<AtlasDbFactory> loader = ServiceLoader.load(AtlasDbFactory.class);
 
     private final KeyValueServiceConfig config;
@@ -53,6 +57,8 @@ public class ServiceDiscoveringAtlasSupplier {
     }
 
     public TimestampService getTimestampService() {
+        log.trace("Fetching timestamp service. This should only happen once.",
+                new RuntimeException("Not necessarily exceptional, but here's a stack trace..."));
         return timestampService.get();
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -117,6 +117,7 @@ public final class TransactionManagers {
             Environment env,
             LockServerOptions lockServerOptions,
             boolean allowHiddenTableAccess) {
+        log.trace("TransactionManagers.create. This should only happen once.");
         ServiceDiscoveringAtlasSupplier atlasFactory =
                 new ServiceDiscoveringAtlasSupplier(config.keyValueService(), config.leader());
         KeyValueService rawKvs = atlasFactory.getKeyValueService();

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
@@ -50,10 +50,13 @@ public class AvailableTimestamps {
     }
 
     public synchronized void refreshBuffer() {
-        long buffer = upperLimit.get() - lastHandedOut();
+        long currentUpperLimit = upperLimit.get();
+        long buffer = currentUpperLimit - lastHandedOut();
 
         if (buffer < MINIMUM_BUFFER || !upperLimit.hasIncreasedWithin(1, MINUTES)) {
-            log.trace("refreshBuffer: refreshing and allocating timestamps");
+            log.trace("refreshBuffer: refreshing and allocating timestamps. Buffer {}, Current upper limit {}.",
+                    buffer,
+                    currentUpperLimit);
             allocateEnoughTimestampsToHandOut(lastHandedOut() + ALLOCATION_BUFFER_SIZE);
         } else {
             log.trace("refreshBuffer: refreshing, but not allocating");
@@ -87,7 +90,7 @@ public class AvailableTimestamps {
     private void allocateEnoughTimestampsToHandOut(long timestamp) {
         log.trace("Increasing limit to at least {}.", timestamp);
         upperLimit.increaseToAtLeast(timestamp);
-        log.trace("Increasing done. Limit is now {}.", timestamp);
+        log.trace("Increased to at least {}. Limit is now {}.", timestamp, getUpperLimit());
     }
 
     public long getUpperLimit() {

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
@@ -19,7 +19,12 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class AvailableTimestamps {
+    private static final Logger log = LoggerFactory.getLogger(AvailableTimestamps.class);
+
     static final long ALLOCATION_BUFFER_SIZE = 1000 * 1000;
     private static final long MINIMUM_BUFFER = ALLOCATION_BUFFER_SIZE / 2;
     private static final long MAX_TIMESTAMPS_TO_HAND_OUT = 10 * 1000;
@@ -28,6 +33,7 @@ public class AvailableTimestamps {
     private final PersistentUpperLimit upperLimit;
 
     public AvailableTimestamps(LastReturnedTimestamp lastReturnedTimestamp, PersistentUpperLimit upperLimit) {
+        log.trace("Creating AvailableTimestamps object. This should only happen once.");
         this.lastReturnedTimestamp = lastReturnedTimestamp;
         this.upperLimit = upperLimit;
     }
@@ -38,14 +44,19 @@ public class AvailableTimestamps {
                 "Can only hand out %s timestamps at a time, but %s were requested",
                 MAX_TIMESTAMPS_TO_HAND_OUT, numberToHandOut);
 
-        return handOutTimestamp(lastHandedOut() + numberToHandOut);
+        long targetTimestamp = lastHandedOut() + numberToHandOut;
+        log.trace("Handing out {} timestamps, taking us to {}.", numberToHandOut, targetTimestamp);
+        return handOutTimestamp(targetTimestamp);
     }
 
     public synchronized void refreshBuffer() {
         long buffer = upperLimit.get() - lastHandedOut();
 
         if (buffer < MINIMUM_BUFFER || !upperLimit.hasIncreasedWithin(1, MINUTES)) {
+            log.trace("refreshBuffer: refreshing and allocating timestamps");
             allocateEnoughTimestampsToHandOut(lastHandedOut() + ALLOCATION_BUFFER_SIZE);
+        } else {
+            log.trace("refreshBuffer: refreshing, but not allocating");
         }
     }
 
@@ -59,6 +70,7 @@ public class AvailableTimestamps {
     }
 
     private synchronized TimestampRange handOutTimestamp(long targetTimestamp) {
+
         checkArgument(
                 targetTimestamp > lastHandedOut(),
                 "Could not hand out timestamp '%s' as it was earlier than the last handed out timestamp: %s",
@@ -73,7 +85,9 @@ public class AvailableTimestamps {
     }
 
     private void allocateEnoughTimestampsToHandOut(long timestamp) {
+        log.trace("Increasing limit to at least {}.", timestamp);
         upperLimit.increaseToAtLeast(timestamp);
+        log.trace("Increasing done. Limit is now {}.", timestamp);
     }
 
     public long getUpperLimit() {

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -19,17 +19,24 @@ import java.util.concurrent.ExecutorService;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Preconditions;
 import com.palantir.common.concurrent.PTExecutors;
 
 @ThreadSafe
 public class PersistentTimestampService implements TimestampService {
+    private static final Logger log = LoggerFactory.getLogger(PersistentTimestampService.class);
+
     private static final int MAX_REQUEST_RANGE_SIZE = 10 * 1000;
 
     private final ExecutorService executor;
     private final AvailableTimestamps availableTimestamps;
 
     public PersistentTimestampService(AvailableTimestamps availableTimestamps, ExecutorService executor) {
+        log.trace("Creating PersistentTimestampService object. This should only happen once.");
+
         this.availableTimestamps = availableTimestamps;
         this.executor = executor;
     }


### PR DESCRIPTION
If customers hit issue #1000, they can turn trace logging on for the
following packages, in order to give us extra information the next time
they hit it:
- com.palantir.atlasdb.cassandra
- com.palantir.atlasdb.keyvalue.cassandra
- com.palantir.atlasdb.factory
- com.palantir.timestamp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1085)
<!-- Reviewable:end -->
