### PR TITLE
Replace CAS Jepsen test with a Jepsen test of the timelock server

### DIFF
--- a/atlasdb-jepsen-tests/.dockerignore
+++ b/atlasdb-jepsen-tests/.dockerignore
@@ -1,5 +1,0 @@
-/Dockerfile
-/build.gradle
-/docker-compose.yml
-/store
-/target

--- a/atlasdb-jepsen-tests/.gitignore
+++ b/atlasdb-jepsen-tests/.gitignore
@@ -1,7 +1,7 @@
+/.lein-failures
+/.lein-repl-history
+/.nrepl-port
 /resources/atlasdb/atlasdb-jepsen-tests-all.jar
 /resources/atlasdb/atlasdb-timelock-server.tgz
-/.lein-failures
-/.nrepl-port
-/.lein-repl-history
-/target/
 /store
+/target/

--- a/atlasdb-jepsen-tests/.gitignore
+++ b/atlasdb-jepsen-tests/.gitignore
@@ -1,2 +1,7 @@
-/resources/atlasdb/atlasdb-ete.tgz
+/resources/atlasdb/atlasdb-jepsen-tests-all.jar
+/resources/atlasdb/atlasdb-timelock-server.tgz
+/.lein-failures
+/.nrepl-port
+/.lein-repl-history
+/target/
 /store

--- a/atlasdb-jepsen-tests/Dockerfile
+++ b/atlasdb-jepsen-tests/Dockerfile
@@ -1,3 +1,0 @@
-FROM tjake/jepsen:latest
-
-CMD wrapdocker bash -c 'source ~/.bashrc && cd /jepsen/atlasdb && lein test'

--- a/atlasdb-jepsen-tests/Dockerfile
+++ b/atlasdb-jepsen-tests/Dockerfile
@@ -1,5 +1,3 @@
 FROM tjake/jepsen:latest
 
-ADD . /jepsen/atlasdb
-
 CMD wrapdocker bash -c 'source ~/.bashrc && cd /jepsen/atlasdb && lein test'

--- a/atlasdb-jepsen-tests/build.gradle
+++ b/atlasdb-jepsen-tests/build.gradle
@@ -59,12 +59,7 @@ task copyTimelockServer(type: Copy, dependsOn: ':atlasdb-timelock-server:distTar
     rename { filename -> 'atlasdb-timelock-server.tgz' }
 }
 
-task composeBuild(type: Exec) {
-    environment = project.dockerCompose.environment
-    commandLine project.dockerCompose.composeCommand('build', '--force-rm')
-}
-
-task jepsenTest(type: Exec, dependsOn: ['copyFatJar', 'copyTimelockServer', 'composeBuild']) {
+task jepsenTest(type: Exec, dependsOn: ['copyFatJar', 'copyTimelockServer']) {
     environment = project.dockerCompose.environment
     commandLine project.dockerCompose.composeCommand('run', '--rm', 'jepsen')
 }

--- a/atlasdb-jepsen-tests/build.gradle
+++ b/atlasdb-jepsen-tests/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     }
 }
 
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'docker-compose'
 apply plugin: 'org.inferred.processors'
 apply plugin: 'org.unbroken-dome.test-sets'
