### PR TITLE
Fix/dont scare users with humungous thread dumps

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -63,7 +63,7 @@ public class ServiceDiscoveringAtlasSupplier {
         return keyValueService.get();
     }
 
-    public TimestampService getTimestampService() {
+    public synchronized TimestampService getTimestampService() {
         DebugLogger.logger.info("Fetching timestamp service from thread {}. This should only happen once.",
                 Thread.currentThread().getName());
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -96,9 +96,8 @@ public class ServiceDiscoveringAtlasSupplier {
             writeStringToStream(outputStream,
                     "This file contains thread dumps that will be useful for the AtlasDB Dev team, in case you hit a "
                             + "MultipleRunningTimestampServices error. In this case, please send this file to them.\n");
-            writeStringToStream(outputStream, "First thread dump: " + timestampServiceCreationInfo);
-            writeStringToStream(outputStream, "Second thread dump: " + ThreadDumps.programmaticThreadDump());
-            outputStream.close();
+            writeStringToStream(outputStream, "First thread dump: " + timestampServiceCreationInfo + "\n");
+            writeStringToStream(outputStream, "Second thread dump: " + ThreadDumps.programmaticThreadDump() + "\n");
             return file.getPath();
         }
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,10 +48,10 @@ v0.25.0
          - Change
 
     *    - |fixed|
-         - Worrying-looking thread dumps no longer appear in logs when we suspect that the 
-           ``MultipleRunningTimestampServicesError`` may have been hit. Instead, we output them to a temporary file, 
+         - Worrying-looking thread dumps no longer appear in logs when we suspect that the
+           ``MultipleRunningTimestampServicesError`` may have been hit. Instead, we output them to a temporary file,
            logging only its path to the user.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1274>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1275>`__)
 
     *    - |fixed|
          - ``--config-root`` and other global parameters can now be passed into dropwizard CLIs.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,12 @@ v0.25.0
          - Change
 
     *    - |fixed|
+         - Worrying-looking thread dumps no longer appear in logs when we suspect that the 
+           ``MultipleRunningTimestampServicesError`` may have been hit. Instead, we output them to a temporary file, 
+           logging only its path to the user.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1274>`__)
+
+    *    - |fixed|
          - ``--config-root`` and other global parameters can now be passed into dropwizard CLIs.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1268>`__)
 


### PR DESCRIPTION
**Save timestamp-related thread dumps to temp files**
Output to unique [temporary files](https://github.com/palantir/atlasdb/files/611207/atlas-timestamps-log553351070509726618.txt). These were 13-25KB for our unit tests, probably larger (but not super large) for an actual application.

Potential improvement: hard-code the file name and replace if the file already exists.

**Synchronise getTimestampService**
Avoid a possible race condition that would prevent us from detecting a failure scenario (when two timestamp services are fetched at once, we previously might not have noticed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1275)
<!-- Reviewable:end -->
