### PR TITLE
Hinted Retry - fixes #1142

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -524,8 +524,9 @@ public class CassandraClientPool {
      *
      * Using getRandomGoodHostForPredicate is preferred because it takes the loads of the servers into account.
      */
-    private CassandraClientPoolingContainer getRedirectTarget(Set<InetSocketAddress> triedHosts,
-                                                              Set<InetSocketAddress> preferredHosts) {
+    @VisibleForTesting
+    CassandraClientPoolingContainer getRedirectTarget(Set<InetSocketAddress> triedHosts,
+                                                      Set<InetSocketAddress> preferredHosts) {
         Optional<CassandraClientPoolingContainer> hostPoolCandidate
                 = getRandomGoodHostForPredicate(address -> preferredHosts.contains(address)
                 && !triedHosts.contains(address));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -321,9 +321,6 @@ public class CassandraClientPool {
         }
     }
 
-    /**
-     * May return absent if the mapping of which C* host contains which data is not known yet.
-     */
     public Optional<List<InetSocketAddress>> getHostsForKey(byte[] key) {
         return Optional.ofNullable(tokenMap.get(new LightweightOppToken(key)));
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -476,8 +476,7 @@ public class CassandraClientPool {
 
     public <V, K extends Exception> V runWithRetryOnHost(
             InetSocketAddress specifiedHost,
-            FunctionCheckedException<Cassandra.Client, V, K> fn
-    ) throws K {
+            FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
         return runWithRetryOnHost(specifiedHost, fn, ImmutableSet.of());
     }
 
@@ -532,7 +531,7 @@ public class CassandraClientPool {
     Optional<CassandraClientPoolingContainer> getRandomUntriedPreferredHost(Set<InetSocketAddress> triedHosts,
                                                                             Set<InetSocketAddress> preferredHosts) {
         return getRandomGoodHostForPredicate(
-                address -> preferredHosts.contains(address) && !triedHosts.contains(address));
+                address -> !triedHosts.contains(address) && preferredHosts.contains(address));
     }
 
     @VisibleForTesting

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -54,11 +54,12 @@ public class CassandraClientPoolTest {
     public static final String HOSTNAME_1 = "1.0.0.0";
     public static final String HOSTNAME_2 = "2.0.0.0";
     public static final String HOSTNAME_3 = "3.0.0.0";
-    public static final byte[] KEY_1 = { 1, 2, 3 };
-    public static final byte[] KEY_2 = { 1, 3, 5 };
-    public static final byte[] KEY_3 = { 2, 1, 1 };
 
     public static final int FUZZING_NUM_TRIALS = 20;
+
+    private static final byte[] KEY_1 = { 1, 2, 3 };
+    private static final byte[] KEY_2 = { 1, 3, 5 };
+    private static final byte[] KEY_3 = { 2, 1, 1 };
 
     @Test
     public void shouldReturnAddressForSingleHostInPool() throws UnknownHostException {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,9 +33,12 @@ import java.util.stream.Collectors;
 
 import org.apache.cassandra.thrift.Cassandra;
 import org.junit.Test;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
@@ -47,6 +51,8 @@ public class CassandraClientPoolTest {
     public static final String HOSTNAME_1 = "1.0.0.0";
     public static final String HOSTNAME_2 = "2.0.0.0";
     public static final String HOSTNAME_3 = "3.0.0.0";
+
+    public static final int FUZZING_NUM_TRIALS = 20;
 
     @Test
     public void shouldReturnAddressForSingleHostInPool() throws UnknownHostException {
@@ -106,8 +112,7 @@ public class CassandraClientPoolTest {
         InetSocketAddress host2 = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
         CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(host1, host2));
 
-        int numTrials = 50;
-        for (int i = 0; i < numTrials; i++) {
+        for (int i = 0; i < FUZZING_NUM_TRIALS; i++) {
             Optional<CassandraClientPoolingContainer> container
                     = cassandraClientPool.getRandomGoodHostForPredicate(address -> address.equals(host1));
             assertThat(container.isPresent(), is(true));
@@ -129,16 +134,78 @@ public class CassandraClientPoolTest {
     }
 
     @Test
+    public void shouldRedirectToPreferredHostsIfAvailable() {
+        InetSocketAddress host1 = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(host1, host2));
+
+        for (int i = 0; i < FUZZING_NUM_TRIALS; i++) {
+            CassandraClientPoolingContainer container
+                    = cassandraClientPool.getRedirectTarget(ImmutableSet.of(), ImmutableSet.of(host1));
+            assertThat(container.getHost(), equalTo(host1));
+        }
+    }
+
+    @Test
+    public void shouldRedirectToOtherPreferredHostAfterTryingOne() {
+        InetSocketAddress host1 = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
+        InetSocketAddress host3 = new InetSocketAddress(HOSTNAME_3, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool
+                = clientPoolWithServersInCurrentPool(ImmutableSet.of(host1, host2, host3));
+
+        for (int i = 0; i < FUZZING_NUM_TRIALS; i++) {
+            CassandraClientPoolingContainer container
+                    = cassandraClientPool.getRedirectTarget(ImmutableSet.of(host1), ImmutableSet.of(host1, host2));
+            assertThat(container.getHost(), equalTo(host2));
+        }
+    }
+
+    @Test
+    public void shouldRedirectToNonPreferredHostsAfterTryingAllPreferred() {
+        InetSocketAddress host1 = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(host1, host2));
+
+        for (int i = 0; i < FUZZING_NUM_TRIALS; i++) {
+            CassandraClientPoolingContainer container
+                    = cassandraClientPool.getRedirectTarget(ImmutableSet.of(host1), ImmutableSet.of(host1));
+            assertThat(container.getHost(), equalTo(host2));
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToRedirectAfterTryingAllHosts() {
+        InetSocketAddress host1 = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(host1, host2));
+
+        cassandraClientPool.getRedirectTarget(ImmutableSet.of(host1, host2), ImmutableSet.of(host1));
+    }
+
+    @Test
+    public void shouldBeResilientToNonexistentPreferredHosts() {
+        InetSocketAddress host = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+        InetSocketAddress fakePreferred = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(host));
+
+        CassandraClientPoolingContainer container =
+                cassandraClientPool.getRedirectTarget(ImmutableSet.of(), ImmutableSet.of(fakePreferred));
+        assertThat(container.getHost(), equalTo(host));
+    }
+
+    @Test
     public void shouldNotAttemptMoreThanOneConnectionOnSuccess() {
         InetSocketAddress host = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
         CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(host));
         cassandraClientPool.runWithRetryOnHost(host, input -> null);
-        verifyNumberOfAttemptsOnHost(host, cassandraClientPool, 1);
+        verifyNumberOfAttemptsOnHost(cassandraClientPool, host, 1);
     }
 
     @Test
     public void shouldRetryOnSameNodeToFailureAndThenRedirect() {
         int numHosts = CassandraClientPool.MAX_TRIES_TOTAL - CassandraClientPool.MAX_TRIES_SAME_HOST + 1;
+        assumeTrue(numHosts > 1);
         List<InetSocketAddress> hostList = Lists.newArrayList();
         for (int i = 0; i < numHosts; i++) {
             hostList.add(new InetSocketAddress(i));
@@ -154,9 +221,9 @@ public class CassandraClientPoolTest {
             // expected, keep going
         }
 
-        verifyNumberOfAttemptsOnHost(hostList.get(0), cassandraClientPool, CassandraClientPool.MAX_TRIES_SAME_HOST);
+        verifyNumberOfAttemptsOnHost(cassandraClientPool, hostList.get(0), CassandraClientPool.MAX_TRIES_SAME_HOST);
         for (int i = 1; i < numHosts; i++) {
-            verifyNumberOfAttemptsOnHost(hostList.get(i), cassandraClientPool, 1);
+            verifyNumberOfAttemptsOnHost(cassandraClientPool, hostList.get(i), 1);
         }
     }
 
@@ -173,13 +240,87 @@ public class CassandraClientPoolTest {
             // expected, keep going
         }
 
-        verifyNumberOfAttemptsOnHost(host, cassandraClientPool, CassandraClientPool.MAX_TRIES_TOTAL);
+        verifyNumberOfAttemptsOnHost(cassandraClientPool, host, CassandraClientPool.MAX_TRIES_TOTAL);
     }
 
-    private void verifyNumberOfAttemptsOnHost(InetSocketAddress host,
-                                              CassandraClientPool cassandraClientPool,
+    @Test
+    public void shouldFollowHostPreferencesWhenRetrying() {
+        // We want to verify the query touches every host. We try MAX_TRIES_SAME_HOST times on the first host, and
+        // then try to contact the other hosts once each.
+        int numHosts = CassandraClientPool.MAX_TRIES_TOTAL - CassandraClientPool.MAX_TRIES_SAME_HOST + 1;
+        assumeTrue(numHosts > 1);
+        List<InetSocketAddress> hostList = Lists.newArrayList();
+        for (int i = 0; i < numHosts; i++) {
+            hostList.add(new InetSocketAddress(i));
+        }
+
+        CassandraClientPool cassandraClientPool = throwingClientPoolWithServersInCurrentPool(
+                ImmutableSet.copyOf(hostList), new SocketTimeoutException());
+
+        try {
+            cassandraClientPool.runWithRetryOnHost(hostList.get(0), input -> null, ImmutableSet.of(hostList.get(1)));
+        } catch (Exception e) {
+            // expected, keep going
+        }
+
+        // Verify we tried host 0 before host 1. This needs to be here in case numHosts == 2
+        verifySequenceOfHostAttempts(cassandraClientPool, ImmutableList.of(hostList.get(0), hostList.get(1)));
+        for (int i = 2; i < numHosts; i++) {
+            // Verify we tried host 0, then host 1, then host i
+            verifySequenceOfHostAttempts(cassandraClientPool, ImmutableList.of(
+                    hostList.get(0), hostList.get(1), hostList.get(i)
+            ));
+        }
+    }
+
+    @Test
+    public void shouldAttemptNonPreferredHostAfterTryingAllPreferredHosts() {
+        // This test insists on there being a non-hinted server, which shouldFollowHintsWhenRetrying() does not.
+        assumeTrue(CassandraClientPool.MAX_TRIES_TOTAL - CassandraClientPool.MAX_TRIES_SAME_HOST >= 2);
+        InetSocketAddress host1 = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+        InetSocketAddress host2 = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
+        InetSocketAddress host3 = new InetSocketAddress(HOSTNAME_3, DEFAULT_PORT);
+        CassandraClientPool cassandraClientPool = throwingClientPoolWithServersInCurrentPool(
+                ImmutableSet.of(host1, host2, host3), new SocketTimeoutException());
+
+        try {
+            cassandraClientPool.runWithRetryOnHost(host1, input -> null, ImmutableSet.of(host2));
+        } catch (Exception e) {
+            // expected, keep going
+        }
+
+        verifyHostAttempted(cassandraClientPool, host3);
+    }
+
+    private void verifySequenceOfHostAttempts(CassandraClientPool cassandraClientPool,
+            List<InetSocketAddress> ordering) {
+        List<CassandraClientPoolingContainer> poolingContainers = ordering.stream()
+                .map(cassandraClientPool.currentPools::get)
+                .collect(Collectors.toList());
+        InOrder inOrder = Mockito.inOrder(poolingContainers.toArray());
+
+        for (CassandraClientPoolingContainer container : poolingContainers) {
+            inOrder.verify(container, Mockito.atLeastOnce()).runWithPooledResource(
+                    Mockito.<FunctionCheckedException<Cassandra.Client, Object, RuntimeException>>any()
+            );
+        }
+    }
+
+    private void verifyHostAttempted(CassandraClientPool cassandraClientPool,
+                                     InetSocketAddress host) {
+        verifyAttemptsOnHost(cassandraClientPool, host, Mockito.atLeastOnce());
+    }
+
+    private void verifyNumberOfAttemptsOnHost(CassandraClientPool cassandraClientPool,
+                                              InetSocketAddress host,
                                               int numAttempts) {
-        Mockito.verify(cassandraClientPool.currentPools.get(host), Mockito.times(numAttempts)).runWithPooledResource(
+        verifyAttemptsOnHost(cassandraClientPool, host, Mockito.times(numAttempts));
+    }
+
+    private void verifyAttemptsOnHost(CassandraClientPool cassandraClientPool,
+                                      InetSocketAddress host,
+                                      VerificationMode verificationMode) {
+        Mockito.verify(cassandraClientPool.currentPools.get(host), verificationMode).runWithPooledResource(
                 Mockito.<FunctionCheckedException<Cassandra.Client, Object, RuntimeException>>any()
         );
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -103,7 +103,7 @@ public class CassandraClientPoolTest {
 
         Optional<CassandraClientPoolingContainer> container
                 = cassandraClientPool.getRandomGoodHostForPredicate(address -> false);
-        assertThat(container.isPresent(), is(false));
+        assertThat(container, is(Optional.empty()));
     }
 
     @Test
@@ -116,7 +116,6 @@ public class CassandraClientPoolTest {
         for (int i = 0; i < FUZZING_NUM_TRIALS; i++) {
             Optional<CassandraClientPoolingContainer> container
                     = cassandraClientPool.getRandomGoodHostForPredicate(address -> address.equals(host1));
-            assertThat(container.isPresent(), is(true));
             assertThat(container.get().getHost(), equalTo(host1));
         }
     }
@@ -131,7 +130,6 @@ public class CassandraClientPoolTest {
         cassandraClientPool.blacklistedHosts.put(host1, System.currentTimeMillis());
         Optional<CassandraClientPoolingContainer> container
                 = cassandraClientPool.getRandomGoodHostForPredicate(address -> address.equals(host1));
-        assertThat(container.isPresent(), is(true));
         assertThat(container.get().getHost(), equalTo(host1));
     }
 
@@ -147,7 +145,7 @@ public class CassandraClientPoolTest {
         assertThat(cassandraClientPool.getRandomUntriedPreferredHost(
                 ImmutableSet.of(host1), ImmutableSet.of(host1, host2)).get().getHost(), is(host2));
         assertThat(cassandraClientPool.getRandomUntriedPreferredHost(
-                ImmutableSet.of(host1, host2), ImmutableSet.of(host1, host2)).isPresent(), is(false));
+                ImmutableSet.of(host1, host2), ImmutableSet.of(host1, host2)), is(Optional.empty()));
     }
 
     @Test
@@ -158,9 +156,9 @@ public class CassandraClientPoolTest {
                 MockCassandraClientPoolUtils.clientPoolWithServersInCurrentPool(ImmutableSet.of(host1, host2));
 
         assertThat(cassandraClientPool.getRandomUntriedPreferredHost(
-                ImmutableSet.of(host1, host2), ImmutableSet.of(host1, host2)).isPresent(), is(false));
+                ImmutableSet.of(host1, host2), ImmutableSet.of(host1, host2)), is(Optional.empty()));
         assertThat(cassandraClientPool.getRandomUntriedPreferredHost(
-                ImmutableSet.of(host1, host2), ImmutableSet.of(host1)).isPresent(), is(false));
+                ImmutableSet.of(host1, host2), ImmutableSet.of(host1)), is(Optional.empty()));
     }
 
     @Test
@@ -183,8 +181,8 @@ public class CassandraClientPoolTest {
         CassandraClientPool cassandraClientPool =
                 MockCassandraClientPoolUtils.clientPoolWithServersInCurrentPool(ImmutableSet.of(host1, host2));
 
-        assertThat(cassandraClientPool.getRandomUntriedHost(ImmutableSet.of(host1, host2)).isPresent(),
-                is(false));
+        assertThat(cassandraClientPool.getRandomUntriedHost(ImmutableSet.of(host1, host2)),
+                is(Optional.empty()));
     }
 
     @Test
@@ -264,9 +262,9 @@ public class CassandraClientPoolTest {
                             new CassandraClientPool.LightweightOppToken(KEY_3), BoundType.OPEN),
                 hostList);
 
-        assertThat(cassandraClientPool.getHostsForKey(KEY_1).get(), is(hostList));
-        assertThat(cassandraClientPool.getHostsForKey(KEY_2).get(), is(hostList));
-        assertThat(cassandraClientPool.getHostsForKey(KEY_3).isPresent(), is(false));
+        assertThat(cassandraClientPool.getHostsForKey(KEY_1), is(Optional.of(hostList)));
+        assertThat(cassandraClientPool.getHostsForKey(KEY_2), is(Optional.of(hostList)));
+        assertThat(cassandraClientPool.getHostsForKey(KEY_3), is(Optional.empty()));
     }
 
     @Test
@@ -276,7 +274,7 @@ public class CassandraClientPoolTest {
         CassandraClientPool cassandraClientPool =
                 MockCassandraClientPoolUtils.clientPoolWithServersInCurrentPool(ImmutableSet.of(host1, host2));
 
-        assertThat(cassandraClientPool.getHostsForKey(KEY_1).isPresent(), is(false));
+        assertThat(cassandraClientPool.getHostsForKey(KEY_1), is(Optional.empty()));
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.junit.Assert.fail;
+
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.util.List;
+
+import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.CqlResultType;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.BoundType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.common.base.FunctionCheckedException;
+
+public class CqlExecutorTest {
+
+    private static final byte[] KEY_1 = { 0, 0, 0 };
+    private static final byte[] KEY_2 = { 1, 0, 0 };
+    private static final byte[] KEY_3 = { 1, 1, 0 };
+
+    private static final Range<CassandraClientPool.LightweightOppToken> DEFAULT_RANGE =
+            Range.range(new CassandraClientPool.LightweightOppToken(KEY_1), BoundType.CLOSED,
+                    new CassandraClientPool.LightweightOppToken(KEY_3), BoundType.OPEN);
+
+    @Test
+    public void shouldDirectQueriesToServerWithRelevantRowKey() {
+        InetSocketAddress host1 = new InetSocketAddress(1);
+        InetSocketAddress host2 = new InetSocketAddress(2);
+        InetSocketAddress host3 = new InetSocketAddress(3);
+
+        CassandraClientPool cassandraClientPool =
+                setupMockCassandraClientPoolWithCqlResponses(ImmutableSet.of(host1, host2, host3));
+        cassandraClientPool.tokenMap = ImmutableRangeMap.of(DEFAULT_RANGE, ImmutableList.of(host1));
+
+        CqlExecutor cqlExecutor = new CqlExecutor(cassandraClientPool, ConsistencyLevel.QUORUM);
+        cqlExecutor.getColumnsForRow(TableReference.createWithEmptyNamespace("foo"), KEY_2, 5);
+
+        MockCassandraClientPoolUtils.verifyNumberOfAttemptsOnHost(cassandraClientPool, host1, 1);
+    }
+
+    @Test
+    public void shouldNotThrowIfTokenMapUnknown() {
+        InetSocketAddress host = new InetSocketAddress(1);
+
+        CassandraClientPool cassandraClientPool =
+                setupMockCassandraClientPoolWithCqlResponses(ImmutableSet.of(host));
+
+        CqlExecutor cqlExecutor = new CqlExecutor(cassandraClientPool, ConsistencyLevel.QUORUM);
+        cqlExecutor.getColumnsForRow(TableReference.createWithEmptyNamespace("foo"), KEY_2, 5);
+    }
+
+    @Test
+    public void shouldPreferentiallyRetryOnServersWithRelevantRowKey() {
+        int numHostsWithData = CassandraClientPool.MAX_TRIES_TOTAL - CassandraClientPool.MAX_TRIES_SAME_HOST + 1;
+
+        List<InetSocketAddress> dataHosts = Lists.newArrayList();
+        for (int i = 0; i < numHostsWithData; i++) {
+            dataHosts.add(new InetSocketAddress(i));
+        }
+        InetSocketAddress nonDataHost = new InetSocketAddress(numHostsWithData);
+
+        List<InetSocketAddress> allHosts = Lists.newArrayList(dataHosts);
+        allHosts.add(nonDataHost);
+
+        CassandraClientPool cassandraClientPool =
+                MockCassandraClientPoolUtils.throwingClientPoolWithServersInCurrentPool(
+                        ImmutableSet.copyOf(allHosts),
+                        new SocketTimeoutException());
+        cassandraClientPool.tokenMap = ImmutableRangeMap.of(DEFAULT_RANGE, ImmutableList.copyOf(dataHosts));
+
+        CqlExecutor cqlExecutor = new CqlExecutor(cassandraClientPool, ConsistencyLevel.QUORUM);
+        try {
+            cqlExecutor.getColumnsForRow(TableReference.createWithEmptyNamespace("foo"), KEY_2, 5);
+            fail();
+        } catch (Exception exception) {
+            // expected
+        }
+
+        MockCassandraClientPoolUtils.verifyNumberOfAttemptsOnHost(cassandraClientPool, nonDataHost, 0);
+    }
+
+    @Test
+    public void shouldRetryOnServersWithoutRowKeyAfterExhaustion() {
+        int numHostsWithData = CassandraClientPool.MAX_TRIES_TOTAL - CassandraClientPool.MAX_TRIES_SAME_HOST;
+
+        List<InetSocketAddress> dataHosts = Lists.newArrayList();
+        for (int i = 0; i < numHostsWithData; i++) {
+            dataHosts.add(new InetSocketAddress(i));
+        }
+        InetSocketAddress nonDataHost = new InetSocketAddress(numHostsWithData);
+
+        List<InetSocketAddress> allHosts = Lists.newArrayList(dataHosts);
+        allHosts.add(nonDataHost);
+
+        CassandraClientPool cassandraClientPool =
+                MockCassandraClientPoolUtils.throwingClientPoolWithServersInCurrentPool(
+                        ImmutableSet.copyOf(allHosts),
+                        new SocketTimeoutException());
+        cassandraClientPool.tokenMap = ImmutableRangeMap.of(DEFAULT_RANGE, ImmutableList.copyOf(dataHosts));
+
+        CqlExecutor cqlExecutor = new CqlExecutor(cassandraClientPool, ConsistencyLevel.QUORUM);
+        try {
+            cqlExecutor.getColumnsForRow(TableReference.createWithEmptyNamespace("foo"), KEY_2, 5);
+            fail();
+        } catch (Exception exception) {
+            // expected
+        }
+
+        dataHosts.forEach(dataHost ->
+                MockCassandraClientPoolUtils.verifySequenceOfHostAttempts(
+                        cassandraClientPool, ImmutableList.of(dataHost, nonDataHost)));
+    }
+
+    private CassandraClientPool setupMockCassandraClientPoolWithCqlResponses(ImmutableSet<InetSocketAddress> hosts) {
+        CassandraClientPool cassandraClientPool =
+                MockCassandraClientPoolUtils.clientPoolWithServersInCurrentPool(hosts);
+
+        cassandraClientPool.currentPools.values().forEach(this::setupPoolingContainerToReturnEmptyCqlResult);
+        return cassandraClientPool;
+    }
+
+    private void setupPoolingContainerToReturnEmptyCqlResult(CassandraClientPoolingContainer poolingContainer) {
+        try {
+            CqlResult cqlResult = new CqlResult(CqlResultType.ROWS);
+            cqlResult.setRows(ImmutableList.of());
+            Mockito.when(poolingContainer.runWithPooledResource(
+                    Mockito.<FunctionCheckedException<Cassandra.Client, CqlResult, Exception>>any()))
+                    .thenReturn(cqlResult);
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/MockCassandraClientPoolUtils.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/MockCassandraClientPoolUtils.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.thrift.Cassandra;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.common.base.FunctionCheckedException;
+
+public final class MockCassandraClientPoolUtils {
+
+    public static final int POOL_REFRESH_INTERVAL_SECONDS = 10;
+
+    private MockCassandraClientPoolUtils() {
+        // utilities
+    }
+
+    public static void verifyHostAttempted(CassandraClientPool cassandraClientPool, InetSocketAddress host) {
+        verifyAttemptsOnHost(cassandraClientPool, host, Mockito.atLeastOnce());
+    }
+
+    public static void verifyNumberOfAttemptsOnHost(
+            CassandraClientPool cassandraClientPool,
+            InetSocketAddress host,
+            int numAttempts) {
+        verifyAttemptsOnHost(cassandraClientPool, host, Mockito.times(numAttempts));
+    }
+
+    private static void verifyAttemptsOnHost(
+            CassandraClientPool cassandraClientPool,
+            InetSocketAddress host,
+            VerificationMode verificationMode) {
+        Mockito.verify(cassandraClientPool.currentPools.get(host), verificationMode).runWithPooledResource(
+                Mockito.<FunctionCheckedException<Cassandra.Client, Object, RuntimeException>>any()
+        );
+    }
+
+    public static void verifySequenceOfHostAttempts(
+            CassandraClientPool cassandraClientPool,
+            List<InetSocketAddress> ordering) {
+        List<CassandraClientPoolingContainer> poolingContainers = ordering.stream()
+                .map(cassandraClientPool.currentPools::get)
+                .collect(Collectors.toList());
+        InOrder inOrder = Mockito.inOrder(poolingContainers.toArray());
+
+        for (CassandraClientPoolingContainer container : poolingContainers) {
+            inOrder.verify(container, Mockito.atLeastOnce()).runWithPooledResource(
+                    Mockito.<FunctionCheckedException<Cassandra.Client, Object, RuntimeException>>any()
+            );
+        }
+    }
+
+
+    public static CassandraClientPool clientPoolWithServers(ImmutableSet<InetSocketAddress> servers) {
+        return clientPoolWith(servers, ImmutableSet.of(), Optional.empty());
+    }
+
+    public static CassandraClientPool clientPoolWithServersInCurrentPool(ImmutableSet<InetSocketAddress> servers) {
+        return clientPoolWith(ImmutableSet.of(), servers, Optional.empty());
+    }
+
+    public static CassandraClientPool throwingClientPoolWithServersInCurrentPool(
+            ImmutableSet<InetSocketAddress> servers,
+            Exception exception) {
+        return clientPoolWith(ImmutableSet.of(), servers, Optional.of(exception));
+    }
+
+    private static CassandraClientPool clientPoolWith(
+            ImmutableSet<InetSocketAddress> servers,
+            ImmutableSet<InetSocketAddress> serversInPool,
+            Optional<Exception> failureMode) {
+        CassandraKeyValueServiceConfig config = mock(CassandraKeyValueServiceConfig.class);
+        when(config.poolRefreshIntervalSeconds()).thenReturn(POOL_REFRESH_INTERVAL_SECONDS);
+        when(config.servers()).thenReturn(servers);
+
+        CassandraClientPool cassandraClientPool = new CassandraClientPool(config);
+        cassandraClientPool.currentPools = serversInPool.stream()
+                .collect(Collectors.toMap(Function.identity(),
+                        address -> getMockPoolingContainerForHost(address, failureMode)));
+        return cassandraClientPool;
+    }
+
+    private static CassandraClientPoolingContainer getMockPoolingContainerForHost(
+            InetSocketAddress address,
+            Optional<Exception> failureMode) {
+        CassandraClientPoolingContainer poolingContainer = mock(CassandraClientPoolingContainer.class);
+        when(poolingContainer.getHost()).thenReturn(address);
+        if (failureMode.isPresent()) {
+            try {
+                when(poolingContainer.runWithPooledResource(
+                        Mockito.<FunctionCheckedException<Cassandra.Client, Object, Exception>>any()))
+                        .thenThrow(failureMode.get());
+            } catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+        }
+        return poolingContainer;
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,7 +51,9 @@ develop
     *    - |improved|
          - Random redirection of queries when retrying a Cassandra operation now retries said queries on distinct
            hosts. Previously, this would independently select hosts randomly, meaning that we might unintentionally
-           try the same operation on the same server(s).
+           try the same operation on the same server(s). Furthermore, for queries targeting specific keys, we also
+           now prioritise the other Cassandra nodes that own that key first in the retry order, to save on unnecessary
+           internode communication.
 
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1139>`__)
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,7 +55,7 @@ develop
            now prioritise the other Cassandra nodes that own that key first in the retry order, to save on unnecessary
            internode communication.
 
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1139>`__)
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/1139>`__ and `Pull Request 2 <https://github.com/palantir/atlasdb/pull/1153>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
This change adds support for specifying a set of preferred servers for retrying Cassandra operations. This is used in `CqlExecutor` and `RowGetter` - if the main server we're trying to contact fails, we first try to talk to another server that owns the relevant data (rather than potentially talking to some other node that knows nothing about our data, thus leading to more internode traffic).

@harrybiddle I'm assigning this to you first, as I'm aware you're tracking the HA stuff and I also vaguely explained the idea I was going with for this (also Ben is heavily loaded with reviews). Though feel free to redirect this if needed.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1153)
<!-- Reviewable:end -->
