### PR TITLE
Don't set additionalEnv. if systemEnv. already has what we want

### DIFF
--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
@@ -44,10 +44,12 @@ public interface CassandraVersion {
 
     static Map<String, String> getEnvironment() {
         String version = System.getenv(CASSANDRA_VERSION);
-        if (Strings.isNullOrEmpty(version)) {
-            version = DEFAULT_VERSION;
+        if (!Strings.isNullOrEmpty(version)) {
+            // Don't want to pass back the environment, because it's already set (docker-compose-rule bug #131)
+            return ImmutableMap.of();
         }
-        return ImmutableMap.of(CASSANDRA_VERSION, version);
+
+        return ImmutableMap.of(CASSANDRA_VERSION, DEFAULT_VERSION);
     }
 
     Pattern replicationFactorRegex();


### PR DESCRIPTION
This works around issue #131 in docker-compose-rule, and should be
reverted once that merges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1237)
<!-- Reviewable:end -->
