### PR TITLE
Move "Java 8 optionals in schema" release note to correct release

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -99,6 +99,11 @@ v0.24.0
            This reduces our dependency footprint.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1222>`__)
 
+    *    - |new|
+         - Add support for generating schemas with Java8 Optionals instead of Guava Optionals.
+           To use Java8 optionals, supply ``OptionalType.JAVA8`` as an additional constructor argument when creating your ``Schema`` object.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1162>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -139,9 +144,6 @@ v0.23.0
     *    - |changed|
          - We now test against Cassandra 2.2.8, rather than Cassandra 2.2.7.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1112>`__)
-
-    *    - |improved|
-         - Add support for generating schemas with Java8 Optionals instead of Guava Optionals.
 
     *    - |improved|
          - Added a significant amount of logging aimed at tracking down the ``MultipleRunningTimestampServicesError``.


### PR DESCRIPTION
The fix for #1144 is available in 0.24.0, not 0.23.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1226)
<!-- Reviewable:end -->
