### PR TITLE
Revert "Log timestamp-y stuff at at least INFO"

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -86,7 +86,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
 
     @Override
     public synchronized long getUpperLimit() {
-        DebugLogger.logger.info("[GET] Getting upper limit");
+        DebugLogger.logger.debug("[GET] Getting upper limit");
         return clientPool.runWithRetry(new FunctionCheckedException<Client, Long, RuntimeException>() {
             @Override
             public Long apply(Client client) {
@@ -116,7 +116,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
 
     @Override
     public synchronized void storeUpperLimit(final long limit) {
-        DebugLogger.logger.info("[PUT] Storing upper limit of {}.", limit);
+        DebugLogger.logger.debug("[PUT] Storing upper limit of {}.", limit);
         clientPool.runWithRetry(new FunctionCheckedException<Client, Void, RuntimeException>() {
             @Override
             public Void apply(Client client) {

--- a/docs/source/configuration/logging.rst
+++ b/docs/source/configuration/logging.rst
@@ -26,9 +26,9 @@ To do this, add the following to your logging configuration:
 
     logging:
       loggers:
-        com.palantir.timestamp.DebugLogger:
-          level: INFO
-          additive: true
+        com.palantir.timestamp:
+          level: TRACE
+          additive: false
           appenders:
             - archivedFileCount: 5
               archivedLogFilenamePattern: '{{service_home}}/var/log/timestamps-%d.log.gz'

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
@@ -41,7 +41,7 @@ public class AvailableTimestamps {
                 MAX_TIMESTAMPS_TO_HAND_OUT, numberToHandOut);
 
         long targetTimestamp = lastHandedOut() + numberToHandOut;
-        DebugLogger.logger.info("Handing out {} timestamps, taking us to {}.", numberToHandOut, targetTimestamp);
+        DebugLogger.logger.trace("Handing out {} timestamps, taking us to {}.", numberToHandOut, targetTimestamp);
         return handOutTimestamp(targetTimestamp);
     }
 
@@ -50,13 +50,13 @@ public class AvailableTimestamps {
         long buffer = currentUpperLimit - lastHandedOut();
 
         if (buffer < MINIMUM_BUFFER || !upperLimit.hasIncreasedWithin(1, MINUTES)) {
-            DebugLogger.logger.info(
+            DebugLogger.logger.trace(
                     "refreshBuffer: refreshing and allocating timestamps. Buffer {}, Current upper limit {}.",
                     buffer,
                     currentUpperLimit);
             allocateEnoughTimestampsToHandOut(lastHandedOut() + ALLOCATION_BUFFER_SIZE);
         } else {
-            DebugLogger.logger.info("refreshBuffer: refreshing, but not allocating");
+            DebugLogger.logger.trace("refreshBuffer: refreshing, but not allocating");
         }
     }
 
@@ -84,9 +84,11 @@ public class AvailableTimestamps {
     }
 
     private void allocateEnoughTimestampsToHandOut(long timestamp) {
-        DebugLogger.logger.info("Increasing limit to at least {}.", timestamp);
+        DebugLogger.logger.trace("Increasing limit to at least {}.", timestamp);
         upperLimit.increaseToAtLeast(timestamp);
-        DebugLogger.logger.info("Increased to at least {}. Limit is now {}.", timestamp, getUpperLimit());
+        if (DebugLogger.logger.isTraceEnabled()) {
+            DebugLogger.logger.trace("Increased to at least {}. Limit is now {}.", timestamp, getUpperLimit());
+        }
     }
 
     public long getUpperLimit() {

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
@@ -57,7 +57,7 @@ public class PersistentUpperLimit {
         if (cachedValue < minimum) {
             store(minimum);
         } else {
-            DebugLogger.logger.info(
+            DebugLogger.logger.trace(
                     "Not storing upper limit of {}, as the cached value {} was higher.",
                     minimum,
                     cachedValue);
@@ -72,13 +72,13 @@ public class PersistentUpperLimit {
     }
 
     private synchronized void store(long upperLimit) {
-        DebugLogger.logger.info("Storing new upper limit of {}.", upperLimit);
+        DebugLogger.logger.trace("Storing new upper limit of {}.", upperLimit);
         checkWeHaveNotBeenInterrupted();
         allocationFailures.verifyWeShouldTryToAllocateMoreTimestamps();
         persistNewUpperLimit(upperLimit);
         cachedValue = upperLimit;
         lastIncreasedTime = clock.getTimeMillis();
-        DebugLogger.logger.info("Stored; upper limit is now {}.", upperLimit);
+        DebugLogger.logger.trace("Stored; upper limit is now {}.", upperLimit);
     }
 
     private void checkWeHaveNotBeenInterrupted() {


### PR DESCRIPTION
Concern was raised about the scale of the logs.

This commit will suppress about 94% of the logs (weighted by frequency) to levels below INFO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1179)
<!-- Reviewable:end -->
