### PR TITLE
bump okhttpclient connection pool size to 100

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -17,12 +17,14 @@ package com.palantir.atlasdb.http;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import com.squareup.okhttp.ConnectionPool;
 
 import feign.Client;
 import feign.Contract;
@@ -100,6 +102,7 @@ public final class AtlasDbHttpClients {
      */
     private static Client newOkHttpClient(Optional<SSLSocketFactory> sslSocketFactory) {
         com.squareup.okhttp.OkHttpClient client = new com.squareup.okhttp.OkHttpClient();
+        client.setConnectionPool(new ConnectionPool(100, TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES)));
         client.setSslSocketFactory(sslSocketFactory.orNull());
         return new OkHttpClient(client);
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -81,6 +81,11 @@ v0.25.0
          - Our Jackson version has been updated from 2.5.1 to 2.6.7 and Dropwizard version from 0.8.2 to 0.9.3.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1209>`__)
 
+    *    - |improved|
+         - OkHttpClient connection pool configured to have 100 idle connections with 10 minute keep-alive, reducing the number of connections
+           that need to be created when a large number of transactions begin.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1273>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Started to make this configurable but looks like that would require adding to both atlas and leader configs which would be a little messy. This matches the values used in https://github.com/palantir/http-remoting/pull/303/files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1273)
<!-- Reviewable:end -->
