### PR TITLE
correctly scope oracle table-name and value-overflow-status caches

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameGetter.java
@@ -23,55 +23,55 @@ import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
 public class OracleTableNameGetter {
     private final String tablePrefix;
     private final String overflowTablePrefix;
-    private final TableReference tableRef;
     private final OracleTableNameMapper oracleTableNameMapper;
     private final OracleTableNameUnmapper oracleTableNameUnmapper;
     private final boolean useTableMapping;
 
-    public OracleTableNameGetter(OracleDdlConfig config, ConnectionSupplier conns, TableReference tableRef) {
+    public OracleTableNameGetter(OracleDdlConfig config) {
         this.tablePrefix = config.tablePrefix();
         this.overflowTablePrefix = config.overflowTablePrefix();
         this.useTableMapping = config.useTableMapping();
 
-        this.oracleTableNameMapper = new OracleTableNameMapper(conns);
-        this.oracleTableNameUnmapper = new OracleTableNameUnmapper(conns);
-
-        this.tableRef = tableRef;
+        this.oracleTableNameMapper = new OracleTableNameMapper();
+        this.oracleTableNameUnmapper = new OracleTableNameUnmapper();
     }
 
-    public String generateShortTableName() {
+    public String generateShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef) {
         if (useTableMapping) {
-            return oracleTableNameMapper.getShortPrefixedTableName(tablePrefix, tableRef);
+            return oracleTableNameMapper.getShortPrefixedTableName(connectionSupplier, tablePrefix, tableRef);
         }
-        return getPrefixedTableName();
+        return getPrefixedTableName(tableRef);
     }
 
-    public String generateShortOverflowTableName() {
+    public String generateShortOverflowTableName(ConnectionSupplier connectionSupplier, TableReference tableRef) {
         if (useTableMapping) {
-            return oracleTableNameMapper.getShortPrefixedTableName(overflowTablePrefix, tableRef);
+            return oracleTableNameMapper.getShortPrefixedTableName(connectionSupplier, overflowTablePrefix, tableRef);
         }
-        return getPrefixedOverflowTableName();
+        return getPrefixedOverflowTableName(tableRef);
     }
 
-    public String getInternalShortTableName() throws TableMappingNotFoundException {
+    public String getInternalShortTableName(ConnectionSupplier connectionSupplier, TableReference tableRef)
+            throws TableMappingNotFoundException {
         if (useTableMapping) {
-            return oracleTableNameUnmapper.getShortTableNameFromMappingTable(tablePrefix, tableRef);
+            return oracleTableNameUnmapper.getShortTableNameFromMappingTable(connectionSupplier, tablePrefix, tableRef);
         }
-        return getPrefixedTableName();
+        return getPrefixedTableName(tableRef);
     }
 
-    public String getInternalShortOverflowTableName() throws TableMappingNotFoundException {
+    public String getInternalShortOverflowTableName(ConnectionSupplier connectionSupplier, TableReference tableRef)
+            throws TableMappingNotFoundException {
         if (useTableMapping) {
-            return oracleTableNameUnmapper.getShortTableNameFromMappingTable(overflowTablePrefix, tableRef);
+            return oracleTableNameUnmapper
+                    .getShortTableNameFromMappingTable(connectionSupplier, overflowTablePrefix, tableRef);
         }
-        return getPrefixedOverflowTableName();
+        return getPrefixedOverflowTableName(tableRef);
     }
 
-    public String getPrefixedTableName() {
+    public String getPrefixedTableName(TableReference tableRef) {
         return tablePrefix + DbKvs.internalTableName(tableRef);
     }
 
-    public String getPrefixedOverflowTableName() {
+    public String getPrefixedOverflowTableName(TableReference tableRef) {
         return overflowTablePrefix + DbKvs.internalTableName(tableRef);
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -21,9 +21,8 @@ import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -36,48 +35,44 @@ import com.palantir.nexus.db.sql.SqlConnection;
 class OracleTableNameUnmapper {
     private static final Logger log = LoggerFactory.getLogger(OracleTableNameUnmapper.class);
 
-    private final ConnectionSupplier conns;
+    private Cache<String, String> unmappingCache;
 
-    private LoadingCache<String, String> unmappingCache = CacheBuilder.newBuilder().build(
-            new CacheLoader<String, String>() {
-                @Override
-                public String load(String fullTableName) throws Exception {
-                    SqlConnection conn = null;
-                    try {
-                        conn = conns.getNewUnsharedConnection();
-                        AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
-                                "SELECT short_table_name "
-                                        + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
-                                        + " WHERE table_name = ?", fullTableName);
-                        if (results.size() == 0) {
-                            throw new TableMappingNotFoundException(
-                                    "The table " + fullTableName + " does not have a mapping."
-                                            + "This might be because the table does not exist.");
-                        }
+    OracleTableNameUnmapper() {
+        unmappingCache = CacheBuilder.newBuilder().build();
+    }
 
-                        return Iterables.getOnlyElement(results.rows()).getString("short_table_name");
-                    } finally {
-                        if (conn != null) {
-                            try {
-                                conn.getUnderlyingConnection().close();
-                            } catch (SQLException e) {
-                                log.error("Couldn't cleanup SQL connection while performing table name unmapping.", e);
-                            }
+    @SuppressWarnings("checkstyle:NestedTryDepth")
+    public String getShortTableNameFromMappingTable(
+            ConnectionSupplier connectionSupplier,
+            String tablePrefix,
+            TableReference tableRef) throws TableMappingNotFoundException {
+        String fullTableName = tablePrefix + DbKvs.internalTableName(tableRef);
+        try {
+            return unmappingCache.get(fullTableName, () -> {
+                SqlConnection conn = null;
+                try {
+                    conn = connectionSupplier.getNewUnsharedConnection();
+                    AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
+                            "SELECT short_table_name "
+                                    + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
+                                    + " WHERE table_name = ?", fullTableName);
+                    if (results.size() == 0) {
+                        throw new TableMappingNotFoundException(
+                                "The table " + fullTableName + " does not have a mapping."
+                                        + "This might be because the table does not exist.");
+                    }
+
+                    return Iterables.getOnlyElement(results.rows()).getString("short_table_name");
+                } finally {
+                    if (conn != null) {
+                        try {
+                            conn.getUnderlyingConnection().close();
+                        } catch (SQLException e) {
+                            log.error("Couldn't cleanup SQL connection while performing table name unmapping.", e);
                         }
                     }
                 }
-            }
-    );
-
-    OracleTableNameUnmapper(ConnectionSupplier conns) {
-        this.conns = conns;
-    }
-
-    public String getShortTableNameFromMappingTable(String tablePrefix, TableReference tableRef)
-            throws TableMappingNotFoundException {
-        String fullTableName = tablePrefix + DbKvs.internalTableName(tableRef);
-        try {
-            return unmappingCache.get(fullTableName);
+            });
         } catch (ExecutionException e) {
             throw new TableMappingNotFoundException(e.getCause());
         }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -31,13 +31,13 @@ import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.nexus.db.sql.ExceptionCheck;
 
-public class SimpleDbWriteTable implements DbWriteTable {
+public abstract class AbstractDbWriteTable implements DbWriteTable {
     protected final DdlConfig config;
     protected final ConnectionSupplier conns;
     protected final TableReference tableRef;
     private final PrefixedTableNames prefixedTableNames;
 
-    public SimpleDbWriteTable(
+    public AbstractDbWriteTable(
             DdlConfig config,
             ConnectionSupplier conns,
             TableReference tableRef,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
@@ -24,6 +24,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.OracleOverflowQueryFactor
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.OracleOverflowWriteTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.OracleRawQueryFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.OracleTableInitializer;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.OracleWriteTable;
 import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
 import com.palantir.nexus.db.DBType;
 
@@ -96,7 +97,7 @@ public class OracleDbTableFactory implements DbTableFactory {
             case OVERFLOW:
                 return OracleOverflowWriteTable.create(config, conns, oracleTableNameGetter, tableRef);
             case RAW:
-                return new OracleSimpleDbWriteTable(config, conns, oracleTableNameGetter, tableRef);
+                return new OracleWriteTable(config, conns, oracleTableNameGetter, tableRef);
             default:
                 throw new EnumConstantNotPresentException(TableValueStyle.class, tableValueStyle.name());
         }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OraclePrefixedTableNames.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OraclePrefixedTableNames.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import com.google.common.base.Throwables;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
+
+public class OraclePrefixedTableNames extends PrefixedTableNames {
+    private OracleTableNameGetter oracleTableNameGetter;
+    private ConnectionSupplier connectionSupplier;
+
+    public OraclePrefixedTableNames(
+            DdlConfig config,
+            ConnectionSupplier connectionSupplier,
+            OracleTableNameGetter oracleTableNameGetter) {
+        super(config);
+        this.connectionSupplier = connectionSupplier;
+        this.oracleTableNameGetter = oracleTableNameGetter;
+    }
+
+    @Override
+    public String get(TableReference tableRef) {
+        try {
+            return oracleTableNameGetter.getInternalShortTableName(connectionSupplier, tableRef);
+        } catch (TableMappingNotFoundException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleSimpleDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleSimpleDbWriteTable.java
@@ -17,16 +17,14 @@ package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
 
-public class PrefixedTableNames {
-    private DdlConfig config;
-
-    public PrefixedTableNames(DdlConfig config) {
-        this.config = config;
+public class OracleSimpleDbWriteTable extends SimpleDbWriteTable {
+    public OracleSimpleDbWriteTable(
+            DdlConfig config,
+            ConnectionSupplier conns,
+            OracleTableNameGetter oracleTableNameGetter,
+            TableReference tableRef) {
+        super(config, conns, tableRef, new OraclePrefixedTableNames(config, conns, oracleTableNameGetter));
     }
-
-    public String get(TableReference tableRef) {
-        return config.tablePrefix() + DbKvs.internalTableName(tableRef);
-    }
-
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresDbTableFactory.java
@@ -25,6 +25,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.PostgresDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresDdlTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresQueryFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresTableInitializer;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresWriteTable;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.nexus.db.DBType;
@@ -76,7 +77,7 @@ public class PostgresDbTableFactory implements DbTableFactory {
 
     @Override
     public DbWriteTable createWrite(TableReference tableRef, ConnectionSupplier conns) {
-        return new SimpleDbWriteTable(config, conns, tableRef, new PrefixedTableNames(config));
+        return new PostgresWriteTable(config, conns, tableRef, new PrefixedTableNames(config));
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresDbTableFactory.java
@@ -76,7 +76,7 @@ public class PostgresDbTableFactory implements DbTableFactory {
 
     @Override
     public DbWriteTable createWrite(TableReference tableRef, ConnectionSupplier conns) {
-        return new SimpleDbWriteTable(config, conns, tableRef);
+        return new SimpleDbWriteTable(config, conns, tableRef, new PrefixedTableNames(config));
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/SimpleDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/SimpleDbWriteTable.java
@@ -37,11 +37,15 @@ public class SimpleDbWriteTable implements DbWriteTable {
     protected final TableReference tableRef;
     private final PrefixedTableNames prefixedTableNames;
 
-    public SimpleDbWriteTable(DdlConfig config, ConnectionSupplier conns, TableReference tableRef) {
+    public SimpleDbWriteTable(
+            DdlConfig config,
+            ConnectionSupplier conns,
+            TableReference tableRef,
+            PrefixedTableNames prefixedTableNames) {
         this.config = config;
         this.conns = conns;
         this.tableRef = tableRef;
-        this.prefixedTableNames = new PrefixedTableNames(config, conns);
+        this.prefixedTableNames = prefixedTableNames;
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TableValueStyle.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TableValueStyle.java
@@ -15,12 +15,12 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
-public enum TableSize {
+public enum TableValueStyle {
     RAW(3), OVERFLOW(4);
 
     private final int id;
 
-    TableSize(int id) {
+    TableValueStyle(int id) {
         this.id = id;
     }
 
@@ -28,7 +28,7 @@ public enum TableSize {
         return id;
     }
 
-    public static TableSize byId(int id) {
+    public static TableValueStyle byId(int id) {
         switch (id) {
             case 3:
                 return RAW;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
@@ -49,26 +49,28 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
     private final ConnectionSupplier conns;
     private final OverflowSequenceSupplier overflowSequenceSupplier;
     private final OracleTableNameGetter oracleTableNameGetter;
+    private final TableReference tableRef;
 
     private OracleOverflowWriteTable(
             OracleDdlConfig config,
             ConnectionSupplier conns,
             OverflowSequenceSupplier sequenceSupplier,
-            OracleTableNameGetter oracleTableNameGetter) {
+            OracleTableNameGetter oracleTableNameGetter,
+            TableReference tableRef) {
         this.config = config;
         this.conns = conns;
         this.overflowSequenceSupplier = sequenceSupplier;
         this.oracleTableNameGetter = oracleTableNameGetter;
+        this.tableRef = tableRef;
     }
 
     public static OracleOverflowWriteTable create(
             OracleDdlConfig config,
             ConnectionSupplier conns,
+            OracleTableNameGetter oracleTableNameGetter,
             TableReference tableRef) {
-        OracleTableNameGetter oracleTableNameGetter =
-                new OracleTableNameGetter(config, conns, tableRef);
         OverflowSequenceSupplier sequenceSupplier = OverflowSequenceSupplier.create(conns, config.tablePrefix());
-        return new OracleOverflowWriteTable(config, conns, sequenceSupplier, oracleTableNameGetter);
+        return new OracleOverflowWriteTable(config, conns, sequenceSupplier, oracleTableNameGetter, tableRef);
     }
 
     @Override
@@ -231,7 +233,7 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
 
     private String getShortTableName() {
         try {
-            return oracleTableNameGetter.getInternalShortTableName();
+            return oracleTableNameGetter.getInternalShortTableName(conns, tableRef);
         } catch (TableMappingNotFoundException e) {
             throw Throwables.propagate(e);
         }
@@ -239,7 +241,7 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
 
     private String getShortOverflowTableName() {
         try {
-            return oracleTableNameGetter.getInternalShortOverflowTableName();
+            return oracleTableNameGetter.getInternalShortOverflowTableName(conns, tableRef);
         } catch (TableMappingNotFoundException e) {
             throw Throwables.propagate(e);
         }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleWriteTable.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
+
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.AbstractDbWriteTable;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
+
+public class OracleWriteTable extends AbstractDbWriteTable {
+    public OracleWriteTable(
+            DdlConfig config,
+            ConnectionSupplier conns,
+            OracleTableNameGetter oracleTableNameGetter,
+            TableReference tableRef) {
+        super(config, conns, tableRef, new OraclePrefixedTableNames(config, conns, oracleTableNameGetter));
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.PostgresDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbDdlTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableSize;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyle;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
 import com.palantir.nexus.db.sql.ExceptionCheck;
@@ -72,7 +72,7 @@ public class PostgresDdlTable implements DbDdlTable {
                             "INSERT INTO %s (table_name, table_size) VALUES (?, ?)",
                             config.metadataTable().getQualifiedName()),
                     tableName.getQualifiedName(),
-                    TableSize.RAW.getId());
+                    TableValueStyle.RAW.getId());
         }, ExceptionCheck::isUniqueConstraintViolation);
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresWriteTable.java
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.AbstractDbWriteTable;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.PrefixedTableNames;
 
-public class OracleSimpleDbWriteTable extends SimpleDbWriteTable {
-    public OracleSimpleDbWriteTable(
+public class PostgresWriteTable extends AbstractDbWriteTable {
+    public PostgresWriteTable(
             DdlConfig config,
             ConnectionSupplier conns,
-            OracleTableNameGetter oracleTableNameGetter,
-            TableReference tableRef) {
-        super(config, conns, tableRef, new OraclePrefixedTableNames(config, conns, oracleTableNameGetter));
+            TableReference tableRef,
+            PrefixedTableNames prefixedTableNames) {
+        super(config, conns, tableRef, prefixedTableNames);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
@@ -44,10 +44,7 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.PrefixedTableNames;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
 import com.palantir.atlasdb.keyvalue.impl.RowResults;
@@ -75,19 +72,19 @@ public class DbKvsGetRanges {
     private final DdlConfig config;
     private final DBType dbType;
     private final Supplier<SqlConnection> connectionSupplier;
-    private OracleTableNameGetter oracleTableNameGetter;
+    private PrefixedTableNames prefixedTableNames;
 
     public DbKvsGetRanges(
             DbKvs kvs,
             DdlConfig config,
             DBType dbType,
             Supplier<SqlConnection> connectionSupplier,
-            OracleTableNameGetter oracleTableNameGetter) {
+            PrefixedTableNames prefixedTableNames) {
         this.kvs = kvs;
         this.config = config;
         this.dbType = dbType;
         this.connectionSupplier = connectionSupplier;
-        this.oracleTableNameGetter = oracleTableNameGetter;
+        this.prefixedTableNames = prefixedTableNames;
     }
 
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
@@ -335,14 +332,7 @@ public class DbKvsGetRanges {
     }
 
     private String getPrefixedTableName(TableReference tableRef) {
-        switch (dbType) {
-            case ORACLE:
-                return new OraclePrefixedTableNames(
-                        config, new ConnectionSupplier(connectionSupplier), oracleTableNameGetter)
-                        .get(tableRef);
-            default:
-                return new PrefixedTableNames(config).get(tableRef);
-        }
+        return new PrefixedTableNames(config).get(tableRef);
     }
 
     private static final String SIMPLE_ROW_SELECT_TEMPLATE =

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameMapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameMapperTest.java
@@ -42,14 +42,15 @@ public class OracleTableNameMapperTest {
 
     private OracleTableNameMapper oracleTableNameMapper;
     private AgnosticResultSet resultSet;
+    private ConnectionSupplier connectionSupplier;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
-        ConnectionSupplier connectionSupplier = mock(ConnectionSupplier.class);
-        oracleTableNameMapper =  new OracleTableNameMapper(connectionSupplier);
+        connectionSupplier = mock(ConnectionSupplier.class);
+        oracleTableNameMapper =  new OracleTableNameMapper();
         SqlConnection sqlConnection = mock(SqlConnection.class);
         when(connectionSupplier.get()).thenReturn(sqlConnection);
         resultSet = mock(AgnosticResultSet.class);
@@ -66,7 +67,8 @@ public class OracleTableNameMapperTest {
         when(resultSet.size()).thenReturn(0);
 
         TableReference tableRef = TableReference.create(Namespace.create("ns1"), "short");
-        String shortPrefixedTableName = oracleTableNameMapper.getShortPrefixedTableName(TEST_PREFIX, tableRef);
+        String shortPrefixedTableName = oracleTableNameMapper
+                .getShortPrefixedTableName(connectionSupplier, TEST_PREFIX, tableRef);
         assertThat(shortPrefixedTableName, is("a_ns__short_00000"));
     }
 
@@ -82,7 +84,7 @@ public class OracleTableNameMapperTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
                 "Cannot create any more tables with name starting with a_te__ThisIsAVeryLongTab");
-        oracleTableNameMapper.getShortPrefixedTableName(TEST_PREFIX, tableRef);
+        oracleTableNameMapper.getShortPrefixedTableName(connectionSupplier, TEST_PREFIX, tableRef);
     }
 
     private String getTableNameWithNumber(int tableNum) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -34,6 +34,17 @@ Changelog
 develop
 =======
 
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |improved|
+         - Oracle query performance improvement; table name cache now global to KVS level.
+         - (`Pull Request <https://github.com/palantir/atlasdb/pull/1325>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -43,7 +43,12 @@ develop
 
     *    - |improved|
          - Oracle query performance improvement; table name cache now global to KVS level.
-         - (`Pull Request <https://github.com/palantir/atlasdb/pull/1325>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1325>`__)
+
+    *    - |fixed|
+         - Oracle value style caching limited in scope to per-KVS, previously per-JVM,
+           which could have in extremely rare cases caused issues for users in odd configurations.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1235>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
This makes the table name cache actually useful; previously the OracleTableName(Un)Mapper was re-instantiated every single query.

This could use a little more refactoring, but I got fed up halfway through with how much BS work was involved in pulling it out even this far. 

I think what I ran up against mostly writing this is that some parts of DbKVS use class extension to separate Oracle and Postgres differences, and some parts switch on DbType in-code, and mixing the two is a mess.
Also, there is something at the very highest level (getFirstBatchForRanges) that needed a Oracle / Postgres logic split, so maybe what we want is OracleKVS and PostgresKVS extending AbstractDbKVS to handle this nicer.


The other oracle-related caches have a different problem, which is that unlike the table unmapper, they are already /too/ global.
They are java `static` when they really should be also per-KVS instead of per-JVM, because there are legitimate cases when you can have multiple Oracle KVSs in the same JVM that don't point to the same DB. (split KVS configurations, or more likely someone doing a KVS migration to move from one Oracle DB to another)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1325)
<!-- Reviewable:end -->
