### PR TITLE
add cross-transaction commit timestamp caching

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.transaction.impl;
+package com.palantir.atlasdb.cache;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -28,7 +28,7 @@ import com.palantir.common.base.Throwables;
 
 public abstract class AbstractTransactionManager implements TransactionManager {
     public static final Logger log = LoggerFactory.getLogger(AbstractTransactionManager.class);
-
+    protected final TimestampCache timestampCache = new TimestampCache();
     private volatile boolean closed = false;
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -28,7 +29,7 @@ import com.palantir.common.base.Throwables;
 
 public abstract class AbstractTransactionManager implements TransactionManager {
     public static final Logger log = LoggerFactory.getLogger(AbstractTransactionManager.class);
-    protected final TimestampCache timestampCache = new TimestampCache();
+    protected final TimestampCache timestampValidationReadCache = new TimestampCache();
     private volatile boolean closed = false;
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TimestampCache.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.transaction.impl;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+// This class just here for readability and not directly leaking / tying us down to a Guava class in our API
+public class TimestampCache {
+    final Cache<Long, Long> timestampCache;
+
+    public TimestampCache() {
+        timestampCache = CacheBuilder.newBuilder()
+                .maximumSize(1_000_000) // up to ~32MB with java Long object bloat
+                .build();
+    }
+
+    // returns null if not present
+    public Long getCommitTimestampIfPresent(Long startTimestamp) {
+        return timestampCache.getIfPresent(startTimestamp);
+    }
+
+    // Be very careful to only insert timestamps here that are already present in the backing store,
+    // effectively using the timestamp table as existing concurrency control for who wins a commit
+    public void putAlreadyCommittedTransaction(Long startTimestamp, Long commitTimestamp) {
+        timestampCache.put(startTimestamp, commitTimestamp);
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TimestampCache.java
@@ -18,23 +18,30 @@ package com.palantir.atlasdb.transaction.impl;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
-// This class just here for readability and not directly leaking / tying us down to a Guava class in our API
+/**
+ * This class just here for readability and not directly leaking / tying us down to a Guava class in our API
+ */
 public class TimestampCache {
     final Cache<Long, Long> timestampCache;
 
     public TimestampCache() {
         timestampCache = CacheBuilder.newBuilder()
-                .maximumSize(1_000_000) // up to ~32MB with java Long object bloat
+                .maximumSize(1_000_000) // up to ~72MB with java Long object bloat
                 .build();
     }
 
-    // returns null if not present
+    /**
+     * Returns null if not present
+     */
     public Long getCommitTimestampIfPresent(Long startTimestamp) {
         return timestampCache.getIfPresent(startTimestamp);
     }
 
-    // Be very careful to only insert timestamps here that are already present in the backing store,
-    // effectively using the timestamp table as existing concurrency control for who wins a commit
+
+    /**
+     * Be very careful to only insert timestamps here that are already present in the backing store,
+     * effectively using the timestamp table as existing concurrency control for who wins a commit
+     */
     public void putAlreadyCommittedTransaction(Long startTimestamp, Long commitTimestamp) {
         timestampCache.put(startTimestamp, commitTimestamp);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
@@ -87,7 +87,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 startTimestamp.get(),
                 constraintCheckingMode,
                 readSentinelBehavior,
-                allowHiddenTableAccess);
+                allowHiddenTableAccess,
+                timestampCache);
         return runTaskThrowOnConflict(task, new ReadTransaction(txn, txn.sweepStrategyManager));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
@@ -88,7 +88,7 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 constraintCheckingMode,
                 readSentinelBehavior,
                 allowHiddenTableAccess,
-                timestampCache);
+                timestampValidationReadCache);
         return runTaskThrowOnConflict(task, new ReadTransaction(txn, txn.sweepStrategyManager));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -46,6 +46,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.UnsignedBytes;
+import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.encoding.PtBytes;
@@ -719,7 +720,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                 transactionReadTimeoutMillis,
                 getReadSentinelBehavior(),
                 allowHiddenTableAccess,
-                timestampCache) {
+                timestampValidationReadCache) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -110,7 +110,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    AtlasDbConstraintCheckingMode constraintCheckingMode,
                                    Long transactionTimeoutMillis,
                                    TransactionReadSentinelBehavior readSentinelBehavior,
-                                   boolean allowHiddenTableAccess) {
+                                   boolean allowHiddenTableAccess,
+                                   TimestampCache timestampCache) {
         super(keyValueService,
               lockService,
               timestampService,
@@ -124,7 +125,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               constraintCheckingMode,
               transactionTimeoutMillis,
               readSentinelBehavior,
-              allowHiddenTableAccess);
+              allowHiddenTableAccess,
+              timestampCache);
     }
 
     @Override
@@ -716,7 +718,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 transactionReadTimeoutMillis,
                 getReadSentinelBehavior(),
