### PR TITLE
PaxosPromise: use factory methods instead of constructors

### DIFF
--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosPromise.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosPromise.java
@@ -40,7 +40,8 @@ public class PaxosPromise implements Comparable<PaxosPromise>, PaxosResponse {
     @Nullable final PaxosProposalId lastAcceptedId;
     @Nullable final PaxosValue lastAcceptedValue;
 
-    public static PaxosPromise accept(PaxosProposalId promisedId,
+    public static PaxosPromise accept(
+            PaxosProposalId promisedId,
             PaxosProposalId lastAcceptedId,
             PaxosValue val) {
         return new PaxosPromise(promisedId, lastAcceptedId, val);
@@ -51,7 +52,8 @@ public class PaxosPromise implements Comparable<PaxosPromise>, PaxosResponse {
     }
 
     @JsonCreator
-    public static PaxosPromise create(@JsonProperty("successful") boolean ack,
+    public static PaxosPromise create(
+            @JsonProperty("successful") boolean ack,
             @JsonProperty("promisedId") PaxosProposalId promisedId,
             @JsonProperty("lastAcceptedId") PaxosProposalId lastAcceptedId,
             @JsonProperty("lastAcceptedValue") PaxosValue val) {

--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosPromise.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosPromise.java
@@ -40,32 +40,42 @@ public class PaxosPromise implements Comparable<PaxosPromise>, PaxosResponse {
     @Nullable final PaxosProposalId lastAcceptedId;
     @Nullable final PaxosValue lastAcceptedValue;
 
-    public PaxosPromise(PaxosProposalId promisedId) {
+    public static PaxosPromise accept(PaxosProposalId promisedId,
+            PaxosProposalId lastAcceptedId,
+            PaxosValue val) {
+        return new PaxosPromise(promisedId, lastAcceptedId, val);
+    }
+
+    public static PaxosPromise reject(PaxosProposalId promisedId) {
+        return new PaxosPromise(promisedId);
+    }
+
+    @JsonCreator
+    public static PaxosPromise create(@JsonProperty("successful") boolean ack,
+            @JsonProperty("promisedId") PaxosProposalId promisedId,
+            @JsonProperty("lastAcceptedId") PaxosProposalId lastAcceptedId,
+            @JsonProperty("lastAcceptedValue") PaxosValue val) {
+        if (ack) {
+            return PaxosPromise.accept(promisedId, lastAcceptedId, val);
+        } else {
+            return PaxosPromise.reject(promisedId);
+        }
+    }
+
+    private PaxosPromise(PaxosProposalId promisedId) {
         ack = false;
         this.promisedId = Preconditions.checkNotNull(promisedId);
         lastAcceptedId = null;
         lastAcceptedValue = null;
     }
 
-    public PaxosPromise(PaxosProposalId promisedId,
-                        PaxosProposalId lastAcceptedId,
-                        PaxosValue val) {
+    private PaxosPromise(PaxosProposalId promisedId,
+            PaxosProposalId lastAcceptedId,
+            PaxosValue val) {
         ack = true;
         this.promisedId = Preconditions.checkNotNull(promisedId);
         this.lastAcceptedId = lastAcceptedId;
         this.lastAcceptedValue = val;
-    }
-
-    @JsonCreator
-    public static PaxosPromise create(@JsonProperty("successful") boolean ack,
-                                      @JsonProperty("promisedId") PaxosProposalId promisedId,
-                                      @JsonProperty("lastAcceptedId") PaxosProposalId lastAcceptedId,
-                                      @JsonProperty("lastAcceptedValue") PaxosValue val) {
-        if (ack) {
-            return new PaxosPromise(promisedId, lastAcceptedId, val);
-        } else {
-            return new PaxosPromise(promisedId);
-        }
     }
 
     @Override

--- a/leader-election-api/src/main/java/com/palantir/paxos/PaxosPromises.java
+++ b/leader-election-api/src/main/java/com/palantir/paxos/PaxosPromises.java
@@ -43,7 +43,7 @@ public class PaxosPromises {
         boolean ack = proto.getAck();
         PaxosProposalId promisedId = PaxosProposalId.hydrateFromProto(proto.getPromisedId());
         if (!ack) {
-            return new PaxosPromise(promisedId);
+            return PaxosPromise.reject(promisedId);
         } else {
             @Nullable PaxosProposalId lastAcceptedId = null;
             @Nullable PaxosValue lastAcceptedValue = null;
@@ -53,7 +53,7 @@ public class PaxosPromises {
             if (proto.hasLastAcceptedValue()) {
                 lastAcceptedValue = PaxosValue.hydrateFromProto(proto.getLastAcceptedValue());
             }
-            return new PaxosPromise(promisedId, lastAcceptedId, lastAcceptedValue);
+            return PaxosPromise.accept(promisedId, lastAcceptedId, lastAcceptedValue);
         }
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -55,33 +55,31 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
             checkLogIfNeeded(seq);
         } catch (Exception e) {
             logger.error("log read failed for request: " + seq, e);
-            return new PaxosPromise(pid); // nack
+            return PaxosPromise.reject(pid); // nack
         }
 
         for (;;) {
             PaxosAcceptorState oldState = state.get(seq);
 
-            // nack
             if (oldState != null && pid.compareTo(oldState.lastPromisedId) < 0) {
-                return new PaxosPromise(oldState.lastPromisedId);
+                return PaxosPromise.reject(oldState.lastPromisedId);
             }
 
             // allow for the same propose to be repeated and return the same result.
             if (oldState != null && pid.compareTo(oldState.lastPromisedId) == 0) {
-                return new PaxosPromise(
+                return PaxosPromise.accept(
                         oldState.lastPromisedId,
                         oldState.lastAcceptedId,
                         oldState.lastAcceptedValue);
             }
 
-            // ack
             PaxosAcceptorState newState = oldState != null
                     ? oldState.withPromise(pid)
                     : PaxosAcceptorState.newState(pid);
             if ((oldState == null && state.putIfAbsent(seq, newState) == null)
                     || (oldState != null && state.replace(seq, oldState, newState))) {
                 log.writeRound(seq, newState);
-                return new PaxosPromise(
+                return PaxosPromise.accept(
                         newState.lastPromisedId,
                         newState.lastAcceptedId,
                         newState.lastAcceptedValue);

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -55,7 +55,7 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
             checkLogIfNeeded(seq);
         } catch (Exception e) {
             logger.error("log read failed for request: " + seq, e);
-            return PaxosPromise.reject(pid); // nack
+            return PaxosPromise.reject(pid);
         }
 
         for (;;) {

--- a/leader-election-impl/src/test/java/com/palantir/paxos/persistence/ProtobufTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/persistence/ProtobufTest.java
@@ -89,22 +89,22 @@ public class ProtobufTest {
         PaxosPromiseProto persisted;
         PaxosPromise actual;
 
-        expected = new PaxosPromise(new PaxosProposalId(3, "unique"));
+        expected = PaxosPromise.reject(new PaxosProposalId(3, "unique"));
         persisted = PaxosPromises.toProto(expected);
         actual = PaxosPromises.fromProto(persisted);
         assertEquals(expected, actual);
 
-        expected = new PaxosPromise(new PaxosProposalId(20, "id"), new PaxosProposalId(6, "fire"), new PaxosValue("me", 5, new byte[]{8, 8, 100}));
+        expected = PaxosPromise.accept(new PaxosProposalId(20, "id"), new PaxosProposalId(6, "fire"), new PaxosValue("me", 5, new byte[]{8, 8, 100}));
         persisted = PaxosPromises.toProto(expected);
         actual = PaxosPromises.fromProto(persisted);
         assertEquals(expected, actual);
 
-        expected = new PaxosPromise(new PaxosProposalId(20, "id"), null, new PaxosValue("me", 5, new byte[]{8, 8, 100}));
+        expected = PaxosPromise.accept(new PaxosProposalId(20, "id"), null, new PaxosValue("me", 5, new byte[]{8, 8, 100}));
         persisted = PaxosPromises.toProto(expected);
         actual = PaxosPromises.fromProto(persisted);
         assertEquals(expected, actual);
 
-        expected = new PaxosPromise(new PaxosProposalId(20, "id"), null, null);
+        expected = PaxosPromise.accept(new PaxosProposalId(20, "id"), null, null);
         persisted = PaxosPromises.toProto(expected);
         actual = PaxosPromises.fromProto(persisted);
         assertEquals(expected, actual);


### PR DESCRIPTION
Now we have `PaxosPromise.accept` and `PaxosPromise.reject`, and don't have to remember which one means we accepted the proposal.

Fixes #622
[no release notes]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1159)
<!-- Reviewable:end -->
