### PR TITLE
Test that a CassandraKeyValueService can initialise on a degraded Cassandra cluster

### DIFF
--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/atlasdb/containers/ThreeNodeCassandraClusterTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/atlasdb/containers/ThreeNodeCassandraClusterTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.containers;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class ThreeNodeCassandraClusterTest {
+
+    public static final String CORRUPT_STRING = "sodu89sydihusd:KSDNLSA";
+
+    @Test
+    public void canParseThreeUpNodesFromNodetoolStatus() {
+        String nodetoolStatus = "Datacenter: dc1\n"
+                + "===============\n"
+                + "Status=Up/Down\n"
+                + "|/ State=Normal/Leaving/Joining/Moving\n"
+                + "--  Address     Load       Tokens       Owns (effective)"
+                + "  Host ID                               Rack\n"
+                + "UN  172.30.0.4  1.74 MB    512          64.4%           "
+                + "  45cc5892-a0d2-4e7c-9080-c77329c05e0b  rack1\n"
+                + "UN  172.30.0.3  1.74 MB    512          66.0%           "
+                + "  7f436bc3-5f5c-4a07-beed-f4bb96189cca  rack1\n"
+                + "UN  172.30.0.2  1.87 MB    512          69.6%           "
+                + "  58b310df-5ce2-4565-a479-0ed37e69b04f  rack1";
+
+        assertThat(ThreeNodeCassandraCluster.parseNumberOfUpNodesFromNodetoolStatus(nodetoolStatus), is(3));
+    }
+
+    @Test
+    public void canParseTwoUpAndOneDownNodesFromNodetoolStatus() {
+        String nodetoolStatus = "Datacenter: dc1\n"
+                + "===============\n"
+                + "Status=Up/Down\n"
+                + "|/ State=Normal/Leaving/Joining/Moving\n"
+                + "--  Address     Load       Tokens       Owns (effective)"
+                + "  Host ID                               Rack\n"
+                + "DN  172.30.0.4  1.72 MB    512          64.4%           "
+                + "  45cc5892-a0d2-4e7c-9080-c77329c05e0b  rack1\n"
+                + "UN  172.30.0.3  1.72 MB    512          66.0%           "
+                + "  7f436bc3-5f5c-4a07-beed-f4bb96189cca  rack1\n"
+                + "UN  172.30.0.2  1.87 MB    512          69.6%           "
+                + "  58b310df-5ce2-4565-a479-0ed37e69b04f  rack1";
+
+        assertThat(ThreeNodeCassandraCluster.parseNumberOfUpNodesFromNodetoolStatus(nodetoolStatus), is(2));
+    }
+
+    @Test
+    public void parsesCorruptResponseFromNodetoolStatusSilently() {
+        assertThat(ThreeNodeCassandraCluster.parseNumberOfUpNodesFromNodetoolStatus(CORRUPT_STRING), is(0));
+    }
+
+    @Test
+    public void parsesReplicationFactorOfSystemAuthKeyspace() {
+        String output = "\n"
+                + " keyspace_name      | durable_writes | strategy_class                              "
+                + "| strategy_options\n"
+                + "--------------------+----------------+---------------------------------------------"
+                + "+----------------------------\n"
+                + "             system |           True |  org.apache.cassandra.locator.LocalStrategy "
+                + "|                         {}\n"
+                + "        system_auth |           True | org.apache.cassandra.locator.SimpleStrategy "
+                + "| {\"replication_factor\":\"4\"}\n"
+                + " system_distributed |           True | org.apache.cassandra.locator.SimpleStrategy "
+                + "| {\"replication_factor\":\"3\"}\n"
+                + "\n"
+                + "(3 rows)";
+        assertThat(ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(output), is(4));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parsingFailsWhenSystemAuthKeyspaceIsNotThere() {
+        String output = "\n"
+                + " keyspace_name      | durable_writes | strategy_class                              "
+                + "| strategy_options\n"
+                + "--------------------+----------------+---------------------------------------------"
+                + "+----------------------------\n"
+                + "             system |           True |  org.apache.cassandra.locator.LocalStrategy "
+                + "|                         {}\n"
+                + " system_distributed |           True | org.apache.cassandra.locator.SimpleStrategy "
+                + "| {\"replication_factor\":\"3\"}\n"
+                + "      system_traces |           True | org.apache.cassandra.locator.SimpleStrategy "
+                + "| {\"replication_factor\":\"2\"}\n"
+                + "\n"
+                + "(3 rows)";
+        ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(output);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parsingFailsWhenSystemAuthKeyspaceIsNotANumber() {
+        String output = "\n"
+                + " keyspace_name      | durable_writes | strategy_class                              "
+                + "| strategy_options\n"
+                + "--------------------+----------------+---------------------------------------------"
+                + "+----------------------------\n"
+                + "             system |           True |  org.apache.cassandra.locator.LocalStrategy "
+                + "|                         {}\n"
+                + "        system_auth |           True | org.apache.cassandra.locator.SimpleStrategy "
+                + "| {\"replication_factor\":\"foo\"}\n"
+                + "      system_traces |           True | org.apache.cassandra.locator.SimpleStrategy "
+                + "| {\"replication_factor\":\"2\"}\n"
+                + "\n"
+                + "(3 rows)";
+        ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(output);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parsingFailsWhenSystemAuthKeyspaceOutputCorrupt() {
+        ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(CORRUPT_STRING);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parsingFailsWhenSystemAuthKeyspaceReplicationStrategyIsNotSimple() {
+        String output = "\n"
+                + " keyspace_name      | durable_writes | strategy_class                                       "
+                + "| strategy_options\n"
+                + "--------------------+----------------+------------------------------------------------------"
+                + "+----------------------------\n"
+                + "             system |           True |  org.apache.cassandra.locator.LocalStrategy          "
+                + "|                         {}\n"
+                + "        system_auth |           True | org.apache.cassandra.locator.NetworkTopologyStrategy "
+                + "| {\"dc1\":\"1\"}\n"
+                + "      system_traces |           True | org.apache.cassandra.locator.SimpleStrategy          "
+                + "| {\"replication_factor\":\"2\"}\n"
+                + "\n"
+                + "(3 rows)";
+        ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(output);
+    }
+}

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/atlasdb/containers/ThreeNodeCassandraClusterTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/atlasdb/containers/ThreeNodeCassandraClusterTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 
 public class ThreeNodeCassandraClusterTest {
-
     public static final String CORRUPT_STRING = "sodu89sydihusd:KSDNLSA";
 
     @Test

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -65,7 +65,7 @@ public class DegradedClusterInitializationTest {
         killFirstCassandraNode();
 
         // startup checks aren't guaranteed to pass immediately after killing the node, so we wait until
-        // they do. unclear if this is an AtlasDB product problem
+        // they do. unclear if this is an AtlasDB product problem. see #1154
         waitUntilStartupChecksPass();
     }
 

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -34,7 +34,6 @@ import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.DockerPort;
 
 public class DegradedClusterInitializationTest {
-
     private static final String CASSANDRA_NODE_TO_KILL = ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME;
     private static final int CASSANDRA_PORT = ThreeNodeCassandraCluster.CASSANDRA_PORT;
 

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.cassandra.multinode;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.jayway.awaitility.Awaitility;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
+import com.palantir.atlasdb.containers.CassandraContainer;
+import com.palantir.atlasdb.containers.Containers;
+import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
+import com.palantir.docker.compose.connection.Container;
+import com.palantir.docker.compose.connection.DockerPort;
+
+public class DegradedClusterInitializationTest {
+
+    private static final String CASSANDRA_NODE_TO_KILL = ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME;
+    private static final int CASSANDRA_PORT = ThreeNodeCassandraCluster.CASSANDRA_PORT;
+
+    @ClassRule
+    public static final Containers CONTAINERS = new Containers(DegradedClusterInitializationTest.class)
+            .with(new ThreeNodeCassandraCluster());
+
+    @BeforeClass
+    public static void createKvsAndDegradeCluster() throws IOException, InterruptedException {
+        createCassandraKeyValueService();
+        degradeCassandraCluster();
+    }
+
+    @AfterClass
+    public static void bringClusterBack() throws IOException, InterruptedException {
+        startDeadCassandraNode();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void creatingCassandraKvsShouldFail()  {
+        createCassandraKeyValueService();
+    }
+
+    private static void createCassandraKeyValueService() {
+        CassandraKeyValueService.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(ThreeNodeCassandraCluster.KVS_CONFIG),
+                CassandraContainer.LEADER_CONFIG);
+    }
+
+    private static void degradeCassandraCluster() throws IOException, InterruptedException {
+        killFirstCassandraNode();
+
+        // startup checks aren't guaranteed to pass immediately after killing the node, so we wait until
+        // they do. unclear if this is an AtlasDB product problem
+        waitUntilStartupChecksPass();
+    }
+
+    private static void killFirstCassandraNode() throws IOException, InterruptedException {
+        Container container = CONTAINERS.getContainer(CASSANDRA_NODE_TO_KILL);
+        container.kill();
+    }
+
+    private static void startDeadCassandraNode() throws IOException, InterruptedException {
+        Container container = CONTAINERS.getContainer(CASSANDRA_NODE_TO_KILL);
+        container.start();
+        waitUntilCassandraIsListening(container);
+    }
+
+    private static void waitUntilCassandraIsListening(Container container) {
+        DockerPort containerPort = new DockerPort(container.getContainerName(), CASSANDRA_PORT, CASSANDRA_PORT);
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .until(containerPort::isListeningNow);
+    }
+
+    private static void waitUntilStartupChecksPass() {
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .until(DegradedClusterInitializationTest::startupChecksPass);
+    }
+
+    private static boolean startupChecksPass() {
+        CassandraKeyValueServiceConfigManager manager = CassandraKeyValueServiceConfigManager.createSimpleManager(
+                ThreeNodeCassandraCluster.KVS_CONFIG);
+        CassandraClientPool pool = new CassandraClientPool(manager.getConfig());
+        try {
+            pool.runOneTimeStartupChecks();
+        } catch (RuntimeException e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -35,7 +35,6 @@ import com.palantir.docker.compose.connection.DockerPort;
 
 public class DegradedClusterInitializationTest {
     private static final String CASSANDRA_NODE_TO_KILL = ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME;
-    private static final int CASSANDRA_PORT = ThreeNodeCassandraCluster.CASSANDRA_PORT;
 
     @ClassRule
     public static final Containers CONTAINERS = new Containers(DegradedClusterInitializationTest.class)
@@ -83,7 +82,9 @@ public class DegradedClusterInitializationTest {
     }
 
     private static void waitUntilCassandraIsListening(Container container) {
-        DockerPort containerPort = new DockerPort(container.getContainerName(), CASSANDRA_PORT, CASSANDRA_PORT);
+        DockerPort containerPort = new DockerPort(container.getContainerName(),
+                CassandraContainer.CASSANDRA_PORT,
+                CassandraContainer.CASSANDRA_PORT);
         Awaitility.await()
                 .atMost(60, TimeUnit.SECONDS)
                 .until(containerPort::isListeningNow);

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -39,8 +39,8 @@ public class DegradedClusterInitializationTest {
             .with(new ThreeNodeCassandraCluster());
 
     @BeforeClass
-    public static void createKvsAndDegradeCluster() throws IOException, InterruptedException {
-        createCassandraKeyValueService();
+    public static void initializeKvsAndDegradeCluster() throws IOException, InterruptedException {
+        createAndDiscardCassandraKvs();
         degradeCassandraCluster();
     }
 
@@ -52,10 +52,10 @@ public class DegradedClusterInitializationTest {
 
     @Test
     public void canCreateCassandraKvs()  {
-        createCassandraKeyValueService();
+        createAndDiscardCassandraKvs();
     }
 
-    private static void createCassandraKeyValueService() {
+    private static void createAndDiscardCassandraKvs() {
         CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(ThreeNodeCassandraCluster.KVS_CONFIG),
                 ThreeNodeCassandraCluster.LEADER_CONFIG);

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -47,7 +47,7 @@ public class DegradedClusterInitializationTest {
     @AfterClass
     public static void bringClusterBack() throws IOException, InterruptedException {
         startDeadCassandraNode();
-        CONTAINERS.waitForContainersToStart();
+        CONTAINERS.waitUntilAllContainersReady();
     }
 
     @Test

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -50,8 +50,8 @@ public class DegradedClusterInitializationTest {
         CONTAINERS.waitForContainersToStart();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void creatingCassandraKvsShouldFail()  {
+    @Test
+    public void canCreateCassandraKvs()  {
         createCassandraKeyValueService();
     }
 

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -60,7 +60,7 @@ public class DegradedClusterInitializationTest {
     private static void createCassandraKeyValueService() {
         CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(ThreeNodeCassandraCluster.KVS_CONFIG),
-                CassandraContainer.LEADER_CONFIG);
+                ThreeNodeCassandraCluster.LEADER_CONFIG);
     }
 
     private static void degradeCassandraCluster() throws IOException, InterruptedException {

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/DegradedClusterInitializationTest.java
@@ -25,13 +25,11 @@ import org.junit.Test;
 
 import com.jayway.awaitility.Awaitility;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
-import com.palantir.atlasdb.containers.CassandraContainer;
 import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.docker.compose.connection.Container;
-import com.palantir.docker.compose.connection.DockerPort;
 
 public class DegradedClusterInitializationTest {
     private static final String CASSANDRA_NODE_TO_KILL = ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME;
@@ -49,6 +47,7 @@ public class DegradedClusterInitializationTest {
     @AfterClass
     public static void bringClusterBack() throws IOException, InterruptedException {
         startDeadCassandraNode();
+        CONTAINERS.waitForContainersToStart();
     }
 
     @Test(expected = IllegalStateException.class)
@@ -78,16 +77,6 @@ public class DegradedClusterInitializationTest {
     private static void startDeadCassandraNode() throws IOException, InterruptedException {
         Container container = CONTAINERS.getContainer(CASSANDRA_NODE_TO_KILL);
         container.start();
-        waitUntilCassandraIsListening(container);
-    }
-
-    private static void waitUntilCassandraIsListening(Container container) {
-        DockerPort containerPort = new DockerPort(container.getContainerName(),
-                CassandraContainer.CASSANDRA_PORT,
-                CassandraContainer.CASSANDRA_PORT);
-        Awaitility.await()
-                .atMost(60, TimeUnit.SECONDS)
-                .until(containerPort::isListeningNow);
     }
 
     private static void waitUntilStartupChecksPass() {

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraCliParser.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraCliParser.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.containers;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class CassandraCliParser {
+    private static final Logger log = LoggerFactory.getLogger(CassandraCliParser.class);
+
+    private CassandraCliParser() {
+    }
+
+    public static int parseSystemAuthReplicationFromCqlsh(String output) throws IllegalArgumentException {
+        try {
+            for (String line : output.split("\n")) {
+                if (line.contains("system_auth")) {
+                    Matcher matcher = Pattern.compile("^.*\\{\"replication_factor\":\"(\\d+)\"\\}$").matcher(line);
+                    matcher.find();
+                    return Integer.parseInt(matcher.group(1));
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed parsing system_auth keyspace RF: " + e);
+            throw new IllegalArgumentException("Cannot determine replication factor of system_auth keyspace");
+        }
+
+        throw new IllegalArgumentException("Cannot determine replication factor of system_auth keyspace");
+    }
+
+    public static int parseNumberOfUpNodesFromNodetoolStatus(String output) {
+        Pattern pattern = Pattern.compile("^UN.*");
+        int upNodes = 0;
+        for (String line : output.split("\n")) {
+            Matcher matcher = pattern.matcher(line);
+            if (matcher.matches()) {
+                upNodes++;
+            }
+        }
+        return upNodes;
+    }
+}

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
+import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 public class CassandraContainer extends Container {
@@ -58,7 +59,7 @@ public class CassandraContainer extends Container {
     }
 
     @Override
-    public SuccessOrFailure isReady() {
+    public SuccessOrFailure isReady(DockerComposeRule rule) {
         return SuccessOrFailure.onResultOf(() -> {
             CassandraKeyValueService.create(
                     CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -30,13 +30,17 @@ import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 public class CassandraContainer extends Container {
+    public static final int CASSANDRA_PORT = 9160;
+    public static final String USERNAME = "cassandra";
+    public static final String PASSWORD = "cassandra";
+
     public static final CassandraKeyValueServiceConfig KVS_CONFIG = ImmutableCassandraKeyValueServiceConfig.builder()
-            .addServers(new InetSocketAddress("cassandra", 9160))
+            .addServers(new InetSocketAddress("cassandra", CASSANDRA_PORT))
             .poolSize(20)
             .keyspace("atlasdb")
             .credentials(ImmutableCassandraCredentialsConfig.builder()
-                    .username("cassandra")
-                    .password("cassandra")
+                    .username(USERNAME)
+                    .password(PASSWORD)
                     .build())
             .replicationFactor(1)
             .mutationBatchCount(10000)

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Container.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Container.java
@@ -15,12 +15,13 @@
  */
 package com.palantir.atlasdb.containers;
 
+import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 public abstract class Container {
     public abstract String getDockerComposeFile();
 
-    public abstract SuccessOrFailure isReady();
+    public abstract SuccessOrFailure isReady(DockerComposeRule rule);
 
     public boolean equals(Object obj) {
         return obj != null && this.getClass() == obj.getClass();

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -77,7 +77,7 @@ public class Containers extends ExternalResource {
         }
     }
 
-    public void waitUntilAllContainersReady() {
+    public static void waitUntilAllContainersReady() {
         Set<Container> allContainers = Sets.union(containersToStart, containersStarted);
         waitUntilContainersReady(allContainers);
     }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -33,6 +33,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
 import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.Duration;
 import com.palantir.atlasdb.testing.DockerProxyRule;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.configuration.DockerComposeFiles;
@@ -69,6 +70,12 @@ public class Containers extends ExternalResource {
             containersToStart.add(container);
         }
         return this;
+    }
+
+    public com.palantir.docker.compose.connection.Container getContainer(String containerName) {
+        synchronized (Containers.class) {
+            return dockerComposeRule.containers().container(containerName);
+        }
     }
 
     @Override

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -132,7 +132,7 @@ public class Containers extends ExternalResource {
             Awaitility.await()
                     .atMost(com.jayway.awaitility.Duration.ONE_MINUTE)
                     .pollInterval(com.jayway.awaitility.Duration.ONE_SECOND)
-                    .until(() -> container.isReady().succeeded());
+                    .until(() -> container.isReady(dockerComposeRule).succeeded());
         }
     }
 

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -77,11 +77,6 @@ public class Containers extends ExternalResource {
         }
     }
 
-    public static void waitUntilAllContainersReady() {
-        Set<Container> allContainers = Sets.union(containersToStart, containersStarted);
-        waitUntilContainersReady(allContainers);
-    }
-
     @Override
     protected void before() throws Throwable {
         synchronized (Containers.class) {
@@ -92,7 +87,7 @@ public class Containers extends ExternalResource {
 
             ensureDockerProxyRuleRunning();
 
-            waitUntilNewContainersReady();
+            waitForContainersToStart();
             containersStarted.addAll(containersToStart);
         }
     }
@@ -138,13 +133,8 @@ public class Containers extends ExternalResource {
         }
     }
 
-    private static void waitUntilNewContainersReady() {
-        Set<Container> newContainers = Sets.difference(containersToStart, containersStarted);
-        waitUntilContainersReady(newContainers);
-    }
-
-    private static void waitUntilContainersReady(Set<Container> containers) {
-        for (Container container : containers) {
+    private static void waitForContainersToStart() {
+        for (Container container : Sets.difference(containersToStart, containersStarted)) {
             Awaitility.await()
                     .atMost(com.jayway.awaitility.Duration.ONE_MINUTE)
                     .pollInterval(com.jayway.awaitility.Duration.ONE_SECOND)

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -92,6 +92,15 @@ public class Containers extends ExternalResource {
         }
     }
 
+    public static void waitForContainersToStart() {
+        for (Container container : Sets.difference(containersToStart, containersStarted)) {
+            Awaitility.await()
+                    .atMost(com.jayway.awaitility.Duration.ONE_MINUTE)
+                    .pollInterval(com.jayway.awaitility.Duration.ONE_SECOND)
+                    .until(() -> container.isReady(dockerComposeRule).succeeded());
+        }
+    }
+
     public String getLogDirectory() {
         return logDirectory;
     }
@@ -130,15 +139,6 @@ public class Containers extends ExternalResource {
         if (!dockerProxyRuleStarted) {
             dockerProxyRuleStarted = true;
             DOCKER_PROXY_RULE.before();
-        }
-    }
-
-    private static void waitForContainersToStart() {
-        for (Container container : Sets.difference(containersToStart, containersStarted)) {
-            Awaitility.await()
-                    .atMost(com.jayway.awaitility.Duration.ONE_MINUTE)
-                    .pollInterval(com.jayway.awaitility.Duration.ONE_SECOND)
-                    .until(() -> container.isReady(dockerComposeRule).succeeded());
         }
     }
 

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -33,7 +33,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
 import com.jayway.awaitility.Awaitility;
-import com.jayway.awaitility.Duration;
 import com.palantir.atlasdb.testing.DockerProxyRule;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.configuration.DockerComposeFiles;

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -33,6 +33,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
 import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.Duration;
 import com.palantir.atlasdb.testing.DockerProxyRule;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.configuration.DockerComposeFiles;
@@ -136,8 +137,8 @@ public class Containers extends ExternalResource {
     private static void waitForContainersToStart() {
         for (Container container : Sets.difference(containersToStart, containersStarted)) {
             Awaitility.await()
-                    .atMost(com.jayway.awaitility.Duration.ONE_MINUTE)
-                    .pollInterval(com.jayway.awaitility.Duration.ONE_SECOND)
+                    .atMost(Duration.TWO_MINUTES)
+                    .pollInterval(Duration.ONE_SECOND)
                     .until(() -> container.isReady(dockerComposeRule).succeeded());
         }
     }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
+import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 public class ThreeNodeCassandraCluster extends Container {
@@ -60,7 +61,7 @@ public class ThreeNodeCassandraCluster extends Container {
     }
 
     @Override
-    public SuccessOrFailure isReady() {
+    public SuccessOrFailure isReady(DockerComposeRule rule) {
         return SuccessOrFailure.onResultOf(() -> {
             CassandraKeyValueService.create(
                     CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -15,10 +15,7 @@
  */
 package com.palantir.atlasdb.containers;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,8 +31,6 @@ import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
-import com.palantir.docker.compose.execution.DockerComposeRunArgument;
-import com.palantir.docker.compose.execution.DockerComposeRunOption;
 
 public class ThreeNodeCassandraCluster extends Container {
     private static final Logger log = LoggerFactory.getLogger(ThreeNodeCassandraCluster.class);
@@ -44,19 +39,16 @@ public class ThreeNodeCassandraCluster extends Container {
     public static final String FIRST_CASSANDRA_CONTAINER_NAME = "cassandra1";
     public static final String SECOND_CASSANDRA_CONTAINER_NAME = "cassandra2";
     public static final String THIRD_CASSANDRA_CONTAINER_NAME = "cassandra3";
-    public static final int CASSANDRA_PORT = 9160;
-    public static final String USERNAME = "cassandra";
-    public static final String PASSWORD = "cassandra";
 
     public static final CassandraKeyValueServiceConfig KVS_CONFIG = ImmutableCassandraKeyValueServiceConfig.builder()
-            .addServers(new InetSocketAddress(FIRST_CASSANDRA_CONTAINER_NAME, CASSANDRA_PORT))
-            .addServers(new InetSocketAddress(SECOND_CASSANDRA_CONTAINER_NAME, CASSANDRA_PORT))
-            .addServers(new InetSocketAddress(THIRD_CASSANDRA_CONTAINER_NAME, CASSANDRA_PORT))
+            .addServers(new InetSocketAddress(FIRST_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_PORT))
+            .addServers(new InetSocketAddress(SECOND_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_PORT))
+            .addServers(new InetSocketAddress(THIRD_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_PORT))
             .poolSize(20)
             .keyspace("atlasdb")
             .credentials(ImmutableCassandraCredentialsConfig.builder()
-                    .username(USERNAME)
-                    .password(PASSWORD)
+                    .username(CassandraContainer.USERNAME)
+                    .password(CassandraContainer.PASSWORD)
                     .build())
             .replicationFactor(3)
             .mutationBatchCount(10000)
@@ -83,13 +75,16 @@ public class ThreeNodeCassandraCluster extends Container {
         return SuccessOrFailure.onResultOf(() -> {
 
             try {
-                if (!nodetoolShowsThreeCassandraNodesUp(rule)) {
+                ThreeNodeCassandraClusterOperations cassandraOperations =
+                        new ThreeNodeCassandraClusterOperations(rule);
+
+                if (!cassandraOperations.nodetoolShowsThreeCassandraNodesUp()) {
                     return false;
                 }
 
                 // slightly hijacking the isReady function here - using it
                 // to actually modify the cluster
-                replicateSystemAuthenticationDataOnAllNodes(rule);
+                cassandraOperations.replicateSystemAuthenticationDataOnAllNodes();
 
                 return canCreateCassandraKeyValueService();
             } catch (Exception e) {
@@ -99,103 +94,10 @@ public class ThreeNodeCassandraCluster extends Container {
         });
     }
 
-    private boolean canCreateCassandraKeyValueService() {
+    private static boolean canCreateCassandraKeyValueService() {
         CassandraKeyValueService.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),
                 LEADER_CONFIG);
         return true;
     }
-
-    private void replicateSystemAuthenticationDataOnAllNodes(DockerComposeRule rule)
-            throws IOException, InterruptedException {
-        if (!systemAuthenticationKeyspaceHasReplicationFactorThree(rule)) {
-            setReplicationFactorOfSystemAuthenticationKeyspaceToThree(rule);
-            runNodetoolRepair(rule);
-        }
-    }
-
-    private void runNodetoolRepair(DockerComposeRule rule) throws IOException, InterruptedException {
-        runNodetoolCommand(rule, "repair system_auth");
-    }
-
-    private void setReplicationFactorOfSystemAuthenticationKeyspaceToThree(DockerComposeRule rule)
-            throws IOException, InterruptedException {
-        runCql(rule,
-                "ALTER KEYSPACE system_auth "
-                + "WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 3};");
-    }
-
-    private boolean systemAuthenticationKeyspaceHasReplicationFactorThree(DockerComposeRule rule)
-            throws IOException, InterruptedException {
-        String output = runCql(rule, "SELECT * FROM system.schema_keyspaces;");
-        int replicationFactor = parseSystemAuthReplicationFromCqlsh(output);
-        return replicationFactor == 3;
-    }
-
-    private boolean nodetoolShowsThreeCassandraNodesUp(DockerComposeRule rule) {
-        try {
-            String output = runNodetoolCommand(rule, "status");
-            int numberNodesUp = parseNumberOfUpNodesFromNodetoolStatus(output);
-            return numberNodesUp == 3;
-        } catch (Exception e) {
-            log.warn("Failed while running nodetool status: " + e);
-            return false;
-        }
-    }
-
-    public static int parseSystemAuthReplicationFromCqlsh(String output) throws IllegalArgumentException {
-        try {
-            for (String line : output.split("\n")) {
-                if (line.contains("system_auth")) {
-                    Matcher matcher = Pattern.compile("^.*\\{\"replication_factor\":\"(\\d+)\"\\}$").matcher(line);
-                    matcher.find();
-                    return Integer.parseInt(matcher.group(1));
-                }
-            }
-        } catch (Exception e) {
-            log.error("Failed parsing system_auth keyspace RF: " + e);
-            throw new IllegalArgumentException("Cannot determine replication factor of system_auth keyspace");
-        }
-
-        throw new IllegalArgumentException("Cannot determine replication factor of system_auth keyspace");
-    }
-
-    public static int parseNumberOfUpNodesFromNodetoolStatus(String output) {
-        Pattern pattern = Pattern.compile("^UN.*");
-        int upNodes = 0;
-        for (String line : output.split("\n")) {
-            Matcher matcher = pattern.matcher(line);
-            if (matcher.matches()) {
-                upNodes++;
-            }
-        }
-        return upNodes;
-    }
-
-    private String runCql(DockerComposeRule rule, String cql) throws IOException, InterruptedException {
-        return runCommandInCliContainer(rule,
-                "cqlsh",
-                "--username", USERNAME,
-                "--password", PASSWORD,
-                FIRST_CASSANDRA_CONTAINER_NAME,
-                "--execute", cql);
-    }
-
-    private String runNodetoolCommand(DockerComposeRule rule, String nodetoolCommand) throws IOException,
-            InterruptedException {
-        return runCommandInCliContainer(rule,
-                "nodetool",
-                "--host", FIRST_CASSANDRA_CONTAINER_NAME,
-                nodetoolCommand);
-
-    }
-
-    private String runCommandInCliContainer(DockerComposeRule rule, String... arguments) throws IOException,
-            InterruptedException {
-        return rule.run(
-                DockerComposeRunOption.options("-T"),
-                CLI_CONTAINER_NAME,
-                DockerComposeRunArgument.arguments(arguments));
-    }
-
 }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,8 +121,8 @@ public class ThreeNodeCassandraCluster extends Container {
     private void setReplicationFactorOfSystemAuthenticationKeyspaceToThree(DockerComposeRule rule)
             throws IOException, InterruptedException {
         runCql(rule,
-            "ALTER KEYSPACE system_auth " +
-            "WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 3};");
+                "ALTER KEYSPACE system_auth "
+                + "WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 3};");
     }
 
     private boolean systemAuthenticationKeyspaceHasReplicationFactorThree(DockerComposeRule rule)
@@ -148,9 +147,9 @@ public class ThreeNodeCassandraCluster extends Container {
         try {
             for (String line : output.split("\n")) {
                 if (line.contains("system_auth")) {
-                    Matcher m = Pattern.compile("^.*\\{\"replication_factor\":\"(\\d+)\"\\}$").matcher(line);
-                    m.find();
-                    return Integer.valueOf(m.group(1));
+                    Matcher matcher = Pattern.compile("^.*\\{\"replication_factor\":\"(\\d+)\"\\}$").matcher(line);
+                    matcher.find();
+                    return Integer.parseInt(matcher.group(1));
                 }
             }
         } catch (Exception e) {
@@ -162,11 +161,11 @@ public class ThreeNodeCassandraCluster extends Container {
     }
 
     public static int parseNumberOfUpNodesFromNodetoolStatus(String output) {
-        Pattern r = Pattern.compile("^UN.*");
+        Pattern pattern = Pattern.compile("^UN.*");
         int upNodes = 0;
         for (String line : output.split("\n")) {
-            Matcher m = r.matcher(line);
-            if (m.matches()) {
+            Matcher matcher = pattern.matcher(line);
+            if (matcher.matches()) {
                 upNodes++;
             }
         }
@@ -182,7 +181,8 @@ public class ThreeNodeCassandraCluster extends Container {
                 "--execute", cql);
     }
 
-    private String runNodetoolCommand(DockerComposeRule rule, String nodetoolCommand) throws IOException, InterruptedException {
+    private String runNodetoolCommand(DockerComposeRule rule, String nodetoolCommand) throws IOException,
+            InterruptedException {
         return runCommandInCliContainer(rule,
                 "nodetool",
                 "--host", FIRST_CASSANDRA_CONTAINER_NAME,
@@ -190,7 +190,8 @@ public class ThreeNodeCassandraCluster extends Container {
 
     }
 
-    private String runCommandInCliContainer(DockerComposeRule rule, String... arguments) throws IOException, InterruptedException {
+    private String runCommandInCliContainer(DockerComposeRule rule, String... arguments) throws IOException,
+            InterruptedException {
         return rule.run(
                 DockerComposeRunOption.options("-T"),
                 CLI_CONTAINER_NAME,

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -112,18 +112,15 @@ public class ThreeNodeCassandraCluster extends Container {
         if (!systemAuthenticationKeyspaceHasReplicationFactorThree(rule)) {
             setReplicationFactorOfSystemAuthenticationKeyspaceToThree(rule);
             runNodetoolRepair(rule);
-            System.out.println("Done");
         }
     }
 
     private void runNodetoolRepair(DockerComposeRule rule) throws IOException, InterruptedException {
-        log.info("Running \"nodetool repair system_auth\"");
-        String output = runNodetoolCommand(rule, "repair system_auth");
+        runNodetoolCommand(rule, "repair system_auth");
     }
 
     private void setReplicationFactorOfSystemAuthenticationKeyspaceToThree(DockerComposeRule rule)
             throws IOException, InterruptedException {
-        log.info("Setting replication factor of system_auth keyspace to 3");
         runCql(rule,
             "ALTER KEYSPACE system_auth " +
             "WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 3};");
@@ -148,7 +145,6 @@ public class ThreeNodeCassandraCluster extends Container {
     }
 
     public static int parseSystemAuthReplicationFromCqlsh(String output) throws IllegalArgumentException {
-
         try {
             for (String line : output.split("\n")) {
                 if (line.contains("system_auth")) {
@@ -195,9 +191,6 @@ public class ThreeNodeCassandraCluster extends Container {
     }
 
     private String runCommandInCliContainer(DockerComposeRule rule, String... arguments) throws IOException, InterruptedException {
-
-        log.info("Running command ");
-        Stream.of(arguments).forEach(arg -> log.info(arg));
         return rule.run(
                 DockerComposeRunOption.options("-T"),
                 CLI_CONTAINER_NAME,

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraClusterOperations.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraClusterOperations.java
@@ -27,10 +27,10 @@ import com.palantir.docker.compose.execution.DockerComposeRunOption;
 public class ThreeNodeCassandraClusterOperations {
     private static final Logger log = LoggerFactory.getLogger(ThreeNodeCassandraClusterOperations.class);
 
-    DockerComposeRule rule;
+    DockerComposeRule dockerComposeRule;
 
-    public ThreeNodeCassandraClusterOperations(DockerComposeRule rule) {
-        this.rule = rule;
+    public ThreeNodeCassandraClusterOperations(DockerComposeRule dockerComposeRule) {
+        this.dockerComposeRule = dockerComposeRule;
     }
 
     public boolean nodetoolShowsThreeCassandraNodesUp() {
@@ -89,7 +89,7 @@ public class ThreeNodeCassandraClusterOperations {
 
     private String runCommandInCliContainer(String... arguments) throws IOException,
             InterruptedException {
-        return rule.run(
+        return dockerComposeRule.run(
                 DockerComposeRunOption.options("-T"),
                 ThreeNodeCassandraCluster.CLI_CONTAINER_NAME,
                 DockerComposeRunArgument.arguments(arguments));

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraClusterOperations.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraClusterOperations.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.containers;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.execution.DockerComposeRunArgument;
+import com.palantir.docker.compose.execution.DockerComposeRunOption;
+
+public class ThreeNodeCassandraClusterOperations {
+    private static final Logger log = LoggerFactory.getLogger(ThreeNodeCassandraClusterOperations.class);
+
+    DockerComposeRule rule;
+
+    public ThreeNodeCassandraClusterOperations(DockerComposeRule rule) {
+        this.rule = rule;
+    }
+
+    public boolean nodetoolShowsThreeCassandraNodesUp() {
+        try {
+            String output = runNodetoolCommand("status");
+            int numberNodesUp = CassandraCliParser.parseNumberOfUpNodesFromNodetoolStatus(output);
+            return numberNodesUp == 3;
+        } catch (Exception e) {
+            log.warn("Failed while running nodetool status: " + e);
+            return false;
+        }
+    }
+
+    public void replicateSystemAuthenticationDataOnAllNodes()
+            throws IOException, InterruptedException {
+        if (!systemAuthenticationKeyspaceHasReplicationFactorThree()) {
+            setReplicationFactorOfSystemAuthenticationKeyspaceToThree();
+            runNodetoolRepair();
+        }
+    }
+
+    private void runNodetoolRepair() throws IOException, InterruptedException {
+        runNodetoolCommand("repair system_auth");
+    }
+
+    private void setReplicationFactorOfSystemAuthenticationKeyspaceToThree()
+            throws IOException, InterruptedException {
+        runCql("ALTER KEYSPACE system_auth "
+                + "WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 3};");
+    }
+
+    private boolean systemAuthenticationKeyspaceHasReplicationFactorThree()
+            throws IOException, InterruptedException {
+        String output = runCql("SELECT * FROM system.schema_keyspaces;");
+        int replicationFactor = CassandraCliParser.parseSystemAuthReplicationFromCqlsh(output);
+        return replicationFactor == 3;
+    }
+
+    private String runCql(String cql) throws IOException, InterruptedException {
+        return runCommandInCliContainer(
+                "cqlsh",
+                "--username", CassandraContainer.USERNAME,
+                "--password", CassandraContainer.PASSWORD,
+                ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME,
+                "--execute", cql);
+    }
+
+    private String runNodetoolCommand(String nodetoolCommand) throws IOException,
+            InterruptedException {
+        return runCommandInCliContainer(
+                "nodetool",
+                "--host", ThreeNodeCassandraCluster.FIRST_CASSANDRA_CONTAINER_NAME,
+                nodetoolCommand);
+
+    }
+
+    private String runCommandInCliContainer(String... arguments) throws IOException,
+            InterruptedException {
+        return rule.run(
+                DockerComposeRunOption.options("-T"),
+                ThreeNodeCassandraCluster.CLI_CONTAINER_NAME,
+                DockerComposeRunArgument.arguments(arguments));
+    }
+}

--- a/atlasdb-container-test-utils/src/main/resources/docker-compose-cassandra-three-node.yml
+++ b/atlasdb-container-test-utils/src/main/resources/docker-compose-cassandra-three-node.yml
@@ -22,3 +22,10 @@ services:
     environment:
       - CASSANDRA_SEEDS=cassandra1,cassandra2,cassandra3
       - LOCAL_JMX=no
+
+  cli:
+    image: palantirtechnologies/docker-cassandra-atlasdb:latest
+    depends_on:
+      - cassandra1
+    entrypoint: [bash, -c, '"$$@"', --]
+    command: exit

--- a/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraCliParserTest.java
+++ b/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraCliParserTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
-public class ThreeNodeCassandraClusterTest {
+public class CassandraCliParserTest {
     public static final String CORRUPT_STRING = "sodu89sydihusd:KSDNLSA";
 
     @Test
@@ -38,7 +38,7 @@ public class ThreeNodeCassandraClusterTest {
                 + "UN  172.30.0.2  1.87 MB    512          69.6%           "
                 + "  58b310df-5ce2-4565-a479-0ed37e69b04f  rack1";
 
-        assertThat(ThreeNodeCassandraCluster.parseNumberOfUpNodesFromNodetoolStatus(nodetoolStatus), is(3));
+        assertThat(CassandraCliParser.parseNumberOfUpNodesFromNodetoolStatus(nodetoolStatus), is(3));
     }
 
     @Test
@@ -56,12 +56,12 @@ public class ThreeNodeCassandraClusterTest {
                 + "UN  172.30.0.2  1.87 MB    512          69.6%           "
                 + "  58b310df-5ce2-4565-a479-0ed37e69b04f  rack1";
 
-        assertThat(ThreeNodeCassandraCluster.parseNumberOfUpNodesFromNodetoolStatus(nodetoolStatus), is(2));
+        assertThat(CassandraCliParser.parseNumberOfUpNodesFromNodetoolStatus(nodetoolStatus), is(2));
     }
 
     @Test
     public void parsesCorruptResponseFromNodetoolStatusSilently() {
-        assertThat(ThreeNodeCassandraCluster.parseNumberOfUpNodesFromNodetoolStatus(CORRUPT_STRING), is(0));
+        assertThat(CassandraCliParser.parseNumberOfUpNodesFromNodetoolStatus(CORRUPT_STRING), is(0));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class ThreeNodeCassandraClusterTest {
                 + "| {\"replication_factor\":\"3\"}\n"
                 + "\n"
                 + "(3 rows)";
-        assertThat(ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(output), is(4));
+        assertThat(CassandraCliParser.parseSystemAuthReplicationFromCqlsh(output), is(4));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -97,7 +97,7 @@ public class ThreeNodeCassandraClusterTest {
                 + "| {\"replication_factor\":\"2\"}\n"
                 + "\n"
                 + "(3 rows)";
-        ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(output);
+        CassandraCliParser.parseSystemAuthReplicationFromCqlsh(output);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -115,12 +115,12 @@ public class ThreeNodeCassandraClusterTest {
                 + "| {\"replication_factor\":\"2\"}\n"
                 + "\n"
                 + "(3 rows)";
-        ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(output);
+        CassandraCliParser.parseSystemAuthReplicationFromCqlsh(output);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void parsingFailsWhenSystemAuthKeyspaceOutputCorrupt() {
-        ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(CORRUPT_STRING);
+        CassandraCliParser.parseSystemAuthReplicationFromCqlsh(CORRUPT_STRING);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -138,6 +138,6 @@ public class ThreeNodeCassandraClusterTest {
                 + "| {\"replication_factor\":\"2\"}\n"
                 + "\n"
                 + "(3 rows)";
-        ThreeNodeCassandraCluster.parseSystemAuthReplicationFromCqlsh(output);
+        CassandraCliParser.parseSystemAuthReplicationFromCqlsh(output);
     }
 }

--- a/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/FirstNginxContainer.java
+++ b/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/FirstNginxContainer.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.containers;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 public class FirstNginxContainer extends Container {
@@ -27,7 +28,7 @@ public class FirstNginxContainer extends Container {
     }
 
     @Override
-    public SuccessOrFailure isReady() {
+    public SuccessOrFailure isReady(DockerComposeRule rule) {
         return SuccessOrFailure.onResultOf(() -> {
             URL url = new URL("http://nginx1/");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();

--- a/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/SecondNginxContainer.java
+++ b/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/SecondNginxContainer.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.containers;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 public class SecondNginxContainer extends Container {
@@ -27,7 +28,7 @@ public class SecondNginxContainer extends Container {
     }
 
     @Override
-    public SuccessOrFailure isReady() {
+    public SuccessOrFailure isReady(DockerComposeRule rule) {
         return SuccessOrFailure.onResultOf(() -> {
             URL url = new URL("http://nginx2");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
In this PR we introduce a test that a CassandraKeyValueService can initialise on a degraded Cassandra cluster.

Have confirmed that the new test, `DegradedClusterInitializationTest`:

- Takes ~2 minutes
- Does not flicker, on six runs on CircleCI

This PR also changes the `ThreeNodeCassandraCluster` to replicate Cassandra authentication data across all three nodes, so that we can still connect to the cluster even if we kill the primary owner of the authentication data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1152)
<!-- Reviewable:end -->
