### PR TITLE
Fix/deprecate create unsafe

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
@@ -45,8 +45,10 @@ public final class TableReference {
     }
 
     public static TableReference createLowerCased(TableReference table) {
+        String name = table.namespace.getName().toLowerCase();
+        Namespace namespace = name.isEmpty() ? Namespace.EMPTY_NAMESPACE : Namespace.create(name);
         return create(
-                Namespace.create(table.namespace.getName().toLowerCase()),
+                namespace,
                 table.tablename.toLowerCase());
     }
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
@@ -44,6 +44,12 @@ public final class TableReference {
         return new TableReference(Namespace.EMPTY_NAMESPACE, tablename);
     }
 
+    public static TableReference createLowerCased(TableReference table) {
+        return create(
+                Namespace.create(table.namespace.getName().toLowerCase()),
+                table.tablename.toLowerCase());
+    }
+
     /**
      * @deprecated please use createFromFullyQualifiedName or createWithEmptyNamespace.
      */
@@ -119,5 +125,4 @@ public final class TableReference {
             throw new IllegalArgumentException(tableReferenceAsString + " is not a valid table reference.");
         }
     }
-
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
@@ -44,6 +44,10 @@ public final class TableReference {
         return new TableReference(Namespace.EMPTY_NAMESPACE, tablename);
     }
 
