### PR TITLE
Feature/dependency recommender plugin

### DIFF
--- a/atlasdb-api/build.gradle
+++ b/atlasdb-api/build.gradle
@@ -3,26 +3,22 @@ apply plugin: 'org.inferred.processors'
 apply from: "../gradle/shared.gradle"
 
 dependencies {
-  compile(project(":atlasdb-commons"))
-  compile(project(":timestamp-api"))
+  compile project(":atlasdb-commons")
+  compile project(":timestamp-api")
   compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
-  compile 'org.apache.commons:commons-lang3:3.1'
-  compile 'com.fasterxml.jackson.core:jackson-annotations:' + libVersions.jackson_annotation
+  compile group: 'org.apache.commons', name: 'commons-lang3'
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
 
   processor 'org.immutables:value:2.0.21'
-  compile 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
-  compile 'javax.validation:validation-api:1.1.0.Final'
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+  compile group: 'javax.validation', name: 'validation-api'
 
-  compile ('com.palantir.remoting:ssl-config:' + libVersions.http_remoting) {
-    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-  }
+  compile 'com.palantir.remoting:ssl-config:' + libVersions.http_remoting
 
-  testCompile(group: 'junit', name: 'junit', version: libVersions.junit) {
-    exclude group: 'org.hamcrest'
-  }
+  testCompile group: 'junit', name: 'junit'
 
-  testCompile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
-  testCompile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
+  testCompile group: 'org.hamcrest', name: 'hamcrest-core'
+  testCompile group: 'org.hamcrest', name: 'hamcrest-library'
 }
 
 task versionInfo << {

--- a/atlasdb-cassandra-multinode-tests/build.gradle
+++ b/atlasdb-cassandra-multinode-tests/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testCompile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
 
     testCompile 'com.palantir.docker.compose:docker-compose-rule:' + libVersions.dockerComposeRule
-    testCompile group: 'com.google.code.findbugs', name: 'annotations', version: libVersions.findbugsAnnotations
+    testCompile group: 'com.google.code.findbugs', name: 'annotations'
 }

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -8,44 +8,19 @@ dependencies {
   compile project(":commons-api")
   compile project(':timestamp-impl')
 
-  compile('org.apache.cassandra:cassandra-all:' + libVersions.cassandra) {
-    exclude(group: 'com.google.guava', module: 'guava')
-    exclude(module: 'junit')
-  }
-  compile('com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core) {
-    exclude group: 'com.google.guava', module: 'guava'
-  }
-  compile 'com.google.guava:guava:' + libVersions.guava
-  compile 'junit:junit:' + libVersions.junit
+  compile 'org.apache.cassandra:cassandra-all:' + libVersions.cassandra
+  compile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
+  compile group: 'com.google.guava', name: 'guava'
+  compile group: 'junit', name: 'junit'
 
   compile 'org.apache.commons:commons-pool2:2.4.2'
 
-  compile ('com.palantir.remoting:ssl-config:' + libVersions.http_remoting) {
-    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-  }
+  compile 'com.palantir.remoting:ssl-config:' + libVersions.http_remoting
 
-  compile group: 'com.google.code.findbugs', name: 'annotations', version: libVersions.findbugsAnnotations
+  compile group: 'com.google.code.findbugs', name: 'annotations'
 
   testCompile 'org.mockito:mockito-core:' + libVersions.mockito
 
   processor 'org.immutables:value:' + libVersions.immutables
   processor 'com.google.auto.service:auto-service:1.0-rc2'
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'ch.qos.logback:logback-classic:1.1.3'
-        force 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
-        force 'com.fasterxml.jackson.core:jackson-core:' + libVersions.jackson
-        force 'com.fasterxml.jackson.datatype:jackson-datatype-guava:' + libVersions.jackson
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'com.googlecode.json-simple:json-simple:1.1.1'
-        force 'joda-time:joda-time:' + libVersions.joda_time
-        force 'org.apache.thrift:libthrift:' + libVersions.libthrift
-        force 'org.slf4j:slf4j-api:1.7.6'
-        force 'org.xerial.snappy:snappy-java:' + libVersions.snappy
-        force 'org.yaml:snakeyaml:1.12'
-        force 'javax.validation:validation-api:1.1.0.Final'
-        force 'commons-codec:commons-codec:' + libVersions.commons_codec
-    }
 }

--- a/atlasdb-cli/build.gradle
+++ b/atlasdb-cli/build.gradle
@@ -15,18 +15,3 @@ dependencies {
 
   testCompile project(':atlasdb-rocksdb')
 }
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-      resolutionStrategy {
-          force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-          force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-          force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-          force 'org.apache.thrift:libthrift:' + libVersions.libthrift
-          force 'ch.qos.logback:logback-classic:1.1.3'
-          force 'commons-codec:commons-codec:' + libVersions.commons_codec
-          force 'com.googlecode.json-simple:json-simple:1.1.1'
-          force 'joda-time:joda-time:' + libVersions.joda_time
-          force 'org.yaml:snakeyaml:1.12'
-          force 'javax.validation:validation-api:1.1.0.Final'
-      }
-}

