### PR TITLE
close sweep stats kvs more quickly

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueService.java
@@ -17,12 +17,10 @@ package com.palantir.atlasdb.keyvalue.impl;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,7 +41,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -145,44 +142,8 @@ public class SweepStatsKeyValueService extends ForwardingKeyValueService {
 
     @Override
     public void close() {
-        terminateExecutor(new Runnable() {
-            @Override
-            public void run() {
-                delegate.close();
-            }
-        });
-    }
-
-    private void forceFlush() {
-        recordModifications(WRITE_THRESHOLD);
-        if (flushExecutor.isShutdown()) {
-            log.warn("Cannot flush stats while shutting down");
-        } else {
-            flushExecutor.execute(createFlushTask());
-        }
-    }
-
-    private void terminateExecutor(Runnable cleanupTask) {
-        forceFlush();
-        flushExecutor.shutdown();
-        try {
-            if (flushExecutor.awaitTermination(1, TimeUnit.MINUTES)) {
-                log.debug("Successfully terminated flush executor");
-            } else {
-                log.warn("Timed out while waiting for flush executor termination");
-                List<Runnable> pendingTasks = flushExecutor.shutdownNow();
-                log.info("Attempting to complete flushing {} pending tasks", pendingTasks.size());
-                Executor directExecutor = MoreExecutors.directExecutor();
-                for (Runnable pendingTask : pendingTasks) {
-                    directExecutor.execute(pendingTask);
-                }
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("Interrupted while terminating flush executor", e);
-        } finally {
-            cleanupTask.run();
-        }
+        flushExecutor.shutdownNow();
+        delegate.close();
     }
 
     // This way of recording the number of writes to tables is obviously not
@@ -218,7 +179,9 @@ public class SweepStatsKeyValueService extends ForwardingKeyValueService {
                         }
                     }
                 } catch (Throwable t) {
-                    log.error("Error occurred while flushing sweep stats: {}", t, t);
+                    if (!Thread.interrupted()) {
+                        log.error("Error occurred while flushing sweep stats: {}", t, t);
+                    }
                 }
             }
         };
@@ -262,6 +225,9 @@ public class SweepStatsKeyValueService extends ForwardingKeyValueService {
             commit(timestamp);
             delegate().put(SWEEP_PRIORITY_TABLE, newWriteCounts, timestamp);
         } catch (RuntimeException e) {
+            if (Thread.interrupted()) {
+                return;
+            }
             Set<TableReference> allTableNames = delegate().getAllTableNames();
             if (!allTableNames.contains(SWEEP_PRIORITY_TABLE)
                     || !allTableNames.contains(TransactionConstants.TRANSACTION_TABLE)) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,8 +41,10 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |improved|
+         - ``SweepStatsKeyValueService`` will no longer flush a final batch of statistics during shutdown. This avoids
+           potentially long pauses that could previously occur when closing a ``Cleaner``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1232>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Flushing sweep stats is not a high priority task. It's fine if a flush
task is lost during shutdown. Shutting down quickly is more important.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1232)
<!-- Reviewable:end -->
