### PR TITLE
Added nohup.out to gitignore to compensate for memory tracking in circle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ atlasdb-cli/var/data/
 
 # Rocksdb data
 var/data/rocksdb
+
+# Memory tracker nohup
+nohup.out
+nohup.err


### PR DESCRIPTION
We found that this nohup.out file was causing release builds to be marked as dirty (I imagine snapshots as well).  By ignoring it we should no longer have problems publishing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1089)
<!-- Reviewable:end -->