--- a/atlasdb-client-protobufs/build.gradle
+++ b/atlasdb-client-protobufs/build.gradle
@@ -19,10 +19,7 @@ protobuf {
 }
 
 dependencies {
-  compile(group: "com.google.protobuf",
-          name: "protobuf-java",
-          version: "2.6.0")
-  {
+  compile(group: "com.google.protobuf", name: "protobuf-java", version: "2.6.0") {
     transitive = false
   }
 }

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -12,45 +12,23 @@ schemas = [
 ]
 
 libsDirName = file('build/artifacts')
-dependencies {
-  compile(project(":atlasdb-commons"))
-  compile(project(":atlasdb-api"))
-  compile(project(":atlasdb-client-protobufs"))
-  compile(group: "com.googlecode.json-simple",
-          name: "json-simple",
-          version: "1.1.1") {
-      exclude(group: 'junit')
-  }
-  compile(group: "commons-lang",
-          name: "commons-lang",
-          version: libVersions.commons_lang)
-  compile(group: "org.xerial.snappy", name: "snappy-java", version: libVersions.snappy) {
-    exclude(group: "osgi.osgi")
-  }
-  compile(group: "com.googlecode.protobuf-java-format",
-          name: "protobuf-java-format",
-          version: "1.2")
-  compile(group: "com.google.protobuf",
-          name: "protobuf-java",
-          version: "2.6.0")
-  compile('com.netflix.feign:feign-jackson:8.6.1') {
-      exclude module: 'jackson-databind'
-  }
 
-  compile('com.netflix.feign:feign-jaxrs:8.6.1') {
-      exclude module: 'jsr311-api'
-  }
-  compile 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
+dependencies {
+  compile project(":atlasdb-commons")
+  compile project(":atlasdb-api")
+  compile project(":atlasdb-client-protobufs")
+  compile group: 'com.googlecode.json-simple', name: 'json-simple'
+  compile group: "commons-lang", name: "commons-lang", version: libVersions.commons_lang
+  compile group: "org.xerial.snappy", name: "snappy-java", version: libVersions.snappy
+  compile group: "com.googlecode.protobuf-java-format", name: "protobuf-java-format", version: "1.2"
+  compile group: "com.google.protobuf", name: "protobuf-java", version: "2.6.0"
+  compile group: 'com.netflix.feign', name: 'feign-jackson'
+  compile group: 'com.netflix.feign', name: 'feign-jaxrs'
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
   compile 'com.fasterxml.jackson.core:jackson-core:' + libVersions.jackson
-  compile('com.fasterxml.jackson.datatype:jackson-datatype-guava:' + libVersions.jackson) {
-      exclude(module: "guava")
-  }
-  testCompile(group: 'junit', name: 'junit', version: libVersions.junit) {
-    exclude group: 'org.hamcrest'
-  }
-  testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
-    exclude group: 'org.hamcrest'
-  }
-  testCompile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
-  testCompile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
+  compile 'com.fasterxml.jackson.datatype:jackson-datatype-guava:' + libVersions.jackson
+  testCompile group: 'junit', name: 'junit'
+  testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock
+  testCompile group: 'org.hamcrest', name: 'hamcrest-core'
+  testCompile group: 'org.hamcrest', name: 'hamcrest-library'
 }

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -13,21 +13,15 @@ repositories {
 
 libsDirName = file('build/artifacts')
 dependencies {
-    compile group: 'com.google.code.findbugs', name: 'jsr305', version: libVersions.jsr305
-    compile group: 'com.google.guava', name: 'guava', version: libVersions.guava
-    compile group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
-    compile(project(":commons-executors"))
+    compile group: 'com.google.code.findbugs', name: 'jsr305'
+    compile group: 'com.google.guava', name: 'guava'
+    compile group: 'org.slf4j', name: 'slf4j-api'
+    compile project(":commons-executors")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:' + libVersions.jackson_annotation
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
 
-    testCompile(group: 'junit', name: 'junit', version: libVersions.junit) {
-        exclude group: 'org.hamcrest'
-    }
-    testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
-        exclude group: 'org.hamcrest'
-    }
-    testCompile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
-    testCompile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
-
+    testCompile group: 'junit', name: 'junit'
+    testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock
+    testCompile group: 'org.hamcrest', name: 'hamcrest-core'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-library'
 }
-

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -8,37 +8,20 @@ dependencies {
     compile project(':leader-election-impl')
     compile project(':lock-impl')
 
-    compile 'com.netflix.feign:feign-jackson:8.6.1'
-    compile('com.netflix.feign:feign-jaxrs:8.6.1') {
-        exclude module: 'jsr311-api'
-    }
+    compile group: 'com.netflix.feign', name: 'feign-jackson'
+    compile group: 'com.netflix.feign', name: 'feign-jaxrs'
     // versions below 8.10.0 have a bug where POST requests must have a body
-    compile('com.netflix.feign:feign-okhttp:8.10.1') {
-        exclude module: 'feign-core'
-    }
-    compile 'javax.validation:validation-api:1.1.0.Final'
+    compile group: 'com.netflix.feign', name: 'feign-okhttp'
+    compile group: 'javax.validation', name: 'validation-api'
 
-    compile 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:' + libVersions.jackson
     compile 'io.dropwizard:dropwizard-jackson:' + libVersions.dropwizard
-    compile group: 'com.google.code.findbugs', name: 'annotations', version: libVersions.findbugsAnnotations
+    compile group: 'com.google.code.findbugs', name: 'annotations'
 
     processor 'org.immutables:value:' + libVersions.immutables
     processor 'com.google.auto.service:auto-service:1.0-rc2'
 
-    testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
-        exclude group: 'org.hamcrest'
-    }
+    testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock
     testCompile 'org.mockito:mockito-core:' + libVersions.mockito
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-        force 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
-        force 'com.fasterxml.jackson.core:jackson-core:' + libVersions.jackson
-        force 'com.fasterxml.jackson.datatype:jackson-datatype-guava:' + libVersions.jackson
-        force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-    }
 }

