### PR TITLE
Switch to cassandra-thrift

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   testCompile project(":atlasdb-docker-test-utils")
   testCompile project(":atlasdb-ete-test-utils")
 
-  testCompile 'org.apache.cassandra:cassandra-all:' + libVersions.cassandra
+  testCompile 'org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra
   testCompile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
 
   testCompile group: 'org.mockito', name: 'mockito-core'

--- a/atlasdb-cassandra-multinode-tests/build.gradle
+++ b/atlasdb-cassandra-multinode-tests/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testCompile project(":atlasdb-docker-test-utils")
     testCompile project(":atlasdb-ete-test-utils")
 
-    testCompile 'org.apache.cassandra:cassandra-all:' + libVersions.cassandra
+    testCompile 'org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra
     testCompile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
 
     testCompile 'com.palantir.docker.compose:docker-compose-rule:' + libVersions.dockerComposeRule

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -8,7 +8,7 @@ dependencies {
   compile project(":commons-api")
   compile project(':timestamp-impl')
 
-  compile ('org.apache.cassandra:cassandra-all:' + libVersions.cassandra) {
+  compile ('org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra) {
     exclude module: 'junit'
   }
   compile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraJmxCompactionConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraJmxCompactionConfig.java
@@ -15,16 +15,19 @@
  */
 package com.palantir.atlasdb.cassandra;
 
+import javax.annotation.Nullable;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 @JsonDeserialize(as = ImmutableCassandraJmxCompactionConfig.class)
 @JsonSerialize(as = ImmutableCassandraJmxCompactionConfig.class)
 @Value.Immutable
 public abstract class CassandraJmxCompactionConfig {
-
     @Value.Default
     public boolean ssl() {
         return false;
@@ -45,16 +48,31 @@ public abstract class CassandraJmxCompactionConfig {
         return 30 * 60;
     }
 
+    @Nullable
     public abstract String keystore();
 
+    @Nullable
     public abstract String keystorePassword();
 
+    @Nullable
     public abstract String truststore();
 
+    @Nullable
     public abstract String truststorePassword();
 
     public abstract String username();
 
     public abstract String password();
 
+    @Value.Check
+    protected final void check() {
+        if (!ssl()) {
+            return;
+        }
+
+        Preconditions.checkState(!Strings.isNullOrEmpty(keystore()), "keystore must be specified");
+        Preconditions.checkState(!Strings.isNullOrEmpty(keystorePassword()), "keystorePassword must be specified");
+        Preconditions.checkState(!Strings.isNullOrEmpty(truststore()), "truststore must be specified");
+        Preconditions.checkState(!Strings.isNullOrEmpty(truststorePassword()), "truststorePassword must be specified");
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompaction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompaction.java
@@ -78,6 +78,10 @@ public final class CassandraJmxCompaction {
         // NOTE: RMI timeout to avoid hanging tcp connection
         System.setProperty("sun.rmi.transport.tcp.responseTimeout", String.valueOf(rmiTimeoutMillis));
 
+        if (!jmxConfig.ssl()) {
+            return;
+        }
+
         String keyStoreFile = jmxConfig.keystore();
         String keyStorePassword = jmxConfig.keystorePassword();
         String trustStoreFile = jmxConfig.truststore();

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
+import com.palantir.atlasdb.cassandra.ImmutableCassandraJmxCompactionConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
@@ -48,6 +49,10 @@ public class CassandraContainer extends Container {
             .fetchBatchCount(1000)
             .safetyDisabled(false)
             .autoRefreshNodes(false)
+            .jmx(ImmutableCassandraJmxCompactionConfig.builder()
+                    .username(USERNAME)
+                    .password(PASSWORD)
+                    .build())
             .build();
 
     public static final Optional<LeaderConfig> LEADER_CONFIG = Optional.of(ImmutableLeaderConfig

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1028,6 +1028,11 @@ public abstract class AbstractKeyValueServiceTest {
         keyValueService.createTable(TEST_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
     }
 
+    @Test
+    public void compactingShouldNotFail() {
+        keyValueService.compactInternally(TEST_TABLE);
+    }
+
     private byte[] dynamicColumn(long columnId) {
         return PtBytes.toBytes(columnId);
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,10 @@ develop
            greatly improve usability for service admins using the CLIs.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1177>`__)
 
+    *    - |improved|
+         - ``atlasdb-cassandra`` now depends on ``cassandra-thrift`` instead of ``cassandra-all``. This reduces our dependency footprint.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1222>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/scripts/get-dependency-diff.sh
+++ b/scripts/get-dependency-diff.sh
@@ -26,7 +26,7 @@ generate_dependency_files() {
 }
 
 print_header() {
-    printf "\033[1;97m$1\033[0m\n"
+    printf "\033[1;97m@@$1@@\033[0m\n"
 }
 
 prepare_diff() {


### PR DESCRIPTION
Dependency changes:
```diff
@@atlasdb-cassandra@@
-ch.qos.logback:logback-classic:1.1.3
-ch.qos.logback:logback-core:1.1.3
-com.addthis.metrics:reporter-config-base:3.0.0
-com.addthis.metrics:reporter-config3:3.0.0
-com.boundary:high-scale-lib:1.0.6
-com.clearspring.analytics:stream:2.5.2
-com.fasterxml:classmate:1.0.0
-com.github.jbellis:jamm:0.3.0
-com.github.tjake:crc32ex:0.1.1
-com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4
-com.lmax:disruptor:3.0.1
-com.ning:compress-lzf:0.8.4
-com.thinkaurelius.thrift:thrift-server:0.3.7
-commons-cli:commons-cli:1.2
-commons-logging:commons-logging:1.1.1
-io.dropwizard.metrics:metrics-core:3.1.1
-io.dropwizard.metrics:metrics-jvm:3.1.1
-io.netty:netty-all:4.0.23.Final
-it.unimi.dsi:fastutil:6.5.7
-joda-time:joda-time:2.7
-net.java.dev.jna:jna:4.1.0
-net.jpountz.lz4:lz4:1.3.0
-net.sf.supercsv:super-csv:2.1.0
-org.antlr:ST4:4.0.8
-org.antlr:antlr-runtime:3.5.2
-org.antlr:antlr:3.5.2
-org.apache.cassandra:cassandra-all:2.2.8
-org.apache.commons:commons-math3:3.2
-org.caffinitas.ohc:ohc-core:0.3.4
-org.codehaus.jackson:jackson-core-asl:1.9.2
-org.codehaus.jackson:jackson-mapper-asl:1.9.2
-org.eclipse.jdt.core.compiler:ecj:4.4.2
-org.fusesource:sigar:1.6.4
-org.hibernate:hibernate-validator:5.1.3.Final
-org.jboss.logging:jboss-logging:3.1.3.GA
-org.mindrot:jbcrypt:0.3m
-org.yaml:snakeyaml:1.12

@@atlasdb-cli@@
-com.addthis.metrics:reporter-config-base:3.0.0
-com.addthis.metrics:reporter-config3:3.0.0
-com.boundary:high-scale-lib:1.0.6
-com.clearspring.analytics:stream:2.5.2
-com.fasterxml:classmate:1.0.0
-com.github.jbellis:jamm:0.3.0
-com.github.tjake:crc32ex:0.1.1
-com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4
-com.lmax:disruptor:3.0.1
-com.ning:compress-lzf:0.8.4
-com.thinkaurelius.thrift:thrift-server:0.3.7
-commons-cli:commons-cli:1.2
-commons-logging:commons-logging:1.1.1
-io.dropwizard.metrics:metrics-core:3.1.1
-io.dropwizard.metrics:metrics-jvm:3.1.1
-io.netty:netty-all:4.0.23.Final
-it.unimi.dsi:fastutil:6.5.7
-net.java.dev.jna:jna:4.1.0
-net.jpountz.lz4:lz4:1.3.0
-net.sf.supercsv:super-csv:2.1.0
-org.antlr:ST4:4.0.8
-org.antlr:antlr-runtime:3.5.2
-org.antlr:antlr:3.5.2
-org.apache.cassandra:cassandra-all:2.2.8
-org.apache.commons:commons-math3:3.2
-org.caffinitas.ohc:ohc-core:0.3.4
-org.codehaus.jackson:jackson-core-asl:1.9.2
-org.codehaus.jackson:jackson-mapper-asl:1.9.2
-org.eclipse.jdt.core.compiler:ecj:4.4.2
-org.fusesource:sigar:1.6.4
-org.hibernate:hibernate-validator:5.1.3.Final
-org.jboss.logging:jboss-logging:3.1.3.GA
-org.mindrot:jbcrypt:0.3m

@@atlasdb-container-test-utils@@
-ch.qos.logback:logback-classic:1.1.3
-ch.qos.logback:logback-core:1.1.3
-com.addthis.metrics:reporter-config-base:3.0.0
-com.addthis.metrics:reporter-config3:3.0.0
-com.boundary:high-scale-lib:1.0.6
-com.clearspring.analytics:stream:2.5.2
-com.fasterxml:classmate:1.0.0
-com.github.jbellis:jamm:0.3.0
-com.github.tjake:crc32ex:0.1.1
-com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4
-com.lmax:disruptor:3.0.1
-com.ning:compress-lzf:0.8.4
-com.thinkaurelius.thrift:thrift-server:0.3.7
-commons-cli:commons-cli:1.2
-commons-logging:commons-logging:1.1.1
-io.dropwizard.metrics:metrics-core:3.1.1
-io.dropwizard.metrics:metrics-jvm:3.1.1
-io.netty:netty-all:4.0.23.Final
-it.unimi.dsi:fastutil:6.5.7
-net.java.dev.jna:jna:4.1.0
-net.jpountz.lz4:lz4:1.3.0
-net.sf.supercsv:super-csv:2.1.0
-org.antlr:ST4:4.0.8
-org.antlr:antlr-runtime:3.5.2
-org.antlr:antlr:3.5.2
-org.apache.cassandra:cassandra-all:2.2.8
-org.apache.commons:commons-math3:3.2
-org.caffinitas.ohc:ohc-core:0.3.4
-org.codehaus.jackson:jackson-core-asl:1.9.2
-org.codehaus.jackson:jackson-mapper-asl:1.9.2
-org.eclipse.jdt.core.compiler:ecj:4.4.2
-org.fusesource:sigar:1.6.4
-org.hibernate:hibernate-validator:5.1.3.Final
-org.jboss.logging:jboss-logging:3.1.3.GA
-org.mindrot:jbcrypt:0.3m
-org.yaml:snakeyaml:1.12

@@atlasdb-dropwizard-bundle@@
-com.addthis.metrics:reporter-config-base:3.0.0
-com.addthis.metrics:reporter-config3:3.0.0
-com.boundary:high-scale-lib:1.0.6
-com.clearspring.analytics:stream:2.5.2
-com.github.jbellis:jamm:0.3.0
-com.github.tjake:crc32ex:0.1.1
-com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4
-com.lmax:disruptor:3.0.1
-com.ning:compress-lzf:0.8.4
-com.thinkaurelius.thrift:thrift-server:0.3.7
-commons-logging:commons-logging:1.1.1
-io.netty:netty-all:4.0.23.Final
-it.unimi.dsi:fastutil:6.5.7
-net.java.dev.jna:jna:4.1.0
-net.jpountz.lz4:lz4:1.3.0
-net.sf.supercsv:super-csv:2.1.0
-org.antlr:ST4:4.0.8
-org.antlr:antlr-runtime:3.5.2
-org.antlr:antlr:3.5.2
-org.apache.cassandra:cassandra-all:2.2.8
-org.apache.commons:commons-math3:3.2
-org.caffinitas.ohc:ohc-core:0.3.4
-org.codehaus.jackson:jackson-core-asl:1.9.2
-org.codehaus.jackson:jackson-mapper-asl:1.9.2
-org.eclipse.jdt.core.compiler:ecj:4.4.2
-org.fusesource:sigar:1.6.4
-org.mindrot:jbcrypt:0.3m

@@atlasdb-ete-tests@@
-com.addthis.metrics:reporter-config-base:3.0.0
-com.addthis.metrics:reporter-config3:3.0.0
-com.boundary:high-scale-lib:1.0.6
-com.clearspring.analytics:stream:2.5.2
-com.github.jbellis:jamm:0.3.0
-com.github.tjake:crc32ex:0.1.1
-com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4
-com.lmax:disruptor:3.0.1
-com.ning:compress-lzf:0.8.4
-com.thinkaurelius.thrift:thrift-server:0.3.7
-io.netty:netty-all:4.0.23.Final
-it.unimi.dsi:fastutil:6.5.7
-net.java.dev.jna:jna:4.1.0
-net.jpountz.lz4:lz4:1.3.0
-net.sf.supercsv:super-csv:2.1.0
-org.antlr:ST4:4.0.8
-org.antlr:antlr-runtime:3.5.2
-org.antlr:antlr:3.5.2
-org.apache.cassandra:cassandra-all:2.2.8
-org.apache.commons:commons-math3:3.2
-org.caffinitas.ohc:ohc-core:0.3.4
-org.codehaus.jackson:jackson-core-asl:1.9.2
-org.codehaus.jackson:jackson-mapper-asl:1.9.2
-org.eclipse.jdt.core.compiler:ecj:4.4.2
-org.fusesource:sigar:1.6.4
-org.mindrot:jbcrypt:0.3m

@@atlasdb-perf@@
-com.addthis.metrics:reporter-config-base:3.0.0
-com.addthis.metrics:reporter-config3:3.0.0
-com.boundary:high-scale-lib:1.0.6
-com.clearspring.analytics:stream:2.5.2
-com.fasterxml:classmate:1.0.0
-com.github.jbellis:jamm:0.3.0
-com.github.tjake:crc32ex:0.1.1
-com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4
-com.lmax:disruptor:3.0.1
-com.ning:compress-lzf:0.8.4
-com.thinkaurelius.thrift:thrift-server:0.3.7
-commons-cli:commons-cli:1.2
-commons-logging:commons-logging:1.1.1
-io.dropwizard.metrics:metrics-core:3.1.1
-io.dropwizard.metrics:metrics-jvm:3.1.1
-io.netty:netty-all:4.0.23.Final
-it.unimi.dsi:fastutil:6.5.7
-net.java.dev.jna:jna:4.1.0
-net.jpountz.lz4:lz4:1.3.0
-net.sf.supercsv:super-csv:2.1.0
-org.antlr:ST4:4.0.8
-org.antlr:antlr-runtime:3.5.2
-org.antlr:antlr:3.5.2
-org.apache.cassandra:cassandra-all:2.2.8
-org.caffinitas.ohc:ohc-core:0.3.4
-org.codehaus.jackson:jackson-core-asl:1.9.2
-org.codehaus.jackson:jackson-mapper-asl:1.9.2
-org.eclipse.jdt.core.compiler:ecj:4.4.2
-org.fusesource:sigar:1.6.4
-org.hibernate:hibernate-validator:5.1.3.Final
-org.jboss.logging:jboss-logging:3.1.3.GA
-org.mindrot:jbcrypt:0.3m

@@========================@@
@@OVERALL FOOTPRINT CHANGE@@
@@========================@@
-com.addthis.metrics:reporter-config-base:3.0.0
-com.addthis.metrics:reporter-config3:3.0.0
-com.boundary:high-scale-lib:1.0.6
-com.clearspring.analytics:stream:2.5.2
-com.github.jbellis:jamm:0.3.0
-com.github.tjake:crc32ex:0.1.1
-com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4
-com.lmax:disruptor:3.0.1
-com.ning:compress-lzf:0.8.4
-com.thinkaurelius.thrift:thrift-server:0.3.7
-io.netty:netty-all:4.0.23.Final
-it.unimi.dsi:fastutil:6.5.7
-net.java.dev.jna:jna:4.1.0
-net.jpountz.lz4:lz4:1.3.0
-net.sf.supercsv:super-csv:2.1.0
-org.antlr:ST4:4.0.8
-org.antlr:antlr-runtime:3.5.2
-org.antlr:antlr:3.5.2
-org.caffinitas.ohc:ohc-core:0.3.4
-org.codehaus.jackson:jackson-core-asl:1.9.2
-org.codehaus.jackson:jackson-mapper-asl:1.9.2
-org.eclipse.jdt.core.compiler:ecj:4.4.2
-org.fusesource:sigar:1.6.4
-org.mindrot:jbcrypt:0.3m
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1222)
<!-- Reviewable:end -->
