### PR TITLE
Add LZ4 compressing input stream

### DIFF
--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     compile project(":commons-executors")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
+    compile 'net.jpountz.lz4:lz4:1.3.0'
 
     testCompile group: 'junit', name: 'junit'
     testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile project(":commons-executors")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
-    compile 'net.jpountz.lz4:lz4:1.3.0'
+    compile 'net.jpountz.lz4:lz4'
 
     testCompile group: 'junit', name: 'junit'
     testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile project(":commons-executors")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
-    compile 'net.jpountz.lz4:lz4'
+    compile group: 'net.jpountz.lz4', name: 'lz4'
 
     testCompile group: 'junit', name: 'junit'
     testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
@@ -84,9 +84,8 @@ public abstract class BufferedDelegateInputStream extends InputStream {
      */
     @Override
     public final int read(byte[] b, int off, int len) throws IOException {
-        if (b == null) {
-            throw new NullPointerException("Provided byte array b cannot be null.");
-        } else if (off < 0 || len < 0 || len > b.length - off) {
+        Preconditions.checkNotNull(b, "Provided byte array b cannot be null.");
+        if (off < 0 || len < 0 || len > b.length - off) {
             throw new IndexOutOfBoundsException();
         } else if (len == 0) {
             return 0;

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
@@ -33,29 +33,19 @@ public abstract class BufferedDelegateInputStream extends InputStream {
     protected static final int BUFFER_START = 0;
 
     protected final InputStream delegate;
+    protected final byte[] buffer;
 
-    // Internal buffer from which data is read
-    protected byte[] buffer;
     // Current position in the buffer
     protected int position;
     // Size in bytes of the data in the buffer
     protected int bufferSize;
 
-    public BufferedDelegateInputStream(InputStream delegate, int bufferSize) {
+    public BufferedDelegateInputStream(InputStream delegate, int bufferLength) {
+        Preconditions.checkArgument(bufferLength >= 0, "buffer size must be greater than or equal to zero");
         this.delegate = delegate;
         this.position = 0;
         this.bufferSize = 0;
-        allocateBuffer(bufferSize);
-    }
-
-    public BufferedDelegateInputStream(InputStream delegate) {
-        this(delegate, 0);
-    }
-
-    public void allocateBuffer(int size) {
-        Preconditions.checkArgument(size >= 0, "buffer size must be greater than or equal to zero");
-        Preconditions.checkState(position == bufferSize, "cannot reallocate a buffer that has not been fully read");
-        this.buffer = new byte[size];
+        this.buffer = new byte[bufferLength];
     }
 
     @Override
@@ -63,7 +53,7 @@ public abstract class BufferedDelegateInputStream extends InputStream {
         if (!ensureBytesAvailable()) {
             return READ_FAILED;
         }
-        return buffer[position++] & 0xff;
+        return buffer[position++] & 0xFF;
     }
 
     // If all bytes in the buffer have been read, attempt to refill
@@ -94,7 +84,7 @@ public abstract class BufferedDelegateInputStream extends InputStream {
     @Override
     public final int read(byte[] b, int off, int len) throws IOException {
         if (b == null) {
-            throw new NullPointerException();
+            throw new NullPointerException("Provided byte array b cannot be null.");
         } else if (off < 0 || len < 0 || len > b.length - off) {
             throw new IndexOutOfBoundsException();
         } else if (len == 0) {

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
@@ -36,9 +36,9 @@ public abstract class BufferedDelegateInputStream extends InputStream {
     protected final byte[] buffer;
 
     // Current position in the buffer
-    protected int position;
+    private int position;
     // Size in bytes of the data in the buffer
-    protected int bufferSize;
+    private int bufferSize;
 
     public BufferedDelegateInputStream(InputStream delegate, int bufferLength) {
         Preconditions.checkArgument(bufferLength >= 0, "buffer size must be greater than or equal to zero");
@@ -61,10 +61,13 @@ public abstract class BufferedDelegateInputStream extends InputStream {
     // the end of the stream and return false.
     private boolean ensureBytesAvailable() throws IOException {
         if (position == bufferSize) {
-            boolean bufferRefilled = refill();
-            if (!bufferRefilled) {
+            position = BUFFER_START;
+            bufferSize = 0;
+            int bytesRefilled = refill();
+            if (bytesRefilled == 0) {
                 return false;
             }
+            bufferSize = bytesRefilled;
         }
         return true;
     }
@@ -119,9 +122,8 @@ public abstract class BufferedDelegateInputStream extends InputStream {
     /**
      * Refills the internal buffer from the delegate {@link InputStream}.
      *
-     * @return True if the buffer was refilled. False if the delegate
-     *         stream has been exhausted and the internal buffer is empty.
+     * @return The number of bytes written to the buffer while refilling it.
      */
-    protected abstract boolean refill() throws IOException;
+    protected abstract int refill() throws IOException;
 
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
@@ -62,12 +62,10 @@ public abstract class BufferedDelegateInputStream extends InputStream {
     private boolean ensureBytesAvailable() throws IOException {
         if (position == bufferSize) {
             position = BUFFER_START;
-            bufferSize = 0;
-            int bytesRefilled = refill();
-            if (bytesRefilled == 0) {
+            bufferSize = refill();
+            if (bufferSize == 0) {
                 return false;
             }
-            bufferSize = bytesRefilled;
         }
         return true;
     }

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/BufferedDelegateInputStream.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.compression;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * {@link InputStream} that wraps a delegate InputStream, buffering reads
+ * to the delegate. Allows a customized strategy for refilling the internal
+ * buffer from the delegate stream for use cases such as decompressing a
+ * compressed stream.
+ */
+public abstract class BufferedDelegateInputStream extends InputStream {
+
+    protected static final int READ_FAILED = -1;
+    protected static final int BUFFER_START = 0;
+
+    protected final InputStream delegate;
+
+    // Internal buffer from which data is read
+    protected byte[] buffer;
+    // Current position in the buffer
+    protected int position;
+    // Size in bytes of the data in the buffer
+    protected int bufferSize;
+
+    public BufferedDelegateInputStream(InputStream delegate, int bufferSize) {
+        this.delegate = delegate;
+        this.position = 0;
+        this.bufferSize = 0;
+        allocateBuffer(bufferSize);
+    }
+
+    public BufferedDelegateInputStream(InputStream delegate) {
+        this(delegate, 0);
+    }
+
+    public void allocateBuffer(int size) {
+        Preconditions.checkArgument(size >= 0, "buffer size must be greater than or equal to zero");
+        Preconditions.checkState(position == bufferSize, "cannot reallocate a buffer that has not been fully read");
+        this.buffer = new byte[size];
+    }
+
+    @Override
+    public final int read() throws IOException {
+        if (!ensureBytesAvailable()) {
+            return READ_FAILED;
+        }
+        return buffer[position++] & 0xff;
+    }
+
+    // If all bytes in the buffer have been read, attempt to refill
+    // the buffer. If the buffer can't be refilled, then we've reached
+    // the end of the stream and return false.
+    private boolean ensureBytesAvailable() throws IOException {
+        if (position == bufferSize) {
+            boolean bufferRefilled = refill();
+            if (!bufferRefilled) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Reads up to {@code len} bytes into the provided byte array {@code b}.
+     * If no remaining unread bytes are available in the internal buffer,
+     * {@link #refill() refill} is called to refill the internal buffer.
+     * Otherwise, either {@code len} bytes or the number of bytes available
+     * in the buffer are read, whichever is smaller.
+     *
+     * To read from the buffer until either the end of the stream is reached
+     * or {@code len} bytes have been read, use
+     * {@link com.google.common.io.ByteStreams#read(InputStream, byte[], int, int)
+     * ByteStreams.read}.
+     */
+    @Override
+    public final int read(byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+
+        if (!ensureBytesAvailable()) {
+            return READ_FAILED;
+        }
+
+        return readBytes(b, off, len);
+    }
+
+    private int readBytes(byte[] dest, int offset, int maxBytesToRead) {
+        int bytesLeftInBuffer = available();
+        int bytesToRead = Math.min(maxBytesToRead, bytesLeftInBuffer);
+        System.arraycopy(buffer, position, dest, offset, bytesToRead);
+        position += bytesToRead;
+        return bytesToRead;
+    }
+
+    @Override
+    public final int available() {
+        return bufferSize - position;
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    /**
+     * Refills the internal buffer from the delegate {@link InputStream}.
+     *
+     * @return True if the buffer was refilled. False if the delegate
+     *         stream has been exhausted and the internal buffer is empty.
+     */
+    protected abstract boolean refill() throws IOException;
+
+}

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/LZ4CompressingInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/LZ4CompressingInputStream.java
@@ -56,11 +56,9 @@ public final class LZ4CompressingInputStream extends BufferedDelegateInputStream
     }
 
     public LZ4CompressingInputStream(InputStream delegate, int blockSize) throws IOException {
-        super(delegate);
+        super(delegate, Math.max(blockSize, COMPRESSOR.maxCompressedLength(blockSize)));
         this.blockSize = blockSize;
-        int compressedBufferSize = COMPRESSOR.maxCompressedLength(blockSize);
         Checksum checksum = XXHashFactory.fastestInstance().newStreamingHash32(DEFAULT_SEED).asChecksum();
-        allocateBuffer(Math.max(blockSize, compressedBufferSize));
         OutputStream delegateOutputStream = new InternalByteArrayOutputStream();
         this.compressingStream = new LZ4BlockOutputStream(delegateOutputStream, blockSize, COMPRESSOR, checksum, true);
         this.readInProgress = false;
@@ -116,7 +114,7 @@ public final class LZ4CompressingInputStream extends BufferedDelegateInputStream
     private void write(byte b[], int off, int len) throws IOException {
         ensureSafeForWrite();
         if (b == null) {
-            throw new NullPointerException();
+            throw new NullPointerException("Provided byte array b cannot be null.");
         }
         if ((off < 0) || (len < 0) || (off + len > b.length)) {
             throw new IndexOutOfBoundsException();

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/LZ4CompressingInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/LZ4CompressingInputStream.java
@@ -98,9 +98,7 @@ public final class LZ4CompressingInputStream extends BufferedDelegateInputStream
     }
 
     private void write(byte b[], int off, int len) throws IOException {
-        if (b == null) {
-            throw new NullPointerException("Provided byte array b cannot be null.");
-        }
+        Preconditions.checkNotNull(b, "Provided byte array b cannot be null.");
         if ((off < 0) || (len < 0) || (off + len > b.length)) {
             throw new IndexOutOfBoundsException();
         }

--- a/atlasdb-commons/src/main/java/com/palantir/common/compression/LZ4CompressingInputStream.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/compression/LZ4CompressingInputStream.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.compression;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.Checksum;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.ByteStreams;
+
+import net.jpountz.lz4.LZ4BlockOutputStream;
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.xxhash.XXHashFactory;
+
+/**
+ * {@link InputStream} that wraps a delegate InputStream, compressing its
+ * contents as they are read. Compression is managed via a compressing
+ * {@link OutputStream}. Reads pull data as necessary from the delegate
+ * InputStream, write the uncompressed data through the OutputStream, then
+ * serve the read from the resulting compressed buffer.
+ */
+public final class LZ4CompressingInputStream extends BufferedDelegateInputStream {
+
+    private static final LZ4Compressor COMPRESSOR = LZ4Factory.fastestInstance().fastCompressor();
+    private static final int DEFAULT_SEED = 0x9747b28c;
+    private static final int DEFAULT_BLOCK_SIZE = 1 << 16; // 64 KB
+
+    private final LZ4BlockOutputStream compressingStream;
+    private final int blockSize;
+
+    // Flag to prevent writes to the internal buffer while the
+    // compressing stream is reading from it.
+    private boolean readInProgress;
+    // Flag to indicate whether this stream has been exhausted.
+    private boolean finished;
+
+    public LZ4CompressingInputStream(InputStream delegate) throws IOException {
+        this(delegate, DEFAULT_BLOCK_SIZE);
+    }
+
+    public LZ4CompressingInputStream(InputStream delegate, int blockSize) throws IOException {
+        super(delegate);
+        this.blockSize = blockSize;
+        int compressedBufferSize = COMPRESSOR.maxCompressedLength(blockSize);
+        Checksum checksum = XXHashFactory.fastestInstance().newStreamingHash32(DEFAULT_SEED).asChecksum();
+        allocateBuffer(Math.max(blockSize, compressedBufferSize));
+        OutputStream delegateOutputStream = new InternalByteArrayOutputStream();
+        this.compressingStream = new LZ4BlockOutputStream(delegateOutputStream, blockSize, COMPRESSOR, checksum, true);
+        this.readInProgress = false;
+        this.finished = false;
+
+        // Flush the LZ4 header so that the compression buffer is empty
+        delegateOutputStream.flush();
+    }
+
+    @Override
+    protected boolean refill() throws IOException {
+        if (finished) {
+            return false;
+        }
+        position = 0;
+        bufferSize = 0;
+
+        // Read a block of data from the delegate input stream.
+        int bytesRead = ByteStreams.read(delegate, buffer, BUFFER_START, blockSize);
+        if (bytesRead == 0) {
+            // The delegate input stream has been exhausted, so we notify
+            // the compressing stream that there are no remaining bytes.
+            // Lastly, we flush the LZ4 footer into the internal buffer.
+            compressingStream.finish();
+            compressingStream.flush();
+            finished = true;
+            return true;
+        }
+
+        // Write the bytes to the compressing stream and flush it.
+        // The compressing stream flushes bytes when it contains more
+        // than blockSize bytes, so we manually flush after writing up to
+        // blockSize bytes to flush the compressed bytes to the internal
+        // buffer. The readInProgress flag protects against simultaneously
+        // reading and writing to the same buffer. The write call will read
+        // from the buffer but should not write to it - only the flush call
+        // should.
+        readInProgress = true;
+        compressingStream.write(buffer, BUFFER_START, bytesRead);
+        readInProgress = false;
+        compressingStream.flush();
+
+        return true;
+    }
+
+    private void write(int b) throws IOException {
+        ensureSafeForWrite();
+        ensureCapacity(bufferSize + 1);
+        buffer[bufferSize] = (byte) b;
+        bufferSize++;
+    }
+
+    private void write(byte b[], int off, int len) throws IOException {
+        ensureSafeForWrite();
+        if (b == null) {
+            throw new NullPointerException();
+        }
+        if ((off < 0) || (len < 0) || (off + len > b.length)) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (len == 0) {
+            return;
+        }
+        ensureCapacity(bufferSize + len);
+        System.arraycopy(b, off, buffer, bufferSize, len);
+        bufferSize += len;
+    }
+
+    private void ensureSafeForWrite() {
+        Preconditions.checkState(!readInProgress, "Cannot simultaneously read and write from the buffer.");
+    }
+
+    // Since the internal buffer size doesn't change, we throw if
+    // someone tries to write past the end of the buffer.
+    private void ensureCapacity(int size) {
+        Preconditions.checkState(buffer.length >= size, "Internal buffer overflow");
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+        compressingStream.close();
+    }
+
+    /**
+     * Internal {@link OutputStream} that wraps the pre-existing buffer. This
+     * is an inner class since LZ4CompressingInputStream cannot extend both
+     * {@link BufferedDelegateInputStream} and {@link OutputStream}.
+     */
+    private final class InternalByteArrayOutputStream extends OutputStream {
+
+        public InternalByteArrayOutputStream() {
+            super();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            LZ4CompressingInputStream.this.write(b);
+        }
+
+        @Override
+        public void write(byte b[], int off, int len) throws IOException {
+            LZ4CompressingInputStream.this.write(b, off, len);
+        }
+    }
+
+}

--- a/atlasdb-commons/src/test/java/com/palantir/common/compression/LZ4CompressionTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/compression/LZ4CompressionTests.java
@@ -1,5 +1,17 @@
-/*
- * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.palantir.common.compression;

--- a/atlasdb-commons/src/test/java/com/palantir/common/compression/LZ4CompressionTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/compression/LZ4CompressionTests.java
@@ -56,51 +56,37 @@ public class LZ4CompressionTests {
 
     @Test
     public void testSingleCharacterStream() throws IOException {
-        byte[] uncompressedData = new byte[] { SINGLE_VALUE };
-        initializeStreams(uncompressedData);
-        verifyStreamContents(uncompressedData);
+        testStream_incompressible(1); // 1 byte input will always be incompressible
     }
 
     @Test
-    public void testSingleCharacterSteam_singleByteRead() throws IOException {
+    public void testSingleCharacterStream_singleByteRead() throws IOException {
         byte[] uncompressedData = new byte[] { SINGLE_VALUE };
         initializeStreams(uncompressedData);
         int value = decompressingStream.read();
 
-        assertEquals(uncompressedData[0], value);
+        assertEquals(Byte.toUnsignedInt(uncompressedData[0]), value);
         assertStreamIsEmpty(decompressingStream);
     }
 
     @Test
-    public void testSingleBlock() throws IOException {
-        byte[] uncompressedData = new byte[BLOCK_SIZE];
-        fillWithCompressibleData(uncompressedData);
-        initializeStreams(uncompressedData);
-        verifyStreamContents(uncompressedData);
+    public void testSingleBlock_compressible() throws IOException {
+        testStream_compressible(BLOCK_SIZE);
     }
 
     @Test
     public void testSingleBlock_incompressible() throws IOException {
-        byte[] uncompressedData = new byte[BLOCK_SIZE];
-        fillWithIncompressibleData(uncompressedData);
-        initializeStreams(uncompressedData);
-        verifyStreamContents(uncompressedData);
+        testStream_incompressible(BLOCK_SIZE);
     }
 
     @Test
     public void testMultiBlock_compressible() throws IOException {
-        byte[] uncompressedData = new byte[16 * BLOCK_SIZE];
-        fillWithCompressibleData(uncompressedData);
-        initializeStreams(uncompressedData);
-        verifyStreamContents(uncompressedData);
+        testStream_compressible(16 * BLOCK_SIZE);
     }
 
     @Test
     public void testMultiBlock_incompressible() throws IOException {
-        byte[] uncompressedData = new byte[16 * BLOCK_SIZE];
-        fillWithIncompressibleData(uncompressedData);
-        initializeStreams(uncompressedData);
-        verifyStreamContents(uncompressedData);
+        testStream_incompressible(16 * BLOCK_SIZE);
     }
 
     @Test
@@ -126,6 +112,20 @@ public class LZ4CompressionTests {
         int bytesRead = ByteStreams.read(decompressingStream, decompressedData, 0, decompressedData.length);
         assertEquals(uncompressedData.length, bytesRead);
         assertArrayEquals(uncompressedData, Arrays.copyOf(decompressedData, bytesRead));
+    }
+
+    private void testStream_compressible(int streamSize) throws IOException {
+        byte[] uncompressedData = new byte[streamSize];
+        fillWithCompressibleData(uncompressedData);
+        initializeStreams(uncompressedData);
+        verifyStreamContents(uncompressedData);
+    }
+
+    private void testStream_incompressible(int streamSize) throws IOException {
+        byte[] uncompressedData = new byte[streamSize];
+        fillWithIncompressibleData(uncompressedData);
+        initializeStreams(uncompressedData);
+        verifyStreamContents(uncompressedData);
     }
 
     private void initializeStreams(byte[] uncompressedData) throws IOException {

--- a/atlasdb-commons/src/test/java/com/palantir/common/compression/LZ4CompressionTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/compression/LZ4CompressionTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.common.compression;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.google.common.io.ByteStreams;
+
+import net.jpountz.lz4.LZ4BlockInputStream;
+
+public class LZ4CompressionTests {
+
+    private static final byte SINGLE_VALUE = 42;
+    private static final int BLOCK_SIZE = 1 << 16; // 64 KB
+
+    private ByteArrayInputStream uncompressedStream;
+    private LZ4CompressingInputStream compressingStream;
+    private LZ4BlockInputStream decompressingStream;
+
+    @After
+    public void after() throws IOException {
+        uncompressedStream.close();
+        compressingStream.close();
+        decompressingStream.close();
+    }
+
+    @Test
+    public void testEmptyStream() throws IOException {
+        initializeStreams(new byte[0]);
+        assertStreamIsEmpty(decompressingStream);
+    }
+
+    @Test
+    public void testSingleCharacterStream() throws IOException {
+        byte[] uncompressedData = new byte[] { SINGLE_VALUE };
+        initializeStreams(uncompressedData);
+        verifyStreamContents(uncompressedData);
+    }
+
+    @Test
+    public void testSingleCharacterSteam_singleByteRead() throws IOException {
+        byte[] uncompressedData = new byte[] { SINGLE_VALUE };
+        initializeStreams(uncompressedData);
+        int value = decompressingStream.read();
+
+        assertEquals(uncompressedData[0], value);
+        assertStreamIsEmpty(decompressingStream);
+    }
+
+    @Test
+    public void testSingleBlock() throws IOException {
+        byte[] uncompressedData = new byte[BLOCK_SIZE];
+        fillWithCompressibleData(uncompressedData);
+        initializeStreams(uncompressedData);
+        verifyStreamContents(uncompressedData);
+    }
+
+    @Test
+    public void testSingleBlock_incompressible() throws IOException {
+        byte[] uncompressedData = new byte[BLOCK_SIZE];
+        fillWithIncompressibleData(uncompressedData);
+        initializeStreams(uncompressedData);
+        verifyStreamContents(uncompressedData);
+    }
+
+    @Test
+    public void testMultiBlock_compressible() throws IOException {
+        byte[] uncompressedData = new byte[16 * BLOCK_SIZE];
+        fillWithCompressibleData(uncompressedData);
+        initializeStreams(uncompressedData);
+        verifyStreamContents(uncompressedData);
+    }
+
+    @Test
+    public void testMultiBlock_incompressible() throws IOException {
+        byte[] uncompressedData = new byte[16 * BLOCK_SIZE];
+        fillWithIncompressibleData(uncompressedData);
+        initializeStreams(uncompressedData);
+        verifyStreamContents(uncompressedData);
+    }
+
+    @Test
+    public void testMultiBlock_singleByteReads() throws IOException {
+        byte[] uncompressedData = new byte[16 * BLOCK_SIZE];
+        fillWithIncompressibleData(uncompressedData);
+        initializeStreams(uncompressedData);
+
+        for (int i = 0; i < uncompressedData.length; ++i) {
+            int value = decompressingStream.read();
+            assertEquals(Byte.toUnsignedInt(uncompressedData[i]), value);
+        }
+        assertStreamIsEmpty(decompressingStream);
+    }
+
+    @Test
+    public void testMultiBlock_readPastEnd() throws IOException {
+        byte[] uncompressedData = new byte[16 * BLOCK_SIZE];
+        fillWithCompressibleData(uncompressedData);
+        initializeStreams(uncompressedData);
+
+        byte[] decompressedData = new byte[17 * BLOCK_SIZE];
+        int bytesRead = ByteStreams.read(decompressingStream, decompressedData, 0, decompressedData.length);
+        assertEquals(uncompressedData.length, bytesRead);
+        assertArrayEquals(uncompressedData, Arrays.copyOf(decompressedData, bytesRead));
+    }
+
+    private void initializeStreams(byte[] uncompressedData) throws IOException {
+        uncompressedStream = new ByteArrayInputStream(uncompressedData);
+        compressingStream = new LZ4CompressingInputStream(uncompressedStream);
+        decompressingStream = new LZ4BlockInputStream(compressingStream);
+    }
+
+    private void fillWithCompressibleData(byte[] data) {
+        Arrays.fill(data, SINGLE_VALUE);
+    }
+
+    private void fillWithIncompressibleData(byte[] data) {
+        new Random(0).nextBytes(data);
+    }
+
+    private void verifyStreamContents(byte[] uncompressedData) throws IOException {
+        byte[] decompressedData = new byte[uncompressedData.length];
+        ByteStreams.read(decompressingStream, decompressedData, 0, decompressedData.length);
+        assertArrayEquals(uncompressedData, decompressedData);
+        assertStreamIsEmpty(decompressingStream);
+    }
+
+    private void assertStreamIsEmpty(InputStream stream) throws IOException {
+        assertEquals(-1, stream.read());
+    }
+}

--- a/versions.props
+++ b/versions.props
@@ -26,6 +26,7 @@ joda-time:joda-time = 2.7
 jp.skypencil.findbugs.slf4j:* = 1.2.4
 junit:junit = 4.12
 net.java.dev.jna:jna = 4.1.0
+net.jpountz.lz4:lz4 = 1.3.0
 one.util:streamex = 0.6.3
 org.apache.commons:commons-lang3 = 3.1
 org.apache.thrift:libthrift = 0.9.2


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

[no release notes]

Alternate implementation to https://github.com/palantir/atlasdb/pull/1312. This is cleaner and simpler, since we simply wrap the existing compressing output stream in an input stream. I've removed extra buffers and buffer copies where possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1347)
<!-- Reviewable:end -->
