### PR TITLE
Devex/cassandra 3.7 tests premerge

### DIFF
--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -13,9 +13,9 @@ CONTAINER_1=(':atlasdb-cassandra-integration-tests:check')
 
 CONTAINER_2=(':atlasdb-ete-tests:check' ':atlasdb-cassandra-multinode-tests:check')
 
-CONTAINER_3=(':lock-impl:check' ':atlasdb-dbkvs-tests:check' ':atlasdb-tests-shared:check' ':atlasdb-ete-test-utils:check' ':atlasdb-cassandra:check' ':atlasdb-api:check' ':atlasdb-jepsen-tests:check' ':atlasdb-ete-tests:check')
+CONTAINER_3=(':atlasdb-dbkvs-tests:check' ':atlasdb-tests-shared:check' ':atlasdb-ete-test-utils:check' ':atlasdb-cassandra:check' ':atlasdb-api:check' ':atlasdb-jepsen-tests:check' ':atlasdb-ete-tests:check')
 
-CONTAINER_4=(':atlasdb-dbkvs:check' ':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check' ':atlasdb-dropwizard-bundle:check')
+CONTAINER_4=(':lock-impl:check' ':atlasdb-dbkvs:check' ':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check' ':atlasdb-dropwizard-bundle:check')
 
 #CONTAINER_5=(':atlasdb-ete-tests:longTest')
 CONTAINER_5=(':atlasdb-cassandra-integration-tests:check')

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -11,13 +11,14 @@ function checkDocsBuild {
 
 CONTAINER_1=(':atlasdb-cassandra-integration-tests:check')
 
-CONTAINER_2=(':atlasdb-ete-tests:check')
+CONTAINER_2=(':atlasdb-ete-tests:check' ':atlasdb-cassandra-multinode-tests:check')
 
-CONTAINER_3=(':lock-impl:check' ':atlasdb-dbkvs-tests:check' ':atlasdb-tests-shared:check' ':atlasdb-ete-test-utils:check' ':atlasdb-cassandra:check' ':atlasdb-api:check' ':atlasdb-jepsen-tests:check')
+CONTAINER_3=(':lock-impl:check' ':atlasdb-dbkvs-tests:check' ':atlasdb-tests-shared:check' ':atlasdb-ete-test-utils:check' ':atlasdb-cassandra:check' ':atlasdb-api:check' ':atlasdb-jepsen-tests:check' ':atlasdb-ete-tests:check')
 
 CONTAINER_4=(':atlasdb-dbkvs:check' ':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check' ':atlasdb-dropwizard-bundle:check')
 
-CONTAINER_5=(':atlasdb-ete-tests:longTest')
+#CONTAINER_5=(':atlasdb-ete-tests:longTest')
+CONTAINER_5=(':atlasdb-cassandra-integration-tests:check')
 
 # Container 0 - runs tasks not found in the below containers
 CONTAINER_0_EXCLUDE=("${CONTAINER_1[@]}" "${CONTAINER_2[@]}" "${CONTAINER_3[@]}" "${CONTAINER_4[@]}" "${CONTAINER_5[@]}")
@@ -39,10 +40,9 @@ fi
 case $CIRCLE_NODE_INDEX in
     0) ./gradlew $TEST_CONTAINER_ARGS check $CONTAINER_0_EXCLUDE_ARGS ;;
     1) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_1[@]} ;;
-    2) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_2[@]} -x :atlasdb-ete-tests:longTest ;;
-    3) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_3[@]} -x :atlasdb-jepsen-tests:jepsenTest ;;
-    4) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_4[@]} ;;
-    5) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_5[@]} ;;
-    6) CASSANDRA_VERSION=3.7 ./gradlew --profile --continue atlasdb-cassandra-integration-tests:test atlasdb-cassandra-multinode-tests:test atlasdb-ete-tests:test ;;
-    7) ./gradlew --profile --continue -x compileJava -x compileTestJava findbugsMain findbugsTest checkstyleMain checkstyleTest && checkDocsBuild ;;
+    2) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_2[@]} ;;
+    3) CASSANDRA_VERSION=3.7 ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_3[@]} -x :atlasdb-jepsen-tests:jepsenTest ;;
+    4) CASSANDRA_VERSION=3.7 ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_4[@]} ;;
+    5) CASSANDRA_VERSION=3.7 ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_5[@]} ;;
+    6) ./gradlew --profile --continue -x compileJava -x compileTestJava findbugsMain findbugsTest checkstyleMain checkstyleTest && checkDocsBuild ;;
 esac

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -43,5 +43,6 @@ case $CIRCLE_NODE_INDEX in
     3) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_3[@]} -x :atlasdb-jepsen-tests:jepsenTest ;;
     4) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_4[@]} ;;
     5) ./gradlew $TEST_CONTAINER_ARGS ${CONTAINER_5[@]} ;;
-    6) ./gradlew --profile --continue -x compileJava -x compileTestJava findbugsMain findbugsTest checkstyleMain checkstyleTest && checkDocsBuild ;;
+    6) CASSANDRA_VERSION=3.7 ./gradlew --profile --continue atlasdb-cassandra-integration-tests:test atlasdb-cassandra-multinode-tests:test atlasdb-ete-tests:test ;;
+    7) ./gradlew --profile --continue -x compileJava -x compileTestJava findbugsMain findbugsTest checkstyleMain checkstyleTest && checkDocsBuild ;;
 esac

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -17,7 +17,6 @@ CONTAINER_3=(':atlasdb-dbkvs-tests:check' ':atlasdb-tests-shared:check' ':atlasd
 
 CONTAINER_4=(':lock-impl:check' ':atlasdb-dbkvs:check' ':atlasdb-cassandra-multinode-tests:check' ':atlasdb-impl-shared:check' ':atlasdb-dropwizard-bundle:check')
 
-#CONTAINER_5=(':atlasdb-ete-tests:longTest')
 CONTAINER_5=(':atlasdb-cassandra-integration-tests:check')
 
 # Container 0 - runs tasks not found in the below containers


### PR DESCRIPTION
Shuffling tests around the circle containers.
- Cassandra 3.7 tests pre-merge
- No extra containers
- Build time not longer (the Cassandra integration test containers take longest - see builds)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1297)
<!-- Reviewable:end -->
