### PR TITLE
Make TimestampChecker more Jepsen-friendly

### DIFF
--- a/atlasdb-jepsen-tests/src/integTest/java/com/palantir/atlasdb/jepsen/TimestampCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/integTest/java/com/palantir/atlasdb/jepsen/TimestampCheckerTest.java
@@ -69,11 +69,11 @@ public class TimestampCheckerTest {
 
     @Test
     public void historyOfDecreasingTimestampsShouldReturnInvalidWithErrors() {
-        Map<Keyword, ?> read1 = ImmutableMap.of(Keyword.intern("type"), "ok",
+        Map<Keyword, ?> read1 = ImmutableMap.of(Keyword.intern("type"), Keyword.intern("ok"),
                 Keyword.intern("process"), SOME_PROCESS,
                 Keyword.intern("time"), TIME_0,
                 Keyword.intern("value"), 1L);
-        Map<Keyword, ?> read2 = ImmutableMap.of(Keyword.intern("type"), "ok",
+        Map<Keyword, ?> read2 = ImmutableMap.of(Keyword.intern("type"), Keyword.intern("ok"),
                 Keyword.intern("process"), SOME_PROCESS,
                 Keyword.intern("time"), TIME_1,
                 Keyword.intern("value"), 0L);

--- a/atlasdb-jepsen-tests/src/integTest/java/com/palantir/atlasdb/jepsen/TimestampCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/integTest/java/com/palantir/atlasdb/jepsen/TimestampCheckerTest.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
-import com.palantir.atlasdb.jepsen.events.Event;
 
 import clojure.lang.Keyword;
 import one.util.streamex.EntryStream;
@@ -47,7 +46,7 @@ public class TimestampCheckerTest {
 
         Map<Keyword, Object> results = TimestampChecker.checkClojureHistory(convertedAllEvents);
 
-        assertThat(results).containsEntry(Keyword.intern("valid"), true);
+        assertThat(results).containsEntry(Keyword.intern("valid?"), true);
         assertThat(results).containsEntry(Keyword.intern("errors"), ImmutableList.of());
     }
 
@@ -64,7 +63,7 @@ public class TimestampCheckerTest {
 
         Map<Keyword, Object> results = TimestampChecker.checkClojureHistory(history);
 
-        assertThat(results).containsEntry(Keyword.intern("valid"), true);
+        assertThat(results).containsEntry(Keyword.intern("valid?"), true);
         assertThat(results).containsEntry(Keyword.intern("errors"), ImmutableList.of());
     }
 
@@ -82,8 +81,8 @@ public class TimestampCheckerTest {
 
         Map<Keyword, Object> results = TimestampChecker.checkClojureHistory(history);
 
-        List<Event> expectedErrors = ImmutableList.of(Event.fromKeywordMap(read1), Event.fromKeywordMap(read2));
-        assertThat(results).containsEntry(Keyword.intern("valid"), false);
+        List<Map<Keyword, ?>> expectedErrors = ImmutableList.of(read1, read2);
+        assertThat(results).containsEntry(Keyword.intern("valid?"), false);
         assertThat(results).containsEntry(Keyword.intern("errors"), expectedErrors);
     }
 

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampChecker.java
@@ -44,7 +44,6 @@ public final class TimestampChecker {
     public static Map<Keyword, Object> checkClojureHistory(List<Map<Keyword, ?>> clojureHistory) {
         List<Event> events = convertClojureHistoryToEventList(clojureHistory);
         return checkHistory(events);
-
     }
 
     private static List<Event> convertClojureHistoryToEventList(List<Map<Keyword, ?>> clojureHistory) {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampChecker.java
@@ -53,12 +53,6 @@ public final class TimestampChecker {
                 .collect(Collectors.toList());
     }
 
-    private static List<Map<Keyword, Object>> convertEventListToClojureHistory(List<Event> events) {
-        return events.stream()
-                .map(Event::toKeywordMap)
-                .collect(Collectors.toList());
-    }
-
     private static Map<Keyword, Object> checkHistory(List<Event> events) {
         MonotonicChecker monotonicChecker = new MonotonicChecker();
         events.forEach(event -> event.accept(monotonicChecker));
@@ -69,6 +63,12 @@ public final class TimestampChecker {
         List<Map<Keyword, Object>> errorsAsClojureHistory = convertEventListToClojureHistory(monotonicChecker.errors());
         return ImmutableMap.of(Keyword.intern("valid?"), monotonicChecker.valid(),
                 Keyword.intern("errors"), errorsAsClojureHistory);
+    }
+
+    private static List<Map<Keyword, Object>> convertEventListToClojureHistory(List<Event> events) {
+        return events.stream()
+                .map(Event::toKeywordMap)
+                .collect(Collectors.toList());
     }
 
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampChecker.java
@@ -60,7 +60,8 @@ public final class TimestampChecker {
 
     private static Map<Keyword, Object> createMapFromCompletedChecker(MonotonicChecker monotonicChecker) {
         List<Map<Keyword, Object>> errorsAsClojureHistory = convertEventListToClojureHistory(monotonicChecker.errors());
-        return ImmutableMap.of(Keyword.intern("valid?"), monotonicChecker.valid(),
+        return ImmutableMap.of(
+                Keyword.intern("valid?"), monotonicChecker.valid(),
                 Keyword.intern("errors"), errorsAsClojureHistory);
     }
 

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampChecker.java
@@ -37,7 +37,7 @@ public final class TimestampChecker {
      *     [{":type": "invoke", "process": 0, "time", 0L},
      *      {":type": "ok",     "process": 0, "time": 0L, "value", 10L}]
      * @return A map of
-     *     :valid      A boolean of whether the check passes
+     *     :valid?     A boolean of whether the check passes
      *     :errors     A list of events that failed the check, or an empty list if the check passed
      * @throws Exception if the parsing of the history fails.
      */
@@ -53,6 +53,12 @@ public final class TimestampChecker {
                 .collect(Collectors.toList());
     }
 
+    private static List<Map<Keyword, Object>> convertEventListToClojureHistory(List<Event> events) {
+        return events.stream()
+                .map(Event::toKeywordMap)
+                .collect(Collectors.toList());
+    }
+
     private static Map<Keyword, Object> checkHistory(List<Event> events) {
         MonotonicChecker monotonicChecker = new MonotonicChecker();
         events.forEach(event -> event.accept(monotonicChecker));
@@ -60,8 +66,9 @@ public final class TimestampChecker {
     }
 
     private static Map<Keyword, Object> createMapFromCompletedChecker(MonotonicChecker monotonicChecker) {
-        return ImmutableMap.of(Keyword.intern("valid"), monotonicChecker.valid(),
-                Keyword.intern("errors"), monotonicChecker.errors());
+        List<Map<Keyword, Object>> errorsAsClojureHistory = convertEventListToClojureHistory(monotonicChecker.errors());
+        return ImmutableMap.of(Keyword.intern("valid?"), monotonicChecker.valid(),
+                Keyword.intern("errors"), errorsAsClojureHistory);
     }
 
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
@@ -41,5 +41,14 @@ public interface Event {
         return new ObjectMapper().convertValue(convertedMap, Event.class);
     }
 
+    static Map<Keyword, Object> toKeywordMap(Event event) {
+        Map<String, Object> stringToObject = new ObjectMapper().convertValue(event, Map.class);
+        Map<Keyword, Object> convertedMap = new HashMap<>();
+        EntryStream.of(stringToObject)
+                .mapKeys(Keyword::intern)
+                .forKeyValue(convertedMap::put);
+        return convertedMap;
+    }
+
     void accept(EventVisitor visitor);
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
@@ -43,11 +43,7 @@ public interface Event {
 
     static Map<Keyword, Object> toKeywordMap(Event event) {
         Map<String, Object> stringToObject = new ObjectMapper().convertValue(event, Map.class);
-        Map<Keyword, Object> convertedMap = new HashMap<>();
-        EntryStream.of(stringToObject)
-                .mapKeys(Keyword::intern)
-                .forKeyValue(convertedMap::put);
-        return convertedMap;
+        EntryStream.of(stringToObject).mapKeys(Keyword::intern).toMap();
     }
 
     void accept(EventVisitor visitor);

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
@@ -45,9 +45,11 @@ public interface Event {
     }
 
     static Map<Keyword, Object> toKeywordMap(Event event) {
-        TypeReference typeRef = new TypeReference<Map<String, Object>>(){};
-        Map<String, Object> mapKeyedByStrings = OBJECT_MAPPER.convertValue(event, typeRef);
-        return EntryStream.of(mapKeyedByStrings).mapKeys(Keyword::intern).toMap();
+        Map<String, Object> rawStringMap = OBJECT_MAPPER.convertValue(event, new TypeReference<Map<String, ?>>() {});
+        return EntryStream.of(rawStringMap)
+                .mapKeys(Keyword::intern)
+                .mapValues(value -> value != null && value instanceof String ? Keyword.intern((String) value) : value)
+                .toMap();
     }
 
     void accept(EventVisitor visitor);


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

Fix the keyword "valid": it should be "valid?".
Convert the Events objects to Maps before they get to Jepsen:
unfortunately, Jepsen isn't happy serialising Events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1270)
<!-- Reviewable:end -->
