### PR TITLE
table name unmapping cache and connection cleanup

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
@@ -74,4 +74,8 @@ public class OracleTableNameGetter {
     public String getPrefixedOverflowTableName() {
         return overflowTablePrefix + DbKvs.internalTableName(tableRef);
     }
+
+    public void clearCacheForTable(String fullTableName) {
+        oracleTableNameUnmapper.clearCacheForTable(fullTableName);
+    }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -15,6 +15,11 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -26,6 +31,24 @@ import com.palantir.nexus.db.sql.AgnosticResultSet;
 class OracleTableNameUnmapper {
     private final ConnectionSupplier conns;
 
+    private LoadingCache<String, String> unmappingCache = CacheBuilder.newBuilder().build(
+            new CacheLoader<String, String>() {
+                @Override
+                public String load(String fullTableName) throws Exception {
+                    AgnosticResultSet results = conns.get().selectResultSetUnregisteredQuery(
+                            "SELECT short_table_name "
+                                    + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
+                                    + " WHERE table_name = ?", fullTableName);
+                    if (results.size() == 0) {
+                        throw new TableMappingNotFoundException(
+                                "The table " + fullTableName + " does not have a mapping."
+                                        + "This might be because the table does not exist.");
+                    }
+                    return Iterables.getOnlyElement(results.rows()).getString("short_table_name");
+                }
+            }
+    );
+
     OracleTableNameUnmapper(ConnectionSupplier conns) {
         this.conns = conns;
     }
@@ -33,16 +56,10 @@ class OracleTableNameUnmapper {
     public String getShortTableNameFromMappingTable(String tablePrefix, TableReference tableRef)
             throws TableMappingNotFoundException {
         String fullTableName = tablePrefix + DbKvs.internalTableName(tableRef);
-
-        AgnosticResultSet results = conns.get().selectResultSetUnregisteredQuery(
-                "SELECT short_table_name "
-                        + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
-                        + " WHERE table_name = ?", fullTableName);
-        if (results.size() == 0) {
-            throw new TableMappingNotFoundException(
-                    "The table " + fullTableName + " does not have a mapping."
-                    + "This might be because the table does not exist.");
+        try {
+            return unmappingCache.get(fullTableName);
+        } catch (ExecutionException e) {
+            throw new TableMappingNotFoundException(e);
         }
-        return Iterables.getOnlyElement(results.rows()).getString("short_table_name");
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -59,7 +59,7 @@ class OracleTableNameUnmapper {
         try {
             return unmappingCache.get(fullTableName);
         } catch (ExecutionException e) {
-            throw new TableMappingNotFoundException(e);
+            throw new TableMappingNotFoundException(e.getCause());
         }
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -62,4 +62,8 @@ class OracleTableNameUnmapper {
             throw new TableMappingNotFoundException(e);
         }
     }
+
+    public void clearCacheForTable(String fullTableName) {
+        unmappingCache.invalidate(fullTableName);
+    }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -15,7 +15,11 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
+import java.sql.SQLException;
 import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -27,15 +31,19 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
 import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
+import com.palantir.nexus.db.sql.SqlConnection;
 
 class OracleTableNameUnmapper {
+    private static final Logger log = LoggerFactory.getLogger(OracleTableNameUnmapper.class);
+
     private final ConnectionSupplier conns;
 
     private LoadingCache<String, String> unmappingCache = CacheBuilder.newBuilder().build(
             new CacheLoader<String, String>() {
                 @Override
                 public String load(String fullTableName) throws Exception {
-                    AgnosticResultSet results = conns.get().selectResultSetUnregisteredQuery(
+                    SqlConnection conn = conns.getFresh();
+                    AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
                             "SELECT short_table_name "
                                     + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
                                     + " WHERE table_name = ?", fullTableName);
@@ -44,7 +52,15 @@ class OracleTableNameUnmapper {
                                 "The table " + fullTableName + " does not have a mapping."
                                         + "This might be because the table does not exist.");
                     }
-                    return Iterables.getOnlyElement(results.rows()).getString("short_table_name");
+                    String mappedName = Iterables.getOnlyElement(results.rows()).getString("short_table_name");
+
+                    try {
+                        conn.getUnderlyingConnection().close();
+                    } catch (SQLException e) {
+                        log.error("Couldn't cleanup SQL connection while performing table name unmapping.", e);
+                    }
+
+                    return mappedName;
                 }
             }
     );

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -156,6 +156,7 @@ public final class OracleDdlTable implements DbDdlTable {
             conns.get().executeUnregisteredQuery(
                     "DELETE FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE + " WHERE table_name = ?",
                     fullTableName);
+            oracleTableNameGetter.clearCacheForTable(fullTableName);
         }
     }
 

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,7 +59,10 @@ public class OracleTableNameUnmapperTest {
         ConnectionSupplier connectionSupplier = mock(ConnectionSupplier.class);
         oracleTableNameUnmapper =  new OracleTableNameUnmapper(connectionSupplier);
         SqlConnection sqlConnection = mock(SqlConnection.class);
-        when(connectionSupplier.get()).thenReturn(sqlConnection);
+        Connection connection = mock(Connection.class);
+        when(sqlConnection.getUnderlyingConnection()).thenReturn(connection);
+        when(connectionSupplier.getFresh()).thenReturn(sqlConnection);
+
         resultSet = mock(AgnosticResultSet.class);
         when(sqlConnection
                 .selectResultSetUnregisteredQuery(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableMappingNotFoundException.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableMappingNotFoundException.java
@@ -19,4 +19,8 @@ public class TableMappingNotFoundException extends Exception {
     public TableMappingNotFoundException(String msg) {
         super(msg);
     }
+
+    public TableMappingNotFoundException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/commons-db/src/main/java/com/palantir/nexus/db/pool/CloseTracking.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/pool/CloseTracking.java
@@ -78,7 +78,9 @@ public class CloseTracking {
 
         public synchronized void check() {
             if (!closed) {
-                log.error(typeName + " never closed!", createTrace);
+                String errorMessage = typeName + " never closed!";
+                log.error(errorMessage, createTrace);
+                assert false : errorMessage + "\n" + createTrace.getStackTrace();
             }
         }
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -46,6 +46,10 @@ develop
            potentially long pauses that could previously occur when closing a ``Cleaner``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1232>`__)
 
+    *    - |improved|
+         - Oracle perf improvement; table names now cached, resulting in fewer round trips to the database.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1215>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
          - Oracle perf improvement; table names now cached, resulting in fewer round trips to the database.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1215>`__)
 
+    *    - |fixed|
+         - Certain Oracle KVS calls no longer attempt to leak connections created internally.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1215>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
~~This only partially addresses #1195 ; I believe there will be (now much smaller number of) connection tracker errors still from not properly closed connections.~~
schlos made me fix both issues; fixes #1195 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1215)
<!-- Reviewable:end -->
