### PR TITLE
Update name in docs from AtlasDB to OSS AtlasDB

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'AtlasDB'
+project = u'OSS AtlasDB'
 copyright = u'2016, Palantir Technologies'
 author = u'Palantir Technologies'
 

--- a/scripts/circle-ci/pr-changelog-status-check.sh
+++ b/scripts/circle-ci/pr-changelog-status-check.sh
@@ -19,7 +19,7 @@ if [ $CHANGELOG_COMMIT_FLAG -eq 0 ]; then
     curl -X POST -f --silent --header "Authorization: token $GITHUB_AUTH_TOKEN" -d '{"state": "success", "description": "Bypassed with commit flag", "context": "changelog"}' "https://api.github.com/repos/palantir/atlasdb/statuses/$CURRENT_REF" >/dev/null
 elif [ $CHANGELOG_MODIFIED -eq 0 ]; then
     curl -X POST -f --silent --header "Authorization: token $GITHUB_AUTH_TOKEN" -d '{"state": "success", "description": "release_notes.rst updated.", "context": "changelog"}' "https://api.github.com/repos/palantir/atlasdb/statuses/$CURRENT_REF" >/dev/null
-elif ./scripts/circle-ci/check-only-docs-changes.sh; then
+elif ./check-only-docs-changes.sh; then
     curl -X POST -f --silent --header "Authorization: token $GITHUB_AUTH_TOKEN" -d '{"state": "success", "description": "Only docs updated!", "context": "changelog"}' "https://api.github.com/repos/palantir/atlasdb/statuses/$CURRENT_REF" >/dev/null
 else
     curl -X POST -f --silent --header "Authorization: token $GITHUB_AUTH_TOKEN" -d '{"state": "failure", "description": "No modifications found in release_notes.rst, bypass by adding [no release notes] to a commit in this PR", "context" : "changelog"}' "https://api.github.com/repos/palantir/atlasdb/statuses/$CURRENT_REF" >/dev/null


### PR DESCRIPTION
Only ramification seems to be a change in the title displayed in the top left corner of the docs.  This will help differentiate these docs from the legacy AtlasDB docs on the internal docs mirror.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1247)
<!-- Reviewable:end -->
