### PR TITLE
Minor refactor of CassandraVerifier

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -140,7 +140,14 @@ public final class CassandraVerifier {
 
     private static void createKeyspace(CassandraKeyValueServiceConfig config) throws TException {
         // We can't use the pool yet because it does things like setting the connection's keyspace for us
-        boolean someHostWasAbleToCreateTheKeyspace = false;
+        if (!attemptToCreateKeyspace(config)) {
+            throw new TException("No host tried was able to create the keyspace requested.");
+        }
+    }
+
+    // Returns true iff we successfully created the keyspace on some host.
+    private static boolean attemptToCreateKeyspace(CassandraKeyValueServiceConfig config)
+            throws InvalidRequestException {
         for (InetSocketAddress host : config.servers()) { // try until we find a server that works
             try {
                 if (!keyspaceAlreadyExists(host, config)) {
@@ -148,13 +155,11 @@ public final class CassandraVerifier {
                 }
 
                 // if we got this far, we're done, no need to continue on other hosts
-                someHostWasAbleToCreateTheKeyspace = true;
-                break;
+                return true;
             } catch (InvalidRequestException ire) {
                 if (attemptedToCreateKeyspaceTwice(ire)) {
                     // if we got this far, we're done, no need to continue on other hosts
-                    someHostWasAbleToCreateTheKeyspace = true;
-                    break;
+                    return true;
                 } else {
                     throw ire;
                 }
@@ -166,9 +171,7 @@ public final class CassandraVerifier {
                 log.debug("Specifically, creating the keyspace failed with the following stack trace", f);
             }
         }
-        if (!someHostWasAbleToCreateTheKeyspace) {
-            throw new TException("No host tried was able to create the keyspace requested.");
-        }
+        return false;
     }
 
     // swallows the expected TException subtype NotFoundException, throws connection problem related ones
@@ -182,6 +185,38 @@ public final class CassandraVerifier {
             return false;
         }
     }
+
+    private static void attemptToCreateKeyspaceOnHost(InetSocketAddress host, CassandraKeyValueServiceConfig config)
+            throws TException {
+        Client client = CassandraClientFactory.getClientInternal(host, config);
+        KsDef ks = new KsDef(config.keyspace(), CassandraConstants.NETWORK_STRATEGY,
+                ImmutableList.of());
+        checkAndSetReplicationFactor(
+                client,
+                ks,
+                true,
+                config.replicationFactor(),
+                config.safetyDisabled());
+        ks.setDurable_writes(true);
+        client.system_add_keyspace(ks);
+        log.info("Created keyspace: {}", config.keyspace());
+        CassandraKeyValueServices.waitForSchemaVersions(
+                client,
+                "(adding the initial empty keyspace)",
+                config.schemaMutationTimeoutMillis());
+    }
+
+    private static boolean attemptedToCreateKeyspaceTwice(InvalidRequestException ex) {
+        String exceptionString = ex.toString();
+        if (exceptionString.contains("case-insensitively unique")) {
+            String[] keyspaceNames = StringUtils.substringsBetween(exceptionString, "\"", "\"");
+            if (keyspaceNames.length == 2 && keyspaceNames[0].equals(keyspaceNames[1])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     private static void updateExistingKeyspace(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config)
             throws TException {
@@ -214,39 +249,7 @@ public final class CassandraVerifier {
         });
     }
 
-    private static void attemptToCreateKeyspaceOnHost(InetSocketAddress host, CassandraKeyValueServiceConfig config)
-            throws TException {
-        Client client = CassandraClientFactory.getClientInternal(host, config);
-        KsDef ks = new KsDef(config.keyspace(), CassandraConstants.NETWORK_STRATEGY,
-                ImmutableList.of());
-        checkAndSetReplicationFactor(
-                client,
-                ks,
-                true,
-                config.replicationFactor(),
-                config.safetyDisabled());
-        ks.setDurable_writes(true);
-        client.system_add_keyspace(ks);
-        log.info("Created keyspace: {}", config.keyspace());
-        CassandraKeyValueServices.waitForSchemaVersions(
-                client,
-                "(adding the initial empty keyspace)",
-                config.schemaMutationTimeoutMillis());
-    }
-
-
-    private static boolean attemptedToCreateKeyspaceTwice(InvalidRequestException ex) {
-        String exceptionString = ex.toString();
-        if (exceptionString.contains("case-insensitively unique")) {
-            String[] keyspaceNames = StringUtils.substringsBetween(exceptionString, "\"", "\"");
-            if (keyspaceNames.length == 2 && keyspaceNames[0].equals(keyspaceNames[1])) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    static void checkAndSetReplicationFactor(
+    private static void checkAndSetReplicationFactor(
             Cassandra.Client client,
             KsDef ks,
             boolean freshInstance,


### PR DESCRIPTION
Reorder some private methods in the class. Extract loop from createKeyspace. Make checkAndSetReplicationFactor private.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1190)
<!-- Reviewable:end -->
