### PR TITLE
Store docs so we can view them in circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,6 +58,8 @@ test:
         parallel: true
     - mkdir -p $CIRCLE_ARTIFACTS/checkstyle $CIRCLE_ARTIFACTS/findbugs:
         parallel: true
+    - "if [ -d docs/build/html ]; then cp -r docs/build/html $CIRCLE_ARTIFACTS/docs; fi":
+        parallel: true
     - find . -type d -regex ".*/build/reports/checkstyle" | sed 's#\./\(\(.*\)/build/reports/checkstyle\)#rsync -uav \1/ $CIRCLE_ARTIFACTS/checkstyle/\2#' | bash:
         parallel: true
     - find . -type d -regex ".*/build/reports/findbugs" | sed 's#\./\(\(.*\)/build/reports/findbugs\)#rsync -uav \1/ $CIRCLE_ARTIFACTS/findbugs/\2#' | bash:


### PR DESCRIPTION
Surprise @rhero!

Go to a build and look for the `docs/index.html` on the artefacts tab (container 0 for docs only changes, container 6 otherwise)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1236)
<!-- Reviewable:end -->