--- a/atlasdb-console/build.gradle
+++ b/atlasdb-console/build.gradle
@@ -3,24 +3,12 @@ apply plugin: 'groovy'
 
 dependencies {
     compile project(':atlasdb-service')
-    compile('org.fusesource.jansi:jansi:1.11')
-    compile('commons-cli:commons-cli:1.2')
-    compile('jline:jline:2.12')
-    compile('org.codehaus.groovy:groovy-all:' + libVersions.groovy)
+    compile 'org.fusesource.jansi:jansi:1.11'
+    compile group: 'commons-cli', name:'commons-cli'
+    compile 'jline:jline:2.12'
+    compile group: 'org.codehaus.groovy', name: 'groovy-all'
 
-    testCompile('org.jmock:jmock-legacy:' + libVersions.jmock) {
-      exclude(module: 'jmock')
-    }
-    testCompile('org.jmock:jmock:' + libVersions.jmock)
-    testCompile('org.gmock:gmock:0.8.3')
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-        force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-        force 'org.apache.thrift:libthrift:' + libVersions.libthrift
-        force 'commons-codec:commons-codec:' + libVersions.commons_codec
-    }
+    testCompile 'org.jmock:jmock-legacy:' + libVersions.jmock
+    testCompile 'org.jmock:jmock:' + libVersions.jmock
+    testCompile 'org.gmock:gmock:0.8.3'
 }

--- a/atlasdb-container-test-utils/build.gradle
+++ b/atlasdb-container-test-utils/build.gradle
@@ -4,33 +4,14 @@ apply from: "${rootProject.projectDir}/gradle/shared.gradle"
 
 dependencies {
     compile project(':atlasdb-api')
-    compile(project(':atlasdb-cassandra')) {
-        exclude(module:'log4j-over-slf4j')
-        exclude(module:'jcl-over-slf4j')
-        exclude(module:'json-simple')
-        exclude(module:'metrics-core')
-        exclude(module:'logback-core')
-        exclude(module:'logback-classic')
-        exclude(module:'joda-time')
-        exclude(module:'snakeyaml')
-        exclude(module:'hibernate-validator')
-        exclude(module:'libthrift')
-        exclude(module:'commons-cli')
-        exclude(module:'jna')
-    }
+    compile project(':atlasdb-cassandra')
     compile project(':atlasdb-docker-test-utils')
 
-    compile group: 'com.google.guava', name: 'guava', version: libVersions.guava
+    compile group: 'com.google.guava', name: 'guava'
     compile group: 'com.palantir.docker.compose', name: 'docker-compose-rule', version: libVersions.dockerComposeRule
 
     processor group: 'org.immutables', name: 'value', version: libVersions.immutables
 
     testCompile group: 'org.assertj', name: 'assertj-core', version: libVersions.assertj
     testCompile group: 'org.mockito', name: 'mockito-core', version: libVersions.mockito
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-    }
 }

