### PR TITLE
chuck a newer copy of our C* partitioner over the wall

### DIFF
--- a/cassandra-partitioner/build.gradle
+++ b/cassandra-partitioner/build.gradle
@@ -4,4 +4,6 @@ dependencies {
     compile('org.apache.cassandra:cassandra-all:' + libVersions.cassandra) {
         transitive = false
     }
+    compile(group: 'org.apache.commons', name: 'commons-lang3', version: libVersions.commons_lang3)
+    compile(group: 'com.google.guava', name: 'guava', version: libVersions.guava)
 }

--- a/cassandra-partitioner/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/dht/AtlasDbOrderedPartitioner.java
+++ b/cassandra-partitioner/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/dht/AtlasDbOrderedPartitioner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Palantir Technologies
+ * Copyright 2016 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,85 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra.dht;
 
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.security.SecureRandom;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Hex;
+import org.apache.cassandra.utils.Pair;
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 
 public class AtlasDbOrderedPartitioner extends ByteOrderedPartitioner {
     private final Random r = new SecureRandom();
     private final AtomicInteger indexCounter = new AtomicInteger(r.nextInt(6));
+    public static final AtlasBytesToken MINIMUM = new AtlasBytesToken(ArrayUtils.EMPTY_BYTE_ARRAY);
+
+    public static final AtlasDbOrderedPartitioner instance = new AtlasDbOrderedPartitioner();
+
+    public static class AtlasBytesToken extends ByteOrderedPartitioner.BytesToken {
+        private static final long serialVersionUID = 8285261694722952407L;
+
+        public AtlasBytesToken(ByteBuffer token)
+        {
+            this(ByteBufferUtil.getArray(token));
+        }
+
+        public AtlasBytesToken(byte[] token) {
+            super(token);
+        }
+
+        @Override
+        public IPartitioner getPartitioner()
+        {
+            return instance;
+        }
+    }
 
     @Override
-    public BytesToken getRandomToken() {
+    public AtlasBytesToken getToken(ByteBuffer key)
+    {
+        if (key.remaining() == 0)
+            return MINIMUM;
+        return new AtlasBytesToken(key);
+    }
+
+
+    @Override
+    public AtlasBytesToken getMinimumToken()
+    {
+        return MINIMUM;
+    }
+
+    @Override
+    public AtlasBytesToken midpoint(Token lt, Token rt)
+    {
+        byte[] leftTokenValue = (byte[]) ((AtlasBytesToken) lt).getTokenValue();
+        byte[] rightTokenValue = (byte[]) ((AtlasBytesToken) rt).getTokenValue();
+
+        int sigbytes = Math.max(leftTokenValue.length, rightTokenValue.length);
+        BigInteger left = bigForBytes(leftTokenValue, sigbytes);
+        BigInteger right = bigForBytes(rightTokenValue, sigbytes);
+
+        Pair<BigInteger,Boolean> midpair = FBUtilities.midpoint(left, right, 8*sigbytes);
+        return new AtlasBytesToken(bytesForBig(midpair.left, sigbytes, midpair.right));
+    }
+
+    @Override
+    public AtlasBytesToken getRandomToken() {
         byte[] buffer = new byte[16];
         r.nextBytes(buffer);
 
@@ -38,18 +105,18 @@ public class AtlasDbOrderedPartitioner extends ByteOrderedPartitioner {
             // This is a very common case.
             // This is used for little endian longs, sha256 hashes as well.
             buffer[0] |= 0x80; // high bit is one for positive longs.
-            return new BytesToken(buffer);
+            return new AtlasBytesToken(buffer);
         case 1:
             // This is the standard case of having a negative fixed long.
             // This is used for little endian longs, sha256 hashes as well.
             buffer[0] &= 0x7f;
-            return new BytesToken(buffer);
+            return new AtlasBytesToken(buffer);
         case 3:
             // This is the 1, fixlong case.
             // This handles the base realm, positive object id specifically.
             buffer[0] = 1;
-            buffer[1] |= 0x80; // we sort postive after neg by doing id ^ Long.MIN_VALUE
-            return new BytesToken(buffer);
+            buffer[1] |= 0x80; // we sort positive after neg by doing id ^ Long.MIN_VALUE
+            return new AtlasBytesToken(buffer);
         case 5:
             // This is the positive varlong case.
             // This handles realm_id which is a var_long in most tables.
@@ -57,10 +124,30 @@ public class AtlasDbOrderedPartitioner extends ByteOrderedPartitioner {
             randVal &= Long.MAX_VALUE;
             byte[] bytes = encodeVarLong(randVal);
             System.arraycopy(bytes, 0, buffer, 0, bytes.length);
-            return new BytesToken(buffer);
+            return new AtlasBytesToken(buffer);
         default:
             throw new IllegalStateException();
         }
+    }
+
+    /**
+     * Get a billion FDEs off my back about their ownership percentages being wonky
+     * because AbstractByteOrdererPartitioner assumes a uniform token distribution that we don't have.
+     * Also should fix an ArrayIndexOutOfBoundsException that can happen while nodetool status-ing soon
+     * after cluster startup.
+     */
+    @Override
+    public Map<Token, Float> describeOwnership(final List<Token> sortedTokens) {
+        return Maps.asMap(ImmutableSet.copyOf(sortedTokens), new Function<Token, Float>() {
+            @Override
+            public Float apply(Token token) {
+                if (sortedTokens.size() > 0) {
+                    return 1f / sortedTokens.size();
+                } else {
+                    return 0f;
+                }
+            }
+        });
     }
 
     private static byte[] encodeVarLong(long value) {
@@ -72,7 +159,7 @@ public class AtlasDbOrderedPartitioner extends ByteOrderedPartitioner {
 
     /**
      * There will be size-1 bits set before there is a zero. All the bits of
-     * value will or-ed (|=) onto the the passed byte[].
+     * value will be or-ed (|=) onto the the passed byte[].
      *
      * @param size must be <= 17 (but will most likely be 10 or 11 at most)
      */
@@ -112,5 +199,95 @@ public class AtlasDbOrderedPartitioner extends ByteOrderedPartitioner {
         if ((value & (0xffffffffffffffffL << 63)) == 0)
             return 9;
         return 10;
+    }
+
+    private final Token.TokenFactory tokenFactory = new Token.TokenFactory() {
+        @Override
+        public ByteBuffer toByteArray(Token token)
+        {
+            AtlasBytesToken bytesToken = (AtlasBytesToken) token;
+            return ByteBuffer.wrap((byte[]) bytesToken.getTokenValue());
+        }
+
+        @Override
+        public Token fromByteArray(ByteBuffer bytes)
+        {
+            return new AtlasBytesToken(bytes);
+        }
+
+        @Override
+        public String toString(Token token)
+        {
+            AtlasBytesToken bytesToken = (AtlasBytesToken) token;
+            return Hex.bytesToHex((byte[]) bytesToken.getTokenValue());
+        }
+
+        @Override
+        public void validate(String token) throws ConfigurationException
+        {
+            try
+            {
+                if (token.length() % 2 == 1)
+                    token = "0" + token;
+                Hex.hexToBytes(token);
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException("Token " + token + " contains non-hex digits");
+            }
+        }
+
+        @Override
+        public Token fromString(String string)
+        {
+            if (string.length() % 2 == 1)
+                string = "0" + string;
+            return new AtlasBytesToken(Hex.hexToBytes(string));
+        }
+    };
+
+    @Override
+    public Token.TokenFactory getTokenFactory()
+    {
+        return tokenFactory;
+    }
+
+    /**
+     * Convert a byte array containing the most significant of 'sigbytes' bytes
+     * representing a big-endian magnitude into a BigInteger.
+     */
+    private BigInteger bigForBytes(byte[] bytes, int sigbytes)
+    {
+        byte[] b;
+        if (sigbytes != bytes.length)
+        {
+            b = new byte[sigbytes];
+            System.arraycopy(bytes, 0, b, 0, bytes.length);
+        } else
+            b = bytes;
+        return new BigInteger(1, b);
+    }
+
+    /**
+     * Convert a (positive) BigInteger into a byte array representing its magnitude.
+     * If remainder is true, an additional byte with the high order bit enabled
+     * will be added to the end of the array
+     */
+    private byte[] bytesForBig(BigInteger big, int sigbytes, boolean remainder)
+    {
+        byte[] bytes = new byte[sigbytes + (remainder ? 1 : 0)];
+        if (remainder)
+        {
+            // remaining bit is the most significant in the last byte
+            bytes[sigbytes] |= 0x80;
+        }
+        // bitmask for a single byte
+        for (int i = 0; i < sigbytes; i++)
+        {
+            int maskpos = 8 * (sigbytes - (i + 1));
+            // apply bitmask and get byte value
+            bytes[i] = (byte)(big.and(BYTE_MASK.shiftLeft(maskpos)).shiftRight(maskpos).intValue() & 0xFF);
+        }
+        return bytes;
     }
 }


### PR DESCRIPTION
Someone asked a question about this code, which made me realize we hadn't chucked new partitioner code over the open source wall in a long time.

The changes are mainly for compatibility with newer versions of Cassandra.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1122)

<!-- Reviewable:end -->
