### PR TITLE
Sweep command doesn't conflate cell versions and cells

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -128,7 +128,7 @@ public class SweepCommand extends SingleBackendCommand {
             while (startRow.isPresent()) {
                 Stopwatch watch = Stopwatch.createStarted();
                 SweepResults results = sweepRunner.run(table, batchSize, cellBatchSize, startRow.get());
-                printer.info("Swept from {} to {} in table {} in {} ms, examined {} unique cells, deleted {} stale values.",
+                printer.info("Swept from {} to {} in table {} in {} ms, examined {} unique cells, deleted {} stale versions of those cells.",
                         encodeStartRow(startRow), encodeEndRow(results.getNextStartRow()),
                         table, watch.elapsed(TimeUnit.MILLISECONDS),
                         results.getCellsExamined(), results.getCellsDeleted());
@@ -146,7 +146,7 @@ public class SweepCommand extends SingleBackendCommand {
                 priorityTable.putCellsExamined(row1, cellsExamined.get());
                 priorityTable.putLastSweepTime(row1, System.currentTimeMillis());
 
-                printer.info("Finished sweeping {}, examined {} unique cells, deleted {} stale values.",
+                printer.info("Finished sweeping {}, examined {} unique cells, deleted {} stale versions of those cells.",
                         table, cellsExamined.get(), cellsDeleted.get());
 
                 if (cellsDeleted.get() > 0) {

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -128,7 +128,7 @@ public class SweepCommand extends SingleBackendCommand {
             while (startRow.isPresent()) {
                 Stopwatch watch = Stopwatch.createStarted();
                 SweepResults results = sweepRunner.run(table, batchSize, cellBatchSize, startRow.get());
-                printer.info("Swept from {} to {} in table {} in {} ms, examined {} unique cells, deleted {} cells.",
+                printer.info("Swept from {} to {} in table {} in {} ms, examined {} unique cells, deleted {} stale values.",
                         encodeStartRow(startRow), encodeEndRow(results.getNextStartRow()),
                         table, watch.elapsed(TimeUnit.MILLISECONDS),
                         results.getCellsExamined(), results.getCellsDeleted());
@@ -146,7 +146,7 @@ public class SweepCommand extends SingleBackendCommand {
                 priorityTable.putCellsExamined(row1, cellsExamined.get());
                 priorityTable.putLastSweepTime(row1, System.currentTimeMillis());
 
-                printer.info("Finished sweeping {}, examined {} unique cells, deleted {} cells.",
+                printer.info("Finished sweeping {}, examined {} unique cells, deleted {} stale values.",
                         table, cellsExamined.get(), cellsDeleted.get());
 
                 if (cellsDeleted.get() > 0) {

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestSweepCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestSweepCommand.java
@@ -97,7 +97,7 @@ public class TestSweepCommand {
 
             Scanner scanner = new Scanner(stdout);
             final long uniqueCells = Long.parseLong(scanner.findInLine("\\d+ unique cells").split(" ")[0]);
-            final long deletedCells = Long.parseLong(scanner.findInLine("deleted \\d+ stale values").split(" ")[1]);
+            final long deletedCells = Long.parseLong(scanner.findInLine("deleted \\d+ stale versions of those cells").split(" ")[1]);
             Assert.assertEquals(1, uniqueCells);
             Assert.assertEquals(1, deletedCells);
 

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestSweepCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestSweepCommand.java
@@ -97,7 +97,7 @@ public class TestSweepCommand {
 
             Scanner scanner = new Scanner(stdout);
             final long uniqueCells = Long.parseLong(scanner.findInLine("\\d+ unique cells").split(" ")[0]);
-            final long deletedCells = Long.parseLong(scanner.findInLine("deleted \\d+ cells").split(" ")[1]);
+            final long deletedCells = Long.parseLong(scanner.findInLine("deleted \\d+ stale values").split(" ")[1]);
             Assert.assertEquals(1, uniqueCells);
             Assert.assertEquals(1, deletedCells);
 


### PR DESCRIPTION


The sweep cli conflates a cell and a (cell, timestamp) pair, causing it to occasionally print scary things like: "exampled 1 cell, deleted 1000 cells"

This swaps the seconds "cells" for "stale values".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1348)
<!-- Reviewable:end -->