--- a/atlasdb-dagger/build.gradle
+++ b/atlasdb-dagger/build.gradle
@@ -5,9 +5,9 @@ apply from: '../gradle/shared.gradle'
 
 dependencies {
   compile project(':atlasdb-service')
-  compile group: 'com.google.dagger', name: 'dagger', version: libVersions.dagger
+  compile group: 'com.google.dagger', name: 'dagger'
 
-  processor(group: 'com.google.dagger', name: 'dagger-compiler', version: libVersions.dagger) {
+  processor(group: 'com.google.dagger', name: 'dagger-compiler') {
       // We need to explicitly exclude these so that intellij does not label them as provided
       if(gradle.startParameter.taskNames.contains('idea')) {
           exclude group: 'com.google.dagger', module: 'dagger'
@@ -25,7 +25,7 @@ shadowJar {
   relocate('dagger', 'com.palantir.atlasdb.shaded.dagger')
 
   dependencies {
-    include dependency(group: 'com.google.dagger', name: 'dagger', version: libVersions.dagger)
+    include dependency(group: 'com.google.dagger', name: 'dagger')
   }
 }
 

--- a/atlasdb-dbkvs-hikari/build.gradle
+++ b/atlasdb-dbkvs-hikari/build.gradle
@@ -4,8 +4,8 @@ apply from: '../gradle/shared.gradle'
 
 dependencies {
   compile project(':commons-db')
-  compile 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
-  compile 'com.codahale.metrics:metrics-core:3.0.2'
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+  compile group: 'com.codahale.metrics', name: 'metrics-core'
 
   processor 'org.immutables:value:' + libVersions.immutables
 }

--- a/atlasdb-dbkvs-tests/build.gradle
+++ b/atlasdb-dbkvs-tests/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
   testCompile 'org.mockito:mockito-core:' + libVersions.mockito
   testCompile 'com.palantir.docker.compose:docker-compose-rule:' + libVersions.dockerComposeRule
-  testCompile 'junit:junit:' + libVersions.junit
+  testCompile group: 'junit', name: 'junit'
 }
 
 test {

--- a/atlasdb-docker-test-utils/build.gradle
+++ b/atlasdb-docker-test-utils/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.inferred.processors'
 apply from: "${rootProject.projectDir}/gradle/shared.gradle"
 
 dependencies {
-    compile group: 'com.google.guava', name: 'guava', version: libVersions.guava
+    compile group: 'com.google.guava', name: 'guava'
     compile group: 'com.palantir.docker.compose', name: 'docker-compose-rule', version: libVersions.dockerComposeRule
     compile group: 'net.amygdalum', name: 'xrayinterface', version: '0.3.0'
 

--- a/atlasdb-dropwizard-bundle/build.gradle
+++ b/atlasdb-dropwizard-bundle/build.gradle
@@ -1,19 +1,7 @@
 apply from: "../gradle/shared.gradle"
 
 dependencies {
-    compile(project(':atlasdb-cli')) {
-        exclude(module: 'log4j-over-slf4j')
-        exclude(module: 'jcl-over-slf4j')
-        exclude(module: 'json-simple')
-        exclude(module: 'metrics-core')
-        exclude(module: 'logback-core')
-        exclude(module: 'logback-classic')
-        exclude(module: 'joda-time')
-        exclude(module: 'snakeyaml')
-        exclude(module: 'hibernate-validator')
-        exclude(module: 'libthrift')
-        exclude(module: 'commons-cli')
-    }
+    compile project(':atlasdb-cli')
     compile project(':atlasdb-config')
     compile project(':atlasdb-console')
 
@@ -21,12 +9,4 @@ dependencies {
 
     testCompile group: 'org.assertj', name: 'assertj-core', version: libVersions.assertj
     testCompile group: 'org.mockito', name: 'mockito-core', version: libVersions.mockito
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force group: 'com.google.code.findbugs', name: 'jsr305', version: libVersions.jsr305
-        force group: 'org.apache.commons', name: 'commons-lang3', version: libVersions.commons_lang3
-        force group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
-    }
 }

--- a/atlasdb-ete-test-utils/build.gradle
+++ b/atlasdb-ete-test-utils/build.gradle
@@ -1,11 +1,9 @@
 apply from: "../gradle/shared.gradle"
 
 dependencies {
-    compile(group: 'junit', name: 'junit', version: libVersions.junit) {
-        exclude group: 'org.hamcrest'
-    }
-    compile group: 'org.hamcrest', name: 'hamcrest-all', version: libVersions.hamcrest
-    compile(group: 'commons-io', name: 'commons-io', version: libVersions.commons_io)
+    compile group: 'junit', name: 'junit'
+    compile group: 'org.hamcrest', name: 'hamcrest-all'
+    compile group: 'commons-io', name: 'commons-io'
 }
 
 sourceCompatibility = '1.8'

--- a/atlasdb-ete-tests/Dockerfile
+++ b/atlasdb-ete-tests/Dockerfile
@@ -4,8 +4,6 @@ RUN apk update && apk add libstdc++ bash wget
 
 ENV DOCKERIZE_VERSION v0.2.0
 
-ENV JAVA_OPTS "-Xmx384M"
-
 RUN wget --no-check-certificate http://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.palantir.gradle.javadist:gradle-java-distribution:0.5.2'
+        classpath 'com.palantir.gradle.javadist:gradle-java-distribution:1.0.1'
     }
 }
 
@@ -9,7 +9,6 @@ apply from: "../gradle/shared.gradle"
 
 apply plugin: 'com.palantir.java-distribution'
 apply plugin: 'org.inferred.processors'
-
 
 dependencies {
     compile project(':lock-impl')

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -22,22 +22,9 @@ dependencies {
 
     runtime project(':atlasdb-dbkvs')
 
-    runtime(project(':atlasdb-cassandra')) {
-        exclude(module:'log4j-over-slf4j')
-        exclude(module:'jcl-over-slf4j')
-        exclude(module:'json-simple')
-        exclude(module:'metrics-core')
-        exclude(module:'logback-core')
-        exclude(module:'logback-classic')
-        exclude(module:'joda-time')
-        exclude(module:'snakeyaml')
-        exclude(module:'hibernate-validator')
-        exclude(module:'libthrift')
-        exclude(module:'commons-cli')
-        exclude(module:'jna')
-    }
+    runtime project(':atlasdb-cassandra')
 
-    compile 'org.apache.thrift:libthrift:' + libVersions.libthrift
+    compile group: 'org.apache.thrift', name: 'libthrift'
 
     processor 'org.immutables:value:' + libVersions.immutables
 
@@ -46,20 +33,6 @@ dependencies {
 
     testCompile "io.dropwizard:dropwizard-testing:" + libVersions.dropwizard
     testCompile 'com.palantir.docker.compose:docker-compose-rule:' + libVersions.dockerComposeRule
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-        force 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
-        force 'com.fasterxml.jackson.core:jackson-core:' + libVersions.jackson
-        force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-        force 'org.apache.thrift:libthrift:' + libVersions.libthrift
-        force 'commons-codec:commons-codec:' + libVersions.commons_codec
-        force 'org.hibernate:hibernate-validator:5.1.3.Final'
-        force 'commons-cli:commons-cli:1.2'
-    }
 }
 
 task prepareForEteTests(type: Copy, dependsOn: 'distTar') {

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -57,6 +57,7 @@ distribution {
     serviceName 'atlasdb-ete'
     mainClass 'com.palantir.atlasdb.AtlasDbEteServer'
     args 'server', 'var/conf/atlasdb-ete.yml'
+    defaultJvmOpts '-Xmx384M'
 }
 
 sourceCompatibility = '1.8'

--- a/atlasdb-exec/build.gradle
+++ b/atlasdb-exec/build.gradle
@@ -9,6 +9,6 @@ repositories {
 
 dependencies {
   compile(project(":atlasdb-client"))
-  
+
   compile 'org.slf4j:slf4j-log4j12:' + libVersions.slf4j
 }

--- a/atlasdb-hikari/build.gradle
+++ b/atlasdb-hikari/build.gradle
@@ -10,10 +10,3 @@ dependencies {
   processor "org.immutables:value:" + libVersions.immutables
   processor "com.google.auto.service:auto-service:1.0-rc2"
 }
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-    }
-}

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -12,12 +12,12 @@ repositories {
 libsDirName = file('build/artifacts')
 
 dependencies {
-  compile(project(":atlasdb-client"))
-  compile(project(":atlasdb-lock-api"))
-  compile(project(":timestamp-api"))
-  compile(project(":timestamp-impl"))
-  compile(project(":atlasdb-commons"))
-  compile(project(":lock-impl"))
+  compile project(":atlasdb-client")
+  compile project(":atlasdb-lock-api")
+  compile project(":timestamp-api")
+  compile project(":timestamp-impl")
+  compile project(":atlasdb-commons")
+  compile project(":lock-impl")
 
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
 

--- a/atlasdb-jdbc/build.gradle
+++ b/atlasdb-jdbc/build.gradle
@@ -13,10 +13,3 @@ dependencies {
   processor "org.immutables:value:" + libVersions.immutables
   processor "com.google.auto.service:auto-service:1.0-rc2"
 }
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-    }
-}

--- a/atlasdb-lock-api/build.gradle
+++ b/atlasdb-lock-api/build.gradle
@@ -9,6 +9,6 @@ repositories {
 
 libsDirName = file('build/artifacts')
 dependencies {
-  compile(project(":atlasdb-api"))
-  compile(project(":lock-api"))
+  compile project(":atlasdb-api")
+  compile project(":lock-api")
 }

--- a/atlasdb-perf/build.gradle
+++ b/atlasdb-perf/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile group: 'io.airlift', name: 'airline', version: '0.7'
   compile group: 'org.reflections', name: 'reflections', version: '0.9.10'
   compile group: 'com.palantir.docker.compose', name: 'docker-compose-rule', version: libVersions.dockerComposeRule
-  compile group: 'ch.qos.logback', name: 'logback-classic', version: libVersions.logback
+  compile group: 'ch.qos.logback', name: 'logback-classic'
 
   compile group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.13'
   processor group: 'org.immutables', name: 'value', version: libVersions.immutables
@@ -25,22 +25,6 @@ dependencies {
           exclude group: 'org.openjdk.jmh', module: 'jmh-core'
       }
   }
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-      resolutionStrategy {
-          force 'javax.validation:validation-api:1.1.0.Final'
-          force 'ch.qos.logback:logback-classic:1.1.3'
-          force 'com.google.code.findbugs:annotations:2.0.3'
-          force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-          force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-          force 'commons-io:commons-io:' + libVersions.commons_io
-          force 'joda-time:joda-time:' + libVersions.joda_time
-          force 'com.googlecode.json-simple:json-simple:' + libVersions.json_simple
-          force 'org.yaml:snakeyaml:' + libVersions.snakeyaml
-          force 'org.apache.thrift:libthrift:' + libVersions.libthrift
-          force 'commons-codec:commons-codec:' + libVersions.commons_codec
-      }
 }
 
 distZip {

--- a/atlasdb-rocksdb-tests/build.gradle
+++ b/atlasdb-rocksdb-tests/build.gradle
@@ -1,7 +1,6 @@
 apply from: "../gradle/shared.gradle"
 
 dependencies {
-  testCompile(project(":atlasdb-rocksdb"))
+  testCompile project(":atlasdb-rocksdb")
   testCompile project(":atlasdb-tests-shared")
 }
-

--- a/atlasdb-service-server/build.gradle
+++ b/atlasdb-service-server/build.gradle
@@ -10,29 +10,9 @@ dependencies {
     compile project(':leader-election-impl')
     compile project(':atlasdb-config')
     runtime project(':atlasdb-rocksdb')
-    runtime(project(':atlasdb-cassandra')) {
-        exclude(module:'log4j-over-slf4j')
-        exclude(module:'jcl-over-slf4j')
-        exclude(module:'json-simple')
-        exclude(module:'metrics-core')
-        exclude(module:'logback-core')
-        exclude(module:'logback-classic')
-        exclude(module:'joda-time')
-        exclude(module:'snakeyaml')
-        exclude(module:'hibernate-validator')
-        exclude(module:'libthrift')
-    }
+    runtime project(':atlasdb-cassandra')
+
     compile "io.dropwizard:dropwizard-core:" + libVersions.dropwizard
 
     testCompile "io.dropwizard:dropwizard-testing:" + libVersions.dropwizard
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-        force 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
-        force 'com.fasterxml.jackson.core:jackson-core:' + libVersions.jackson
-        force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-    }
 }

--- a/atlasdb-service/build.gradle
+++ b/atlasdb-service/build.gradle
@@ -6,10 +6,3 @@ dependencies {
     compile project(':atlasdb-config')
     compile 'javax.inject:javax.inject:1'
 }
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-    }
-}

--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -6,19 +6,15 @@ schemas = [
 ]
 
 dependencies {
-  compile(project(":atlasdb-impl-shared"))
-  compile 'com.netflix.feign:feign-jackson:8.6.1'
-  compile('com.netflix.feign:feign-jaxrs:8.6.1') {
-      exclude module: 'jsr311-api'
-  }
-  testCompile(project(":atlasdb-config"))
+  compile project(":atlasdb-impl-shared")
+  testCompile project(":atlasdb-config")
 
-  compile(group: 'junit', name: 'junit', version: libVersions.junit) {
-    exclude group: 'org.hamcrest'
-  }
-  testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
-    exclude group: 'org.hamcrest'
-  }
-  compile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
-  compile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
+  compile group: 'com.netflix.feign', name: 'feign-jackson'
+  compile group: 'com.netflix.feign', name: 'feign-jaxrs'
+
+  compile group: 'junit', name: 'junit'
+  compile group: 'org.hamcrest', name: 'hamcrest-core'
+  compile group: 'org.hamcrest', name: 'hamcrest-library'
+
+  testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock
 }