@@ -24,9 +25,12 @@ jacocoTestReport {
 check.dependsOn integTest
 
 dependencies {
+    compile project(':atlasdb-config')
+
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     compile group: 'com.google.guava', name: 'guava'
+    compile group: 'com.jayway.awaitility', name: 'awaitility'
     compile group: 'one.util', name: 'streamex'
     compile group: 'org.clojure', name: 'clojure'
     compile group: 'org.slf4j', name: 'slf4j-api'
@@ -37,19 +41,30 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core'
 }
 
-task prepareForJepsen(type: Copy, dependsOn: ':atlasdb-ete-tests:distTar') {
-    from tasks.getByPath(':atlasdb-ete-tests:distTar').outputs
-    into 'resources/atlasdb/'
-
-    rename { filename -> 'atlasdb-ete.tgz' }
+shadowJar {
+    dependencies {
+        exclude(dependency(group: 'org.clojure', name: 'clojure'))
+    }
 }
 
-task composeBuild(type: Exec, dependsOn: 'prepareForJepsen') {
+task copyFatJar(type: Copy, dependsOn: 'shadowJar') {
+    from tasks.getByPath('shadowJar').outputs
+    into 'resources/atlasdb/'
+    rename { filename -> 'atlasdb-jepsen-tests-all.jar' }
+}
+
+task copyTimelockServer(type: Copy, dependsOn: ':atlasdb-timelock-server:distTar') {
+    from tasks.getByPath(':atlasdb-timelock-server:distTar').outputs
+    into 'resources/atlasdb/'
+    rename { filename -> 'atlasdb-timelock-server.tgz' }
+}
+
+task composeBuild(type: Exec) {
     environment = project.dockerCompose.environment
     commandLine project.dockerCompose.composeCommand('build', '--force-rm')
 }
 
-task jepsenTest(type: Exec, dependsOn: 'composeBuild') {
+task jepsenTest(type: Exec, dependsOn: ['copyFatJar', 'copyTimelockServer', 'composeBuild']) {
     environment = project.dockerCompose.environment
     commandLine project.dockerCompose.composeCommand('run', '--rm', 'jepsen')
 }

--- a/atlasdb-jepsen-tests/build.gradle
+++ b/atlasdb-jepsen-tests/build.gradle
@@ -47,7 +47,7 @@ shadowJar {
     }
 }
 
-task copyFatJar(type: Copy, dependsOn: 'shadowJar') {
+task copyShadowJar(type: Copy, dependsOn: 'shadowJar') {
     from tasks.getByPath('shadowJar').outputs
     into 'resources/atlasdb/'
     rename { filename -> 'atlasdb-jepsen-tests-all.jar' }
@@ -59,7 +59,7 @@ task copyTimelockServer(type: Copy, dependsOn: ':atlasdb-timelock-server:distTar
     rename { filename -> 'atlasdb-timelock-server.tgz' }
 }
 
-task jepsenTest(type: Exec, dependsOn: ['copyFatJar', 'copyTimelockServer']) {
+task jepsenTest(type: Exec, dependsOn: ['copyShadowJar', 'copyTimelockServer']) {
     environment = project.dockerCompose.environment
     commandLine project.dockerCompose.composeCommand('run', '--rm', 'jepsen')
 }

--- a/atlasdb-jepsen-tests/docker-compose.yml
+++ b/atlasdb-jepsen-tests/docker-compose.yml
@@ -1,5 +1,6 @@
 jepsen:
-  build: .
+  image: tjake/jepsen:latest
   privileged: true
   volumes:
     - ./:/jepsen/atlasdb
+  command: "wrapdocker bash -c 'source ~/.bashrc && cd /jepsen/atlasdb && lein test'"

--- a/atlasdb-jepsen-tests/docker-compose.yml
+++ b/atlasdb-jepsen-tests/docker-compose.yml
@@ -2,4 +2,4 @@ jepsen:
   build: .
   privileged: true
   volumes:
-    - ./store:/jepsen/atlasdb/store
+    - ./:/jepsen/atlasdb

--- a/atlasdb-jepsen-tests/project.clj
+++ b/atlasdb-jepsen-tests/project.clj
@@ -1,5 +1,6 @@
 (defproject jepsen.atlasdb "0.1.0"
+  :resource-paths ["resources/atlasdb/atlasdb-jepsen-tests-all.jar"]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [jepsen "0.1.1-SNAPSHOT"]
+                 [jepsen "0.1.3"]
                  [cheshire "5.6.1"]
                  [clj-http "3.1.0"]])

--- a/atlasdb-jepsen-tests/resources/atlasdb/timelock.yml
+++ b/atlasdb-jepsen-tests/resources/atlasdb/timelock.yml
@@ -2,7 +2,7 @@ clients:
   - test
 
 cluster:
-  localServer: HOSTNAME:8700
+  localServer: <HOSTNAME>:8700
   servers:
     - n1:8700
     - n2:8700

--- a/atlasdb-jepsen-tests/resources/atlasdb/timelock.yml
+++ b/atlasdb-jepsen-tests/resources/atlasdb/timelock.yml
@@ -1,0 +1,11 @@
+clients:
+  - test
+
+cluster:
+  localServer: HOSTNAME:8700
+  servers:
+    - n1:8700
+    - n2:8700
+    - n3:8700
+    - n4:8700
+    - n5:8700

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
@@ -31,7 +31,7 @@
         (c/upload "resources/atlasdb/timelock.yml" "/atlasdb-timelock-server/var/conf")
         (c/exec :sed :-i (format "s/<HOSTNAME>/%s/" (name node)) "/atlasdb-timelock-server/var/conf/timelock.yml")
         (info node "Starting timelock server")
-        (c/exec :env "JAVA_HOME=/usr/lib/jvm/java-8-oracle/" "/atlasdb-timelock-server/service/bin/init.sh" "start")
+        (c/exec "source" "/etc/profile" "&&" "/atlasdb-timelock-server/service/bin/init.sh" "start")
         (info node "Waiting until timelock cluster is ready")
         (TimestampClient/waitUntilHostReady (name node))
         (TimestampClient/waitUntilTimestampClusterReady '("n1" "n2" "n3" "n4" "n5"))))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
@@ -59,7 +59,7 @@
     (setup!
       [this test node]
       "Factory that returns an object implementing client/Client"
-        (create-client (TimestampClient/randomizeHostsAndCreate '("n1" "n2" "n3" "n4" "n5"))))
+        (create-client (TimestampClient/create '("n1" "n2" "n3" "n4" "n5"))))
 
     (invoke!
       [this test op]

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
@@ -1,178 +1,99 @@
 (ns jepsen.atlasdb
-  (:require [cheshire.core :as json]
-            [clj-http.client :as http]
+  (:require [clj-http.client :as http]
             [clojure.tools.logging :refer :all]
-            [jepsen.core :as jepsen]
             [jepsen.checker :as checker]
-            [jepsen.checker.timeline :as timeline]
             [jepsen.client :as client]
             [jepsen.control :as c]
             [jepsen.db :as db]
             [jepsen.generator :as gen]
-            [jepsen.model :as model]
             [jepsen.nemesis :as nemesis]
             [jepsen.os.debian :as debian]
-            [jepsen.tests :as tests]))
+            [jepsen.util :refer [timeout]]
+            [knossos.history :as history]
+            [jepsen.tests :as tests])
+  (:import com.palantir.atlasdb.jepsen.JepsenHistoryChecker)
+  (:import com.palantir.atlasdb.jepsen.TimestampClient))
 
-(def ATLASDB_LOG_FILES ["/atlasdb-ete/var/log/atlasdb-ete.log",
-                        "/atlasdb-ete/var/log/atlasdb-ete-request.log",
-                        "/atlasdb-ete/var/log/atlasdb-ete-startup.log"])
-(def CASSANDRA_LOG_FILES ["/var/log/cassandra/system.log",
-                          "/var/log/cassandra/debug.log"])
-
-(def CASSANDRA_VERSION "2.2.6")
-
-(defn install-atlasdb
-  "Install AtlasDB ETE Server"
-  [node]
-  (c/su
-   (info node "installing AtlasDB")
-   (debian/install-jdk8!)
-   (c/upload "resources/atlasdb/atlasdb-ete.tgz" "/")
-   (c/exec :rm "-rf" "/atlasdb-ete")
-   (c/exec :mkdir "/atlasdb-ete")
-   (c/exec :tar "xf" "/atlasdb-ete.tgz" "-C" "/atlasdb-ete" "--strip-components" "1")
-   (info node "waiting for Cassandra")
-   (c/exec (c/lit "(while [[ $? != 52 ]]; do sleep 1; curl n4:9160; done; true)"))
-   (info node "running AtlasDB")
-   (c/exec :mkdir "-p" "/atlasdb-ete/var/conf")
-   (c/upload "resources/atlasdb/atlasdb-ete.yml.template" "/atlasdb-ete/var/conf/")
-   (c/cd
-    "/atlasdb-ete"
-    (c/exec :sed (format "s/{{LOCAL_HOSTNAME}}/%s/g" (name node)) "var/conf/atlasdb-ete.yml.template" :> "var/conf/atlasdb-ete.yml")
-    (c/exec "service/bin/init.sh" "start"))
-   (c/exec (c/lit (format "(false; while [[ $? != 0 ]]; do sleep 1; curl -sfo /dev/null http://%s:3828/cas; done)" (name node))))
-   (info node "AtlasDB is ready")))
-
-(defn install-cassandra
-  [node version]
-  (c/su
-   (info node "installing Cassandra" version)
-   (debian/add-repo!
-    "cassandra"
-    "deb http://www.apache.org/dist/cassandra/debian 22x main")
-   (debian/install {:cassandra version})
-   (info node "starting Cassandra")
-   (c/upload "resources/cassandra/cassandra.yaml.template" "/etc/cassandra/")
-   (c/exec :sed (c/lit "\"s/{{LOCAL_ADDRESS}}/$(hostname -I)/g\"") "/etc/cassandra/cassandra.yaml.template" :> "/etc/cassandra/cassandra.yaml")
-   (c/upload "resources/cassandra/cassandra-env.sh" "/etc/cassandra/")
-   (c/exec :service :cassandra :start)
-   (info node "Cassandra is ready")))
-
-(defn teardown-atlasdb
-  [node]
-  (c/su
-   (info node "tearing down AtlasDB")
-   (c/cd
-    "/atlasdb-ete"
-    (c/exec "service/bin/init.sh" "stop"))))
-
-(defn teardown-cassandra
-  [node]
-  (c/su
-   (info node "tearing down Cassandra")
-   (c/exec :service :cassandra :stop)
-   (c/exec :rm "-rf" "/var/lib/cassandra/{saved_caches,data,commitlog}")))
-
-(defn db
-  "AtlasDB node setup."
+(defn create-server
+  "Creates an object that implements the db/DB protocol.
+   This object defines how to setup and teardown a timelock server on a given
+   node, and specifies where the log files can be found.
+  "
   []
   (reify db/DB
-    (setup! [_ test node]
-      (if (some #{node} (:nodes test))
-        (install-atlasdb node))
-      (if (some #{node} (:cassandra-nodes test))
-        (install-cassandra node CASSANDRA_VERSION)))
+    (setup! [_ _ node]
+      (c/su
+        (debian/install-jdk8!)
+        (c/upload "resources/atlasdb/atlasdb-timelock-server.tgz" "/")
+        (info node "Uploading and unpacking timelock server")
+        (c/exec :mkdir "/atlasdb-timelock-server")
+        (c/exec :tar :xf "/atlasdb-timelock-server.tgz" "-C" "/atlasdb-timelock-server" "--strip-components" "1")
+        (c/upload "resources/atlasdb/timelock.yml" "/atlasdb-timelock-server/var/conf")
+        (c/exec :sed :-i (format "'s/HOSTNAME/%s/'" (name node)) "/atlasdb-timelock-server/var/conf/timelock.yml")
+        (info node "Starting timelock server")
+        (c/exec :env "JAVA_HOME=/usr/lib/jvm/java-8-oracle/" "/atlasdb-timelock-server/service/bin/init.sh" "start")
+        (info node "Waiting until timelock cluster is ready")
+        (TimestampClient/waitUntilHostReady (name node))
+        (TimestampClient/waitUntilTimestampClusterReady '("n1" "n2" "n3" "n4" "n5"))))
 
-    (teardown! [_ test node]
-      (if (some #{node} (:nodes test))
-        (teardown-atlasdb node))
-      (if (some #{node} (:cassandra-nodes test))
-        (teardown-cassandra node)))
+    (teardown! [_ _ node]
+      (c/su
+        (try (c/exec "/atlasdb-timelock-server/service/bin/init.sh" "stop") (catch Exception _))
+        (try (c/exec :rm :-rf "/atlasdb-timelock-server") (catch Exception _))
+        (try (c/exec :rm :-f "/atlasdb-timelock-server.tgz") (catch Exception _))))
 
     db/LogFiles
     (log-files [_ test node]
-      (cond
-        (some #{node} (:nodes test)) ATLASDB_LOG_FILES
-        (some #{node} (:cassandra-nodes)) CASSANDRA_LOG_FILES))))
+      ["/atlasdb-timelock-server/var/log/atlasdb-timelock-server-startup.log"])))
 
-(defn atlasdb-get [node]
-  (json/parse-string (:body (http/get (format "http://%s:3828/cas" (name node)) {:content-type :json}))))
+(defn read-operation [_ _] {:type :invoke, :f :read-operation, :value nil})
 
-(defn atlasdb-put! [node new-value]
-  (let [contents (json/generate-string new-value)]
-    (http/put (format "http://%s:3828/cas" (name node)) {:content-type :json :body contents})))
+(defn create-client
+  "Creates an object that implements the client/Client protocol.
+   The object defines how you create a timestamp client, and how to request
+   timestamps from it. The first call to this function will return an invalid
+   object: you should call 'setup' on the returned object to get a valid one.
+  "
+  [timestamp-client]
+  (reify client/Client
 
-(defn atlasdb-cas! [node old-value new-value]
-  (let [contents (json/generate-string {:oldValue old-value :newValue new-value})]
-    (json/parse-string (:body (http/patch (format "http://%s:3828/cas" (name node)) {:content-type :json :body contents})))))
+    (setup!
+      [this test node]
+      "Factory that returns an object implementing client/Client"
+        (create-client (TimestampClient/randomizeHostsAndCreate '("n1" "n2" "n3" "n4" "n5"))))
 
-(defrecord CASClient [node]
-  client/Client
-  (setup! [this test node]
-    (atlasdb-put! node nil)
-    (assoc this :node node))
+    (invoke!
+      [this test op]
+      "Run an operation on our client"
+      (case (:f op)
+        :read-operation
+          (timeout (* 30 1000)
+            (assoc op :type :fail :error :timeout)
+            (try
+              (assoc op :type :ok :value (.getFreshTimestamp timestamp-client))
+              (catch Exception e
+                (assoc op :type :fail :error (.toString e)))))))
 
-  (invoke! [this test op]
-    (case (:f op)
-      :read  (try (assoc op :type :ok :value (atlasdb-get node))
-                  (catch Exception e
-                    (warn e "Read failed")
-                    (assoc op :type :fail)))
+    (teardown! [_ test])))
 
-      :write (do (atlasdb-put! node (:value op))
-                 (assoc op :type :ok))
-      :cas   (let [[value value'] (:value op)
-                   ok? (atlasdb-cas! node value value')]
-               (assoc op :type (if ok? :ok :fail)))))
-
-  (teardown! [_ test]))
-
-(defn cas-client
-  "A compare and set register built around a single consul node."
-  []
-  (CASClient. nil))
-
-(defn r   [_ _] {:type :invoke, :f :read, :value nil})
-(defn w   [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
-(defn cas [_ _] {:type :invoke, :f :cas, :value [(rand-int 5) (rand-int 5)]})
-
-(defmacro with-cassandra
-  "Wraps body in Cassandra setup and teardown."
-  [test & body]
-  `(c/with-ssh (:ssh ~test)
-    (jepsen/with-resources [sessions#
-                            (bound-fn* c/session)
-                            c/disconnect
-                            (:cassandra-nodes ~test)]
-      (let [test# (->> sessions#
-                      (map vector (:cassandra-nodes ~test))
-                      (into {})
-                      (assoc ~test :sessions))]
-        (jepsen/with-os test#
-          (jepsen/with-db test#
-            ~@body))))))
+(def checker
+  (reify checker/Checker
+    (check [this test model history opts]
+      (.checkClojureHistory (JepsenHistoryChecker/createWithStandardCheckers) history))))
 
 (defn atlasdb-test
   []
   (assoc tests/noop-test
-         :name "atlasdb"
-         :nodes ["n1" "n2" "n3"]
-         :cassandra-nodes ["n4"]
-         :os debian/os
-         :db (db)
-         :client (cas-client)
-         :nemesis (nemesis/partition-random-halves)
-         :model (model/cas-register)
-         :checker (checker/compose
-                   {:html (timeline/html)
-                    :perf (checker/perf)
-                    :linear checker/linearizable})
-         :generator (->> (gen/mix [r w cas])
-                         (gen/stagger 1)
-                         (gen/nemesis
-                          (gen/seq (cycle [(gen/sleep 5)
-                                           {:type :info, :f :start}
-                                           (gen/sleep 5)
-                                           {:type :info, :f :stop}])))
-                         (gen/time-limit 15))))
+    :os debian/os
+    :client (create-client nil)
+    :nemesis (nemesis/partition-random-halves)
+    :generator (->> read-operation
+                    (gen/stagger 0.1)
+                    (gen/nemesis
+                    (gen/seq (cycle [(gen/sleep 5)
+                                     {:type :info, :f :start}
+                                     (gen/sleep 20)
+                                     {:type :info, :f :stop}])))
+                    (gen/time-limit 300))
+    :db (create-server)
+    :checker checker))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
@@ -24,8 +24,8 @@
     (setup! [_ _ node]
       (c/su
         (debian/install-jdk8!)
-        (c/upload "resources/atlasdb/atlasdb-timelock-server.tgz" "/")
         (info node "Uploading and unpacking timelock server")
+        (c/upload "resources/atlasdb/atlasdb-timelock-server.tgz" "/")
         (c/exec :mkdir "/atlasdb-timelock-server")
         (c/exec :tar :xf "/atlasdb-timelock-server.tgz" "-C" "/atlasdb-timelock-server" "--strip-components" "1")
         (c/upload "resources/atlasdb/timelock.yml" "/atlasdb-timelock-server/var/conf")
@@ -56,7 +56,6 @@
   "
   [timestamp-client]
   (reify client/Client
-
     (setup!
       [this test node]
       "Factory that returns an object implementing client/Client"

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb.clj
@@ -29,7 +29,7 @@
         (c/exec :mkdir "/atlasdb-timelock-server")
         (c/exec :tar :xf "/atlasdb-timelock-server.tgz" "-C" "/atlasdb-timelock-server" "--strip-components" "1")
         (c/upload "resources/atlasdb/timelock.yml" "/atlasdb-timelock-server/var/conf")
-        (c/exec :sed :-i (format "'s/HOSTNAME/%s/'" (name node)) "/atlasdb-timelock-server/var/conf/timelock.yml")
+        (c/exec :sed :-i (format "s/<HOSTNAME>/%s/" (name node)) "/atlasdb-timelock-server/var/conf/timelock.yml")
         (info node "Starting timelock server")
         (c/exec :env "JAVA_HOME=/usr/lib/jvm/java-8-oracle/" "/atlasdb-timelock-server/service/bin/init.sh" "start")
         (info node "Waiting until timelock cluster is ready")

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampClient.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.jepsen;
+
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.jayway.awaitility.Awaitility;
+import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.timestamp.TimestampService;
+
+public final class TimestampClient {
+    private static final int PORT = 8080;
+    private static final String NAMESPACE = "test";
+    private static final int TIMEOUT_SECONDS = 60;
+
+    private TimestampClient() {
+    }
+
+    public static TimestampService create(List<String> hosts) {
+        List<String> endpointUris = hostnamesToEndpointUris(hosts);
+        return createFromUris(endpointUris);
+    }
+
+    public static TimestampService randomizeHostsAndCreate(List<String> hosts) {
+        List<String> randomizedHosts = new ArrayList<>(hosts);
+        Collections.shuffle(randomizedHosts);
+        return create(randomizedHosts);
+    }
+
+    public static void waitUntilHostReady(String host) {
+        Awaitility.await()
+                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .until(() -> hostIsListening(host));
+    }
+
+    public static void waitUntilTimestampClusterReady(List<String> hosts) {
+        Awaitility.await()
+                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .until(() -> clusterReturnsTimestamp(hosts));
+    }
+
+    private static boolean clusterReturnsTimestamp(List<String> hosts) {
+        try {
+            TimestampService service = create(hosts);
+            service.getFreshTimestamp();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static List<String> hostnamesToEndpointUris(List<String> hosts) {
+        return Lists.transform(hosts, host -> String.format("http://%s:%d/%s", host, PORT, NAMESPACE));
+    }
+
+    public static TimestampService createFromUris(List<String> endpointUris) {
+        return AtlasDbHttpClients.createProxyWithFailover(Optional.<SSLSocketFactory>absent(), endpointUris,
+                TimestampService.class);
+    }
+
+    private static boolean hostIsListening(String host) {
+        Socket socket = null;
+        try {
+            socket = new Socket(host, PORT);
+            return true;
+        } catch (Exception e) {
+            return false;
+        } finally {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (Exception e) {
+                }
+            }
+        }
+    }
+}

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampClient.java
@@ -42,6 +42,13 @@ public final class TimestampClient {
         return createFromUris(endpointUris);
     }
 
+    public static TimestampService createFromUris(List<String> endpointUris) {
+        return AtlasDbHttpClients.createProxyWithFailover(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUris,
+                TimestampService.class);
+    }
+
     public static TimestampService randomizeHostsAndCreate(List<String> hosts) {
         List<String> randomizedHosts = new ArrayList<>(hosts);
         Collections.shuffle(randomizedHosts);
@@ -72,11 +79,6 @@ public final class TimestampClient {
 
     private static List<String> hostnamesToEndpointUris(List<String> hosts) {
         return Lists.transform(hosts, host -> String.format("http://%s:%d/%s", host, PORT, NAMESPACE));
-    }
-
-    public static TimestampService createFromUris(List<String> endpointUris) {
-        return AtlasDbHttpClients.createProxyWithFailover(Optional.<SSLSocketFactory>absent(), endpointUris,
-                TimestampService.class);
     }
 
     private static boolean hostIsListening(String host) {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/TimestampClient.java
@@ -80,19 +80,11 @@ public final class TimestampClient {
     }
 
     private static boolean hostIsListening(String host) {
-        Socket socket = null;
         try {
-            socket = new Socket(host, PORT);
+            new Socket(host, PORT);
             return true;
         } catch (Exception e) {
             return false;
-        } finally {
-            if (socket != null) {
-                try {
-                    socket.close();
-                } catch (Exception e) {
-                }
-            }
         }
     }
 }

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -4,6 +4,4 @@
             [jepsen.atlasdb :as atlasdb]))
 
 (deftest atlasdb-test
-  (let [test (atlasdb/atlasdb-test)]
-    (atlasdb/with-cassandra test
-      (is (:valid? (:results (jepsen/run! test)))))))
+   (is (:valid? (:results (jepsen/run! (atlasdb/atlasdb-test))))))

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -8,7 +8,7 @@ dependencies {
   compile group: 'org.hamcrest', name: 'hamcrest-library'
 
   testCompile group: 'junit', name: 'junit'
-  testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock
-  testCompile 'com.jayway.awaitility:awaitility:1.6.5'
+  testCompile group: 'org.jmock', name: 'jmock', version: libVersions.jmock
+  testCompile group: 'com.jayway.awaitility', name: 'awaitility'
   testCompile group: 'org.mockito', name: 'mockito-core'
 }

--- a/versions.props
+++ b/versions.props
@@ -8,6 +8,7 @@ com.google.dagger:dagger = 2.0.2
 com.google.dagger:dagger-compiler = 2.0.2
 com.google.guava:* = 18.0
 com.googlecode.json-simple:json-simple = 1.1.1
+com.jayway.awaitility:awaitility = 1.6.5
 com.palantir.config.crypto:encrypted-config-value-module = 1.0.0
 com.palantir.remoting:* = 0.13.0
 com.palantir.remoting1:* = 1.0.3


### PR DESCRIPTION
This PR removes the old Jepsen test, replacing it with one for the timelock server. The intention is that we will be able to re-visit the old test, and put it back into place.

Things this PR includes:

- Mount the `atlasdb-jepsen-test` directory, rather than `ADD`ing it.
- Compile `atlasdb-jepsen-test` into a fat jar so that it can be included in the JVM that runs the Jepsen test
- Add some Java code to create timestamp clients and wait for them to be ready, so that we don't have to write this in Clojure
- Use a newer Jepsen version (0.1.3)
- Move the awaitility version into `version.props`

Future work for the timelock Jepsen test that this PR does not include:

- Having it run at a reasonable speed, appropriate for our CI
- Enabling it on our CircleCI build
- Breaking the timelock server (e.g. add some noise to the timestamps) and ensuring that these tests fail appropriately

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1305)
<!-- Reviewable:end -->
