### PR TITLE
Retry Atomix operations instead of Futures.getUnchecked()

### DIFF
--- a/atlasdb-timelock-server/build.gradle
+++ b/atlasdb-timelock-server/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     compile project(":timestamp-api")
     compile project(":lock-impl")
 
+    compile group: 'com.github.rholder', name: 'guava-retrying'
     compile group: 'com.palantir.remoting1', name: 'jersey-servers'
     compile group: 'com.palantir.remoting1', name: 'ssl-config'
     compile group: 'io.atomix', name: 'atomix'

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
@@ -23,7 +23,8 @@ import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
-import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.Futures;
 
 import io.atomix.copycat.session.ClosedSessionException;
 
@@ -42,11 +43,11 @@ public final class AtomixRetryer {
     @SuppressWarnings("unchecked") // We only want to create 1 retryer; this is safe given the type of supplier.
     public static <T> T getWithRetry(Supplier<CompletableFuture<T>> supplier) {
         try {
-            return (T) RETRYER.call(() -> supplier.get().join());
+            return (T) RETRYER.call(() -> Futures.getUnchecked(supplier.get()));
         } catch (RetryException e) {
-            throw new UncheckedExecutionException(e);
+            throw Throwables.propagate(e);
         } catch (ExecutionException e) {
-            throw new UncheckedExecutionException(e.getCause());
+            throw Throwables.propagate(e.getCause());
         }
     }
 }

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.timelock.atomix;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.google.common.base.Throwables;
+
+import io.atomix.copycat.session.ClosedSessionException;
+
+public class AtomixRetryer {
+    public static final int RETRY_ATTEMPTS = 3;
+
+    private static final Retryer<Object> RETRYER = RetryerBuilder.newBuilder()
+            .retryIfExceptionOfType(ClosedSessionException.class)
+            .withStopStrategy(StopStrategies.stopAfterAttempt(RETRY_ATTEMPTS))
+            .build();
+
+    private AtomixRetryer() {
+        // utility
+    }
+
+    @SuppressWarnings("unchecked") // We only want to create 1 retryer; this is safe given the type of supplier.
+    public static <T> T getWithRetry(Supplier<CompletableFuture<T>> supplier) {
+        try {
+            return (T) RETRYER.call(() -> supplier.get().join());
+        } catch (ExecutionException | RetryException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
@@ -35,10 +35,9 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.atomix.copycat.session.ClosedSessionException;
 
 public final class AtomixRetryer {
-    public static final int RETRY_ATTEMPTS = 3;
-
     private static final Logger log = LoggerFactory.getLogger(AtomixRetryer.class);
 
+    public static final int RETRY_ATTEMPTS = 3;
     private static final Retryer<Object> RETRYER = RetryerBuilder.newBuilder()
             .retryIfException(AtomixRetryer::canBeRetried)
             .withRetryListener(new RetryListener() {

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
@@ -45,8 +45,7 @@ public final class AtomixRetryer {
                 @Override
                 public <V> void onRetry(Attempt<V> attempt) {
                     if (attempt.hasException() && canBeRetried(attempt.getExceptionCause())) {
-                        log.warn("Encountered a retriable exception [{}] in an Atomix operation (attempt {}/{}). "
-                                        + "Retrying",
+                        log.warn("Encountered a retriable exception [{}] in an Atomix operation (attempt {}/{}). ",
                                 attempt.getExceptionCause(),
                                 attempt.getAttemptNumber(),
                                 RETRY_ATTEMPTS);

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryer.java
@@ -25,6 +25,7 @@ import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import io.atomix.copycat.session.ClosedSessionException;
 
@@ -32,7 +33,8 @@ public final class AtomixRetryer {
     public static final int RETRY_ATTEMPTS = 3;
 
     private static final Retryer<Object> RETRYER = RetryerBuilder.newBuilder()
-            .retryIfExceptionOfType(ClosedSessionException.class)
+            .retryIfException(e -> e instanceof UncheckedExecutionException
+                    && e.getCause() instanceof ClosedSessionException)
             .withStopStrategy(StopStrategies.stopAfterAttempt(RETRY_ATTEMPTS))
             .build();
 

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixTimestampService.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixTimestampService.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.timelock.atomix;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.Futures;
 import com.palantir.timestamp.TimestampRange;
 import com.palantir.timestamp.TimestampService;
 
@@ -48,7 +47,7 @@ public class AtomixTimestampService implements TimestampService {
         Preconditions.checkArgument(numTimestampsRequested <= MAX_GRANT_SIZE,
                 "Must request at most %s timestamps, requested: %s", MAX_GRANT_SIZE, numTimestampsRequested);
 
-        long lastTimestampHandedOut = Futures.getUnchecked(timestamp.getAndAdd(numTimestampsRequested));
+        long lastTimestampHandedOut = AtomixRetryer.getWithRetry(() -> timestamp.getAndAdd(numTimestampsRequested));
 
         return TimestampRange.createInclusiveRange(
                 lastTimestampHandedOut + 1,

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/DistributedValues.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/DistributedValues.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.timelock.atomix;
 
-import com.google.common.util.concurrent.Futures;
-
 import io.atomix.Atomix;
 import io.atomix.group.DistributedGroup;
 import io.atomix.variables.DistributedLong;
@@ -28,14 +26,14 @@ public final class DistributedValues {
     }
 
     public static DistributedValue<LeaderAndTerm> getLeaderInfo(Atomix atomix) {
-        return Futures.getUnchecked(atomix.<LeaderAndTerm>getValue("atlasdb/leader"));
+        return AtomixRetryer.getWithRetry(() -> atomix.<LeaderAndTerm>getValue("atlasdb/leader"));
     }
 
     public static DistributedLong getTimestampForClient(Atomix atomix, String client) {
-        return Futures.getUnchecked(atomix.getLong("atlasdb/timestamp/" + client));
+        return AtomixRetryer.getWithRetry(() -> atomix.getLong("atlasdb/timestamp/" + client));
     }
 
     public static DistributedGroup getTimeLockGroup(Atomix atomix) {
-        return Futures.getUnchecked(atomix.getGroup("atlasdb/timelock"));
+        return AtomixRetryer.getWithRetry(() -> atomix.getGroup("atlasdb/timelock"));
     }
 }

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryerTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryerTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.timelock.atomix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.rholder.retry.RetryException;
+
+import io.atomix.Atomix;
+import io.atomix.copycat.session.ClosedSessionException;
+import io.atomix.variables.DistributedLong;
+
+public class AtomixRetryerTest {
+    private static final String LONG_KEY = "long";
+
+    private Atomix atomix;
+
+    @Before
+    public void setUp() {
+        atomix = mock(Atomix.class);
+    }
+
+    @Test
+    public void retriesOperationsWithClosedSessionException() {
+        when(atomix.getLong(LONG_KEY)).thenThrow(new ClosedSessionException());
+        try {
+            AtomixRetryer.getWithRetry(() -> atomix.getLong(LONG_KEY));
+            fail();
+        } catch (RuntimeException e) {
+            if (!(e.getCause() instanceof RetryException)) {
+                fail();
+            }
+            // RuntimeException with a RetryException as the cause
+        }
+        verify(atomix, times(AtomixRetryer.RETRY_ATTEMPTS)).getLong(eq(LONG_KEY));
+    }
+
+    @Test
+    public void doesNotRetrySuccessfulOperations() {
+        CompletableFuture<DistributedLong> happyFuture = new CompletableFuture<>();
+        happyFuture.complete(null);
+        when(atomix.getLong(LONG_KEY)).thenReturn(happyFuture);
+
+        DistributedLong distributedLong = AtomixRetryer.getWithRetry(() -> atomix.getLong(LONG_KEY));
+
+        assertThat(distributedLong).isNull();
+        verify(atomix, times(1)).getLong(eq(LONG_KEY));
+    }
+
+    @Test
+    public void rethrowsOtherExceptions() {
+        when(atomix.getLong(LONG_KEY)).thenThrow(new IllegalArgumentException());
+        try {
+            AtomixRetryer.getWithRetry(() -> atomix.getLong(LONG_KEY));
+            fail();
+        } catch (RuntimeException e) {
+            if (!(e.getCause() instanceof ExecutionException)) {
+                fail();
+            }
+            // RuntimeException with an ExecutionException as the cause
+        }
+        verify(atomix, times(1)).getLong(eq(LONG_KEY));
+    }
+}

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryerTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryerTest.java
@@ -83,4 +83,16 @@ public class AtomixRetryerTest {
         }
         verify(atomix, times(1)).getLong(eq(LONG_KEY));
     }
+
+    @Test
+    public void rethrowsOnErrorWhenGettingFuture() {
+        when(atomix.getLong(LONG_KEY)).thenThrow(new OutOfMemoryError("oom"));
+        try {
+            AtomixRetryer.getWithRetry(() -> atomix.getLong(LONG_KEY));
+            fail();
+        } catch (OutOfMemoryError e) {
+            assertThat(e).hasMessageContaining("oom");
+        }
+        verify(atomix, times(1)).getLong(eq(LONG_KEY));
+    }
 }

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryerTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryerTest.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.github.rholder.retry.RetryException;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import io.atomix.Atomix;
 import io.atomix.copycat.session.ClosedSessionException;
@@ -51,7 +50,7 @@ public class AtomixRetryerTest {
         try {
             AtomixRetryer.getWithRetry(() -> atomix.getLong(LONG_KEY));
             fail();
-        } catch (UncheckedExecutionException e) {
+        } catch (RuntimeException e) {
             assertThat(e.getCause()).isInstanceOf(RetryException.class);
         }
         verify(atomix, times(AtomixRetryer.RETRY_ATTEMPTS)).getLong(eq(LONG_KEY));
@@ -76,9 +75,8 @@ public class AtomixRetryerTest {
         try {
             AtomixRetryer.getWithRetry(() -> atomix.getLong(LONG_KEY));
             fail();
-        } catch (UncheckedExecutionException e) {
-            assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("foo");
+        } catch (IllegalArgumentException e) {
+            assertThat(e).hasMessageContaining("foo");
         }
         verify(atomix, times(1)).getLong(eq(LONG_KEY));
     }

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryerTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/AtomixRetryerTest.java
@@ -78,7 +78,8 @@ public class AtomixRetryerTest {
             AtomixRetryer.getWithRetry(() -> atomix.getLong(LONG_KEY));
             fail();
         } catch (UncheckedExecutionException e) {
-            assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class)
+            assertThat(e.getCause())
+                    .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("foo");
         }
         verify(atomix, times(1)).getLong(eq(LONG_KEY));

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/InvalidatingLeaderProxyTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/InvalidatingLeaderProxyTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.nio.channels.ByteChannel;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.ServiceUnavailableException;
@@ -97,8 +96,7 @@ public class InvalidatingLeaderProxyTest {
 
     @Test
     public void shouldThrowTheUncheckedExecutionExceptionWhenNotIoException() {
-        Exception expectedInnerException =
-                new CompletionException(new Exception("the inner exception"));
+        Exception expectedInnerException = new Exception("the inner exception");
         when(LEADER_INFO.get()).thenReturn(Futures.exceptionalFuture(expectedInnerException));
 
         assertThatThrownBy(atomicString::get)

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/InvalidatingLeaderProxyTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/atomix/InvalidatingLeaderProxyTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.nio.channels.ByteChannel;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.ServiceUnavailableException;
@@ -96,7 +97,8 @@ public class InvalidatingLeaderProxyTest {
 
     @Test
     public void shouldThrowTheUncheckedExecutionExceptionWhenNotIoException() {
-        Exception expectedInnerException = new Exception("the inner exception");
+        Exception expectedInnerException =
+                new CompletionException(new Exception("the inner exception"));
         when(LEADER_INFO.get()).thenReturn(Futures.exceptionalFuture(expectedInnerException));
 
         assertThatThrownBy(atomicString::get)

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,7 @@
 ch.qos.logback:* = 1.1.3
 com.codahale.metrics:metrics-core = 3.0.2
 com.fasterxml.jackson.*:* = 2.6.7
+com.github.rholder:guava-retrying = 2.0.0
 com.github.tomakehurst:wiremock = 1.57
 com.google.code.findbugs:annotations = 2.0.3
 com.google.code.findbugs:jsr305 = 1.3.9


### PR DESCRIPTION
We used Futures.getUnchecked() for reading a lot of the values in Timelock Server. However, there are legitimate cases where the get operations can fail and we can reasonably recover from them (see #1280). 

This change introduces a retryer that retries said operations up to 3 times before failing out, and changes the Timelock Server to retry things in the event of a `ClosedSessionException` instead of crashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1291)
<!-- Reviewable:end -->