--- a/atlasdb-timelock-ete/build.gradle
+++ b/atlasdb-timelock-ete/build.gradle
@@ -31,17 +31,7 @@ dependencies {
     compile project(':atlasdb-ete-test-utils')
 
     testCompile 'com.palantir.docker.compose:docker-compose-rule:' + libVersions.dockerComposeRule
-    testCompile 'ch.qos.logback:logback-classic:1.1.7'
+    testCompile group: 'ch.qos.logback', name: 'logback-classic'
 }
 
 test.dependsOn ':atlasdb-timelock-server:prepareForEteTests'
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-        force 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
-        force 'com.fasterxml.jackson.core:jackson-core:' + libVersions.jackson
-        force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-    }
-}

--- a/atlasdb-timelock-server/build.gradle
+++ b/atlasdb-timelock-server/build.gradle
@@ -19,15 +19,15 @@ dependencies {
     compile project(':atlasdb-rocksdb')
 
     compile "io.dropwizard:dropwizard-core:" + libVersions.dropwizard
-    compile 'com.google.dagger:dagger:' + libVersions.dagger
+    compile 'com.google.dagger:dagger'
 
     compile "org.rocksdb:rocksdbjni:4.1.0"
     compile 'org.postgresql:postgresql:' + libVersions.postgresql
 
-    compile 'org.apache.thrift:libthrift:' + libVersions.libthrift
+    compile group: 'org.apache.thrift', name: 'libthrift'
 
     processor 'org.immutables:value:' + libVersions.immutables
-    processor('com.google.dagger:dagger-compiler:' + libVersions.dagger) {
+    processor('com.google.dagger:dagger-compiler') {
         // We need to explicitly exclude these so that intellij does not label them as provided
         if(gradle.startParameter.taskNames.contains('idea')) {
             exclude group: 'com.google.guava'
@@ -38,19 +38,6 @@ dependencies {
     testCompile "io.dropwizard:dropwizard-testing:" + libVersions.dropwizard
 }
 
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-        force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-        force 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
-        force 'com.fasterxml.jackson.core:jackson-core:' + libVersions.jackson
-        force 'org.apache.commons:commons-lang3:' + libVersions.commons_lang3
-        force 'org.apache.thrift:libthrift:' + libVersions.libthrift
-        force 'commons-codec:commons-codec:' + libVersions.commons_codec
-        force 'org.hibernate:hibernate-validator:5.1.3.Final'
-    }
-}
 
 task prepareForEteTests(type: Copy, dependsOn: 'distTar') {
     from distTar.outputs

--- a/atlasdb-timelock-server/build.gradle
+++ b/atlasdb-timelock-server/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.palantir.gradle.javadist:gradle-java-distribution:0.5.2'
+        classpath 'com.palantir.gradle.javadist:gradle-java-distribution:1.0.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         classpath 'com.palantir:gradle-baseline-java:0.7.1'
         classpath 'com.palantir:jacoco-coverage:0.4.0'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:3.6.3'
+        classpath 'com.netflix.nebula:nebula-publishing-plugin:4.9.1'
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.4'
         classpath 'com.palantir:gradle-baseline-java:0.7.1'
         classpath 'com.palantir:jacoco-coverage:0.4.0'
+        classpath 'com.netflix.nebula:nebula-dependency-recommender:3.6.3'
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
     }
 }
@@ -50,9 +51,24 @@ jacoco {
     toolVersion = libVersions.jacoco
 }
 
+allprojects {
+    apply plugin: 'nebula.dependency-recommender'
+
+    dependencyRecommendations {
+        strategy OverrideTransitives
+        propertiesFile file: project.rootProject.file('versions.props')
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            failOnVersionConflict()
+        }
+    }
+}
+
 subprojects {
-  apply plugin: 'com.palantir.configuration-resolver'
-  task allDeps(type: DependencyReportTask) {}
+    apply plugin: 'com.palantir.configuration-resolver'
+    task allDeps(type: DependencyReportTask) {}
 }
 
 apply from: 'idea.gradle'