+    /**
+     * @deprecated please use createFromFullyQualifiedName or createWithEmptyNamespace.
+     */
+    @Deprecated
     public static TableReference createUnsafe(String fullTableName) {
         return fullTableName.indexOf('.') < 0
                 ? createWithEmptyNamespace(fullTableName)

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
@@ -28,6 +28,10 @@ public final class TableReference {
     private final Namespace namespace;
     private final String tablename;
 
+    /**
+     * Creates a table reference based on fullTableName.
+     * fullTableName is assumed to be of the format namespace.tableName, and must contain a dot.
+     */
     public static TableReference createFromFullyQualifiedName(String fullTableName) {
         int index = fullTableName.indexOf('.');
         Preconditions.checkArgument(index > 0, "Table name %s is not a fully qualified table name.");
@@ -40,6 +44,10 @@ public final class TableReference {
         return new TableReference(namespace, tablename);
     }
 
+    /**
+     * Creates a table reference with an empty namespace, based on tablename.
+     * This should only be used when creating a TableReference for a system table.
+     */
     public static TableReference createWithEmptyNamespace(String tablename) {
         return new TableReference(Namespace.EMPTY_NAMESPACE, tablename);
     }
@@ -53,7 +61,8 @@ public final class TableReference {
     }
 
     /**
-     * @deprecated please use createFromFullyQualifiedName or createWithEmptyNamespace.
+     * @deprecated please use createFromFullyQualifiedName, if fullTableName includes the namespace,
+     * or createWithEmptyNamespace, if you're passing in a system table name.
      */
     @Deprecated
     public static TableReference createUnsafe(String fullTableName) {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReference.java
@@ -34,7 +34,7 @@ public final class TableReference {
      */
     public static TableReference createFromFullyQualifiedName(String fullTableName) {
         int index = fullTableName.indexOf('.');
-        Preconditions.checkArgument(index > 0, "Table name %s is not a fully qualified table name.");
+        Preconditions.checkArgument(index > 0, "Table name %s is not a fully qualified table name.", fullTableName);
         return create(
                 Namespace.create(fullTableName.substring(0, index), Namespace.UNCHECKED_NAME),
                 fullTableName.substring(index + 1));

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TableReferenceTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TableReferenceTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TableReferenceTest {
+    @Test
+    public void createLowerCasedWithNamespace() {
+        String upperFoo = "FOO";
+        String upperBar = "BAR";
+
+        TableReference upper = TableReference.create(Namespace.create(upperFoo), upperBar);
+        TableReference lower = TableReference.createLowerCased(upper);
+
+        assertEquals(lower.getNamespace().getName(), upperFoo.toLowerCase());
+        assertEquals(lower.getTablename(), upperBar.toLowerCase());
+    }
+
+    @Test
+    public void createLowerCasedWithoutNamespace() {
+        String upperBar = "BAR";
+
+        TableReference upper = TableReference.createWithEmptyNamespace(upperBar);
+        TableReference lower = TableReference.createLowerCased(upper);
+
+        assertEquals(lower.getNamespace(), Namespace.EMPTY_NAMESPACE);
+        assertEquals(lower.getTablename(), upperBar.toLowerCase());
+    }
+
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -1409,7 +1409,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 CassandraVerifier.sanityCheckTableName(table);
 
                 TableReference tableRefLowerCased = TableReference
-                        .createUnsafe(table.getQualifiedName().toLowerCase());
+                        .createLowerCased(table);
                 if (!existingTablesLowerCased.contains(tableRefLowerCased)) {
                     filteredTables.put(table, metadata);
                 } else {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -49,7 +49,7 @@ public class SchemaMutationLockTables {
         return client.describe_keyspace(config.keyspace()).getCf_defs().stream()
                 .map(CfDef::getName)
                 .filter(IS_LOCK_TABLE)
-                .map(TableReference::createUnsafe)
+                .map(TableReference::createWithEmptyNamespace)
                 .collect(Collectors.toSet());
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
@@ -39,12 +39,12 @@ public class HiddenTablesTest {
 
     @Test public void
     shouldSayAnOldStyleLocksTableIsHidden() {
-        assertThat(hiddenTables.isHidden(TableReference.createUnsafe("_locks")), is(true));
+        assertThat(hiddenTables.isHidden(TableReference.createWithEmptyNamespace("_locks")), is(true));
     }
 
     @Test public void
     shouldSayANewStyleLocksTableIsHidden() {
-        assertThat(hiddenTables.isHidden(TableReference.createUnsafe("_locks_aaaa_123")), is(true));
+        assertThat(hiddenTables.isHidden(TableReference.createWithEmptyNamespace("_locks_aaaa_123")), is(true));
     }
 
     @Test public void

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -299,9 +299,13 @@ public abstract class AbstractKeyValueService implements KeyValueService {
         return tableName.replaceFirst("\\.", "__");
     }
 
+    /** @deprecated uses TableReference.createUnsafe, which is itself deprecated.
+     *
+     */
+    @Deprecated
     protected static TableReference fromInternalTableName(String tableName) {
         if (tableName.startsWith("_")) {
-            return TableReference.createUnsafe(tableName);
+            return TableReference.createWithEmptyNamespace(tableName);
         }
         return TableReference.createUnsafe(tableName.replaceFirst("__", "."));
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -237,7 +237,8 @@ public abstract class AbstractKeyValueService implements KeyValueService {
                                     " bytes, larger than maximum size of " + maximumBytesPerPartition +
                                     " defined per entire batch, while doing a write to " + tableName +
                                     ". Attempting to batch anyways.";
-                            if (AtlasDbConstants.TABLES_KNOWN_TO_BE_POORLY_DESIGNED.contains(TableReference.createUnsafe(tableName))) {
+                            if (AtlasDbConstants.TABLES_KNOWN_TO_BE_POORLY_DESIGNED.contains(
+                                    TableReference.createWithEmptyNamespace(tableName))) {
                                 log.warn(message);
                             } else {
                                 log.warn(message + " This can potentially cause out-of-memory errors.");

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -996,7 +996,7 @@ public class DbKvs extends AbstractKeyValueService {
     }
 
     public void checkDatabaseVersion() {
-        runDdl(TableReference.createUnsafe(""), new Function<DbDdlTable, Void>() {
+        runDdl(TableReference.createWithEmptyNamespace(""), new Function<DbDdlTable, Void>() {
             @Override
             public Void apply(DbDdlTable table) {
                 table.checkDatabaseVersion();

--- a/atlasdb-service/build.gradle
+++ b/atlasdb-service/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     compile project(':leader-election-impl')
     compile project(':atlasdb-config')
     compile 'javax.inject:javax.inject:1'
+
+    testCompile group: 'org.mockito', name: 'mockito-core', version: libVersions.mockito
 }
 
 configurations.matching({ it.name in ['compile', 'runtime'] }).all {

--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/impl/AtlasDbServiceImpl.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/impl/AtlasDbServiceImpl.java
@@ -175,7 +175,7 @@ public class AtlasDbServiceImpl implements AtlasDbService {
 
     @Override
     public void truncateTable(final String fullyQualifiedTableName) {
-        kvs.truncateTable(getTableRef(fullyQualifiedTableName));
+        kvs.truncateTable(TableReference.createFromFullyQualifiedName(fullyQualifiedTableName));
     }
 
     private <T> T runReadOnly(TransactionToken token, RuntimeTransactionTask<T> task) {

--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/impl/AtlasDbServiceImpl.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/impl/AtlasDbServiceImpl.java
@@ -175,7 +175,7 @@ public class AtlasDbServiceImpl implements AtlasDbService {
 
     @Override
     public void truncateTable(final String fullyQualifiedTableName) {
-        kvs.truncateTable(TableReference.createFromFullyQualifiedName(fullyQualifiedTableName));
+        kvs.truncateTable(getTableRef(fullyQualifiedTableName));
     }
 
     private <T> T runReadOnly(TransactionToken token, RuntimeTransactionTask<T> task) {

--- a/atlasdb-service/src/test/java/com/palantir/atlasdb/impl/AtlasDbServiceImplTest.java
+++ b/atlasdb-service/src/test/java/com/palantir/atlasdb/impl/AtlasDbServiceImplTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.impl;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
+
+public class AtlasDbServiceImplTest {
+    private KeyValueService kvs;
+    private AtlasDbServiceImpl atlasDbService;
+
+    @Before
+    public void setUp() {
+        kvs = mock(KeyValueService.class);
+        SerializableTransactionManager txManager = mock(SerializableTransactionManager.class);
+        TableMetadataCache metadataCache = mock(TableMetadataCache.class);
+        atlasDbService = new AtlasDbServiceImpl(kvs, txManager, metadataCache);
+    }
+
+    @Test
+    public void shouldTruncateSystemTables() throws Exception {
+        atlasDbService.truncateTable("_locks");
+
+        TableReference tableToTruncate = TableReference.createWithEmptyNamespace("_locks");
+        verify(kvs, atLeastOnce()).truncateTable(tableToTruncate);
+    }
+
+    @Test
+    public void shouldTruncateNamespacedTables() throws Exception {
+        atlasDbService.truncateTable("ns.table");
+
+        TableReference tableToTruncate = TableReference.createFromFullyQualifiedName("ns.table");
+        verify(kvs, atLeastOnce()).truncateTable(tableToTruncate);
+    }
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -156,8 +156,8 @@ public class TableTasksTest {
 
     @Test
     public void shouldAllowSameTablenameDifferentNamespace() {
-        TableReference fooBar = TableReference.createUnsafe("foo.bar");
-        TableReference bazBar = TableReference.createUnsafe("baz.bar");
+        TableReference fooBar = TableReference.createFromFullyQualifiedName("foo.bar");
+        TableReference bazBar = TableReference.createFromFullyQualifiedName("baz.bar");
 
         // try create table in same call
         kvs.createTables(

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,8 +45,12 @@ develop
          - Added a significant amount of logging aimed at tracking down the ``MultipleRunningTimestampServicesError``.
            If clients are hitting this error, then they should add trace logging for ``com.palantir.timestamp``.
            These logs can also be directed to a separate file, see the :ref:`documentation <logging-configuration>` for more details.
-
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1098>`__)
+
+    *    - |deprecated|
+         - ``TableReference.createUnsafe`` is now deprecated. ``createWithEmptyNamespace`` or ``createFromFullyQualifiedName`` should be used instead.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1121>`__)
+           
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
Deprecated TableReferences.createUnsafe.

Removed a number of instances, but there are still over 20 remaining, largely because in these cases we actually get a String (or worse, a byte array) from the outside world.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1121)

<!-- Reviewable:end -->
