### PR TITLE
clarify timestampservice contract

### DIFF
--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.MediaType;
 public interface TimestampService {
     /**
      * This will get a fresh timestamp that is guaranteed to be newer than any other timestamp
-     * handed out before this method was called.
+     * requested before this method was called.
      */
     @POST // This has to be POST because we can't allow caching.
     @Path("fresh-timestamp")

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -24,8 +24,8 @@ import javax.ws.rs.core.MediaType;
 @Path("/timestamp")
 public interface TimestampService {
     /**
-     * This will get a fresh timestamp that is guaranteed to be newer than any other timestamp
-     * requested before this method was called.
+     * A request to this method should return a result greater than any timestamp
+     * that may have been observed before the request was initiated.
      */
     @POST // This has to be POST because we can't allow caching.
     @Path("fresh-timestamp")

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.MediaType;
 @Path("/timestamp")
 public interface TimestampService {
     /**
-     * A request to this method should return a result greater than any timestamp
+     * A request to this method should return a timestamp greater than any timestamp
      * that may have been observed before the request was initiated.
      */
     @POST // This has to be POST because we can't allow caching.


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
CC @carrino @jeremyk-91 

Was talking with Carrino the other day when I had a concern about correctness of our impl and he clarified a misunderstanding I had in the guarantees we require from TimestampService in Atlas.

Specifically a call to /fresh-timestamp needs to return a strictly greater timestamp than any other timestamp returned by an *earlier request*. Thus the following set of steps are actually okay:
- Node A is the Leader
- Node A receives request for timestamp
- Node A enters bad GC cycle / jvm goes to sleep
- Node B becomes the Leader
- Node B receives request for timestamp
- Node B hands out timestamp X+1 and its client receives it
- Node A becomes functional again
- Node A hands out timestamp X and its client receives it

I'm open to wording the javadoc differently, I just wanted to make it clear somewhere that this is the level of guarantee we're providing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1260)
<!-- Reviewable:end -->
