### PR TITLE
allow delete to be used for truncate

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DdlConfig.java
@@ -61,10 +61,19 @@ public abstract class DdlConfig {
         return 2 * 1024 * 1024;
     }
 
+    @Value.Default
+    public TruncateStyle truncateStyle() {
+        return TruncateStyle.TRUNCATE;
+    }
+
     @Value.Check
     protected final void check() {
         Preconditions.checkState(
                 metadataTable().getNamespace().isEmptyNamespace(),
                 "'metadataTable' should have empty namespace'");
+    }
+
+    public enum TruncateStyle {
+        TRUNCATE, DELETE;
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -175,7 +175,18 @@ public final class OracleDdlTable implements DbDdlTable {
     @Override
     public void truncate() {
         try {
-            conns.get().executeUnregisteredQuery("TRUNCATE TABLE " + oracleTableNameGetter.getInternalShortTableName());
+            switch (config.truncateStyle()) {
+                case TRUNCATE:
+                    conns.get().executeUnregisteredQuery("TRUNCATE TABLE "
+                            + oracleTableNameGetter.getInternalShortTableName());
+                    break;
+                case DELETE:
+                    conns.get().executeUnregisteredQuery("DELETE FROM "
+                            + oracleTableNameGetter.getInternalShortTableName());
+                    break;
+                default:
+                    throw new IllegalStateException();
+            }
         } catch (TableMappingNotFoundException | RuntimeException e) {
             throw new IllegalStateException(
                     String.format(

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -86,7 +86,16 @@ public class PostgresDdlTable implements DbDdlTable {
 
     @Override
     public void truncate() {
-        conns.get().executeUnregisteredQuery("TRUNCATE TABLE " + prefixedTableName());
+        switch (config.truncateStyle()) {
+            case TRUNCATE:
+                conns.get().executeUnregisteredQuery("TRUNCATE TABLE " + prefixedTableName());
+                break;
+            case DELETE:
+                conns.get().executeUnregisteredQuery("DELETE FROM " + prefixedTableName());
+                break;
+            default:
+                throw new IllegalStateException();
+        }
     }
 
     @Override


### PR DESCRIPTION
@clockfort 

we are running into a lot of postgres issues where truncates cause queries to backup and socket time out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1321)
<!-- Reviewable:end -->
