### PR TITLE
Add methods to catch additional lock and unlock methods in the LockRefereshingLockService

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,6 +45,10 @@ develop
          - The ``clean-cass-locks-state`` CLI would drop the whole _locks table, which is a valid way to clear the schema mutation lock, but this differs from how an actual lockholder clears the _locks table.
            Now the CLI sets the schema mutation lock to a special "cleared" value to be more consistent with how real lockholders behave.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1056>`__)
+    *    - |fixed|
+         - Fixed an issue where some locks were not being tracked for continuous refreshing due to one of the lock methods not being
+           overridden by the ``LockRefreshingLockService``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1134>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -90,6 +90,16 @@ public class LockRefreshingLockService extends ForwardingLockService {
     }
 
     @Override
+    public HeldLocksToken lockAndGetHeldLocks(String client, LockRequest request)
+            throws InterruptedException {
+        HeldLocksToken lock = super.lockAndGetHeldLocks(client, request);
+        if (lock != null) {
+            toRefresh.add(lock.getLockRefreshToken());
+        }
+        return lock;
+    }
+
+    @Override
     public LockRefreshToken lock(String client, LockRequest request)
             throws InterruptedException {
         LockRefreshToken ret = super.lock(client, request);
@@ -130,6 +140,12 @@ public class LockRefreshingLockService extends ForwardingLockService {
     public boolean unlockSimple(SimpleHeldLocksToken token) {
         toRefresh.remove(token.asLockRefreshToken());
         return super.unlockSimple(token);
+    }
+
+    @Override
+    public boolean unlockAndFreeze(HeldLocksToken token) {
+        toRefresh.remove(token.getLockRefreshToken());
+        return super.unlockAndFreeze(token);
     }
 
     @Override


### PR DESCRIPTION
This is going to preempt https://github.com/palantir/atlasdb/pull/1123/ to get a minimum fix in fast.  Refactor will follow to ensure it doesn't reoccur and will increase testing on the interfact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1134)
<!-- Reviewable:end -->
