### PR TITLE
Change scrubber logging from info to debug

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,6 +49,9 @@ develop
          - Fixed an issue where some locks were not being tracked for continuous refreshing due to one of the lock methods not being
            overridden by the ``LockRefreshingLockService``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1134>`__)
+    *    - |improved|
+         - Actions performed by the ``Scrubber`` are now logged at debug instead of info.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1137>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
The existing info logging is very verbose.

Also use slf4j string formatting to remove most is*Enabled checks.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1137)

<!-- Reviewable:end -->