--- a/commons-db/build.gradle
+++ b/commons-db/build.gradle
@@ -6,12 +6,13 @@ dependencies {
   compile project(":commons-api")
   compile project(":commons-proxy")
 
-  compile(group: 'commons-dbutils', name: 'commons-dbutils', version: libVersions.commons_dbutils)
-  compile(group: 'org.apache.commons', name: 'commons-lang3', version: libVersions.commons_lang3)
-  compile(group: 'commons-io', name: 'commons-io', version: libVersions.commons_io)
-  compile(group: 'log4j', name: 'log4j', version: libVersions.log4j)
-  { transitive = false }
-  compile(group: 'com.mchange', name: 'c3p0', version: libVersions.c3p0)
+  compile group: 'commons-dbutils', name: 'commons-dbutils', version: libVersions.commons_dbutils
+  compile group: 'org.apache.commons', name: 'commons-lang3'
+  compile group: 'commons-io', name: 'commons-io'
+  compile(group: 'log4j', name: 'log4j', version: libVersions.log4j) {
+    transitive = false
+  }
+  compile group: 'com.mchange', name: 'c3p0', version: libVersions.c3p0
 
   // Danger, Will Robinson!
   //
@@ -19,14 +20,12 @@ dependencies {
   // Severe performance regressions in 1202,3,4.
   // Severe correctness issues in 1204,5,6.
   // Update with care and caution.
-  compile(group: 'org.postgresql', name: 'postgresql', version: libVersions.postgresql)
-  { exclude( module: 'waffle-jna', ) }
+  compile group: 'org.postgresql', name: 'postgresql', version: libVersions.postgresql
 
-  compile(group: 'com.zaxxer', name: 'HikariCP', version: libVersions.hikariCP)
-  { exclude( group: 'org.slf4j', ) }
-  compile(group: 'joda-time', name: 'joda-time', version: libVersions.joda_time)
+  compile group: 'com.zaxxer', name: 'HikariCP', version: libVersions.hikariCP
+  compile group: 'joda-time', name: 'joda-time'
   compile "io.dropwizard:dropwizard-jackson:" + libVersions.dropwizard
   processor 'com.google.auto.service:auto-service:1.0-rc2'
 
-  testCompile(group: 'junit', name: 'junit', version: libVersions.junit)
+  testCompile group: 'junit', name: 'junit'
 }

--- a/commons-executors/build.gradle
+++ b/commons-executors/build.gradle
@@ -13,5 +13,5 @@ repositories {
 
 libsDirName = file('build/artifacts')
 dependencies {
-    testCompile group: 'com.google.guava', name: 'guava', version: libVersions.guava
+    testCompile group: 'com.google.guava', name: 'guava'
 }

--- a/commons-proxy/build.gradle
+++ b/commons-proxy/build.gradle
@@ -5,5 +5,5 @@ targetCompatibility = 1.6
 ideaSetModuleLevel(idea, targetCompatibility)
 
 dependencies {
-  compile group: 'org.slf4j', name: 'slf4j-api', version: libVersions.slf4j
+  compile group: 'org.slf4j', name: 'slf4j-api'
 }

--- a/examples/profile-client-protobufs/build.gradle
+++ b/examples/profile-client-protobufs/build.gradle
@@ -1,11 +1,9 @@
 apply from: "../../gradle/shared.gradle"
 
 group = 'com.palantir.atlasdb.examples'
+
 dependencies {
-  compile(group: "com.google.protobuf",
-          name: "protobuf-java",
-          version: "2.6.0")
-  {
+  compile(group: "com.google.protobuf", name: "protobuf-java", version: "2.6.0") {
     transitive = false
   }
 }

--- a/examples/profile-client/build.gradle
+++ b/examples/profile-client/build.gradle
@@ -5,8 +5,9 @@ schemas = [
 ]
 
 group = 'com.palantir.atlasdb.examples'
+
 dependencies {
-  compile(project(":atlasdb-client"))
-  compile(project(":examples:profile-client-protobufs"))
-  testCompile(project(":atlasdb-impl-shared"))
+  compile project(":atlasdb-client")
+  compile project(":examples:profile-client-protobufs")
+  testCompile project(":atlasdb-impl-shared")
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'maven-publish'
+apply plugin: 'nebula.maven-resolved-dependencies'
 
 task sourceJar(type: Jar) {
     from project.sourceSets.main.allSource

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -34,15 +34,7 @@ libsDirName = file('build/artifacts')
 
 dependencies {
     checkstyle group: 'com.puppycrawl.tools', name: 'checkstyle', version: libVersions.checkstyle
-    testCompile group: 'junit', name: 'junit', version: libVersions.junit
-}
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-            force 'net.java.dev.jna:jna:' + libVersions.jna
-            force 'com.google.code.findbugs:jsr305:' + libVersions.jsr305
-            force 'org.slf4j:slf4j-api:' + libVersions.slf4j
-        }
+    testCompile group: 'junit', name: 'junit'
 }
 
 apply from: rootProject.file('gradle/javadoc.gradle'), to: javadoc

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -49,9 +49,3 @@ ext.libVersions =
     c3p0: '0.9.5.1',
     log4j: '1.2.17'
 ]
-
-configurations.matching({ it.name in ['compile', 'runtime'] }).all {
-    resolutionStrategy {
-        failOnVersionConflict()
-    }
-}

--- a/leader-election-api-protobufs/build.gradle
+++ b/leader-election-api-protobufs/build.gradle
@@ -1,10 +1,7 @@
 apply from: "../gradle/shared.gradle"
 
 dependencies {
-  compile(group: "com.google.protobuf",
-          name: "protobuf-java",
-          version: "2.6.0")
-  {
+  compile(group: "com.google.protobuf", name: "protobuf-java", version: "2.6.0") {
     transitive = false
   }
 }

--- a/leader-election-api/build.gradle
+++ b/leader-election-api/build.gradle
@@ -9,11 +9,9 @@ repositories {
 
 libsDirName = file('build/artifacts')
 dependencies {
-  compile(project(":atlasdb-commons"))
-  compile(project(":leader-election-api-protobufs"))
-  compile(group: "commons-lang",
-          name: "commons-lang",
-          version: libVersions.commons_lang)
+  compile project(":atlasdb-commons")
+  compile project(":leader-election-api-protobufs")
+  compile group: "commons-lang", name: "commons-lang", version: libVersions.commons_lang
   compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
-  compile 'com.fasterxml.jackson.core:jackson-annotations:' + libVersions.jackson_annotation
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
 }

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -5,7 +5,7 @@ dependencies {
   compile project(":atlasdb-commons")
   compile group: "com.google.protobuf", name: "protobuf-java", version: libVersions.protobuf
   compile group: "commons-lang", name: "commons-lang", version: libVersions.commons_lang
-  compile group: "commons-io", name: "commons-io", version: "2.1"
+  compile group: "commons-io", name: "commons-io"
 
   testCompile group: 'org.mockito', name: 'mockito-core', version: libVersions.mockito
   testCompile group: 'org.assertj', name: 'assertj-core', version: libVersions.assertj

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -13,14 +13,12 @@ repositories {
 
 libsDirName = file('build/artifacts')
 dependencies {
-    compile(project(":atlasdb-commons"))
+    compile project(":atlasdb-commons")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:' + libVersions.jackson_annotation
-    compile 'com.fasterxml.jackson.core:jackson-databind:' + libVersions.jackson
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
 
-    testCompile(group: 'junit', name: 'junit', version: libVersions.junit) {
-        exclude group: 'org.hamcrest'
-    }
-    testCompile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
-    testCompile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
+    testCompile group: 'junit', name: 'junit'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-core'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-library'
 }

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -1,8 +1,8 @@
 apply from: "../gradle/shared.gradle"
 
 dependencies {
-  compile(project(":lock-api"))
-  compile(project(":atlasdb-commons"))
+  compile project(":lock-api")
+  compile project(":atlasdb-commons")
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
-  compile 'joda-time:joda-time:' + libVersions.joda_time
+  compile group: 'joda-time', name: 'joda-time'
 }

--- a/timestamp-api/build.gradle
+++ b/timestamp-api/build.gradle
@@ -2,5 +2,5 @@ apply from: "../gradle/shared.gradle"
 
 dependencies {
   compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
-  compile 'com.fasterxml.jackson.core:jackson-annotations:' + libVersions.jackson_annotation
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
 }

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -4,14 +4,11 @@ dependencies {
   compile(project(":timestamp-api"))
   compile(project(":atlasdb-commons"))
 
-  testCompile(group: 'junit', name: 'junit', version: libVersions.junit) {
-    exclude group: 'org.hamcrest'
-  }
-  testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
-    exclude group: 'org.hamcrest'
-  }
+  compile group: 'org.hamcrest', name: 'hamcrest-core'
+  compile group: 'org.hamcrest', name: 'hamcrest-library'
+
+  testCompile group: 'junit', name: 'junit'
+  testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock
   testCompile 'com.jayway.awaitility:awaitility:1.6.5'
   testCompile 'org.mockito:mockito-core:' + libVersions.mockito
-  compile 'org.hamcrest:hamcrest-core:' + libVersions.hamcrest
-  compile 'org.hamcrest:hamcrest-library:' + libVersions.hamcrest
 }

--- a/versions.props
+++ b/versions.props
@@ -1,0 +1,29 @@
+ch.qos.logback:* = 1.1.3
+com.codahale.metrics:metrics-core = 3.0.2
+com.google.dagger:dagger = 2.0.2
+com.google.dagger:dagger-compiler = 2.0.2
+com.fasterxml.jackson.*:* = 2.5.1
+com.google.code.findbugs:annotations = 2.0.3
+com.google.code.findbugs:jsr305 = 1.3.9
+com.google.guava:* = 18.0
+com.googlecode.json-simple:json-simple = 1.1.1
+commons-cli:commons-cli = 1.2
+commons-codec:commons-codec = 1.10
+commons-io:commons-io = 2.1
+io.dropwizard.metrics:metrics-core = 3.1.1
+javax.validation:validation-api = 1.1.0.Final
+joda-time:joda-time = 2.7
+junit:junit = 4.12
+net.java.dev.jna:jna = 4.1.0
+org.apache.commons:commons-lang3 = 3.1
+org.apache.thrift:libthrift = 0.9.2
+org.codehaus.groovy:groovy-all = 2.4.4
+org.hamcrest:* = 1.3
+org.ow2.asm:asm = 5.0.4
+org.slf4j:* = 1.7.5
+org.yaml:snakeyaml = 1.12
+org.hibernate:hibernate-validator = 5.1.3.Final
+
+// versions below 8.10.0 have a bug where POST requests must have a body
+com.netflix.feign:* = 8.6.1
+com.netflix.feign:feign-okhttp = 8.10.1


### PR DESCRIPTION
This enabled the netflix dependency recommender plugin which allows us to remove all of our exclude/force statements. Yay!

_THIS IS ONLY A FIRST PASS_: We need to go over all of the remaining dependencies and move to using `version.props` instead of `gradle/versions.gradle`. Probably in another PR since this PR is already huge.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1133)

<!-- Reviewable:end -->
