### PR TITLE
allow users to debug oversize cell components

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
@@ -16,10 +16,14 @@
 package com.palantir.atlasdb.keyvalue.api;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,6 +42,7 @@ import com.palantir.atlasdb.encoding.PtBytes;
  */
 public final class Cell implements Serializable, Comparable<Cell> {
     private static final long serialVersionUID = 1L;
+    private static final Logger log = LoggerFactory.getLogger(Cell.class);
 
     // Oracle has an upper bound on RAW types of 2000.
     public static final int MAX_NAME_LENGTH = 1500;
@@ -62,10 +67,18 @@ public final class Cell implements Serializable, Comparable<Cell> {
         return name != null && name.length > 0 && name.length <= MAX_NAME_LENGTH;
     }
 
-    public static void validateNameValid(byte[] name) {
+    private void validateNameValid(byte[] name) {
         Preconditions.checkNotNull(name, "name cannot be null");
         Preconditions.checkArgument(name.length > 0, "name must be non-empty");
-        Preconditions.checkArgument(name.length <= MAX_NAME_LENGTH, "name must be no larger than " + MAX_NAME_LENGTH);
+
+        String lengthErrorMessage = "name must be no longer than " + MAX_NAME_LENGTH;
+        if (log.isDebugEnabled()) {
+            lengthErrorMessage += ". Cell creation that was attempted was: " + this
+                    + "; since the vast majority of people encountering this problem are using unbounded Strings as"
+                    + " components, it may aid your debugging to know the ASCII interpretation of the bad field was:"
+                    + " [" + new String(name, StandardCharsets.US_ASCII) + "]";
+        }
+        Preconditions.checkArgument(name.length <= MAX_NAME_LENGTH, lengthErrorMessage);
     }
 
     private final byte[] rowName;
@@ -82,11 +95,11 @@ public final class Cell implements Serializable, Comparable<Cell> {
     private Cell(@JsonProperty("rowName") byte[] rowName,
                  @JsonProperty("columnName") byte[] columnName,
                  @JsonProperty("ttlDurationMillis") long ttlDurationMillis) {
-        validateNameValid(rowName);
-        validateNameValid(columnName);
         this.rowName = rowName;
         this.columnName = columnName;
         this.ttlDurationMillis = ttlDurationMillis;
+        validateNameValid(rowName);
+        validateNameValid(columnName);
     }
 
     /**

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
@@ -78,8 +78,8 @@ public final class Cell implements Serializable, Comparable<Cell> {
                     MAX_NAME_LENGTH);
         } catch (IllegalArgumentException e) {
             log.debug("Cell creation that was attempted was: {}; since the vast majority of people encountering this "
-                    + "problem are using unbounded Strings as components, it may aid your debugging to know the ASCII "
-                    + "interpretation of the bad field was: [{}]", this, new String(name, StandardCharsets.US_ASCII));
+                    + "problem are using unbounded Strings as components, it may aid your debugging to know the UTF-8 "
+                    + "interpretation of the bad field was: [{}]", this, new String(name, StandardCharsets.UTF_8));
             throw e;
         }
     }
@@ -101,6 +101,7 @@ public final class Cell implements Serializable, Comparable<Cell> {
         this.rowName = rowName;
         this.columnName = columnName;
         this.ttlDurationMillis = ttlDurationMillis;
+
         validateNameValid(rowName);
         validateNameValid(columnName);
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Cell.java
@@ -71,14 +71,17 @@ public final class Cell implements Serializable, Comparable<Cell> {
         Preconditions.checkNotNull(name, "name cannot be null");
         Preconditions.checkArgument(name.length > 0, "name must be non-empty");
 
-        String lengthErrorMessage = "name must be no longer than " + MAX_NAME_LENGTH;
-        if (log.isDebugEnabled()) {
-            lengthErrorMessage += ". Cell creation that was attempted was: " + this
-                    + "; since the vast majority of people encountering this problem are using unbounded Strings as"
-                    + " components, it may aid your debugging to know the ASCII interpretation of the bad field was:"
-                    + " [" + new String(name, StandardCharsets.US_ASCII) + "]";
+        try {
+            Preconditions.checkArgument(
+                    name.length <= MAX_NAME_LENGTH,
+                    "name must be no longer than {}.",
+                    MAX_NAME_LENGTH);
+        } catch (IllegalArgumentException e) {
+            log.debug("Cell creation that was attempted was: {}; since the vast majority of people encountering this "
+                    + "problem are using unbounded Strings as components, it may aid your debugging to know the ASCII "
+                    + "interpretation of the bad field was: [{}]", this, new String(name, StandardCharsets.US_ASCII));
+            throw e;
         }
-        Preconditions.checkArgument(name.length <= MAX_NAME_LENGTH, lengthErrorMessage);
     }
 
     private final byte[] rowName;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,14 @@ v0.25.0
          - Our Jackson version has been updated from 2.5.1 to 2.6.7 and Dropwizard version from 0.8.2 to 0.9.3.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1209>`__)
 
+    *    - |improved|
+         - Additional debugging available for those receiving 'name must be no longer than 1500 bytes' errors.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1117>`__)
+
+    *    - |breaking|
+         - ``Cell.validateNameValid`` is now private; consider ``Cell.isNameValid`` instead
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1117>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
The weirdness here is because I don't want to put actual data in the logs normally. Happy to take suggestions/patches for a cleaner way to do it.

The context for this is that in the last day I've seen two atlas-using-products (both of whom have user-controlled unbounded-length strings tucked inside of their row components) have issues figuring out where their oversize components are coming from.
With logging like this, if they encounter the problem and turn this logging on, instead of "something somewhere was too big when you tried to do a write" they'll see their offending row component.

I also checked and did not see anyone using this public code endpoint which I here privatized and de-static'd so I could see the whole cell from it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1117)

<!-- Reviewable:end -->
