### PR TITLE
Make sure to schedule refreshes properly for all locks

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -217,7 +217,7 @@ public final class TransactionManagers {
             LockAndTimestampServices lockAndTimestampServices) {
         return ImmutableLockAndTimestampServices.builder()
                 .from(lockAndTimestampServices)
-                .lock(LockRefreshingRemoteLockService.create(lockAndTimestampServices.lock()))
+                .lock(new LockRefreshingRemoteLockService(lockAndTimestampServices.lock()))
                 .build();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -95,7 +95,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
         TransactionTables.createTables(keyValueService);
 
         TransactionService transactionService = TransactionServices.createTransactionService(keyValueService);
-        RemoteLockService lock = LockRefreshingLockService.create(LockServiceImpl.create(new LockServerOptions() {
+        RemoteLockService lock = new LockRefreshingLockService(LockServiceImpl.create(new LockServerOptions() {
             private static final long serialVersionUID = 1L;
 
             @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,11 +50,6 @@ develop
            overridden by the ``LockRefreshingLockService``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1134>`__)
 
-    *    - |fixed|
-         - Fixed an issue where some locks were not being tracked for continuous refreshing due to one of the lock methods not being
-           overridden by the ``LockRefreshingLockService``.  Code has been refactored to reduce the risk of this mistake happening again.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1123>`__)
-
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
            overridden by the ``LockRefreshingLockService``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1134>`__)
 
+    *    - |fixed|
+         - Fixed an issue where some locks were not being tracked for continuous refreshing due to one of the lock methods not being
+           overridden by the ``LockRefreshingLockService``.  Code has been refactored to reduce the risk of this mistake happening again.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1123>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.lock.client;
+
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.TimeDuration;
+
+class LockRefresher {
+    private static final Logger log = LoggerFactory.getLogger(LockRefresher.class);
+
+    private final RemoteLockService delegate;
+    private final Set<LockRefreshToken> toRefresh;
+    private final ScheduledExecutorService exec;
+    private final long refreshFrequencyMillis;
+    private volatile boolean isClosed = false;
+
+    public static LockRefresher create(RemoteLockService delegate,
+            ScheduledExecutorService executor, TimeDuration refreshRate) {
+        LockRefresher refresher = new LockRefresher(delegate, executor, refreshRate);
+        refresher.scheduleRefresh();
+        return refresher;
+    }
+
+    private LockRefresher(RemoteLockService delegate,
+            ScheduledExecutorService executor, TimeDuration refreshRate) {
+        this.delegate = delegate;
+        toRefresh = Sets.newConcurrentHashSet();
+        this.exec = executor;
+        refreshFrequencyMillis = refreshRate.toMillis();
+    }
+
+    void scheduleRefresh() {
+        exec.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                long startTime = System.currentTimeMillis();
+                try {
+                    refreshLocks();
+                } catch (Throwable t) {
+                    log.error("Failed to refresh locks", t);
+                } finally {
+                    long elapsed = System.currentTimeMillis() - startTime;
+
+                    if (elapsed > LockRequest.DEFAULT_LOCK_TIMEOUT.toMillis()/2) {
+                        log.error("Refreshing locks took " + elapsed + " milliseconds" +
+                                " for tokens: " + toRefresh);
+                    } else if (elapsed > refreshFrequencyMillis) {
+                        log.warn("Refreshing locks took " + elapsed + " milliseconds" +
+                                " for tokens: " + toRefresh);
+                    }
+                }
+            }
+        }, 0, refreshFrequencyMillis, TimeUnit.MILLISECONDS);
+    }
+
+    private void refreshLocks() {
+        ImmutableSet<LockRefreshToken> refreshCopy = ImmutableSet.copyOf(toRefresh);
+        if (refreshCopy.isEmpty()) {
+            return;
+        }
+        Set<LockRefreshToken> refreshedTokens = delegate.refreshLockRefreshTokens(refreshCopy);
+        for (LockRefreshToken token : refreshCopy) {
+            if (!refreshedTokens.contains(token)
+                    && toRefresh.contains(token)) {
+                log.error("failed to refresh lock: " + token);
+                toRefresh.remove(token);
+            }
+        }
+    }
+
+    public boolean startRefreshing(LockRefreshToken token) {
+        return toRefresh.add(token);
+    }
+
+    public boolean stopRefreshing(LockRefreshToken token) {
+        return toRefresh.remove(token);
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        if (!isClosed) {
+            log.warn("Closing in the finalize method.  This should be closed explicitly.");
+            dispose();
+        }
+    }
+
+    public void dispose() {
+        exec.shutdown();
+        isClosed = true;
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingRemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingRemoteLockService.java
@@ -19,114 +19,75 @@ import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.lock.ForwardingRemoteLockService;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.TimeDuration;
 
-public class LockRefreshingRemoteLockService extends ForwardingRemoteLockService {
-    private static final Logger log = LoggerFactory.getLogger(LockRefreshingRemoteLockService.class);
+public class LockRefreshingRemoteLockService implements RemoteLockService {
 
-    final RemoteLockService delegate;
-    final Set<LockRefreshToken> toRefresh;
-    final ScheduledExecutorService exec;
-    final long refreshFrequencyMillis = 5000;
-    volatile boolean isClosed = false;
+    private final RemoteLockService delegate;
+    protected final LockRefresher refresher;
 
-    public static LockRefreshingRemoteLockService create(RemoteLockService delegate) {
-        final LockRefreshingRemoteLockService ret = new LockRefreshingRemoteLockService(delegate);
-        ret.exec.scheduleWithFixedDelay(new Runnable() {
-            @Override
-            public void run() {
-                long startTime = System.currentTimeMillis();
-                try {
-                    ret.refreshLocks();
-                } catch (Throwable t) {
-                    log.error("Failed to refresh locks", t);
-                } finally {
-                    long elapsed = System.currentTimeMillis() - startTime;
-
-                    if (elapsed > LockRequest.DEFAULT_LOCK_TIMEOUT.toMillis()/2) {
-                        log.error("Refreshing locks took " + elapsed + " milliseconds" +
-                                " for tokens: " + ret.toRefresh);
-                    } else if (elapsed > ret.refreshFrequencyMillis) {
-                        log.warn("Refreshing locks took " + elapsed + " milliseconds" +
-                                " for tokens: " + ret.toRefresh);
-                    }
-                }
-            }
-        }, 0, ret.refreshFrequencyMillis, TimeUnit.MILLISECONDS);
-        return ret;
+    public LockRefreshingRemoteLockService(RemoteLockService delegate) {
+        this(delegate, PTExecutors.newScheduledThreadPoolExecutor(1,
+                PTExecutors.newNamedThreadFactory(true)), SimpleTimeDuration.of(5, TimeUnit.SECONDS));
     }
 
-    private LockRefreshingRemoteLockService(RemoteLockService delegate) {
+    LockRefreshingRemoteLockService(RemoteLockService delegate,
+            ScheduledExecutorService executor, TimeDuration refreshRate) {
         this.delegate = delegate;
-        toRefresh = Sets.newConcurrentHashSet();
-        exec = PTExecutors.newScheduledThreadPool(1, PTExecutors.newNamedThreadFactory(true));
-    }
-
-    @Override
-    protected RemoteLockService delegate() {
-        return delegate;
+        refresher = LockRefresher.create(delegate, executor, refreshRate);
     }
 
     @Override
     public LockRefreshToken lock(String client, LockRequest request) throws InterruptedException {
-        LockRefreshToken ret = super.lock(client, request);
+        LockRefreshToken ret = delegate.lock(client, request);
         if (ret != null) {
-            toRefresh.add(ret);
+            refresher.startRefreshing(ret);
         }
         return ret;
     }
 
     @Override
     public HeldLocksToken lockAndGetHeldLocks(String client, LockRequest request) throws InterruptedException {
-        HeldLocksToken ret = super.lockAndGetHeldLocks(client, request);
+        HeldLocksToken ret = delegate.lockAndGetHeldLocks(client, request);
         if (ret != null) {
-            toRefresh.add(ret.getLockRefreshToken());
+            refresher.startRefreshing(ret.getLockRefreshToken());
         }
         return ret;
     }
 
     @Override
     public boolean unlock(LockRefreshToken token) {
-        toRefresh.remove(token);
-        return super.unlock(token);
-    }
-
-    private void refreshLocks() {
-        ImmutableSet<LockRefreshToken> refreshCopy = ImmutableSet.copyOf(toRefresh);
-        if (refreshCopy.isEmpty()) {
-            return;
-        }
-        Set<LockRefreshToken> refreshedTokens = delegate().refreshLockRefreshTokens(refreshCopy);
-        for (LockRefreshToken token : refreshCopy) {
-            if (!refreshedTokens.contains(token)
-                    && toRefresh.contains(token)) {
-                log.error("failed to refresh lock: " + token);
-                toRefresh.remove(token);
-            }
-        }
-    }
-
-    @Override
-    protected void finalize() throws Throwable {
-        super.finalize();
-        if (!isClosed) {
-            log.warn("Closing in the finalize method.  This should be closed explicitly.");
-            dispose();
-        }
+        refresher.stopRefreshing(token);
+        return delegate.unlock(token);
     }
 
     public void dispose() {
-        exec.shutdown();
-        isClosed = true;
+        refresher.dispose();
+    }
+
+    @Override
+    public Set<LockRefreshToken> refreshLockRefreshTokens(Iterable<LockRefreshToken> tokens) {
+        return delegate.refreshLockRefreshTokens(tokens);
+    }
+
+    @Override
+    public Long getMinLockedInVersionId(String client) {
+        return delegate.getMinLockedInVersionId(client);
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return delegate.currentTimeMillis();
+    }
+
+    @Override
+    public void logCurrentState() {
+        delegate.logCurrentState();
     }
 }

--- a/lock-impl/src/test/java/com/palantir/lock/client/LockRefreshingLockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/client/LockRefreshingLockServiceTest.java
@@ -46,7 +46,7 @@ public class LockRefreshingLockServiceTest {
 //    private LockDescriptor lock2;
 
     @Before public void setUp() {
-        server = LockRefreshingLockService.create(LockServiceImpl.create(
+        server = new LockRefreshingLockService(LockServiceImpl.create(
                 new LockServerOptions() {
                     private static final long serialVersionUID = 1L;
                     @Override public boolean isStandaloneServer() {


### PR DESCRIPTION
Also make the lock refreshing classes not extend
ForwardingLockService since that leaves open an easy
opportunity for failing to add the code to refresh locks
when adding new methods of acquiring locks.  Plus
a little extra refactoring.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1123)

<!-- Reviewable:end -->
