### PR TITLE
don't retry if lock tokens will never refresh

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
@@ -88,14 +88,6 @@ public abstract class AbstractLockAwareTransactionManager
                     log.warn("Failing after {} tries", failureCount, e);
                     throw e;
                 }
-                if (e instanceof TransactionLockTimeoutException && !Iterables.isEmpty(lockTokens)) {
-                    Set<LockRefreshToken> refreshedTokens = getLockService().refreshLockRefreshTokens(
-                            Iterables.transform(lockTokens, HeldLocksToken::getLockRefreshToken));
-                    if (refreshedTokens.size() < Iterables.size(lockTokens)) {
-                        log.warn("Locks timed out while processing transaction.", e);
-                        throw e;
-                    }
-                }
                 log.info("retrying transaction", e);
             } catch (RuntimeException e) {
                 log.warn("RuntimeException while processing transaction.", e);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
@@ -128,7 +128,9 @@ public abstract class AbstractLockAwareTransactionManager
         Set<LockRefreshToken> refreshedTokens = getLockService().refreshLockRefreshTokens(toRequest);
         ImmutableSet<LockRefreshToken> failedTokens = Sets.difference(toRequest, refreshedTokens).immutableCopy();
         if (!failedTokens.isEmpty()) {
-            throw new TransactionLockTimeoutException("lock tokens did not refresh: " + failedTokens, ex);
+            throw new TransactionLockTimeoutException("Provided lock tokens expired. Retry is not possible. tokens: "
+                    + failedTokens,
+                    ex);
         }
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,10 @@ develop
            that would otherwise require creating many new connections to Cassandra from the clients.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1402>`__)
 
+    *    - |fixed|
+         - Don't retry transactions when the locks are invalid. Previously, AtlasDB tried repeatedly to run a transaction when the external locks are already invalid.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1323>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -86,7 +90,7 @@ v0.27.0
 
     *    - |new|
          - AtlasDB now supports stream store compression.
-           Streams can be compressed client-side by adding the ``compressStreamInClient`` option to the stream 
+           Streams can be compressed client-side by adding the ``compressStreamInClient`` option to the stream
            definition. Reads from the stream store will transparently decompress the data.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1357>`__)
 


### PR DESCRIPTION
@clockfort 

We are running into a bug where atlas tries repeatedly to run a transaction where the external locks are already invalid.  This was due to lock server failover.  It tries to commit the transaction 11 times.

Additionally, these retries each write their data to the KV store and are rolled back and need to be cleaned up so they generate a lot of garbage also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1323)
<!-- Reviewable:end -->
