### PR TITLE
add sweep tables to hiddenTables

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
@@ -59,7 +60,9 @@ public class AtlasDbConstants {
             PUNCH_TABLE,
             SCRUB_TABLE,
             NAMESPACE_TABLE,
-            PARTITION_MAP_TABLE);
+            PARTITION_MAP_TABLE,
+            SweepSchema.SWEEP_PRIORITY_TABLE,
+            SweepSchema.SWEEP_PROGRESS_TABLE);
     public static final Set<TableReference> SKIP_POSTFILTER_TABLES = ImmutableSet.of(TransactionConstants.TRANSACTION_TABLE,
             NAMESPACE_TABLE);
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SweepSchema.java
@@ -20,6 +20,9 @@ import java.io.File;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.schema.generated.SweepPriorityTable;
+import com.palantir.atlasdb.schema.generated.SweepProgressTable;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
@@ -35,6 +38,8 @@ public enum SweepSchema implements AtlasSchema {
             return generateSchema();
         }
     });
+    public static final TableReference SWEEP_PRIORITY_TABLE = TableReference.create(SweepSchema.NAMESPACE, SweepPriorityTable.getRawTableName());
+    public static final TableReference SWEEP_PROGRESS_TABLE = TableReference.create(SweepSchema.NAMESPACE, SweepProgressTable.getRawTableName());
 
     private static Schema generateSchema() {
         Schema schema = new Schema("Sweep",


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1129)

<!-- Reviewable:end -->

Opening this PR because tests on my local machine are sad.  It's not clear from the code what the guarantees around hiddenTables are (we should add a comment above it or something) and there are so many consumers of it , so I'm not sure if what I did was safe.

My ultimate goal here is to get KeyValueServiceValidator.validate() to skip the sweep tables during validation.  I can get unblocked by just manually forcing it in a separate build but this seemed like the more correct long term answer.
