### PR TITLE
Only ignore Primary Key constraint violation

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -38,6 +38,7 @@ public class AtlasDbConstants {
     public static final TableReference DEFAULT_ORACLE_METADATA_TABLE = TableReference.createWithEmptyNamespace("atlasdb_metadata");
 
     public static final String ORACLE_NAME_MAPPING_TABLE = "atlasdb_table_names";
+    public static final String NAME_MAPPING_PK_CONSTRAINT = "pk_" + ORACLE_NAME_MAPPING_TABLE;
     public static final String ORACLE_OVERFLOW_SEQUENCE = "overflow_seq";
 
     public static final String NAMESPACE_PREFIX = "_n_";

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -38,7 +38,7 @@ public class AtlasDbConstants {
     public static final TableReference DEFAULT_ORACLE_METADATA_TABLE = TableReference.createWithEmptyNamespace("atlasdb_metadata");
 
     public static final String ORACLE_NAME_MAPPING_TABLE = "atlasdb_table_names";
-    public static final String NAME_MAPPING_PK_CONSTRAINT = "pk_" + ORACLE_NAME_MAPPING_TABLE;
+    public static final String ORACLE_NAME_MAPPING_PK_CONSTRAINT = "pk_" + ORACLE_NAME_MAPPING_TABLE;
     public static final String ORACLE_OVERFLOW_SEQUENCE = "overflow_seq";
 
     public static final String NAMESPACE_PREFIX = "_n_";

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleErrorConstants.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleErrorConstants.java
@@ -22,5 +22,4 @@ public final class OracleErrorConstants {
 
     public static final String ORACLE_ALREADY_EXISTS_ERROR = "ORA-00955";
     public static final String ORACLE_NOT_EXISTS_ERROR = "ORA-00942";
-    public static final String ORACLE_UNIQUE_CONSTRAINT_ERROR =  "ORA-00001";
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -116,17 +116,21 @@ public final class OracleDdlTable implements DbDdlTable {
 
     private void putTableNameMapping(String fullTableName, String shortTableName) {
         if (config.useTableMapping()) {
-            try {
-                conns.get().insertOneUnregisteredQuery(
-                        "INSERT INTO " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
-                                + " (table_name, short_table_name) VALUES (?, ?)",
-                        fullTableName,
-                        shortTableName);
-            } catch (PalantirSqlException ex) {
-                if (ex.getMessage().contains(OracleErrorConstants.ORACLE_UNIQUE_CONSTRAINT_ERROR)) {
-                    dropTableInternal(fullTableName, shortTableName);
-                }
-                log.error(ex.getMessage(), ex);
+            insertTableMappingIgnoringPrimaryKeyViolation(fullTableName, shortTableName);
+        }
+    }
+
+    private void insertTableMappingIgnoringPrimaryKeyViolation(String fullTableName, String shortTableName) {
+        try {
+            conns.get().insertOneUnregisteredQuery(
+                    "INSERT INTO " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
+                            + " (table_name, short_table_name) VALUES (?, ?)",
+                    fullTableName,
+                    shortTableName);
+        } catch (PalantirSqlException ex) {
+            if (!ex.getMessage().toLowerCase().contains(AtlasDbConstants.NAME_MAPPING_PK_CONSTRAINT.toLowerCase())) {
+                log.error("Error occurred trying to create table mapping {} -> {}", fullTableName, shortTableName, ex);
+                dropTableInternal(fullTableName, shortTableName);
                 throw ex;
             }
         }
@@ -208,7 +212,7 @@ public final class OracleDdlTable implements DbDdlTable {
             conns.get().executeUnregisteredQuery(sql);
         } catch (PalantirSqlException e) {
             if (!e.getMessage().contains(errorToIgnore)) {
-                log.error(e.getMessage(), e);
+                log.error("Error occurred trying to execute the query {}.", sql, e);
                 throw e;
             }
         }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,12 +129,16 @@ public final class OracleDdlTable implements DbDdlTable {
                     fullTableName,
                     shortTableName);
         } catch (PalantirSqlException ex) {
-            if (!ex.getMessage().toLowerCase().contains(AtlasDbConstants.NAME_MAPPING_PK_CONSTRAINT.toLowerCase())) {
+            if (!isPrimaryKeyViolation(ex)) {
                 log.error("Error occurred trying to create table mapping {} -> {}", fullTableName, shortTableName, ex);
                 dropTableInternal(fullTableName, shortTableName);
                 throw ex;
             }
         }
+    }
+
+    private boolean isPrimaryKeyViolation(PalantirSqlException ex) {
+        return !StringUtils.containsIgnoreCase(ex.getMessage(), AtlasDbConstants.ORACLE_NAME_MAPPING_PK_CONSTRAINT);
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleTableInitializer.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleTableInitializer.java
@@ -60,7 +60,7 @@ public class OracleTableInitializer implements DbTableInitializer {
                                 + "CONSTRAINT unique_%s UNIQUE (short_table_name)"
                                 + ")",
                         AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE,
-                        AtlasDbConstants.NAME_MAPPING_PK_CONSTRAINT,
+                        AtlasDbConstants.ORACLE_NAME_MAPPING_PK_CONSTRAINT,
                         AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE),
                 OracleErrorConstants.ORACLE_ALREADY_EXISTS_ERROR);
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleTableInitializer.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleTableInitializer.java
@@ -56,11 +56,11 @@ public class OracleTableInitializer implements DbTableInitializer {
                         "CREATE TABLE %s ("
                                 + "table_name varchar(2000) NOT NULL,"
                                 + "short_table_name varchar(30) NOT NULL,"
-                                + "CONSTRAINT pk_%s PRIMARY KEY (table_name),"
+                                + "CONSTRAINT %s PRIMARY KEY (table_name),"
                                 + "CONSTRAINT unique_%s UNIQUE (short_table_name)"
                                 + ")",
                         AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE,
-                        AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE,
+                        AtlasDbConstants.NAME_MAPPING_PK_CONSTRAINT,
                         AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE),
                 OracleErrorConstants.ORACLE_ALREADY_EXISTS_ERROR);
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,6 +58,10 @@ develop
          - Certain Oracle KVS calls no longer attempt to leak connections created internally.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1215>`__)
 
+    *    - |fixed|
+         - Oracle will not drop a table that already exists on  ``createTable`` calls when multiple AtlasDB clients make the call to create the same table.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1243>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Fix bug in Ete tests. The table was being dropped on any unique key violation, which meant that if table already exists it gets deleted. Now, the table will be deleted only if the primary key constraint is voilated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1243)
<!-- Reviewable:end -->
