### PR TITLE
Revert/1237

### DIFF
--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
@@ -44,12 +44,10 @@ public interface CassandraVersion {
 
     static Map<String, String> getEnvironment() {
         String version = System.getenv(CASSANDRA_VERSION);
-        if (!Strings.isNullOrEmpty(version)) {
-            // Don't want to pass back the environment, because it's already set (docker-compose-rule bug #131)
-            return ImmutableMap.of();
+        if (Strings.isNullOrEmpty(version)) {
+            version = DEFAULT_VERSION;
         }
-
-        return ImmutableMap.of(CASSANDRA_VERSION, DEFAULT_VERSION);
+        return ImmutableMap.of(CASSANDRA_VERSION, version);
     }
 
     Pattern replicationFactorRegex();

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -11,7 +11,7 @@ ext.libVersions =
     mockito: '1.10.17',
     assertj: '3.5.2',
     dropwizard:   '0.8.2',
-    dockerComposeRule: '0.26.0',
+    dockerComposeRule: '0.27.1',
     commons_codec: '1.10',
     commons_lang: '2.6',
     commons_lang3: '3.1',


### PR DESCRIPTION
The docker-compose-rule bug fix got [merged](https://github.com/palantir/docker-compose-rule/pull/132) and [released](https://github.com/palantir/docker-compose-rule/releases/tag/0.27.1), so we can revert our workaround (#1237).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1290)
<!-- Reviewable:end -->
