### PR TITLE
Retry on Distinct Servers; fixes #885

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -291,9 +291,9 @@ public class CassandraClientPool {
             livingHosts = filteredHosts;
         }
 
-        CassandraClientPoolingContainer poolingContainer
-                = pools.get(getRandomHostByActiveConnections(Maps.filterKeys(currentPools, livingHosts::contains)));
-        return Optional.of(poolingContainer);
+        InetSocketAddress randomLivingHost = getRandomHostByActiveConnections(
+                Maps.filterKeys(currentPools, livingHosts::contains));
+        return Optional.of(pools.get(randomLivingHost));
     }
 
     public InetSocketAddress getRandomHostForKey(byte[] key) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -293,7 +293,7 @@ public class CassandraClientPool {
 
         InetSocketAddress randomLivingHost = getRandomHostByActiveConnections(
                 Maps.filterKeys(currentPools, livingHosts::contains));
-        return Optional.of(pools.get(randomLivingHost));
+        return Optional.ofNullable(pools.get(randomLivingHost));
     }
 
     public InetSocketAddress getRandomHostForKey(byte[] key) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -89,8 +89,10 @@ public class CassandraClientPool {
      * This is the maximum number of times we'll accept connection failures to one host before blacklisting it. Note
      * that subsequent hosts we try in the same call will actually be blacklisted after one connection failure
      */
-    private static final int MAX_TRIES_SAME_HOST = 3;
-    private static final int MAX_TRIES_TOTAL = 6;
+    @VisibleForTesting
+    static final int MAX_TRIES_SAME_HOST = 3;
+    @VisibleForTesting
+    static final int MAX_TRIES_TOTAL = 6;
 
     volatile RangeMap<LightweightOppToken, List<InetSocketAddress>> tokenMap = ImmutableRangeMap.of();
     Map<InetSocketAddress, Long> blacklistedHosts = Maps.newConcurrentMap();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -268,12 +268,14 @@ public class CassandraClientPool {
         return getRandomGoodHostForPredicate(address -> true);
     }
 
-    private CassandraClientPoolingContainer getRandomGoodHostForPredicate(Predicate<InetSocketAddress> predicate) {
+    @VisibleForTesting
+    CassandraClientPoolingContainer getRandomGoodHostForPredicate(Predicate<InetSocketAddress> predicate) {
         Map<InetSocketAddress, CassandraClientPoolingContainer> pools = currentPools;
 
         Set<InetSocketAddress> filteredHosts = pools.keySet().stream().filter(predicate).collect(Collectors.toSet());
         if (filteredHosts.isEmpty()) {
-            throw new IllegalArgumentException("No hosts match the provided predicate!");
+            log.error("No hosts match the provided predicate. We will ignore said predicate.");
+            filteredHosts = pools.keySet();
         }
 
         Set<InetSocketAddress> livingHosts = Sets.difference(filteredHosts, blacklistedHosts.keySet());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -32,6 +32,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.cassandra.thrift.Cassandra;
@@ -264,13 +265,22 @@ public class CassandraClientPool {
     }
 
     private CassandraClientPoolingContainer getRandomGoodHost() {
+        return getRandomGoodHostForPredicate(address -> true);
+    }
+
+    private CassandraClientPoolingContainer getRandomGoodHostForPredicate(Predicate<InetSocketAddress> predicate) {
         Map<InetSocketAddress, CassandraClientPoolingContainer> pools = currentPools;
 
-        Set<InetSocketAddress> livingHosts = Sets.difference(pools.keySet(), blacklistedHosts.keySet());
+        Set<InetSocketAddress> filteredHosts = pools.keySet().stream().filter(predicate).collect(Collectors.toSet());
+        if (filteredHosts.isEmpty()) {
+            throw new IllegalArgumentException("No hosts match the provided predicate!");
+        }
+
+        Set<InetSocketAddress> livingHosts = Sets.difference(filteredHosts, blacklistedHosts.keySet());
         if (livingHosts.isEmpty()) {
-            log.error("There are no known live hosts in the connection pool. We're choosing"
+            log.error("There are no known live hosts in the connection pool matching the predicate. We're choosing"
                     + " one at random in a last-ditch attempt at forward progress.");
-            livingHosts = pools.keySet();
+            livingHosts = filteredHosts;
         }
 
         return pools.get(getRandomHostByActiveConnections(Maps.filterKeys(currentPools, livingHosts::contains)));
@@ -455,6 +465,7 @@ public class CassandraClientPool {
             FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
         int numTries = 0;
         boolean shouldRetryOnDifferentHost = false;
+        final Set<InetSocketAddress> triedHosts = Sets.newHashSet();
         while (true) {
             if (log.isTraceEnabled()) {
                 log.trace("Running function on host {}.", specifiedHost.getHostString());
@@ -463,13 +474,14 @@ public class CassandraClientPool {
 
             if (blacklistedHosts.containsKey(specifiedHost) || hostPool == null || shouldRetryOnDifferentHost) {
                 log.warn("Randomly redirected a query intended for host {}.", specifiedHost);
-                hostPool = getRandomGoodHost();
+                hostPool = getRandomGoodHostForPredicate(address -> !triedHosts.contains(address));
             }
 
             try {
                 return hostPool.runWithPooledResource(fn);
             } catch (Exception e) {
                 numTries++;
+                triedHosts.add(hostPool.getHost());
                 this.<K>handleException(numTries, hostPool.getHost(), e);
                 if (isRetriableWithBackoffException(e)) {
                     log.warn("Retrying with backoff a query intended for host {}.", hostPool.getHost(), e);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -171,7 +171,7 @@ public class CassandraClientPoolTest {
             // expected, keep going
         }
 
-        verifyNumberOfAttemptsOnHost(host, cassandraClientPool, 6);
+        verifyNumberOfAttemptsOnHost(host, cassandraClientPool, CassandraClientPool.MAX_TRIES_TOTAL);
     }
 
     private void verifyNumberOfAttemptsOnHost(InetSocketAddress host,

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -15,8 +15,8 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.thrift.Cassandra;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
@@ -221,8 +222,7 @@ public class CassandraClientPoolTest {
                         Mockito.<FunctionCheckedException<Cassandra.Client, Object, Exception>>any()))
                         .thenThrow(failureMode.get());
             } catch (Exception e) {
-                // Theoretically the runWithPooledResource *could* throw something we don't want,
-                // which makes javac unhappy.
+                throw Throwables.propagate(e);
             }
         }
         return poolingContainer;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,13 @@ develop
 
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1098>`__)
 
+    *    - |improved|
+         - Random redirection of queries when retrying a Cassandra operation now retries said queries on distinct
+           hosts. Previously, this would independently select hosts randomly, meaning that we might unintentionally
+           try the same operation on the same server(s).
+
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1139>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
This addresses #885 by adding a mechanism for filtering of which servers should be considered when doing runWithRetryOnHost(). We then keep track of which servers we've tried on the current run, and where feasible don't try them again after hitting a retriable exception. If we run out of servers (e.g. a 3-node cluster with all nodes failing in this sense) then we select randomly from any server in the pool once this happens.

I've also added a few unit tests around this predicate matching and the retry logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1139)
<!-- Reviewable:end -->
