### PR TITLE
Improve perf of getRowsColumnRange

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,4 @@ ignore:
   - "atlasdb-ete-tests/" # these run in docker containers so they're not tracked
   - "atlasdb-exec/src/main/java/com/palantir/atlasdb/clis/RegenerateCodeForSchemas.java" # only run by devs in IDE
   - "cassandra-partitioner/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/dht/AtlasDbOrderedPartitioner.java" # only here for documentation
+  - "atlasdb-perf/" # benchmarks that are run separately

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbQueryFactory.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.base.Joiner;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+
+public abstract class AbstractDbQueryFactory implements DbQueryFactory {
+    @Override
+    public FullQuery getRowsColumnRangeQuery(
+            Map<byte[], BatchColumnRangeSelection> columnRangeSelectionsByRow,
+            long ts) {
+        List<String> subQueries = new ArrayList<>(columnRangeSelectionsByRow.size());
+        int totalArgs = 0;
+        for (BatchColumnRangeSelection columnRangeSelection : columnRangeSelectionsByRow.values()) {
+            totalArgs += 2 + ((columnRangeSelection.getStartCol().length > 0) ? 1 : 0)
+                    + ((columnRangeSelection.getEndCol().length > 0) ? 1 : 0);
+        }
+        List<Object> args = new ArrayList<>(totalArgs);
+        for (Map.Entry<byte[], BatchColumnRangeSelection> entry : columnRangeSelectionsByRow.entrySet()) {
+            FullQuery query = getRowsColumnRangeSubQuery(entry.getKey(), ts, entry.getValue());
+            subQueries.add(query.getQuery());
+            for (Object arg : query.getArgs()) {
+                args.add(arg);
+            }
+        }
+        String query = Joiner.on(") UNION ALL (").appendTo(new StringBuilder("("), subQueries).append(")")
+                .append(" ORDER BY row_name ASC, col_name ASC").toString();
+        return new FullQuery(query).withArgs(args);
+    }
+
+    @Override
+    public FullQuery getRowsColumnRangeQuery(RowsColumnRangeBatchRequest batch, long ts) {
+        List<FullQuery> fullQueries = new ArrayList<>();
+        if (batch.getPartialFirstRow().isPresent()) {
+            fullQueries.add(getRowsColumnRangeSubQuery(batch.getPartialFirstRow().get().getKey(),
+                    ts,
+                    batch.getPartialFirstRow().get().getValue()));
+        }
+        if (!batch.getRowsToLoadFully().isEmpty()) {
+            fullQueries.add(getRowsColumnRangeFullyLoadedRowsSubQuery(batch.getRowsToLoadFully(),
+                    ts,
+                    batch.getColumnRangeSelection()));
+
+        }
+        if (batch.getPartialLastRow().isPresent()) {
+            fullQueries.add(getRowsColumnRangeSubQuery(batch.getPartialLastRow().get().getKey(),
+                    ts,
+                    batch.getPartialLastRow().get().getValue()));
+        }
+
+        List<String> subQueries = fullQueries.stream().map(FullQuery::getQuery).collect(Collectors.toList());
+        int totalArgs = fullQueries.stream().mapToInt(fullQuery -> fullQuery.getArgs().length).sum();
+        List<Object> args = fullQueries.stream()
+                .flatMap(fullQuery -> Stream.of(fullQuery.getArgs()))
+                .collect(Collectors.toCollection(() -> new ArrayList<>(totalArgs)));
+        String query = Joiner.on(") UNION ALL (")
+                .appendTo(new StringBuilder("("), subQueries)
+                .append(")")
+                .append(" ORDER BY row_name ASC, col_name ASC")
+                .toString();
+        return new FullQuery(query).withArgs(args);
+    }
+
+    protected abstract FullQuery getRowsColumnRangeFullyLoadedRowsSubQuery(
+            List<byte[]> rowsToLoadFully,
+            long ts,
+            ColumnRangeSelection columnRangeSelection);
+
+    protected abstract FullQuery getRowsColumnRangeSubQuery(byte[] key, long ts, BatchColumnRangeSelection value);
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbQueryFactory.java
@@ -53,22 +53,16 @@ public abstract class AbstractDbQueryFactory implements DbQueryFactory {
     @Override
     public FullQuery getRowsColumnRangeQuery(RowsColumnRangeBatchRequest batch, long ts) {
         List<FullQuery> fullQueries = new ArrayList<>();
-        if (batch.getPartialFirstRow().isPresent()) {
-            fullQueries.add(getRowsColumnRangeSubQuery(batch.getPartialFirstRow().get().getKey(),
-                    ts,
-                    batch.getPartialFirstRow().get().getValue()));
-        }
+        batch.getPartialFirstRow()
+                .ifPresent(entry -> fullQueries.add(getRowsColumnRangeSubQuery(entry.getKey(), ts, entry.getValue())));
         if (!batch.getRowsToLoadFully().isEmpty()) {
             fullQueries.add(getRowsColumnRangeFullyLoadedRowsSubQuery(batch.getRowsToLoadFully(),
                     ts,
                     batch.getColumnRangeSelection()));
 
         }
-        if (batch.getPartialLastRow().isPresent()) {
-            fullQueries.add(getRowsColumnRangeSubQuery(batch.getPartialLastRow().get().getKey(),
-                    ts,
-                    batch.getPartialLastRow().get().getValue()));
-        }
+        batch.getPartialLastRow()
+                .ifPresent(entry -> fullQueries.add(getRowsColumnRangeSubQuery(entry.getKey(), ts, entry.getValue())));
 
         List<String> subQueries = fullQueries.stream().map(FullQuery::getQuery).collect(Collectors.toList());
         int totalArgs = fullQueries.stream().mapToInt(fullQuery -> fullQuery.getArgs().length).sum();

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbReadTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbReadTable.java
@@ -254,6 +254,17 @@ public abstract class AbstractDbReadTable implements DbReadTable {
     }
 
     @Override
+    public ClosableIterator<AgnosticLightResultRow> getRowsColumnRange(
+             RowsColumnRangeBatchRequest rowsColumnRangeBatch,
+             long ts) {
+        FullQuery query = queryFactory.getRowsColumnRangeQuery(rowsColumnRangeBatch, ts);
+        AgnosticLightResultSet results =
+                conns.get().selectLightResultSetUnregisteredQuery(query.getQuery(), query.getArgs());
+        results.setFetchSize(MAX_ROW_COLUMN_RANGES_FETCH_SIZE);
+        return ClosableIterators.wrap(results.iterator(), results);
+    }
+
+    @Override
     public boolean hasOverflowValues() {
         return queryFactory.hasOverflowValues();
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -19,6 +19,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -607,13 +608,18 @@ public class DbKvs extends AbstractKeyValueService {
         List<byte[]> rowList = ImmutableList.copyOf(rows);
         Map<Sha256Hash, byte[]> rowHashesToBytes = Maps.uniqueIndex(rowList, Sha256Hash::computeHash);
 
-        Map<Sha256Hash, Integer> ordered =
+        Map<Sha256Hash, Integer> columnCountByRowHash =
                 getColumnCounts(tableRef, rowList, columnRangeSelection, timestamp);
 
         Iterator<Map<Sha256Hash, Integer>> batches =
-                DbKvsPartitioners.partitionByTotalCount(ordered, cellBatchHint).iterator();
+                DbKvsPartitioners.partitionByTotalCount(columnCountByRowHash, cellBatchHint).iterator();
         Iterator<Iterator<Map.Entry<Cell, Value>>> results =
-                loadColumnsForBatches(tableRef, columnRangeSelection, timestamp, rowHashesToBytes, batches);
+                loadColumnsForBatches(tableRef,
+                                      columnRangeSelection,
+                                      timestamp,
+                                      rowHashesToBytes,
+                                      batches,
+                                      columnCountByRowHash);
         return new LocalRowColumnRangeIterator(Iterators.concat(results));
     }
 
@@ -622,7 +628,8 @@ public class DbKvs extends AbstractKeyValueService {
             ColumnRangeSelection columnRangeSelection,
             long timestamp,
             Map<Sha256Hash, byte[]> rowHashesToBytes,
-            Iterator<Map<Sha256Hash, Integer>> batches) {
+            Iterator<Map<Sha256Hash, Integer>> batches,
+            Map<Sha256Hash, Integer> columnCountByRowHash) {
         Iterator<Iterator<Map.Entry<Cell, Value>>> results = new AbstractIterator<Iterator<Map.Entry<Cell, Value>>>() {
             private Sha256Hash lastRowHashInPreviousBatch = null;
             private byte[] lastColumnInPreviousBatch = null;
@@ -633,8 +640,8 @@ public class DbKvs extends AbstractKeyValueService {
                     return endOfData();
                 }
                 Map<Sha256Hash, Integer> currentBatch = batches.next();
-                Map<byte[], BatchColumnRangeSelection> columnRangeSelectionsByRow =
-                        getBatchColumnRangeSelectionsByRow(currentBatch);
+                RowsColumnRangeBatchRequest columnRangeSelectionsByRow =
+                        getBatchColumnRangeSelectionsByRow(currentBatch, columnCountByRowHash);
 
                 Map<byte[], List<Map.Entry<Cell, Value>>> resultsByRow =
                         runRead(tableRef, dbReadTable ->
@@ -657,23 +664,38 @@ public class DbKvs extends AbstractKeyValueService {
                 return loadedColumns.iterator();
             }
 
-            private Map<byte[], BatchColumnRangeSelection> getBatchColumnRangeSelectionsByRow(
-                    Map<Sha256Hash, Integer> columnCountsByRowHash) {
-                Map<byte[], BatchColumnRangeSelection> columnRangeSelectionsByRow =
-                        new HashMap<>(columnCountsByRowHash.size());
-                for (Map.Entry<Sha256Hash, Integer> entry : columnCountsByRowHash.entrySet()) {
+            private RowsColumnRangeBatchRequest getBatchColumnRangeSelectionsByRow(
+                    Map<Sha256Hash, Integer> columnCountsByRowHashInBatch,
+                    Map<Sha256Hash, Integer> totalColumnCountsByRowHash) {
+                RowsColumnRangeBatchRequest.Builder rowsColumnRangeBatch =
+                        new RowsColumnRangeBatchRequest.Builder().columnRangeSelectionForFullRows(columnRangeSelection);
+                Iterator<Map.Entry<Sha256Hash, Integer>> entries = columnCountsByRowHashInBatch.entrySet().iterator();
+                while (entries.hasNext()) {
+                    Map.Entry<Sha256Hash, Integer> entry = entries.next();
                     Sha256Hash rowHash = entry.getKey();
-                    byte[] startCol = Objects.equals(lastRowHashInPreviousBatch, rowHash)
-                            ? RangeRequests.nextLexicographicName(lastColumnInPreviousBatch)
-                            : columnRangeSelection.getStartCol();
-                    BatchColumnRangeSelection batchColumnRangeSelection =
-                            BatchColumnRangeSelection.create(
-                                    startCol,
-                                    columnRangeSelection.getEndCol(),
-                                    entry.getValue());
-                    columnRangeSelectionsByRow.put(rowHashesToBytes.get(rowHash), batchColumnRangeSelection);
+                    byte[] row = rowHashesToBytes.get(rowHash);
+                    boolean isPartialFirstRow = Objects.equals(lastRowHashInPreviousBatch, rowHash);
+                    if (isPartialFirstRow) {
+                        byte[] startCol = RangeRequests.nextLexicographicName(lastColumnInPreviousBatch);
+                        BatchColumnRangeSelection columnRange =
+                                BatchColumnRangeSelection.create(
+                                        startCol,
+                                        columnRangeSelection.getEndCol(),
+                                        entry.getValue());
+                        rowsColumnRangeBatch.partialFirstRow(row, columnRange);
+                        continue;
+                    }
+                    boolean isFullyLoadedRow = totalColumnCountsByRowHash.get(rowHash).equals(entry.getValue());
+                    if (isFullyLoadedRow) {
+                        rowsColumnRangeBatch.fullRow(row);
+                    } else {
+                        Preconditions.checkArgument(!entries.hasNext(), "Only the last row should be partial.");
+                        BatchColumnRangeSelection columnRange =
+                                BatchColumnRangeSelection.create(columnRangeSelection, entry.getValue());
+                        rowsColumnRangeBatch.partialLastRow(row, columnRange);
+                    }
                 }
-                return columnRangeSelectionsByRow;
+                return rowsColumnRangeBatch.build();
             }
         };
         return results;
@@ -747,13 +769,33 @@ public class DbKvs extends AbstractKeyValueService {
         return extractRowColumnRangePage(table, Maps.toMap(rows, Functions.constant(columnRangeSelection)), ts);
     }
 
-    private Map<byte[], List<Map.Entry<Cell, Value>>> extractRowColumnRangePage(
-            DbReadTable table,
-            Map<byte[], BatchColumnRangeSelection> columnRangeSelectionsByRow,
+    private Map<byte[], List<Entry<Cell, Value>>> extractRowColumnRangePage(
+            DbReadTable dbReadTable,
+            Map<byte[], BatchColumnRangeSelection> columnRangeSelection,
             long ts) {
-        Map<Sha256Hash, byte[]> hashesToBytes = Maps.newHashMapWithExpectedSize(columnRangeSelectionsByRow.size());
+        return extractRowColumnRangePageInternal(
+            dbReadTable,
+            table -> table.getRowsColumnRange(columnRangeSelection, ts),
+            columnRangeSelection.keySet());
+    }
+
+    private Map<byte[], List<Entry<Cell, Value>>> extractRowColumnRangePage(
+            DbReadTable dbReadTable,
+            RowsColumnRangeBatchRequest rowsColumnRangeBatch,
+            long ts) {
+        return extractRowColumnRangePageInternal(
+            dbReadTable,
+            table -> table.getRowsColumnRange(rowsColumnRangeBatch, ts),
+            RowsColumnRangeBatchRequests.getAllRowsInOrder(rowsColumnRangeBatch));
+    }
+
+    private Map<byte[], List<Map.Entry<Cell, Value>>> extractRowColumnRangePageInternal(
+            DbReadTable table,
+            Function<DbReadTable, ClosableIterator<AgnosticLightResultRow>> rowLoader,
+            Collection<byte[]> allRowsInOrder) {
+        Map<Sha256Hash, byte[]> hashesToBytes = Maps.newHashMapWithExpectedSize(allRowsInOrder.size());
         Map<Sha256Hash, List<Cell>> cellsByRow = Maps.newHashMap();
-        for (byte[] row : columnRangeSelectionsByRow.keySet()) {
+        for (byte[] row : allRowsInOrder) {
             Sha256Hash rowHash = Sha256Hash.computeHash(row);
             hashesToBytes.put(rowHash, row);
             cellsByRow.put(rowHash, Lists.newArrayList());
@@ -763,7 +805,7 @@ public class DbKvs extends AbstractKeyValueService {
         Map<Cell, Value> values = Maps.newHashMap();
         Map<Cell, OverflowValue> overflowValues = Maps.newHashMap();
 
-        try (ClosableIterator<AgnosticLightResultRow> iter = table.getRowsColumnRange(columnRangeSelectionsByRow, ts)) {
+        try (ClosableIterator<AgnosticLightResultRow> iter = rowLoader.apply(table)) {
             while (iter.hasNext()) {
                 AgnosticLightResultRow row = iter.next();
                 Cell cell = Cell.create(row.getBytes("row_name"), row.getBytes("col_name"));
@@ -789,7 +831,7 @@ public class DbKvs extends AbstractKeyValueService {
         fillOverflowValues(table, overflowValues, values);
 
         Map<byte[], List<Map.Entry<Cell, Value>>> results =
-                Maps.newHashMapWithExpectedSize(columnRangeSelectionsByRow.size());
+                Maps.newHashMapWithExpectedSize(allRowsInOrder.size());
         for (Entry<Sha256Hash, List<Cell>> e : cellsByRow.entrySet()) {
             List<Map.Entry<Cell, Value>> fullResults = Lists.newArrayListWithExpectedSize(e.getValue().size());
             for (Cell c : e.getValue()) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbQueryFactory.java
@@ -48,5 +48,5 @@ public interface DbQueryFactory {
 
     FullQuery getRowsColumnRangeCountsQuery(Iterable<byte[]> rows, long ts, ColumnRangeSelection columnRangeSelection);
     FullQuery getRowsColumnRangeQuery(Map<byte[], BatchColumnRangeSelection> columnRangeSelectionsByRow, long ts);
-    FullQuery getRowsColumnRangeQuery(RowsColumnRangeBatchRequest partition, long ts);
+    FullQuery getRowsColumnRangeQuery(RowsColumnRangeBatchRequest batch, long ts);
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbQueryFactory.java
@@ -48,4 +48,5 @@ public interface DbQueryFactory {
 
     FullQuery getRowsColumnRangeCountsQuery(Iterable<byte[]> rows, long ts, ColumnRangeSelection columnRangeSelection);
     FullQuery getRowsColumnRangeQuery(Map<byte[], BatchColumnRangeSelection> columnRangeSelectionsByRow, long ts);
+    FullQuery getRowsColumnRangeQuery(RowsColumnRangeBatchRequest partition, long ts);
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbReadTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbReadTable.java
@@ -51,6 +51,9 @@ public interface DbReadTable {
     ClosableIterator<AgnosticLightResultRow> getRowsColumnRange(
             Map<byte[], BatchColumnRangeSelection> columnRangeSelectionsByRow,
             long ts);
+    ClosableIterator<AgnosticLightResultRow> getRowsColumnRange(
+            RowsColumnRangeBatchRequest rowsColumnRangeBatch,
+            long ts);
 
     boolean hasOverflowValues();
     ClosableIterator<AgnosticLightResultRow> getOverflow(Collection<OverflowValue> overflowIds);

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequest.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+
+/**
+ * Represents a batch to load in {@link com.palantir.atlasdb.keyvalue.api.KeyValueService#getRowsColumnRange(
+ * com.palantir.atlasdb.keyvalue.api.TableReference, Iterable, ColumnRangeSelection, int, long)}. The overall iteration
+ * order returns all requested columns for the first row, followed by all requested columns for the second row, and so
+ * forth. Hence, a single batch consists of some contiguous group of rows to fully load, plus optionally a first row
+ * that has a different starting column and optionally a last row where we load a number of columns less than the total.
+ */
+public final class RowsColumnRangeBatchRequest {
+    private final Optional<Map.Entry<byte[], BatchColumnRangeSelection>> partialFirstRow;
+    private final ImmutableList<byte[]> rowsToLoadFully;
+    private final ColumnRangeSelection columnRangeSelection;
+    private final Optional<Map.Entry<byte[], BatchColumnRangeSelection>> partialLastRow;
+
+    private RowsColumnRangeBatchRequest(Optional<Entry<byte[], BatchColumnRangeSelection>> partialFirstRow,
+            ImmutableList<byte[]> rowsToLoadFully,
+            ColumnRangeSelection columnRangeSelection,
+            Optional<Entry<byte[], BatchColumnRangeSelection>> partialLastRow) {
+        this.partialFirstRow = partialFirstRow;
+        this.rowsToLoadFully = rowsToLoadFully;
+        this.columnRangeSelection = columnRangeSelection;
+        this.partialLastRow = partialLastRow;
+    }
+
+    public boolean hasPartialFirstRow() {
+        return partialFirstRow.isPresent();
+    }
+
+    public Map.Entry<byte[], BatchColumnRangeSelection> getPartialFirstRow() {
+        return partialFirstRow.get();
+    }
+
+    public List<byte[]> getRowsToLoadFully() {
+        return rowsToLoadFully;
+    }
+
+    public ColumnRangeSelection getColumnRangeSelection() {
+        return columnRangeSelection;
+    }
+
+    public boolean hasPartialLastRow() {
+        return partialLastRow.isPresent();
+    }
+
+    public Map.Entry<byte[], BatchColumnRangeSelection> getPartialLastRow() {
+        return partialLastRow.get();
+    }
+
+    public static class Builder {
+        private Optional<Map.Entry<byte[], BatchColumnRangeSelection>> partialFirstRow = Optional.empty();
+        private final ImmutableList.Builder<byte[]> rowsToLoadFully = ImmutableList.builder();
+        private ColumnRangeSelection columnRangeSelection;
+        private Optional<Map.Entry<byte[], BatchColumnRangeSelection>> partialLastRow = Optional.empty();
+
+        public Builder partialFirstRow(byte[] row, BatchColumnRangeSelection columnRange) {
+            return partialFirstRow(Maps.immutableEntry(row, columnRange));
+        }
+
+        public Builder partialFirstRow(Map.Entry<byte[], BatchColumnRangeSelection> row) {
+            this.partialFirstRow = Optional.of(row);
+            return this;
+        }
+
+        public Builder columnRangeSelectionForFullRows(ColumnRangeSelection columnRange) {
+            this.columnRangeSelection = columnRange;
+            return this;
+        }
+
+        public Builder fullRow(byte[] row) {
+            this.rowsToLoadFully.add(row);
+            return this;
+        }
+
+        public Builder fullRows(Iterable<byte[]> rows) {
+            this.rowsToLoadFully.addAll(rows);
+            return this;
+        }
+
+        public Builder partialLastRow(byte[] row, BatchColumnRangeSelection batchColumnRange) {
+            return partialLastRow(Maps.immutableEntry(row, batchColumnRange));
+        }
+
+        public Builder partialLastRow(Map.Entry<byte[], BatchColumnRangeSelection> row) {
+            this.partialLastRow = Optional.of(row);
+            return this;
+        }
+
+        public RowsColumnRangeBatchRequest build() {
+            ImmutableList<byte[]> rows = rowsToLoadFully.build();
+            Preconditions.checkState(columnRangeSelection != null || rows.isEmpty(),
+                                     "Must specify a column range selection when loading full rows.");
+            return new RowsColumnRangeBatchRequest(partialFirstRow, rows, columnRangeSelection, partialLastRow);
+        }
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequests.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequests.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+public final class RowsColumnRangeBatchRequests {
+    private RowsColumnRangeBatchRequests() {
+        // Utility class
+    }
+
+    public static List<byte[]> getAllRowsInOrder(RowsColumnRangeBatchRequest batch) {
+        List<byte[]> allRows = new ArrayList<>(batch.getRowsToLoadFully().size() + 2);
+        if (batch.hasPartialFirstRow()) {
+            allRows.add(batch.getPartialFirstRow().getKey());
+        }
+        allRows.addAll(batch.getRowsToLoadFully());
+        if (batch.hasPartialLastRow()) {
+            allRows.add(batch.getPartialLastRow().getKey());
+        }
+        return allRows;
+    }
+
+    public static List<RowsColumnRangeBatchRequest> partition(RowsColumnRangeBatchRequest batch, int partitionSize) {
+        if (getAllRowsInOrder(batch).size() <= partitionSize) {
+            return ImmutableList.of(batch);
+        }
+
+        List<List<byte[]>> partitionedRows = Lists.partition(getAllRowsInOrder(batch), partitionSize);
+        List<RowsColumnRangeBatchRequest> partitions = new ArrayList<>(partitionedRows.size());
+        for (int partitionNumber = 0; partitionNumber < partitionedRows.size(); partitionNumber++) {
+            List<byte[]> allRowsInPartition = partitionedRows.get(partitionNumber);
+            boolean partitionHasPartialFirstRow = partitionNumber == 0 && batch.hasPartialFirstRow();
+            boolean partitionHasPartialLastRow =
+                    partitionNumber == partitionedRows.size() - 1 && batch.hasPartialLastRow();
+
+            RowsColumnRangeBatchRequest.Builder partition = new RowsColumnRangeBatchRequest.Builder();
+            if (partitionHasPartialFirstRow) {
+                partition = partition.partialFirstRow(batch.getPartialFirstRow());
+            }
+            List<byte[]> rowsToFullyLoad =
+                    getRowsToFullyLoad(allRowsInPartition, partitionHasPartialFirstRow, partitionHasPartialLastRow);
+            if (!rowsToFullyLoad.isEmpty()) {
+                partition = partition.columnRangeSelectionForFullRows(batch.getColumnRangeSelection())
+                                     .fullRows(rowsToFullyLoad);
+            }
+            if (partitionHasPartialLastRow) {
+                partition = partition.partialLastRow(batch.getPartialLastRow());
+            }
+
+            partitions.add(partition.build());
+        }
+        return partitions;
+    }
+
+    private static List<byte[]> getRowsToFullyLoad(List<byte[]> rows, boolean partialFirstRow, boolean partialLastRow) {
+        int fromIndex = partialFirstRow ? 1 : 0;
+        int toIndex = partialLastRow ? rows.size() - 1 : rows.size();
+        return rows.subList(fromIndex, toIndex);
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresQueryFactory.java
@@ -15,13 +15,9 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
@@ -32,12 +28,11 @@ import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.dbkvs.PostgresDdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbQueryFactory;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.AbstractDbQueryFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.FullQuery;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowValue;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.RowsColumnRangeBatchRequest;
 
-public class PostgresQueryFactory implements DbQueryFactory {
+public class PostgresQueryFactory extends AbstractDbQueryFactory {
     private final String tableName;
     private final PostgresDdlConfig config;
 
@@ -331,62 +326,10 @@ public class PostgresQueryFactory implements DbQueryFactory {
     }
 
     @Override
-    public FullQuery getRowsColumnRangeQuery(
-            Map<byte[], BatchColumnRangeSelection> columnRangeSelectionsByRow,
-            long ts) {
-        List<String> subQueries = new ArrayList<>(columnRangeSelectionsByRow.size());
-        int totalArgs = 0;
-        for (BatchColumnRangeSelection columnRangeSelection : columnRangeSelectionsByRow.values()) {
-            totalArgs += 2 + ((columnRangeSelection.getStartCol().length > 0) ? 1 : 0)
-                    + ((columnRangeSelection.getEndCol().length > 0) ? 1 : 0);
-        }
-        List<Object> args = new ArrayList<>(totalArgs);
-        for (Map.Entry<byte[], BatchColumnRangeSelection> entry : columnRangeSelectionsByRow.entrySet()) {
-            FullQuery query = getRowsColumnRangeSubQuery(entry.getKey(), ts, entry.getValue());
-            subQueries.add(query.getQuery());
-            for (Object arg : query.getArgs()) {
-                args.add(arg);
-            }
-        }
-        String query = Joiner.on(") UNION ALL (").appendTo(new StringBuilder("("), subQueries).append(")")
-                .append(" ORDER BY row_name ASC, col_name ASC").toString();
-        return new FullQuery(query).withArgs(args);
-    }
-
-    @Override
-    public FullQuery getRowsColumnRangeQuery(RowsColumnRangeBatchRequest batch, long ts) {
-        List<FullQuery> fullQueries = new ArrayList<>();
-        if (batch.hasPartialFirstRow()) {
-            fullQueries.add(getRowsColumnRangeSubQuery(batch.getPartialFirstRow().getKey(),
-                    ts,
-                    batch.getPartialFirstRow().getValue()));
-        }
-        if (!batch.getRowsToLoadFully().isEmpty()) {
-            fullQueries.add(getRowsColumnRangeFullyLoadedRowsSubQuery(batch.getRowsToLoadFully(),
-                    ts,
-                    batch.getColumnRangeSelection()));
-
-        }
-        if (batch.hasPartialLastRow()) {
-            fullQueries.add(getRowsColumnRangeSubQuery(batch.getPartialLastRow().getKey(),
-                    ts,
-                    batch.getPartialLastRow().getValue()));
-        }
-
-        List<String> subQueries = fullQueries.stream().map(FullQuery::getQuery).collect(Collectors.toList());
-        int totalArgs = fullQueries.stream().mapToInt(fullQuery -> fullQuery.getArgs().length).sum();
-        List<Object> args = fullQueries.stream()
-                .flatMap(fullQuery -> Stream.of(fullQuery.getArgs()))
-                .collect(Collectors.toCollection(() -> new ArrayList<>(totalArgs)));
-        String query = Joiner.on(") UNION ALL (")
-                .appendTo(new StringBuilder("("), subQueries)
-                .append(")")
-                .append(" ORDER BY row_name ASC, col_name ASC")
-                .toString();
-        return new FullQuery(query).withArgs(args);
-    }
-
-    private FullQuery getRowsColumnRangeSubQuery(byte[] row, long ts, BatchColumnRangeSelection columnRangeSelection) {
+    protected FullQuery getRowsColumnRangeSubQuery(
+            byte[] row,
+            long ts,
+            BatchColumnRangeSelection columnRangeSelection) {
         String query = " /* GET_ROWS_COLUMN_RANGE (" + tableName + ") */ "
                 + " SELECT m.row_name, m.col_name, max(m.ts) as ts"
                 + "   FROM " + prefixedTableName() + " m "
@@ -408,7 +351,8 @@ public class PostgresQueryFactory implements DbQueryFactory {
         return fullQuery;
     }
 
-    private FullQuery getRowsColumnRangeFullyLoadedRowsSubQuery(
+    @Override
+    protected FullQuery getRowsColumnRangeFullyLoadedRowsSubQuery(
             List<byte[]> rows,
             long ts,
             ColumnRangeSelection columnRangeSelection) {

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequestsTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequestsTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.primitives.Ints;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+
+@RunWith(Parameterized.class)
+public class RowsColumnRangeBatchRequestsTest {
+    private final boolean hasPartialFirstRow;
+    private final boolean hasPartialLastRow;
+
+    public RowsColumnRangeBatchRequestsTest(boolean hasPartialFirstRow, boolean hasPartialLastRow) {
+        this.hasPartialFirstRow = hasPartialFirstRow;
+        this.hasPartialLastRow = hasPartialLastRow;
+    }
+
+    @Parameters(name = "Partial first row: {0}, partial last row: {1}")
+    public static List<Object[]> getParameters() {
+        return ImmutableList.of(
+                new Object[] {false, false},
+                new Object[] {false, true},
+                new Object[] {true, false},
+                new Object[] {true, true});
+    }
+
+    @Test
+    public void testPartitionSimple() {
+        testPartition(createRequest(1000), 100);
+    }
+
+    @Test
+    public void testSinglePartition() {
+        testPartition(createRequest(10), 100);
+    }
+
+    @Test
+    public void testPartitionSizeDoesNotDivideNumberOfRows() {
+        testPartition(createRequest(100), 23);
+    }
+
+    private RowsColumnRangeBatchRequest createRequest(int numTotalRows) {
+        ColumnRangeSelection fullColumnRange = new ColumnRangeSelection(col(0), col(5));
+        ImmutableRowsColumnRangeBatchRequest.Builder request =
+                ImmutableRowsColumnRangeBatchRequest.builder().columnRangeSelection(fullColumnRange);
+        if (hasPartialFirstRow) {
+            request.partialFirstRow(Maps.immutableEntry(row(0), BatchColumnRangeSelection.create(col(3), col(5), 10)));
+        }
+        int firstFullRowIndex = hasPartialFirstRow ? 2 : 1;
+        int lastFullRowIndex = hasPartialLastRow ? numTotalRows - 1 : numTotalRows;
+        for (int rowNum = firstFullRowIndex; rowNum <= lastFullRowIndex; rowNum++) {
+            request.addRowsToLoadFully(row(rowNum));
+        }
+        if (hasPartialLastRow) {
+            request.partialLastRow(
+                    Maps.immutableEntry(row(numTotalRows), BatchColumnRangeSelection.create(fullColumnRange, 10)));
+        }
+        return request.build();
+    }
+
+    private static byte[] row(int rowNum) {
+        return Ints.toByteArray(rowNum);
+    }
+
+    private static byte[] col(int colNum) {
+        return Ints.toByteArray(colNum);
+    }
+
+    private static void testPartition(RowsColumnRangeBatchRequest request, int partitionSize) {
+        List<RowsColumnRangeBatchRequest> partitions = RowsColumnRangeBatchRequests.partition(request, partitionSize);
+        assertIntermediatePartitionsHaveNoPartialRows(partitions);
+        assertRowsInPartitionsMatchOriginal(request, partitions);
+        assertColumnRangesInPartitionsMatchOriginal(request, partitions);
+        assertPartitionsHaveCorrectSize(partitions, partitionSize);
+    }
+
+    private static void assertIntermediatePartitionsHaveNoPartialRows(List<RowsColumnRangeBatchRequest> partitions) {
+        // No partition other than the first should have a partial first row
+        for (RowsColumnRangeBatchRequest partition : partitions.subList(1, partitions.size())) {
+            Assert.assertFalse(partition.getPartialFirstRow().isPresent());
+        }
+        // No partition other than the last should have a partial last row
+        for (RowsColumnRangeBatchRequest partition : partitions.subList(0, partitions.size() - 1)) {
+            Assert.assertFalse(partition.getPartialLastRow().isPresent());
+        }
+    }
+
+    private static void assertRowsInPartitionsMatchOriginal(
+            RowsColumnRangeBatchRequest original,
+            List<RowsColumnRangeBatchRequest> partitions) {
+        List<byte[]> actualAllRows =
+                partitions.stream()
+                        .flatMap(partition -> RowsColumnRangeBatchRequests.getAllRowsInOrder(partition).stream())
+                        .collect(Collectors.toList());
+        Assert.assertEquals(RowsColumnRangeBatchRequests.getAllRowsInOrder(original), actualAllRows);
+    }
+
+    private static void assertColumnRangesInPartitionsMatchOriginal(
+            RowsColumnRangeBatchRequest request,
+            List<RowsColumnRangeBatchRequest> partitions) {
+        Assert.assertEquals(request.getPartialFirstRow(), partitions.get(0).getPartialFirstRow());
+        Assert.assertEquals(request.getPartialLastRow(), partitions.get(partitions.size() - 1).getPartialLastRow());
+
+        for (RowsColumnRangeBatchRequest partition : partitions) {
+            Assert.assertTrue(partition.getRowsToLoadFully().isEmpty()
+                    || partition.getColumnRangeSelection().equals(request.getColumnRangeSelection()));
+        }
+    }
+
+    private static void assertPartitionsHaveCorrectSize(
+            List<RowsColumnRangeBatchRequest> partitions,
+            int expectedSize) {
+        for (int i = 0; i < partitions.size(); i++) {
+            int actualPartitionSize = RowsColumnRangeBatchRequests.getAllRowsInOrder(partitions.get(i)).size();
+            if (i < partitions.size() - 1) {
+                Assert.assertEquals(expectedSize, actualPartitionSize);
+            } else {
+                Assert.assertTrue(actualPartitionSize <= expectedSize);
+            }
+        }
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
@@ -35,7 +35,6 @@ import com.google.common.primitives.Ints;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.performance.benchmarks.table.Tables;
 import com.palantir.atlasdb.performance.benchmarks.table.WideRowTable;
 
 /**
@@ -63,7 +62,7 @@ public class KvsGetDynamicBenchmarks {
     public Object getAllColumnsImplicitly(WideRowTable table) throws UnsupportedEncodingException {
         Map<Cell, Value> result = table.getKvs().getRows(
                 table.getTableRef(),
-                Collections.singleton(Tables.ROW_BYTES.array()),
+                Collections.singleton(WideRowTable.getRow()),
                 ColumnSelection.all(),
                 Long.MAX_VALUE);
         Preconditions.checkState(result.size() == WideRowTable.NUM_COLS,
@@ -87,7 +86,7 @@ public class KvsGetDynamicBenchmarks {
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitlyGetRows(WideRowTable table) throws UnsupportedEncodingException {
         Map<Cell, Value> result = table.getKvs()
-                .getRows(table.getTableRef(), Collections.singleton(Tables.ROW_BYTES.array()),
+                .getRows(table.getTableRef(), Collections.singleton(WideRowTable.getRow()),
                         ColumnSelection.create(
                                 table.getFirstCellAsSet().stream().map(Cell::getColumnName).collect(Collectors.toList())
                         ),

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsColumnRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsColumnRangeBenchmarks.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.palantir.atlasdb.performance.benchmarks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.performance.benchmarks.table.WideRowsTable;
+
+@State(Scope.Benchmark)
+public class KvsGetRowsColumnRangeBenchmarks {
+
+    @Benchmark
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
+    public Object getAllColumnsAligned(WideRowsTable table) {
+        List<byte[]> rows =
+                IntStream.rangeClosed(0, WideRowsTable.NUM_ROWS - 1)
+                        .mapToObj(WideRowsTable::getRow)
+                        .collect(Collectors.toList());
+        RowColumnRangeIterator rowsColumnRange =
+                table.getKvs().getRowsColumnRange(
+                        table.getTableRef(),
+                        rows,
+                        new ColumnRangeSelection(null, null),
+                        10000,
+                        Long.MAX_VALUE);
+        int expectedNumCells = WideRowsTable.NUM_ROWS * WideRowsTable.NUM_COLS_PER_ROW;
+        List<Map.Entry<Cell, Value>> loadedCells = new ArrayList<>(expectedNumCells);
+        while (rowsColumnRange.hasNext()) {
+            loadedCells.add(rowsColumnRange.next());
+        }
+        Preconditions.checkState(loadedCells.size() == expectedNumCells,
+                "Should be %s cells, but were: %s", expectedNumCells, loadedCells.size());
+        return loadedCells;
+    }
+
+    @Benchmark
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
+    public Object getAllColumnsUnaligned(WideRowsTable table) {
+        List<byte[]> rows =
+                IntStream.rangeClosed(0, WideRowsTable.NUM_ROWS - 1)
+                        .mapToObj(WideRowsTable::getRow)
+                        .collect(Collectors.toList());
+        RowColumnRangeIterator rowsColumnRange =
+                table.getKvs().getRowsColumnRange(
+                        table.getTableRef(),
+                        rows,
+                        new ColumnRangeSelection(null, null),
+                        10017,
+                        Long.MAX_VALUE);
+        int expectedNumCells = WideRowsTable.NUM_ROWS * WideRowsTable.NUM_COLS_PER_ROW;
+        List<Map.Entry<Cell, Value>> loadedCells = new ArrayList<>(expectedNumCells);
+        while (rowsColumnRange.hasNext()) {
+            loadedCells.add(rowsColumnRange.next());
+        }
+        Preconditions.checkState(loadedCells.size() == expectedNumCells,
+                "Should be %s cells, but were: %s", expectedNumCells, loadedCells.size());
+        return loadedCells;
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
@@ -34,7 +34,6 @@ import com.google.common.primitives.Ints;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
-import com.palantir.atlasdb.performance.benchmarks.table.Tables;
 import com.palantir.atlasdb.performance.benchmarks.table.WideRowTable;
 
 /**
@@ -64,7 +63,7 @@ public class TransactionGetDynamicBenchmarks {
     public Object getAllColumnsImplicitly(WideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             SortedMap<byte[], RowResult<byte[]>> result = txn.getRows(table.getTableRef(),
-                    Collections.singleton(Tables.ROW_BYTES.array()),
+                    Collections.singleton(WideRowTable.getRow()),
                     ColumnSelection.all());
             int count = Iterables.getOnlyElement(result.values()).getColumns().size();
             Preconditions.checkState(count == WideRowTable.NUM_COLS,
@@ -93,7 +92,7 @@ public class TransactionGetDynamicBenchmarks {
     public Object getFirstColumnExplicitlyGetRows(WideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             SortedMap<byte[], RowResult<byte[]>> result = txn.getRows(table.getTableRef(),
-                    Collections.singleton(Tables.ROW_BYTES.array()),
+                    Collections.singleton(WideRowTable.getRow()),
                     ColumnSelection.create(
                             table.getFirstCellAsSet().stream().map(Cell::getColumnName).collect(Collectors.toList())
                     ));

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/AbstractWideRowsTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/AbstractWideRowsTable.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.performance.benchmarks.table;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.performance.backend.AtlasDbServicesConnector;
+import com.palantir.atlasdb.performance.benchmarks.Benchmarks;
+import com.palantir.atlasdb.services.AtlasDbServices;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+
+@State(Scope.Benchmark)
+public abstract class AbstractWideRowsTable {
+    private final int numRows;
+    private final int numColumnsPerRow;
+
+    private AtlasDbServicesConnector connector;
+    private AtlasDbServices services;
+
+    protected AbstractWideRowsTable(int numRows, int numColumnsPerRow) {
+        this.numRows = numRows;
+        this.numColumnsPerRow = numColumnsPerRow;
+    }
+
+    public abstract TableReference getTableRef();
+
+    public KeyValueService getKvs() {
+        return services.getKeyValueService();
+    }
+
+    public TransactionManager getTransactionManager() {
+        return services.getTransactionManager();
+    }
+
+    @TearDown(Level.Trial)
+    public void cleanup() throws Exception {
+        getKvs().dropTables(ImmutableSet.of(getTableRef()));
+        connector.close();
+    }
+
+    @Setup(Level.Trial)
+    public void setup(AtlasDbServicesConnector conn) {
+        connector = conn;
+        services = conn.connect();
+        if (!services.getKeyValueService().getAllTableNames().contains(getTableRef())) {
+            Benchmarks.createTable(getKvs(), getTableRef(), Tables.ROW_COMPONENT, Tables.COLUMN_NAME);
+            storeData();
+        }
+    }
+
+    private void storeData() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Map<Cell, byte[]> values = new HashMap<>(numRows * numColumnsPerRow);
+            for (int i = 0; i < numRows; i++) {
+                for (int j = 0; j < numColumnsPerRow; j++) {
+                    values.put(cell(i, j), Ints.toByteArray(i * numColumnsPerRow + j));
+                }
+            }
+            txn.put(getTableRef(), values);
+            return null;
+        });
+    }
+
+    protected static Cell cell(int rowIndex, int colIndex) {
+        return Cell.create(getRow(rowIndex), getColumn(colIndex));
+    }
+
+    public static byte[] getRow(int rowIndex) {
+        return ("row_" + rowIndex).getBytes(StandardCharsets.UTF_8);
+    }
+
+    public static byte[] getColumn(int colIndex) {
+        return ("col_" + colIndex).getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/Tables.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/Tables.java
@@ -31,7 +31,6 @@ public final class Tables {
     static final TableReference TABLE_REF = TableReference.createFromFullyQualifiedName("performance.table");
 
     static final String ROW_COMPONENT = "key";
-    public static final ByteBuffer ROW_BYTES = ByteBuffer.wrap(ROW_COMPONENT.getBytes(StandardCharsets.UTF_8));
 
     static final String COLUMN_NAME = "value";
     public static final ByteBuffer COLUMN_NAME_IN_BYTES = ByteBuffer.wrap(COLUMN_NAME.getBytes(StandardCharsets.UTF_8));

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTable.java
@@ -15,106 +15,54 @@
  */
 package com.palantir.atlasdb.performance.benchmarks.table;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.primitives.Ints;
 import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.performance.backend.AtlasDbServicesConnector;
-import com.palantir.atlasdb.performance.benchmarks.Benchmarks;
-import com.palantir.atlasdb.services.AtlasDbServices;
-import com.palantir.atlasdb.transaction.api.TransactionManager;
 
 /**
  * State class for creating a single Atlas table with one wide row.
  */
 @State(Scope.Benchmark)
-public class WideRowTable {
+public class WideRowTable extends AbstractWideRowsTable {
     public static final int NUM_COLS = 50000;
 
-    private AtlasDbServicesConnector connector;
-    private AtlasDbServices services;
-
-    private TableReference tableRef;
-
-    private Map<Cell, Long> allCellsAtMaxTimestamp;
-    private Map<Cell, Long> firstCellAtMaxTimestamp;
-
-    public TransactionManager getTransactionManager() {
-        return services.getTransactionManager();
+    public WideRowTable() {
+        super(1, NUM_COLS);
     }
 
-    public KeyValueService getKvs() {
-        return services.getKeyValueService();
-    }
-
+    @Override
     public TableReference getTableRef() {
         return Tables.TABLE_REF;
     }
 
     public Map<Cell, Long> getAllCellsAtMaxTimestamp() {
-        return allCellsAtMaxTimestamp;
+        return Maps.asMap(getAllCells(), Functions.constant(Long.MAX_VALUE));
     }
 
     public Map<Cell, Long> getFirstCellAtMaxTimestampAsMap() {
-        return firstCellAtMaxTimestamp;
+        return ImmutableMap.of(cell(0, 0), Long.MAX_VALUE);
     }
 
     public Set<Cell> getAllCells() {
-        return allCellsAtMaxTimestamp.keySet();
+        return IntStream.range(0, NUM_COLS).mapToObj(index -> cell(0, index)).collect(Collectors.toSet());
     }
 
     public Set<Cell> getFirstCellAsSet() {
-        return firstCellAtMaxTimestamp.keySet();
+        return ImmutableSet.of(cell(0, 0));
     }
 
-    @Setup
-    public void setup(AtlasDbServicesConnector conn) throws UnsupportedEncodingException {
-        this.connector = conn;
-        services = conn.connect();
-        tableRef = Benchmarks.createTableWithDynamicColumns(
-                services.getKeyValueService(),
-                getTableRef(),
-                Tables.ROW_COMPONENT,
-                Tables.COLUMN_COMPONENT);
-        storeData();
+    public static byte[] getRow() {
+        return getRow(0);
     }
-
-    @TearDown
-    public void cleanup() throws Exception {
-        services.getKeyValueService().dropTables(Sets.newHashSet(tableRef));
-        connector.close();
-    }
-
-    private void storeData() {
-        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
-            Map<Cell, byte[]> values = Maps.newHashMap();
-            allCellsAtMaxTimestamp = Maps.newHashMap();
-            firstCellAtMaxTimestamp = Maps.newHashMap();
-            firstCellAtMaxTimestamp.put(cell(0), Long.MAX_VALUE);
-            for (int i = 0; i < NUM_COLS; i++) {
-                Cell curCell = cell(i);
-                values.put(curCell, Ints.toByteArray(i));
-                allCellsAtMaxTimestamp.put(curCell, Long.MAX_VALUE);
-            }
-            txn.put(this.tableRef, values);
-            return null;
-        });
-    }
-
-    private Cell cell(int index) {
-        return Cell.create(Tables.ROW_BYTES.array(), ("col_" + index).getBytes(StandardCharsets.UTF_8));
-    }
-
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowsTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowsTable.java
@@ -20,9 +20,6 @@ import org.openjdk.jmh.annotations.State;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
-/**
- * State class for creating a single Atlas table with one wide row.
- */
 @State(Scope.Benchmark)
 public class WideRowsTable extends AbstractWideRowsTable {
     public static final int NUM_ROWS = 10000;

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowsTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowsTable.java
@@ -20,6 +20,10 @@ import org.openjdk.jmh.annotations.State;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
+/**
+ * State class for creating a single Atlas table with {@link #NUM_ROWS} wide rows, each with {@link #NUM_COLS_PER_ROW}
+ * columns.
+ */
 @State(Scope.Benchmark)
 public class WideRowsTable extends AbstractWideRowsTable {
     public static final int NUM_ROWS = 10000;

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowsTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowsTable.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance.benchmarks.table;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.performance.backend.AtlasDbServicesConnector;
+import com.palantir.atlasdb.performance.benchmarks.Benchmarks;
+import com.palantir.atlasdb.services.AtlasDbServices;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+
+/**
+ * State class for creating a single Atlas table with one wide row.
+ */
+@State(Scope.Benchmark)
+public class WideRowsTable {
+    public static final int NUM_ROWS = 10000;
+    public static final int NUM_COLS_PER_ROW = 20;
+
+    private AtlasDbServicesConnector connector;
+    private AtlasDbServices services;
+
+    private TableReference tableRef;
+
+    public TransactionManager getTransactionManager() {
+        return services.getTransactionManager();
+    }
+
+    public KeyValueService getKvs() {
+        return services.getKeyValueService();
+    }
+
+    public TableReference getTableRef() {
+        return Tables.TABLE_REF;
+    }
+
+    @Setup public void setup(AtlasDbServicesConnector conn) {
+        this.connector = conn;
+        services = conn.connect();
+        tableRef = Benchmarks.createTableWithDynamicColumns(
+                services.getKeyValueService(),
+                getTableRef(),
+                Tables.ROW_COMPONENT,
+                Tables.COLUMN_COMPONENT);
+        storeData();
+    }
+
+    @TearDown
+    public void cleanup() throws Exception {
+        services.getKeyValueService().dropTables(Sets.newHashSet(tableRef));
+        connector.close();
+    }
+
+    private void storeData() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Map<Cell, byte[]> values = new HashMap<>(NUM_ROWS * NUM_COLS_PER_ROW);
+            for (int i = 0; i < NUM_ROWS; i++) {
+                for (int j = 0; j < NUM_COLS_PER_ROW; j++) {
+                    values.put(cell(i, j), Ints.toByteArray(i * NUM_COLS_PER_ROW + j));
+                }
+            }
+            txn.put(this.tableRef, values);
+            return null;
+        });
+    }
+
+    private static Cell cell(int rowIndex, int colIndex) {
+        return Cell.create(getRow(rowIndex), getColumn(colIndex));
+    }
+
+    public static byte[] getRow(int rowIndex) {
+        return ("row_" + rowIndex).getBytes(StandardCharsets.UTF_8);
+    }
+
+    public static byte[] getColumn(int colIndex) {
+        return ("col_" + colIndex).getBytes(StandardCharsets.UTF_8);
+    }
+
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowsTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowsTable.java
@@ -15,90 +15,25 @@
  */
 package com.palantir.atlasdb.performance.benchmarks.table;
 
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 
-import com.google.common.collect.Sets;
-import com.google.common.primitives.Ints;
-import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.performance.backend.AtlasDbServicesConnector;
-import com.palantir.atlasdb.performance.benchmarks.Benchmarks;
-import com.palantir.atlasdb.services.AtlasDbServices;
-import com.palantir.atlasdb.transaction.api.TransactionManager;
 
 /**
  * State class for creating a single Atlas table with one wide row.
  */
 @State(Scope.Benchmark)
-public class WideRowsTable {
+public class WideRowsTable extends AbstractWideRowsTable {
     public static final int NUM_ROWS = 10000;
     public static final int NUM_COLS_PER_ROW = 20;
 
-    private AtlasDbServicesConnector connector;
-    private AtlasDbServices services;
-
-    private TableReference tableRef;
-
-    public TransactionManager getTransactionManager() {
-        return services.getTransactionManager();
+    public WideRowsTable() {
+        super(NUM_ROWS, NUM_COLS_PER_ROW);
     }
 
-    public KeyValueService getKvs() {
-        return services.getKeyValueService();
-    }
-
+    @Override
     public TableReference getTableRef() {
         return Tables.TABLE_REF;
     }
-
-    @Setup public void setup(AtlasDbServicesConnector conn) {
-        this.connector = conn;
-        services = conn.connect();
-        tableRef = Benchmarks.createTableWithDynamicColumns(
-                services.getKeyValueService(),
-                getTableRef(),
-                Tables.ROW_COMPONENT,
-                Tables.COLUMN_COMPONENT);
-        storeData();
-    }
-
-    @TearDown
-    public void cleanup() throws Exception {
-        services.getKeyValueService().dropTables(Sets.newHashSet(tableRef));
-        connector.close();
-    }
-
-    private void storeData() {
-        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
-            Map<Cell, byte[]> values = new HashMap<>(NUM_ROWS * NUM_COLS_PER_ROW);
-            for (int i = 0; i < NUM_ROWS; i++) {
-                for (int j = 0; j < NUM_COLS_PER_ROW; j++) {
-                    values.put(cell(i, j), Ints.toByteArray(i * NUM_COLS_PER_ROW + j));
-                }
-            }
-            txn.put(this.tableRef, values);
-            return null;
-        });
-    }
-
-    private static Cell cell(int rowIndex, int colIndex) {
-        return Cell.create(getRow(rowIndex), getColumn(colIndex));
-    }
-
-    public static byte[] getRow(int rowIndex) {
-        return ("row_" + rowIndex).getBytes(StandardCharsets.UTF_8);
-    }
-
-    public static byte[] getColumn(int colIndex) {
-        return ("col_" + colIndex).getBytes(StandardCharsets.UTF_8);
-    }
-
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -34,6 +34,17 @@ Changelog
 develop
 =======
 
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |improved|
+         - Substantially improved performance of the DbKvs implementation of the single-iterator version of getRowsColumnRange.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1132>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

It looks like UNION ALL is not particularly performant, so it's
probably not a good idea to UNION ALL a number of queries equal
to the number of requested rows. Since it's guaranteed that all
column range selections will be identical except for possibly
the first and last row, we can merge all the queries for those
intermediate rows into a single query.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1132)

<!-- Reviewable:end -->
