### PR TITLE
fix regression in CKVS.createTable

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -1451,7 +1451,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             // if no existing table or if existing table's metadata is different
             if (!Arrays.equals(existingTableMetadata.get(tableReference), newMetadata)) {
                 Set<TableReference> matchingTables = Sets.filter(existingTableMetadata.keySet(), existingTableRef ->
-                        existingTableRef.getTablename().equalsIgnoreCase(tableReference.getTablename()));
+                        existingTableRef.getQualifiedName().equalsIgnoreCase(tableReference.getQualifiedName()));
 
                 // completely new table, not an update
                 if (matchingTables.isEmpty()) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,13 @@ v0.21.0
     *    - |fixed|
          - If ``hashFirstRowComponent()`` is used in a table definition, we no longer throw ``IllegalStateException`` when generating schema code.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1091>`__)
+ 
+
+    *    - |fixed|
+         - Fixed (and added tests for) a regression where you could no longer have tables
+           with the same table name spanned over multiple namespaces when running on Cassandra.
+	   (`Pull Request <https://github.com/palantir/atlasdb/pull/1110>`__)
+	
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
Discovered by internal product tests that have 
NSv1.fooTable and NSv2.fooTable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1110)
<!-- Reviewable:end -->
