### PR TITLE
Apply merge=union strategy for the release notes file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/docs/source/release_notes/release-notes.rst merge=union 


### PR DESCRIPTION
This should reduce the pain around merge conflicts because of the release-notes file.
[no release notes] (ironically)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1235)
<!-- Reviewable:end -->
