### PR TITLE
bump cass pool size, increase frequency of connection eviction checking

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -44,7 +44,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
 
     @Value.Default
     public int poolSize() {
-        return 20;
+        return 30;
     }
 
     @Value.Default

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -44,7 +44,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
 
     @Value.Default
     public int poolSize() {
-        return 30;
+        return 20;
     }
 
     /**
@@ -54,7 +54,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
      */
     @Value.Default
     public int maxConnectionBurstSize() {
-        return 100;
+        return 5 * poolSize();
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -47,6 +47,28 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         return 30;
     }
 
+    /**
+     * The proportion of {@link #poolSize()} connections that are checked approximately
+     * every {@link #timeBetweenConnectionEvictionRunsSeconds()} seconds to see if has been idle at least
+     * {@link #idleConnectionTimeoutSeconds()} seconds and evicts it from the pool if so. For example, given the
+     * the default values, 0.1 * 30 = 3 connections will be checked approximately every 20 seconds and will
+     * be evicted from the pool if it has been idle for at least 10 minutes.
+     */
+    @Value.Default
+    public double proportionConnectionsToCheckPerEvictionRun() {
+        return 0.1;
+    }
+
+    @Value.Default
+    public int idleConnectionTimeoutSeconds() {
+        return 10 * 60;
+    }
+
+    @Value.Default
+    public int timeBetweenConnectionEvictionRunsSeconds() {
+        return 20;
+    }
+
     @Value.Default
     public int poolRefreshIntervalSeconds() {
         return 5 * 60;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -48,6 +48,16 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     }
 
     /**
+     * The cap at which the connection pool is able to grow over the {@link #poolSize()}
+     * given high request load. When load is depressed, the pool will shrink back to its
+     * idle {@link #poolSize()} value.
+     */
+    @Value.Default
+    public int maxConnectionBurstSize() {
+        return 100;
+    }
+
+    /**
      * The proportion of {@link #poolSize()} connections that are checked approximately
      * every {@link #timeBetweenConnectionEvictionRunsSeconds()} seconds to see if has been idle at least
      * {@link #idleConnectionTimeoutSeconds()} seconds and evicts it from the pool if so. For example, given the
@@ -197,5 +207,8 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
             Preconditions.checkState(addr.getPort() > 0, "each server must specify a port ([host]:[port])");
         }
         Preconditions.checkNotNull(keyspace(), "'keyspace' must be specified");
+        double evictionCheckProportion = proportionConnectionsToCheckPerEvictionRun();
+        Preconditions.checkArgument(evictionCheckProportion > 0 && evictionCheckProportion <= 1,
+                "'proportionConnectionsToCheckPerEvictionRun' must be between 0 and 1");
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -195,8 +195,8 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
 
     /**
      * Pool size:
-     *    Always keep {@code config.poolSize()} (default 20) connections around, per host.
-     *    Allow bursting up to poolSize * 5 (default 100) connections per host under load.
+     *    Always keep {@code config.poolSize()} (default 30) connections around, per host.
+     *    Allow bursting up to poolSize * 5 (default 150) connections per host under load.
      *
      * Borrowing from pool:
      *    On borrow, check if the connection is actually open. If it is not,
@@ -208,9 +208,9 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
      *
      *
      * In an asynchronous thread:
-     *    Every approximately 1 minute, examine approximately a third of the connections in pool.
-     *    Discard any connections in this third of the pool whose TCP connections are closed.
-     *    Discard any connections in this third of the pool that have been idle for more than 3 minutes,
+     *    Every 20-30 seconds, examine approximately a tenth of the connections in pool.
+     *    Discard any connections in this tenth of the pool whose TCP connections are closed.
+     *    Discard any connections in this tenth of the pool that have been idle for more than 10 minutes,
      *       while still keeping a minimum number of idle connections around for fast borrows.
      *
      */

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -237,7 +237,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         int delta = ThreadLocalRandom.current().nextInt(Math.min(timeBetweenEvictionsSeconds / 2, 10));
         poolConfig.setTimeBetweenEvictionRunsMillis(
                 TimeUnit.MILLISECONDS.convert(timeBetweenEvictionsSeconds + delta, TimeUnit.SECONDS));
-        poolConfig.setNumTestsPerEvictionRun(- (int) (1.0 / config.proportionConnectionsToCheckPerEvictionRun()));
+        poolConfig.setNumTestsPerEvictionRun(-(int) (1.0 / config.proportionConnectionsToCheckPerEvictionRun()));
         poolConfig.setTestWhileIdle(true);
 
         poolConfig.setJmxNamePrefix(host.getHostString());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -229,13 +229,13 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         // this test is free/just checks a boolean and does not block; borrow is still fast
         poolConfig.setTestOnBorrow(true);
 
