### PR TITLE
Add OutputPrinter class for clis to output to

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/CleanCassLocksStateCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/CleanCassLocksStateCommand.java
@@ -15,10 +15,13 @@
  */
 package com.palantir.atlasdb.cli.command;
 
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
+import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
@@ -27,6 +30,7 @@ import io.airlift.airline.Command;
 @Command(name = "clean-cass-locks-state", description = "Clean up and get the schema mutation "
         + "locks for the CassandraKVS into a good state")
 public class CleanCassLocksStateCommand extends AbstractCommand {
+    private static final OutputPrinter printer = new OutputPrinter(LoggerFactory.getLogger(CleanCassLocksStateCommand.class));
 
     @Override
     public Integer call() throws Exception {
@@ -38,6 +42,7 @@ public class CleanCassLocksStateCommand extends AbstractCommand {
                 Optional.absent());
 
         ckvs.cleanUpSchemaMutationLockTablesState();
+        printer.info("Schema mutation lock cli completed successfully.");
         return 0;
     }
 

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
@@ -19,13 +19,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
@@ -43,7 +43,7 @@ import io.airlift.airline.OptionType;
 
 @Command(name = "migrate", description = "Migrate your data from one key value service to another.")
 public class KvsMigrationCommand implements Callable<Integer> {
-    private static final Logger log = LoggerFactory.getLogger(KvsMigrationCommand.class);
+    private static final OutputPrinter printer = new OutputPrinter(LoggerFactory.getLogger(KvsMigrationCommand.class));
 
     @Option(name = {"-fc", "--fromConfig"},
             title = "CONFIG PATH",
@@ -106,7 +106,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         if (inlineConfig == null && toConfigFile == null) {
-            log.error("Argument -mc/--migrateConfig is required when not running as a dropwizard CLI");
+            printer.error("Argument -mc/--migrateConfig is required when not running as a dropwizard CLI");
             return 1;
         }
 
@@ -117,7 +117,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
 
     public int execute(AtlasDbServices fromServices, AtlasDbServices toServices) {
         if (!setup && !migrate && !validate) {
-            log.error("At least one of --setup, --migrate, or --validate should be specified.");
+            printer.error("At least one of --setup, --migrate, or --validate should be specified.");
             return 1;
         }
         KeyValueServiceMigrator migrator;
@@ -140,7 +140,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
                     batchSize,
                     ImmutableMap.of(),
                     (String message, KeyValueServiceMigrator.KvsMigrationMessageLevel level) -> {
-                        log.info(level.toString() + ": " + message);
+                        printer.info(level.toString() + ": " + message);
                     },
                     ImmutableSet.of());
             validator.validate(true);
@@ -190,12 +190,12 @@ public class KvsMigrationCommand implements Callable<Integer> {
                 batchSize,
                 ImmutableMap.of(),
                 (String message, KeyValueServiceMigrator.KvsMigrationMessageLevel level) -> {
-                    log.info(level.toString() + ": " + message);
+                    printer.info(level.toString() + ": " + message);
                 },
                 new TaskProgress() {
                     @Override
                     public void beginTask(String message, int tasks) {
-                        log.info(message);
+                        printer.info(message);
                     }
 
                     @Override

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Functions;
@@ -32,6 +31,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.schema.generated.SweepPriorityTable;
@@ -47,7 +47,7 @@ import io.airlift.airline.Option;
 @Command(name = "sweep", description = "Sweep old table rows")
 public class SweepCommand extends SingleBackendCommand {
 
-    private static final Logger log = LoggerFactory.getLogger(SweepCommand.class);
+    private static final OutputPrinter printer = new OutputPrinter(LoggerFactory.getLogger(SweepCommand.class));
 
     @Option(name = {"-n", "--namespace"},
             description = "An atlas namespace to sweep")
@@ -87,11 +87,11 @@ public class SweepCommand extends SingleBackendCommand {
         SweepTaskRunner sweepRunner = services.getSweepTaskRunner();
 
         if (!((namespace != null) ^ (table != null) ^ sweepAllTables)) {
-            log.error("Specify one of --namespace, --table, or --all options.");
+            printer.error("Specify one of --namespace, --table, or --all options.");
             return 1;
         }
         if ((namespace != null) && (row != null)) {
-            log.error("Cannot specify a start row (" + row + ") when sweeping multiple tables (in namespace " + namespace + ")");
+            printer.error("Cannot specify a start row (" + row + ") when sweeping multiple tables (in namespace " + namespace + ")");
             return 1;
         }
 
@@ -128,7 +128,7 @@ public class SweepCommand extends SingleBackendCommand {
             while (startRow.isPresent()) {
                 Stopwatch watch = Stopwatch.createStarted();
                 SweepResults results = sweepRunner.run(table, batchSize, cellBatchSize, startRow.get());
-                log.info("Swept from {} to {} in table {} in {} ms, examined {} unique cells, deleted {} cells.",
+                printer.info("Swept from {} to {} in table {} in {} ms, examined {} unique cells, deleted {} cells.",
                         encodeStartRow(startRow), encodeEndRow(results.getNextStartRow()),
                         table, watch.elapsed(TimeUnit.MILLISECONDS),
                         results.getCellsExamined(), results.getCellsDeleted());
@@ -146,13 +146,13 @@ public class SweepCommand extends SingleBackendCommand {
                 priorityTable.putCellsExamined(row1, cellsExamined.get());
                 priorityTable.putLastSweepTime(row1, System.currentTimeMillis());
 
-                log.info("Finished sweeping {}, examined {} unique cells, deleted {} cells.",
+                printer.info("Finished sweeping {}, examined {} unique cells, deleted {} cells.",
                         table, cellsExamined.get(), cellsDeleted.get());
 
                 if (cellsDeleted.get() > 0) {
                     Stopwatch watch = Stopwatch.createStarted();
                     services.getKeyValueService().compactInternally(table);
-                    log.info("Finished performing compactInternally on {} in {} ms.",
+                    printer.info("Finished performing compactInternally on {} in {} ms.",
                             table, watch.elapsed(TimeUnit.MILLISECONDS));
                 }
                 return null;

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/AbstractTimestampCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/AbstractTimestampCommand.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.cli.command.SingleBackendCommand;
+import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.services.AtlasDbServices;
 
 import io.airlift.airline.Option;

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/AbstractTimestampCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/AbstractTimestampCommand.java
@@ -22,12 +22,12 @@ import java.nio.file.Files;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.cli.command.SingleBackendCommand;
 import com.palantir.atlasdb.services.AtlasDbServices;
 
@@ -36,7 +36,7 @@ import io.airlift.airline.OptionType;
 
 public abstract class AbstractTimestampCommand extends SingleBackendCommand {
 
-    private static final Logger log = LoggerFactory.getLogger(AbstractTimestampCommand.class);
+    private static final OutputPrinter printer = new OutputPrinter(LoggerFactory.getLogger(AbstractTimestampCommand.class));
 
     @Option(name = {"-f", "--file"},
             title = "TIMESTAMP_FILE",
@@ -76,7 +76,7 @@ public abstract class AbstractTimestampCommand extends SingleBackendCommand {
         try {
             timestampString = StringUtils.strip(Iterables.getOnlyElement(Files.readAllLines(file.toPath())));
         } catch (IOException e) {
-            log.error("IOException thrown reading timestamp from file: {}", file.getPath());
+            printer.error("IOException thrown reading timestamp from file: {}", file.getPath());
             throw Throwables.propagate(e);
         }
         return Long.parseLong(timestampString);
@@ -90,7 +90,7 @@ public abstract class AbstractTimestampCommand extends SingleBackendCommand {
             }
             Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            log.error("IOException thrown writing timestamp to file: {}", file.getPath());
+            printer.error("IOException thrown writing timestamp to file: {}", file.getPath());
             Throwables.propagate(e);
         }
     }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/FastForwardTimestamp.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/FastForwardTimestamp.java
@@ -15,9 +15,9 @@
  */
 package com.palantir.atlasdb.cli.command.timestamp;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.services.AtlasDbServices;
 import com.palantir.timestamp.PersistentTimestampService;
 import com.palantir.timestamp.TimestampService;
@@ -28,7 +28,7 @@ import io.airlift.airline.Command;
         + " service to the specified timestamp.  Is used in the restore process to ensure that all future timestamps used are"
         + " explicity greater than any that may have been used to write data to the KVS before backing up the underlying storage.")
 public class FastForwardTimestamp extends AbstractTimestampCommand {
-    private static final Logger log = LoggerFactory.getLogger(FastForwardTimestamp.class);
+    private static final OutputPrinter printer = new OutputPrinter(LoggerFactory.getLogger(FastForwardTimestamp.class));
 
     @Override
     public boolean isOnlineRunSupported() {
@@ -44,14 +44,14 @@ public class FastForwardTimestamp extends AbstractTimestampCommand {
     protected int executeTimestampCommand(AtlasDbServices services) {
         TimestampService ts = services.getTimestampService();
         if (!(ts instanceof PersistentTimestampService)) {
-            log.error("Timestamp service must be of type {}, but yours is {}.  Exiting.",
+            printer.error("Timestamp service must be of type {}, but yours is {}.  Exiting.",
                     PersistentTimestampService.class.toString(), ts.getClass().toString());
             return 1;
         }
         PersistentTimestampService pts = (PersistentTimestampService) ts;
 
         pts.fastForwardTimestamp(timestamp);
-        log.info("Timestamp succesfully fast-forwarded to {}", timestamp);
+        printer.info("Timestamp succesfully fast-forwarded to {}", timestamp);
         return 0;
     }
 }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/FetchTimestamp.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/FetchTimestamp.java
@@ -17,10 +17,10 @@ package com.palantir.atlasdb.cli.command.timestamp;
 
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.cleaner.KeyValueServicePuncherStore;
+import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.services.AtlasDbServices;
 
 import io.airlift.airline.Command;
@@ -30,7 +30,7 @@ import io.airlift.airline.OptionType;
 @Command(name = "fetch", description = "Fetches a timestamp. By default"
         + " this will be a fresh timestamp unless otherwise specified.")
 public class FetchTimestamp extends AbstractTimestampCommand {
-    private static final Logger log = LoggerFactory.getLogger(FetchTimestamp.class);
+    private static final OutputPrinter printer = new OutputPrinter(LoggerFactory.getLogger(FetchTimestamp.class));
 
     @Option(name = {"-i", "--immutable"},
             type = OptionType.COMMAND,
@@ -66,7 +66,7 @@ public class FetchTimestamp extends AbstractTimestampCommand {
             timestamp = services.getTimestampService().getFreshTimestamp();
             name = FRESH_STRING;
         }
-        log.info("The {} timestamp is: {}", name, timestamp);
+        printer.info("The {} timestamp is: {}", name, timestamp);
         writeTimestampToFileIfSpecified();
 
         if (dateTime) {
@@ -74,10 +74,10 @@ public class FetchTimestamp extends AbstractTimestampCommand {
                     services.getKeyValueService(), timestamp);
             DateTime dt = new DateTime(timeMillis);
             String stringTime = ISODateTimeFormat.dateTime().print(dt);
-            log.info("Wall clock datetime of {} timestamp is: {}", name, stringTime);
+            printer.info("Wall clock datetime of {} timestamp is: {}", name, stringTime);
         }
 
-        log.info("Timestamp command completed succesfully.");
+        printer.info("Timestamp command completed succesfully.");
         return 0;
     }
 }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/output/OutputPrinter.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/output/OutputPrinter.java
@@ -27,11 +27,11 @@ public class OutputPrinter {
 
     public void info(String message, Object... args) {
         logger.info(message, args);
-        System.out.println(MessageFormatter.format(message, args));
+        System.out.println(MessageFormatter.arrayFormat(message, args).getMessage());
     }
 
     public void error(String message, Object... args) {
         logger.error(message, args);
-        System.err.println(MessageFormatter.format(message, args));
+        System.err.println(MessageFormatter.arrayFormat(message, args));
     }
 }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/output/OutputPrinter.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/output/OutputPrinter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.cli.output;
+
+import org.slf4j.Logger;
+import org.slf4j.helpers.MessageFormatter;
+
+public class OutputPrinter {
+    private Logger logger;
+
+    public OutputPrinter(Logger logger) {
+        this.logger = logger;
+    }
+
+    public void info(String message, Object... args) {
+        logger.info(message, args);
+        System.out.println(MessageFormatter.format(message, args));
+    }
+
+    public void error(String message, Object... args) {
+        logger.error(message, args);
+        System.err.println(MessageFormatter.format(message, args));
+    }
+}

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/output/OutputPrinter.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/output/OutputPrinter.java
@@ -32,6 +32,6 @@ public class OutputPrinter {
 
     public void error(String message, Object... args) {
         logger.error(message, args);
-        System.err.println(MessageFormatter.arrayFormat(message, args));
+        System.err.println(MessageFormatter.arrayFormat(message, args).getMessage());
     }
 }

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/output/OutputPrinterTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/output/OutputPrinterTest.java
@@ -17,53 +17,32 @@ package com.palantir.atlasdb.cli.output;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
+
+import com.palantir.atlasdb.cli.runner.StandardStreamUtilities;
 
 public class OutputPrinterTest {
     private static final OutputPrinter print = new OutputPrinter(LoggerFactory.getLogger(OutputPrinterTest.class));
 
-    private interface StandardStreamSetter {
-        void set(PrintStream ps);
-    }
-
-    private String wrapGenericStream(Runnable runnable, PrintStream original, StandardStreamSetter standardStreamSetter) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        standardStreamSetter.set(new PrintStream(baos));
-        try {
-            runnable.run();
-        } finally {
-            standardStreamSetter.set(original);
-        }
-        return baos.toString().replace("\n", " ").replace("\r", " ");
-    }
-
-    private String wrapSystemOut(Runnable runnable) {
-        return wrapGenericStream(runnable, System.out, System::setOut);
-    }
-
-    private String wrapSystemErr(Runnable runnable) {
-        return wrapGenericStream(runnable, System.err, System::setErr);
-    }
-
     @Test
     public void testInfoPrintingWorksWithSingleReplacement() {
-        String systemOut = wrapSystemOut(() -> print.info("Test this gets {}", "replaced"));
+        String systemOut = StandardStreamUtilities.wrapSystemOut(
+                () -> print.info("Test this gets {}", "replaced"));
         assertThat(systemOut).isEqualTo("Test this gets replaced ");
     }
 
     @Test
     public void testInfoPrintingWorksWithMultipleReplacement() {
-        String systemOut = wrapSystemOut(() -> print.info("Replace {} of {} {}.", "all", "these", "fields"));
+        String systemOut = StandardStreamUtilities.wrapSystemOut(
+                () -> print.info("Replace {} of {} {}.", "all", "these", "fields"));
         assertThat(systemOut).isEqualTo("Replace all of these fields. ");
     }
 
     @Test
     public void testErrorPrintingWorksWithMultipleReplacement() {
-        String systemErr = wrapSystemErr(() -> print.error("Replace {} of {} {}.", "all", "these", "fields"));
+        String systemErr = StandardStreamUtilities.wrapSystemErr(
+                () -> print.error("Replace {} of {} {}.", "all", "these", "fields"));
         assertThat(systemErr).isEqualTo("Replace all of these fields. ");
     }
 }

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/output/OutputPrinterTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/output/OutputPrinterTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.cli.output;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+public class OutputPrinterTest {
+    private static final OutputPrinter print = new OutputPrinter(LoggerFactory.getLogger(OutputPrinterTest.class));
+
+    private interface StandardStreamSetter {
+        void set(PrintStream ps);
+    }
+
+    private String wrapGenericStream(Runnable runnable, PrintStream original, StandardStreamSetter standardStreamSetter) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        standardStreamSetter.set(new PrintStream(baos));
+        try {
+            runnable.run();
+        } finally {
+            standardStreamSetter.set(original);
+        }
+        return baos.toString().replace("\n", " ").replace("\r", " ");
+    }
+
+    private String wrapSystemOut(Runnable runnable) {
+        return wrapGenericStream(runnable, System.out, System::setOut);
+    }
+
+    private String wrapSystemErr(Runnable runnable) {
+        return wrapGenericStream(runnable, System.err, System::setErr);
+    }
+
+    @Test
+    public void testInfoPrintingWorksWithSingleReplacement() {
+        String systemOut = wrapSystemOut(() -> print.info("Test this gets {}", "replaced"));
+        assertThat(systemOut).isEqualTo("Test this gets replaced ");
+    }
+
+    @Test
+    public void testInfoPrintingWorksWithMultipleReplacement() {
+        String systemOut = wrapSystemOut(() -> print.info("Replace {} of {} {}.", "all", "these", "fields"));
+        assertThat(systemOut).isEqualTo("Replace all of these fields. ");
+    }
+
+    @Test
+    public void testErrorPrintingWorksWithMultipleReplacement() {
+        String systemErr = wrapSystemErr(() -> print.error("Replace {} of {} {}.", "all", "these", "fields"));
+        assertThat(systemErr).isEqualTo("Replace all of these fields. ");
+    }
+}

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/runner/AbstractTestRunner.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/runner/AbstractTestRunner.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.cli.runner;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -72,18 +70,12 @@ public abstract class AbstractTestRunner <S extends AtlasDbServices> implements 
 
     @Override
     public String run(boolean failOnNonZeroExit, boolean singleLine) {
-        PrintStream ps = System.out;
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(baos));
-        try {
+        return StandardStreamUtilities.wrapSystemOut(() -> {
             int ret = cmd.execute(services);
             if (ret != 0 && failOnNonZeroExit) {
                 throw new RuntimeException("CLI returned with nonzero exit code");
             }
-        } finally {
-            System.setOut(ps);
-        }
-        return singleLine ? baos.toString().replace("\n", " ").replace("\r", " ") : baos.toString();
+        }, singleLine);
     }
 
     @Override

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/runner/StandardStreamUtilities.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/runner/StandardStreamUtilities.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.cli.runner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class StandardStreamUtilities {
+    private interface StandardStreamSetter {
+        void set(PrintStream ps);
+    }
+
+    private static String wrapGenericStream(
+            Runnable runnable,
+            PrintStream original,
+            StandardStreamSetter standardStreamSetter,
+            boolean singleLine) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        standardStreamSetter.set(new PrintStream(baos));
+        try {
+            runnable.run();
+        } finally {
+            standardStreamSetter.set(original);
+        }
+
+        return singleLine ? baos.toString().replace("\n", " ").replace("\r", " ") : baos.toString();
+    }
+
+    public static String wrapSystemOut(Runnable runnable, boolean singleLine) {
+        return wrapGenericStream(runnable, System.out, System::setOut, singleLine);
+    }
+
+    public static String wrapSystemErr(Runnable runnable, boolean singleLine) {
+        return wrapGenericStream(runnable, System.err, System::setErr, singleLine);
+    }
+
+    public static String wrapSystemOut(Runnable runnable) {
+        return wrapSystemOut(runnable, true);
+    }
+
+    public static String wrapSystemErr(Runnable runnable) {
+        return wrapSystemErr(runnable, true);
+    }
+}

--- a/atlasdb-cli/src/test/resources/logback.xml
+++ b/atlasdb-cli/src/test/resources/logback.xml
@@ -1,0 +1,29 @@
+<!--~
+  ~ Copyright 2016 Palantir Technologies
+  ~
+  ~ Licensed under the BSD-3 License (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://opensource.org/licenses/BSD-3-Clause
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
          - The migration CLI will now decrypt encrypted values and will now use the dropwizard config as the new configuration.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1171>`__)
 
+    *    - |improved|
+         - CLIs now output to standard out and standard error as well as the longs while running.  This should
+           greatly improve usability for service admins using the CLIs.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1177>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,7 +51,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1171>`__)
 
     *    - |improved|
-         - CLIs now output to standard out and standard error as well as the longs while running.  This should
+         - CLIs now output to standard out and standard error as well as the logs while running.  This should
            greatly improve usability for service admins using the CLIs.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1177>`__)
 


### PR DESCRIPTION
This allows printing to info or error which will both hit the slf4j impls as well as sysout and syserr
respectively.  This is not perfect as some methods still use logging in other methods outside of the
command class to inform the user of progress.  Notably: CleanCassLocksStateCommand

Fixes #1116

Another concern here is the dual rendering of the args into the message for the logger and then for system out.  None of the messages occur enough for this to pose a perf problem.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1177)
<!-- Reviewable:end -->
