### PR TITLE
add call to get a completely new connection

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -44,7 +44,7 @@ class OracleTableNameUnmapper {
                 public String load(String fullTableName) throws Exception {
                     SqlConnection conn = null;
                     try {
-                        conn = conns.getFresh();
+                        conn = conns.getNewUnsharedConnection();
                         AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
                                 "SELECT short_table_name "
                                         + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionSupplier.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionSupplier.java
@@ -50,7 +50,7 @@ public class ConnectionSupplier implements SqlConnectionSupplier {
     }
 
     /**
-     * Responsibility of the consumer to close this connection when finished
+     * Responsibility of the consumer to close this connection when finished.
      */
     public SqlConnection getNewUnsharedConnection() {
         return delegate.get();

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionSupplier.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionSupplier.java
@@ -49,6 +49,13 @@ public class ConnectionSupplier implements SqlConnectionSupplier {
         return delegate.get();
     }
 
+    /**
+     * Responsibility of the consumer to close this connection when finished
+     */
+    public SqlConnection getNewUnsharedConnection() {
+        return delegate.get();
+    }
+
     @Override
     public synchronized void close() {
         if (sharedConnection != null) {

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
@@ -66,7 +66,7 @@ public class OracleTableNameUnmapperTest {
         SqlConnection sqlConnection = mock(SqlConnection.class);
         Connection connection = mock(Connection.class);
         when(sqlConnection.getUnderlyingConnection()).thenReturn(connection);
-        when(connectionSupplier.getFresh()).thenReturn(sqlConnection);
+        when(connectionSupplier.getNewUnsharedConnection()).thenReturn(sqlConnection);
 
         resultSet = mock(AgnosticResultSet.class);
         when(sqlConnection

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -66,6 +66,10 @@ develop
          - Our jackson version has been updated from 2.5.1 to 2.6.7 and dropwizard version from 0.8.2 to 0.9.3.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1209>`__)
 
+    *    - |new|
+         - ConnectionSupplier consumers can now choose to receive a brand new unshared connection.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1258>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
ConnectionSupplier#getFresh is actually ConnectionSupplier#closeExistingConnectionAndReplaceItWithFreshOne , which wasn't what I wanted here.

fixes #1257

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1258)
<!-- Reviewable:end -->