-        poolConfig.setMinEvictableIdleTimeMillis(TimeUnit.MILLISECONDS.convert(3, TimeUnit.MINUTES));
+        poolConfig.setMinEvictableIdleTimeMillis(TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES));
         // the randomness here is to prevent all of the pools for all of the hosts
         // evicting all at at once, which isn't great for C*.
         poolConfig.setTimeBetweenEvictionRunsMillis(
-                TimeUnit.MILLISECONDS.convert(60 + ThreadLocalRandom.current().nextInt(10), TimeUnit.SECONDS));
-        // test one third of objects per eviction run  // (Apache Commons Pool has the worst API)
-        poolConfig.setNumTestsPerEvictionRun(-3);
+                TimeUnit.MILLISECONDS.convert(20 + ThreadLocalRandom.current().nextInt(10), TimeUnit.SECONDS));
+        // test one tenth of objects per eviction run  // (Apache Commons Pool has the worst API)
+        poolConfig.setNumTestsPerEvictionRun(-10);
         poolConfig.setTestWhileIdle(true);
 
         poolConfig.setJmxNamePrefix(host.getHostString());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -195,8 +195,8 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
 
     /**
      * Pool size:
-     *    Always keep {@code config.poolSize()} (default 30) connections around, per host.
-     *    Allow bursting up to poolSize * 5 (default 150) connections per host under load.
+     *    Always keep {@link CassandraKeyValueServiceConfig#poolSize()} connections around, per host. Allow bursting
+     *    up to {@link CassandraKeyValueServiceConfig#maxConnectionBurstSize()} connections per host under load.
      *
      * Borrowing from pool:
      *    On borrow, check if the connection is actually open. If it is not,
@@ -219,8 +219,8 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
 
         poolConfig.setMinIdle(config.poolSize());
-        poolConfig.setMaxIdle(5 * config.poolSize());
-        poolConfig.setMaxTotal(5 * config.poolSize());
+        poolConfig.setMaxIdle(config.maxConnectionBurstSize());
+        poolConfig.setMaxTotal(config.maxConnectionBurstSize());
 
         // immediately throw when we try and borrow from a full pool; dealt with at higher level
         poolConfig.setBlockWhenExhausted(false);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -42,6 +42,7 @@ import com.palantir.common.base.FunctionCheckedException;
 
 public class CassandraClientPoolTest {
     public static final int POOL_REFRESH_INTERVAL_SECONDS = 10;
+    public static final int TIME_BETWEEN_EVICTION_RUNS_SECONDS = 20;
     public static final int DEFAULT_PORT = 5000;
     public static final int OTHER_PORT = 6000;
     public static final String HOSTNAME_1 = "1.0.0.0";
@@ -203,6 +204,7 @@ public class CassandraClientPoolTest {
             Optional<Exception> failureMode) {
         CassandraKeyValueServiceConfig config = mock(CassandraKeyValueServiceConfig.class);
         when(config.poolRefreshIntervalSeconds()).thenReturn(POOL_REFRESH_INTERVAL_SECONDS);
+        when(config.timeBetweenConnectionEvictionRunsSeconds()).thenReturn(TIME_BETWEEN_EVICTION_RUNS_SECONDS);
         when(config.servers()).thenReturn(servers);
 
         CassandraClientPool cassandraClientPool = CassandraClientPool.createWithoutChecksForTesting(config);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -76,6 +76,11 @@ develop
            This means that we won't, over time, fill up the temp folder without the user realising.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1332>`__)
 
+    *    - |improved|
+         - Increase default Cassandra ``poolSize`` to 30 connections, increase connection pool idle timeout to 10 minutes,
+           and reduce eviction check frequency to 20-30 seconds at 1/10 of connections.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1336>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -78,7 +78,10 @@ develop
 
     *    - |improved|
          - Increase default Cassandra ``poolSize`` to 30 connections, increase connection pool idle timeout to 10 minutes,
-           and reduce eviction check frequency to 20-30 seconds at 1/10 of connections.
+           and reduce eviction check frequency to 20-30 seconds at 1/10 of connections. Note that there is now a configuration called ``maxConnectionBurstSize``,
+           which configures how large the pool is able to grow when receiving a large burst of requests. Previously this was hard-coded to 5x the ``poolSize``.
+           So if you have a non-default ``poolSize`` much greater than the old default of 20, you may need to increase ``maxConnectionBurstSize`` as well to account
+           for fluctuations in your connection pool.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1336>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -77,11 +77,9 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1332>`__)
 
     *    - |improved|
-         - Increase default Cassandra ``poolSize`` to 30 connections, increase connection pool idle timeout to 10 minutes,
-           and reduce eviction check frequency to 20-30 seconds at 1/10 of connections. Note that there is now a configuration called ``maxConnectionBurstSize``,
-           which configures how large the pool is able to grow when receiving a large burst of requests. Previously this was hard-coded to 5x the ``poolSize``.
-           So if you have a non-default ``poolSize`` much greater than the old default of 20, you may need to increase ``maxConnectionBurstSize`` as well to account
-           for fluctuations in your connection pool.
+         - Increase connection pool idle timeout to 10 minutes, and reduce eviction check frequency to 20-30 seconds at 1/10 of connections.
+           Note that there is now a configuration called ``maxConnectionBurstSize``, which configures how large the pool is able to grow when
+           receiving a large burst of requests. Previously this was hard-coded to 5x the ``poolSize`` (which is now the default for the parameter).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1336>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>


### PR DESCRIPTION
Based on discussion in https://github.com/palantir/atlasdb/issues/1233

@clockfort open to recommendations on specific values of this, but this spreads out load much more since now it checks 3 every 20-30 seconds by default and now holds on for 10 mins to reduce frequency of actually evicting. So load actually increases a little on average since it's checking more often, but this reduces the spikes. Here's a before-and-after when the server is relatively idle:

![cass-connection-idle-bump](https://cloud.githubusercontent.com/assets/4187816/20900968/425993fc-bae5-11e6-82ca-08b0f8b4cf28.png)

Also seems to smooth out when under load as well. Not a huge difference but seems worth it to minimize these spikes in load (primarily since it causes a bunch of context switching) when the application is bursty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1336)
<!-- Reviewable:end -->
