### PR TITLE
Always save thread dumps to the same file

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -19,10 +19,14 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ServiceLoader;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -86,9 +90,19 @@ public class ServiceDiscoveringAtlasSupplier {
         }
     }
 
-    private String saveThreadDumps() throws IOException {
-        File file = File.createTempFile("atlas-timestamps-log", ".log");
+    @VisibleForTesting
+    String saveThreadDumps() throws IOException {
+        File file = getTempFile();
         return saveThreadDumpsToFile(file);
+    }
+
+    private static File getTempFile() throws IOException {
+        String tempDir = System.getProperty("java.io.tmpdir");
+        Path path = Paths.get(tempDir, "atlas-timestamp-service-creation.log");
+        if (!Files.exists(path)) {
+            Files.createFile(path);
+        }
+        return path.toFile();
     }
 
     private String saveThreadDumpsToFile(File file) throws IOException {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
@@ -17,8 +17,11 @@ package com.palantir.atlasdb.factory;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -81,6 +84,16 @@ public class ServiceDiscoveringAtlasSupplierTest {
                 mock(TimestampService.class));
 
         assertThat(supplier.getTimestampService(), is(not(sameObjectAs(supplier.getTimestampService()))));
+    }
+
+    @Test
+    public void alwaysSaveThreadDumpsToTheSameFile() throws IOException {
+        ServiceDiscoveringAtlasSupplier supplier = new ServiceDiscoveringAtlasSupplier(kvsConfig, leaderConfig);
+
+        String firstPath = supplier.saveThreadDumps();
+        String secondPath = supplier.saveThreadDumps();
+
+        assertEquals(firstPath, secondPath);
     }
 
     private Matcher<Object> sameObjectAs(Object initial) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -71,6 +71,11 @@ develop
          - ``LockAwareTransactionManager.runTaskWithLocksWithRetry`` now fails faster if given lock tokens that time out in a way that cannot be recovered from.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1322>`__)
 
+    *    - |improved|
+         - ``MultipleRunningTimestampServicesError`` thread dumps: we now overwrite a hard-coded "thread dumps" file rather than saving to a new file each time.
+           This means that we won't, over time, fill up the temp folder without the user realising.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1332>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Verified locally that we replace the file rather than appending to it -
the size of the generated file does not grow with successive calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1332)
<!-- Reviewable:end -->
