### PR TITLE
Fix to reject no changes as a failure [no release notes]

### DIFF
--- a/scripts/circle-ci/check-only-docs-changes.sh
+++ b/scripts/circle-ci/check-only-docs-changes.sh
@@ -16,7 +16,7 @@ fi
 for file in $FILES_CHANGED
 do
     if [[ $file != ${DOCS_REPO}* ]]; then
-        echo "None docs changes detected in $file" >&2
+        echo "No docs changes detected in $file" >&2
         exit 1;
     fi
 done

--- a/scripts/circle-ci/check-only-docs-changes.sh
+++ b/scripts/circle-ci/check-only-docs-changes.sh
@@ -7,9 +7,16 @@ DOCS_REPO="docs/"
 
 FILES_CHANGED=$(git diff --name-only origin/develop...HEAD)
 
+if [ -z $FILES_CHANGED ]; then
+    # no files have changed, likely a merge commit into develop
+    echo "No file changes detected, not a docs only commit" >&2
+    exit 2;
+fi
+
 for file in $FILES_CHANGED
 do
     if [[ $file != ${DOCS_REPO}* ]]; then
+        echo "None docs changes detected in $file" >&2
         exit 1;
     fi
 done


### PR DESCRIPTION
Fix problem that was causing tests to be skipped on develop which would detect not changed files.
@rhero

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1207)
<!-- Reviewable:end -->
