### PR TITLE
Dont return short table_names as is

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameMapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameMapper.java
@@ -39,15 +39,12 @@ public class OracleTableNameMapper {
         Preconditions.checkState(tablePrefix.length() <= AtlasDbConstants.MAX_TABLE_PREFIX_LENGTH,
                 "The tablePrefix can be at most %s characters long", AtlasDbConstants.MAX_TABLE_PREFIX_LENGTH);
 
-        String fullTableName = tablePrefix + DbKvs.internalTableName(tableRef);
-        if (fullTableName.length() <= PREFIXED_TABLE_NAME_LENGTH) {
-            return fullTableName;
-        }
-
         TableReference shortenedNamespaceTableRef = truncateNamespace(tableRef);
 
         String prefixedTableName = tablePrefix + DbKvs.internalTableName(shortenedNamespaceTableRef);
         String truncatedTableName = truncate(prefixedTableName, PREFIXED_TABLE_NAME_LENGTH);
+
+        String fullTableName = tablePrefix + DbKvs.internalTableName(tableRef);
         return truncatedTableName + getTableNumberSuffix(fullTableName, truncatedTableName);
     }
 

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameMapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameMapperTest.java
@@ -55,7 +55,8 @@ public class OracleTableNameMapperTest {
         resultSet = mock(AgnosticResultSet.class);
         when(sqlConnection
                 .selectResultSetUnregisteredQuery(
-                        startsWith("SELECT short_table_name FROM atlasdb_table_names WHERE LOWER(short_table_name)"), anyObject()))
+                        startsWith("SELECT short_table_name FROM atlasdb_table_names WHERE LOWER(short_table_name)"),
+                        anyObject()))
                 .thenReturn(resultSet);
     }
 


### PR DESCRIPTION
With the introduction of the useTableMapping, this codepath is not useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1187)
<!-- Reviewable:end -->
