### PR TITLE
Feature/variable publishing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -64,7 +64,7 @@ test:
         parallel: true
 
 deployment:
-  publish-docs
+  publish-docs:
     branch: develop
     owner: palantir
     commands:

--- a/circle.yml
+++ b/circle.yml
@@ -64,11 +64,10 @@ test:
         parallel: true
 
 deployment:
-  publish-docs-and-snapshots:
+  publish-docs
     branch: develop
     owner: palantir
     commands:
-      - ./gradlew artifactoryPublish -x check
       - ./scripts/circle-ci/publish-github-page.sh
   bintray:
     tag: /[0-9]+(\.[0-9]+){2}(-alpha|-beta)?(\+[0-9]{3})?/

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,13 +50,11 @@ develop
     *    - |deprecated|
          - ``TableReference.createUnsafe`` is now deprecated. ``createWithEmptyNamespace`` or ``createFromFullyQualifiedName`` should be used instead.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1121>`__)
-           
 
     *    - |improved|
          - Random redirection of queries when retrying a Cassandra operation now retries said queries on distinct
            hosts. Previously, this would independently select hosts randomly, meaning that we might unintentionally
            try the same operation on the same server(s).
-
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1139>`__)
     *    - |new|
          - Added the ability to do custom performance logging for Sweep. This is currently only available for
@@ -74,6 +72,11 @@ develop
           mapped to shorter names by truncating and appending a sequence number.
           See :ref:`oracle_table_mapping` for details on how table names are mapped.
           (`Pull Request <https://github.com/palantir/atlasdb/pull/1076>`__)
+
+    *    - |deprecated|
+         - We no longer publish snapshots to oss.jfrog.org, they are instead published to an internal repository.  We can reenable external snapshots
+           if it is required by a product.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1164>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -65,8 +65,8 @@ artifactory {
         contextUrl = System.env.ARTIFACTORY_URL
         repository {
             repoKey = System.env.ARTIFACTORY_REPO
-            //            username = System.env.ARTIFACTORY_USERNAME
-            //            password = System.env.ARTIFACTORY_PASSWORD
+            username = System.env.ARTIFACTORY_USERNAME
+            password = System.env.ARTIFACTORY_PASSWORD
             maven = true
         }
         defaults {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -65,8 +65,8 @@ artifactory {
         contextUrl = System.env.ARTIFACTORY_URL
         repository {
             repoKey = System.env.ARTIFACTORY_REPO
-            username = System.env.ARTIFACTORY_USERNAME
-            password = System.env.ARTIFACTORY_PASSWORD
+            //            username = System.env.ARTIFACTORY_USERNAME
+            //            password = System.env.ARTIFACTORY_PASSWORD
             maven = true
         }
         defaults {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -23,7 +23,7 @@ publishing {
             artifact(testJar) {
                 classifier 'tests'
             }
-            version project.version.replaceAll(/-\d+.*/, (circleBuildNum ? '.b' + circleBuildNum : '') + '-SNAPSHOT')
+            // version project.version.replaceAll(/-\d+.*/, (circleBuildNum ? '.b' + circleBuildNum : '') + '-SNAPSHOT')
             pom.withXml {
                 def scm = asNode().appendNode('scm')
                 scm.appendNode('url', 'https://github.com/palantir/atlasdb')
@@ -62,9 +62,9 @@ bintrayUpload.dependsOn 'generatePomFileForArtifactoryPublication', 'sourceJar',
 
 artifactory {
     publish {
-        contextUrl = 'https://oss.jfrog.org/artifactory/'
+        contextUrl = System.env.ARTIFACTORY_URL
         repository {
-            repoKey = 'oss-snapshot-local'
+            repoKey = System.env.ARTIFACTORY_REPO
             username = System.env.ARTIFACTORY_USERNAME
             password = System.env.ARTIFACTORY_PASSWORD
             maven = true
@@ -77,6 +77,6 @@ artifactory {
 }
 
 artifactoryPublish.onlyIf {
-  System.getenv('ARTIFACTORY_USERNAME') && System.getenv('ARTIFACTORY_PASSWORD') && !(project.version ==~ releaseVersionRegex)
+  System.getenv('ARTIFACTORY_USERNAME') && System.getenv('ARTIFACTORY_PASSWORD') && System.getenv('ARTIFACTORY_REPO') && System.getenv('ARTIFACTORY_URL') && !(project.version ==~ releaseVersionRegex)
 }
 artifactoryPublish.dependsOn 'generatePomFileForArtifactoryPublication', 'sourceJar', 'testJar', 'build'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -23,7 +23,6 @@ publishing {
             artifact(testJar) {
                 classifier 'tests'
             }
-            // version project.version.replaceAll(/-\d+.*/, (circleBuildNum ? '.b' + circleBuildNum : '') + '-SNAPSHOT')
             pom.withXml {
                 def scm = asNode().appendNode('scm')
                 scm.appendNode('url', 'https://github.com/palantir/atlasdb')


### PR DESCRIPTION
This will stop us from publishing snapshots to oss.jfrog.org at the end of every develop build.  This should increase build time as we no longer publish.  Snapshot publishes can still be kicked off with the appropriate env variables specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1164)
<!-- Reviewable:end -->
