### PR TITLE
Remove unnecessary dropwizard and autoservice dependencies

### DIFF
--- a/atlasdb-jdbc/build.gradle
+++ b/atlasdb-jdbc/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   compile project(":atlasdb-client")
   compile project(":timestamp-impl")
 
-  compile group: 'io.dropwizard', name: 'dropwizard-jackson'
   compile "org.jooq:jooq:3.6.4"
 
   processor "org.immutables:value:" + libVersions.immutables

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/jdbc/config/JdbcDataSourceConfiguration.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/jdbc/config/JdbcDataSourceConfiguration.java
@@ -20,12 +20,8 @@ import javax.sql.DataSource;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.google.auto.service.AutoService;
 
-import io.dropwizard.jackson.Discoverable;
-
-@AutoService(Discoverable.class)
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type", visible = false)
+@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
 public interface JdbcDataSourceConfiguration {
 
     String getType();

--- a/atlasdb-jdbc/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/atlasdb-jdbc/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,0 +1,1 @@
+com.palantir.atlasdb.jdbc.config.JdbcDataSourceConfiguration

--- a/commons-db/build.gradle
+++ b/commons-db/build.gradle
@@ -24,8 +24,6 @@ dependencies {
 
   compile group: 'com.zaxxer', name: 'HikariCP', version: libVersions.hikariCP
   compile group: 'joda-time', name: 'joda-time'
-  compile group: 'io.dropwizard', name: 'dropwizard-jackson'
-  processor 'com.google.auto.service:auto-service:1.0-rc2'
 
   testCompile group: 'junit', name: 'junit'
 }

--- a/commons-db/src/main/java/com/palantir/db/oracle/JdbcHandler.java
+++ b/commons-db/src/main/java/com/palantir/db/oracle/JdbcHandler.java
@@ -22,16 +22,12 @@ import java.sql.SQLException;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.google.auto.service.AutoService;
-
-import io.dropwizard.jackson.Discoverable;
 
 /**
  * JdbcHandler allows Oracle dependent logic to be injected into the SQL
  * dependent classes that support both Legacy DB and AtlasDB's Dbkvs
  */
-@AutoService(Discoverable.class)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", visible = false)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface JdbcHandler {
     interface BlobHandler {
         void freeTemporary() throws SQLException;

--- a/commons-db/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/commons-db/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,0 +1,1 @@
+com.palantir.db.oracle.JdbcHandler


### PR DESCRIPTION
[no release notes]

Dependency change:
```diff
@@atlasdb-dbkvs-hikari@@
-ch.qos.logback:logback-classic:1.1.3
-ch.qos.logback:logback-core:1.1.3
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.1
-com.fasterxml.jackson.datatype:jackson-datatype-jdk7:2.5.1
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.1
-com.fasterxml.jackson.module:jackson-module-afterburner:2.5.1
-io.dropwizard:dropwizard-jackson:0.8.2
-io.dropwizard:dropwizard-util:0.8.2

@@atlasdb-dbkvs@@
-ch.qos.logback:logback-classic:1.1.3
-ch.qos.logback:logback-core:1.1.3
-com.fasterxml.jackson.datatype:jackson-datatype-jdk7:2.5.1
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.1
-com.fasterxml.jackson.module:jackson-module-afterburner:2.5.1
-io.dropwizard:dropwizard-jackson:0.8.2
-io.dropwizard:dropwizard-util:0.8.2

@@atlasdb-hikari@@
-ch.qos.logback:logback-classic:1.1.3
-ch.qos.logback:logback-core:1.1.3
-com.fasterxml.jackson.datatype:jackson-datatype-jdk7:2.5.1
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.1
-com.fasterxml.jackson.module:jackson-module-afterburner:2.5.1
-io.dropwizard:dropwizard-jackson:0.8.2
-io.dropwizard:dropwizard-util:0.8.2
-joda-time:joda-time:2.7

@@atlasdb-jdbc@@
-ch.qos.logback:logback-classic:1.1.3
-ch.qos.logback:logback-core:1.1.3
-com.fasterxml.jackson.datatype:jackson-datatype-jdk7:2.5.1
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.1
-com.fasterxml.jackson.module:jackson-module-afterburner:2.5.1
-io.dropwizard:dropwizard-jackson:0.8.2
-io.dropwizard:dropwizard-util:0.8.2
-joda-time:joda-time:2.7

@@commons-db@@
-ch.qos.logback:logback-classic:1.1.3
-ch.qos.logback:logback-core:1.1.3
-com.fasterxml.jackson.core:jackson-core:2.5.1
-com.fasterxml.jackson.core:jackson-databind:2.5.1
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.5.1
-com.fasterxml.jackson.datatype:jackson-datatype-jdk7:2.5.1
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.5.1
-com.fasterxml.jackson.module:jackson-module-afterburner:2.5.1
-io.dropwizard:dropwizard-jackson:0.8.2
-io.dropwizard:dropwizard-util:0.8.2
```
<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1131)

<!-- Reviewable:end -->
