### PR TITLE
better handling for lock timeouts in runTaskWithLocksWithRetry

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -67,6 +67,10 @@ develop
          - Transaction perf improvement; commit timestamp lookups are now cached across transactions.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1238>`__)
 
+    *    - |improved|
+         - ``LockAwareTransactionManager.runTaskWithLocksWithRetry`` now fails faster if given lock tokens that time out in a way that cannot be recovered from.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1322>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Held locks that are passed in cannot be relocked if they time out. We
should abort immediately if they time out instead of retrying (which
cannot succeed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1322)
<!-- Reviewable:end -->