-                allowHiddenTableAccess) {
+                allowHiddenTableAccess,
+                timestampCache) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -92,7 +92,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner.getTransactionReadTimeoutMillis(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 allowHiddenTableAccess,
-                timestampCache);
+                timestampValidationReadCache);
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -91,7 +91,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 constraintModeSupplier.get(),
                 cleaner.getTransactionReadTimeoutMillis(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                allowHiddenTableAccess);
+                allowHiddenTableAccess,
+                timestampCache);
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -30,14 +30,16 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                                long startTimeStamp,
                                AtlasDbConstraintCheckingMode constraintCheckingMode,
                                TransactionReadSentinelBehavior readSentinelBehavior,
-                               boolean allowHiddenTableAccess) {
+                               boolean allowHiddenTableAccess,
+                               TimestampCache timestampCache) {
         super(keyValueService,
               transactionService,
               null,
               startTimeStamp,
               constraintCheckingMode,
               readSentinelBehavior,
-              allowHiddenTableAccess);
+              allowHiddenTableAccess,
+              timestampCache);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
+import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -190,7 +190,7 @@ import com.palantir.timestamp.TimestampService;
                 cleaner.getTransactionReadTimeoutMillis(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 allowHiddenTableAccess,
-                timestampCache);
+                timestampValidationReadCache);
     }
 
     @Override
@@ -212,7 +212,7 @@ import com.palantir.timestamp.TimestampService;
                 cleaner.getTransactionReadTimeoutMillis(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 allowHiddenTableAccess,
-                timestampCache);
+                timestampValidationReadCache);
         return runTaskThrowOnConflict(task, new ReadTransaction(transaction, sweepStrategyManager));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -189,7 +189,8 @@ import com.palantir.timestamp.TimestampService;
                 constraintModeSupplier.get(),
                 cleaner.getTransactionReadTimeoutMillis(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                allowHiddenTableAccess);
+                allowHiddenTableAccess,
+                timestampCache);
     }
 
     @Override
@@ -210,7 +211,8 @@ import com.palantir.timestamp.TimestampService;
                 constraintModeSupplier.get(),
                 cleaner.getTransactionReadTimeoutMillis(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                allowHiddenTableAccess);
+                allowHiddenTableAccess,
+                timestampCache);
         return runTaskThrowOnConflict(task, new ReadTransaction(transaction, sweepStrategyManager));
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -97,7 +97,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 null,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                true) {
+                true,
+                timestampCache) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, new Function<byte[], byte[]>() {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -48,6 +48,7 @@ import com.google.common.collect.Ordering;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedBytes;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -81,6 +81,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
 public abstract class AbstractTransactionTest extends TransactionTestSetup {
 
+    protected final TimestampCache timestampCache = new TimestampCache();
     protected boolean supportsReverse() {
         return true;
     }
@@ -99,7 +100,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                         TransactionConstants.TRANSACTION_TABLE,
                         ConflictHandler.IGNORE_ALL),
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
-                TransactionReadSentinelBehavior.THROW_EXCEPTION);
+                TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                timestampCache);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -92,6 +92,6 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 conflictDetectionManager.get(),
                 constraintModeSupplier.get(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
-                timestampCache);
+                timestampValidationReadCache);
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -91,6 +91,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 timestampService.getFreshTimestamp(),
                 conflictDetectionManager.get(),
                 constraintModeSupplier.get(),
-                TransactionReadSentinelBehavior.THROW_EXCEPTION);
+                TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                timestampCache);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -98,6 +98,8 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockService;
 
 public class SnapshotTransactionTest extends AtlasDbTestCase {
+    protected final TimestampCache timestampCache = new TimestampCache();
+
     private class UnstableKeyValueService extends ForwardingKeyValueService {
         private final KeyValueService delegate;
         private final Random random;
@@ -271,7 +273,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 transactionTs,
                 ImmutableMap.of(TABLE, ConflictHandler.RETRY_ON_WRITE_WRITE),
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
-                TransactionReadSentinelBehavior.THROW_EXCEPTION);
+                TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                timestampCache);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
             fail();
@@ -325,7 +328,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 transactionTs,
                 ImmutableMap.of(TABLE, ConflictHandler.RETRY_ON_WRITE_WRITE),
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
-                TransactionReadSentinelBehavior.THROW_EXCEPTION);
+                TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                timestampCache);
         snapshot.put(TABLE, ImmutableMap.of(cell, PtBytes.EMPTY_BYTE_ARRAY));
         snapshot.commit();
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -57,6 +57,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.AtlasDbTestCase;
+import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
            that need to be created when a large number of transactions begin.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1294>`__)
 
+    *    - |improved|
+         - Transaction perf improvement; commit timestamp lookups are now cached across transactions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1238>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
overall goal is reducing extra work done and round trips.

It's a reasonably large cache, but I think it's fairly justified to be that large with how useful it should be for most mixed workloads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1238)
<!-- Reviewable:end -->
