### PR TITLE
Feature/stream store compression

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinition.java
@@ -36,8 +36,13 @@ public class StreamStoreDefinition {
 
     private int inMemoryThreshold;
 
-    StreamStoreDefinition(Map<String, TableDefinition> streamStoreTables, String shortName, String longName,
-            ValueType idType, int inMemoryThreshold, boolean compressStream) {
+    StreamStoreDefinition(
+            Map<String, TableDefinition> streamStoreTables,
+            String shortName,
+            String longName,
+            ValueType idType,
+            int inMemoryThreshold,
+            boolean compressStream) {
         this.streamStoreTables = streamStoreTables;
         this.shortName = shortName;
         this.longName = longName;
@@ -51,12 +56,15 @@ public class StreamStoreDefinition {
     }
 
     public StreamStoreRenderer getRenderer(String packageName, String name) {
-        return new StreamStoreRenderer(Renderers.CamelCase(longName), idType, packageName, name, inMemoryThreshold,
-                compressStream);
+        String renderedLongName = Renderers.CamelCase(longName);
+        return new StreamStoreRenderer(renderedLongName, idType, packageName, name, inMemoryThreshold, compressStream);
     }
 
-    public Multimap<String, Supplier<OnCleanupTask>> getCleanupTasks(String packageName, String name,
-            StreamStoreRenderer renderer, Namespace namespace) {
+    public Multimap<String, Supplier<OnCleanupTask>> getCleanupTasks(
+            String packageName,
+            String name,
+            StreamStoreRenderer renderer,
+            Namespace namespace) {
         Multimap<String, Supplier<OnCleanupTask>> cleanupTasks = ArrayListMultimap.create();
 
         // We use reflection and wrap these in suppliers because these classes are generated classes that

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinition.java
@@ -32,15 +32,18 @@ public class StreamStoreDefinition {
     private final Map<String, TableDefinition> streamStoreTables;
     private final String shortName, longName;
     private final ValueType idType;
+    private final boolean compressStream;
 
     private int inMemoryThreshold;
 
-    StreamStoreDefinition(Map<String, TableDefinition> streamStoreTables, String shortName, String longName, ValueType idType, int inMemoryThreshold) {
+    StreamStoreDefinition(Map<String, TableDefinition> streamStoreTables, String shortName, String longName,
+            ValueType idType, int inMemoryThreshold, boolean compressStream) {
         this.streamStoreTables = streamStoreTables;
         this.shortName = shortName;
         this.longName = longName;
         this.idType = idType;
         this.inMemoryThreshold = inMemoryThreshold;
+        this.compressStream = compressStream;
     }
 
     public Map<String, TableDefinition> getTables() {
@@ -48,13 +51,16 @@ public class StreamStoreDefinition {
     }
 
     public StreamStoreRenderer getRenderer(String packageName, String name) {
-        return new StreamStoreRenderer(Renderers.CamelCase(longName), idType, packageName, name, inMemoryThreshold);
+        return new StreamStoreRenderer(Renderers.CamelCase(longName), idType, packageName, name, inMemoryThreshold,
+                compressStream);
     }
 
-    public Multimap<String, Supplier<OnCleanupTask>> getCleanupTasks(String packageName, String name, StreamStoreRenderer renderer, Namespace namespace) {
+    public Multimap<String, Supplier<OnCleanupTask>> getCleanupTasks(String packageName, String name,
+            StreamStoreRenderer renderer, Namespace namespace) {
         Multimap<String, Supplier<OnCleanupTask>> cleanupTasks = ArrayListMultimap.create();
 
-        // We use reflection and wrap these in suppliers because these classes are generated classes that might not always exist.
+        // We use reflection and wrap these in suppliers because these classes are generated classes that
+        // might not always exist.
         cleanupTasks.put(StreamTableType.METADATA.getTableName(shortName), new Supplier<OnCleanupTask>() {
             @Override
             public OnCleanupTask get() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
@@ -27,16 +27,20 @@ import com.palantir.atlasdb.table.description.ValueType;
 public class StreamStoreDefinitionBuilder {
     private final ValueType valueType;
     private final String shortName, longName;
-    private Map<String, StreamTableDefinitionBuilder> streamTables =  Maps.newHashMapWithExpectedSize(StreamTableType.values().length);
+    private Map<String, StreamTableDefinitionBuilder> streamTables =
+            Maps.newHashMapWithExpectedSize(StreamTableType.values().length);
     private int inMemoryThreshold = AtlasDbConstants.DEFAULT_STREAM_IN_MEMORY_THRESHOLD;
+    private boolean compressStream;
 
     public StreamStoreDefinitionBuilder(String shortName, String longName, ValueType valueType) {
         for (StreamTableType tableType : StreamTableType.values()) {
-            streamTables.put(tableType.getTableName(shortName), new StreamTableDefinitionBuilder(tableType, longName, valueType));
+            streamTables.put(tableType.getTableName(shortName),
+                    new StreamTableDefinitionBuilder(tableType, longName, valueType));
         }
         this.valueType = valueType;
         this.shortName = shortName;
         this.longName = longName;
+        this.compressStream = false;
     }
 
     public StreamStoreDefinitionBuilder hashFirstRowComponent() {
@@ -54,18 +58,24 @@ public class StreamStoreDefinitionBuilder {
         return this;
     }
 
+    public StreamStoreDefinitionBuilder compressStreamInClient() {
+        compressStream = true;
+        return this;
+    }
+
     public StreamStoreDefinitionBuilder inMemoryThreshold(int inMemoryThreshold) {
         this.inMemoryThreshold = inMemoryThreshold;
         return this;
     }
 
     public StreamStoreDefinition build() {
-        Map<String, TableDefinition> tablesToCreate = streamTables.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().build()));
+        Map<String, TableDefinition> tablesToCreate = streamTables.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().build()));
 
         Preconditions.checkArgument(valueType.getJavaClassName().equals("long"), "Stream ids must be a long");
 
-
-        return new StreamStoreDefinition(tablesToCreate, shortName, longName, valueType, inMemoryThreshold);
+        return new StreamStoreDefinition(tablesToCreate, shortName, longName, valueType, inMemoryThreshold,
+                compressStream);
     }
 
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
@@ -74,7 +74,12 @@ public class StreamStoreDefinitionBuilder {
 
         Preconditions.checkArgument(valueType.getJavaClassName().equals("long"), "Stream ids must be a long");
 
-        return new StreamStoreDefinition(tablesToCreate, shortName, longName, valueType, inMemoryThreshold,
+        return new StreamStoreDefinition(
+                tablesToCreate,
+                shortName,
+                longName,
+                valueType,
+                inMemoryThreshold,
                 compressStream);
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
@@ -104,7 +104,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
         }
     }
 
-    private InputStream makeStream(ID id, StreamMetadata metadata) {
+    protected InputStream makeStream(ID id, StreamMetadata metadata) {
         long totalBlocks = getNumberOfBlocksFromMetadata(metadata);
         int blocksInMemory = getNumberOfBlocksThatFitInMemory();
 
@@ -139,7 +139,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
     }
 
     @Override
-    public File loadStreamAsFile(Transaction transaction, ID id) {
+    public final File loadStreamAsFile(Transaction transaction, ID id) {
         StreamMetadata metadata = getMetadata(transaction, id);
         checkStreamStored(id, metadata);
         return loadToNewTempFile(transaction, id, metadata);
@@ -156,7 +156,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
         }
     }
 
-    protected void checkStreamStored(ID id, StreamMetadata metadata) {
+    private void checkStreamStored(ID id, StreamMetadata metadata) {
         if (metadata == null) {
             log.error("Error loading stream {} because it was never stored.", id);
             throw new IllegalArgumentException("Unable to load stream " + id + " because it was never stored.");
@@ -183,6 +183,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
         }
     }
 
+    // This method is overridden in generated code. Changes to this method may have unintended consequences.
     protected void tryWriteStreamToFile(Transaction transaction, ID id, StreamMetadata metadata, FileOutputStream fos)
             throws IOException {
         long numBlocks = getNumberOfBlocksFromMetadata(metadata);
@@ -198,7 +199,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
 
     protected abstract Map<ID, StreamMetadata> getMetadata(Transaction tx, Set<ID> streamIds);
 
-    protected StreamMetadata getMetadata(Transaction transaction, ID id) {
+    private StreamMetadata getMetadata(Transaction transaction, ID id) {
         return Iterables.getOnlyElement(getMetadata(transaction, Sets.newHashSet(id)).entrySet()).getValue();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
@@ -65,13 +65,13 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
     protected abstract long getInMemoryThreshold();
 
     @Override
-    public final InputStream loadStream(Transaction transaction, final ID id) {
+    public InputStream loadStream(Transaction transaction, final ID id) {
         StreamMetadata metadata = getMetadata(transaction, id);
         return getStream(transaction, id, metadata);
     }
 
     @Override
-    public final Map<ID, InputStream> loadStreams(Transaction transaction, Set<ID> ids) {
+    public Map<ID, InputStream> loadStreams(Transaction transaction, Set<ID> ids) {
         Map<ID, InputStream> ret = Maps.newHashMap();
         Map<ID, StreamMetadata> idsToMetadata = getMetadata(transaction, ids);
         for (Map.Entry<ID, StreamMetadata> entry : idsToMetadata.entrySet()) {
@@ -139,7 +139,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
     }
 
     @Override
-    public final File loadStreamAsFile(Transaction transaction, ID id) {
+    public File loadStreamAsFile(Transaction transaction, ID id) {
         StreamMetadata metadata = getMetadata(transaction, id);
         checkStreamStored(id, metadata);
         return loadToNewTempFile(transaction, id, metadata);
@@ -156,7 +156,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
         }
     }
 
-    private void checkStreamStored(ID id, StreamMetadata metadata) {
+    protected void checkStreamStored(ID id, StreamMetadata metadata) {
         if (metadata == null) {
             log.error("Error loading stream {} because it was never stored.", id);
             throw new IllegalArgumentException("Unable to load stream " + id + " because it was never stored.");
@@ -183,7 +183,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
         }
     }
 
-    private void tryWriteStreamToFile(Transaction transaction, ID id, StreamMetadata metadata, FileOutputStream fos)
+    protected void tryWriteStreamToFile(Transaction transaction, ID id, StreamMetadata metadata, FileOutputStream fos)
             throws IOException {
         long numBlocks = getNumberOfBlocksFromMetadata(metadata);
         for (long i = 0; i < numBlocks; i++) {
@@ -198,7 +198,7 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
 
     protected abstract Map<ID, StreamMetadata> getMetadata(Transaction tx, Set<ID> streamIds);
 
-    private StreamMetadata getMetadata(Transaction transaction, ID id) {
+    protected StreamMetadata getMetadata(Transaction transaction, ID id) {
         return Iterables.getOnlyElement(getMetadata(transaction, Sets.newHashSet(id)).entrySet()).getValue();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/ImportRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/ImportRenderer.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 
 public class ImportRenderer extends Renderer {
-    private static final List<String> IMPORT_PREFIXES = ImmutableList.of("java.", "javax.", "org.", "com.");
+    private static final List<String> IMPORT_PREFIXES = ImmutableList.of("java.", "javax.", "org.", "com.", "net.");
     private final Collection<Class<?>> imports;
 
     public ImportRenderer(Renderer parent, Collection<Class<?>> imports) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -579,7 +579,7 @@ public class StreamStoreRenderer {
                     line("try {"); {
                         line("// Hash the data before compressing it");
                         line("compressedStream = new LZ4CompressingInputStream(new DigestInputStream(stream, digest));");
-                    } line ("catch (IOException e) {"); {
+                    } line ("} catch (IOException e) {"); {
                         line("throw new RuntimeException(e);");
                     } line("}");
                     line("StreamMetadata metadata = storeBlocksAndGetFinalMetadata(transaction, id, compressedStream, false);");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -540,8 +540,8 @@ public class StreamStoreRenderer {
                 line("protected StreamMetadata storeBlocksAndGetFinalMetadata(Transaction t, long id, InputStream stream) {"); {
                     line("//Hash the data before compressing it");
                     line("MessageDigest digest = Sha256Hash.getMessageDigest();");
-                    line("try (InputStream hashingStream = new DigestInputStream(stream, digest);"); {
-                        line("    InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {");
+                    line("try (InputStream hashingStream = new DigestInputStream(stream, digest);");
+                    line("        InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {"); {
                         line("StreamMetadata metadata = storeBlocksAndGetHashlessMetadata(t, id, compressingStream);");
                         line("return StreamMetadata.newBuilder(metadata)");
                         line("        .setHash(ByteString.copyFrom(digest.digest()))");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -541,16 +541,14 @@ public class StreamStoreRenderer {
                     line("//Hash the data before compressing it");
                     line("MessageDigest digest = Sha256Hash.getMessageDigest();");
                     line("InputStream hashingStream = new DigestInputStream(stream, digest);");
-                    line("InputStream compressingStream;");
-                    line("try {"); {
-                        line("compressingStream = new LZ4CompressingInputStream(hashingStream);");
+                    line("try (InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {"); {
+                        line("StreamMetadata metadata = storeBlocksAndGetHashlessMetadata(t, id, compressingStream);");
+                        line("return StreamMetadata.newBuilder(metadata)");
+                        line("        .setHash(ByteString.copyFrom(digest.digest()))");
+                        line("        .build();");
                     } line("} catch (IOException e) {"); {
                         line("throw new RuntimeException(e);");
                     } line("}");
-                    line("StreamMetadata metadata = storeBlocksAndGetHashlessMetadata(t, id, compressingStream);");
-                    line("return StreamMetadata.newBuilder(metadata)");
-                    line("        .setHash(ByteString.copyFrom(digest.digest()))");
-                    line("        .build();");
                 } line("}");
             }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -540,8 +540,8 @@ public class StreamStoreRenderer {
                 line("protected StreamMetadata storeBlocksAndGetFinalMetadata(Transaction t, long id, InputStream stream) {"); {
                     line("//Hash the data before compressing it");
                     line("MessageDigest digest = Sha256Hash.getMessageDigest();");
-                    line("InputStream hashingStream = new DigestInputStream(stream, digest);");
-                    line("try (InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {"); {
+                    line("try (InputStream hashingStream = new DigestInputStream(stream, digest);"); {
+                        line("    InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {");
                         line("StreamMetadata metadata = storeBlocksAndGetHashlessMetadata(t, id, compressingStream);");
                         line("return StreamMetadata.newBuilder(metadata)");
                         line("        .setHash(ByteString.copyFrom(digest.digest()))");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -39,6 +39,7 @@ import javax.annotation.Generated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -50,6 +51,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
+import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingInputStream;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
@@ -66,12 +68,16 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.impl.TxTask;
 import com.palantir.common.base.Throwables;
+import com.palantir.common.compression.LZ4CompressingInputStream;
 import com.palantir.common.io.ConcatenatedInputStream;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.ByteArrayIOStream;
+import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
+
+import net.jpountz.lz4.LZ4BlockInputStream;
 
 public class StreamStoreRenderer {
     private final String name;
@@ -79,13 +85,15 @@ public class StreamStoreRenderer {
     private final String packageName;
     private final String schemaName;
     private final int inMemoryThreshold;
+    private final boolean clientSideCompression;
 
-    public StreamStoreRenderer(String name, ValueType streamIdType, String packageName, String schemaName, int inMemoryThreshold) {
+    public StreamStoreRenderer(String name, ValueType streamIdType, String packageName, String schemaName, int inMemoryThreshold, boolean clientSideCompression) {
         this.name = name;
         this.streamIdType = streamIdType;
         this.packageName = packageName;
         this.schemaName = schemaName;
         this.inMemoryThreshold = inMemoryThreshold;
+        this.clientSideCompression = clientSideCompression;
     }
 
     public String getPackageName() {
@@ -157,6 +165,18 @@ public class StreamStoreRenderer {
                     line();
                     getBlock();
                     line();
+                    if (clientSideCompression) {
+                        storeStreamWithCompression();
+                        line();
+                        storeStreamsWithCompression();
+                        line();
+                        loadStreamWithCompression();
+                        line();
+                        loadStreamsWithCompression();
+                        line();
+                        tryWriteStreamToFile();
+                        line();
+                    }
                     getMetadata();
                     line();
                     lookupStreamIdsByHash();
@@ -516,6 +536,95 @@ public class StreamStoreRenderer {
                     line("index.delete(toDelete);");
                 } line("}");
             }
+
+            private void storeStreamWithCompression() {
+                line("@Override");
+                line("public Pair<", StreamId, ", Sha256Hash> storeStream(InputStream stream) {"); {
+                    line("long id = storeEmptyMetadata();");
+                    line();
+                    line("MessageDigest digest = Sha256Hash.getMessageDigest();");
+                    line("InputStream compressedStream;");
+                    line("try {"); {
+                        line("// Hash the data before compression");
+                        line("compressedStream = new LZ4CompressingInputStream(new DigestInputStream(stream, digest));");
+                    } line("} catch (IOException e) {"); {
+                        line("throw new RuntimeException(e);");
+                    } line("}");
+                    line("StreamMetadata metadata = storeBlocksAndGetFinalMetadata(null, id, compressedStream, false);");
+                    line();
+                    line("ByteString hashByteString = ByteString.copyFrom(digest.digest());");
+                    line("StreamMetadata correctedMetadata = StreamMetadata.newBuilder(metadata)");
+                    line("        .setHash(hashByteString)");
+                    line("        .build();");
+                    line("// Store the corrected metadata with the correct hash");
+                    line("storeMetadataAndIndex(id, correctedMetadata);");
+                    line();
+                    line("return Pair.create(id, new Sha256Hash(correctedMetadata.getHash().toByteArray()));");
+                } line("}");
+            }
+
+            private void storeStreamsWithCompression() {
+                line("@Override");
+                line("public Map<", StreamId, ", Sha256Hash> storeStreams(final Transaction t, final Map<", StreamId, ", InputStream> streams) {"); {
+                    line("if (streams.isEmpty()) {"); {
+                        line("return ImmutableMap.of();");
+                    } line("}");
+                    line();
+                    line("Map<", StreamId, ", StreamMetadata> idsToEmptyMetadata = Maps.transformValues(streams, Functions.constant(getEmptyMetadata()));");
+                    line("putMetadataAndHashIndexTask(t, idsToEmptyMetadata);");
+                    line();
+                    line("Map<", StreamId, ", StreamMetadata> idsToMetadata = Maps.transformEntries(streams, (id, stream) -> {"); {
+                        line("MessageDigest digest = Sha256Hash.getMessageDigest();");
+                        line("InputStream compressedStream;");
+                        line("try {"); {
+                            line("// Hash the data before compression");
+                            line("compressedStream = new LZ4CompressingInputStream(new DigestInputStream(stream, digest));");
+                        } line("} catch (IOException e) {"); {
+                            line("throw new RuntimeException(e);");
+                        } line("}");
+                        line("StreamMetadata metadata = storeBlocksAndGetFinalMetadata(t, id, compressedStream, false);");
+                        line("ByteString hashByteString = ByteString.copyFrom(digest.digest());");
+                        line("return StreamMetadata.newBuilder(metadata)");
+                        line("        .setHash(hashByteString)");
+                        line("        .build();");
+                    } line("});");
+                    line("// Store the corrected metadata with the correct hashes");
+                    line("putMetadataAndHashIndexTask(t, idsToMetadata);");
+                    line();
+                    line("Map<", StreamId, ", Sha256Hash> hashes = Maps.transformValues(idsToMetadata,");
+                    line("        metadata -> new Sha256Hash(metadata.getHash().toByteArray()));");
+                    line("return hashes;");
+                } line("}");
+            }
+
+            private void loadStreamWithCompression() {
+                line("@Override");
+                line("public InputStream loadStream(Transaction t, final ", StreamId, " id) {"); {
+                    line("return new LZ4BlockInputStream(super.loadStream(t, id));");
+                } line("}");
+            }
+
+            private void loadStreamsWithCompression() {
+                line("@Override");
+                line("public Map<", StreamId, ", InputStream> loadStreams(Transaction t, Set<", StreamId, "> ids) {"); {
+                    line("Map<", StreamId, ", InputStream> compressedStreams = super.loadStreams(t, ids);");
+                    line("return Maps.transformValues(compressedStreams, stream -> {"); {
+                        line("return new LZ4BlockInputStream(stream);");
+                    } line("});");
+                } line("}");
+            }
+
+            private void tryWriteStreamToFile() {
+                line("@Override");
+                line("protected void tryWriteStreamToFile(Transaction transaction, ", StreamId, " id, StreamMetadata metadata, FileOutputStream fos) throws IOException {"); {
+                    line("try (InputStream blockStream = makeStream(id, metadata);");
+                    line("        InputStream decompressingStream = new LZ4BlockInputStream(blockStream);");
+                    line("        OutputStream fileStream = fos;) {"); {
+                        line("ByteStreams.copy(decompressingStream, fileStream);");
+                    } line("}");
+                } line("}");
+            }
+
         }.render();
     }
 
@@ -713,5 +822,10 @@ public class StreamStoreRenderer {
         List.class,
         CheckForNull.class,
         Generated.class,
+        LZ4CompressingInputStream.class,
+        LZ4BlockInputStream.class,
+        Pair.class,
+        Functions.class,
+        ByteStreams.class,
     };
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
@@ -15,12 +15,13 @@
  */
 package com.palantir.atlasdb.schema.stream;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.fail;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Random;
@@ -54,6 +55,7 @@ import com.google.protobuf.ByteString;
 import com.palantir.atlasdb.AtlasDbTestCase;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.protos.generated.StreamPersistence;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.schema.stream.generated.DeletingStreamStore;
 import com.palantir.atlasdb.schema.stream.generated.KeyValueTable;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestStreamHashAidxTable;
@@ -62,8 +64,11 @@ import com.palantir.atlasdb.schema.stream.generated.StreamTestStreamStore;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestStreamValueTable;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestTableFactory;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow;
+import com.palantir.atlasdb.schema.stream.generated.StreamTestWithHashStreamMetadataTable;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow;
+import com.palantir.atlasdb.schema.stream.generated.StreamTestWithHashStreamStore;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueRow;
+import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.table.description.Schemas;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionConflictException;
@@ -74,7 +79,8 @@ import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 
 public class StreamTest extends AtlasDbTestCase {
-    private StreamTestStreamStore store;
+    private PersistentStreamStore defaultStore;
+    private PersistentStreamStore compressedStore;
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -84,7 +90,8 @@ public class StreamTest extends AtlasDbTestCase {
         Schemas.deleteTablesAndIndexes(StreamTestSchema.getSchema(), keyValueService);
         Schemas.createTablesAndIndexes(StreamTestSchema.getSchema(), keyValueService);
 
-        store = StreamTestStreamStore.of(txManager, StreamTestTableFactory.of());
+        defaultStore = StreamTestStreamStore.of(txManager, StreamTestTableFactory.of());
+        compressedStore = StreamTestWithHashStreamStore.of(txManager, StreamTestTableFactory.of());
     }
 
     @Test
@@ -101,9 +108,9 @@ public class StreamTest extends AtlasDbTestCase {
                 byte[] data = PtBytes.toBytes("streamed");
                 Sha256Hash hash = Sha256Hash.computeHash(data);
                 byte[] reference = "ref".getBytes();
-                long streamId = store.getByHashOrStoreStreamAndMarkAsUsed(t, hash, new ByteArrayInputStream(data), reference);
+                long streamId = defaultStore.getByHashOrStoreStreamAndMarkAsUsed(t, hash, new ByteArrayInputStream(data), reference);
                 try {
-                    store.loadStream(t, 1L).read(data, 0, data.length);
+                    defaultStore.loadStream(t, 1L).read(data, 0, data.length);
                 } catch (NoSuchElementException e) {
                     // expected
                 }
@@ -113,7 +120,7 @@ public class StreamTest extends AtlasDbTestCase {
         txManager.runTaskWithRetry(new TransactionTask<Void, Exception>() {
             @Override
             public Void execute(Transaction t) throws Exception {
-                Assert.assertEquals(data.length, store.loadStream(t, streamId).read(data, 0, data.length));
+                Assert.assertEquals(data.length, defaultStore.loadStream(t, streamId).read(data, 0, data.length));
                 return null;
             }
         });
@@ -147,18 +154,18 @@ public class StreamTest extends AtlasDbTestCase {
     }
 
     @Test
-    public void testStoreEmptyByteStream() throws IOException {
-        storeAndCheckByteStreams(0);
+    public void testStoreEmptyByteStream_defaultStream() throws IOException {
+        storeAndCheckByteStreams(defaultStore, getIncompressibleBytes(0));
     }
 
     @Test
-    public void testStoreSmallByteStream() throws IOException {
-        storeAndCheckByteStreams(100);
+    public void testStoreEmptyByteStream_compressedStream() throws IOException {
+        storeAndCheckByteStreams(compressedStore, getIncompressibleBytes(0));
     }
 
     @Test
-    public void testStoreByteStreamJustBiggerThanOneBlock() throws IOException {
-        storeAndCheckByteStreams(StreamTestStreamStore.BLOCK_SIZE_IN_BYTES + 500);
+    public void testStoreSmallByteStream_defaultStream() throws IOException {
+        storeAndCheckByteStreams(defaultStore, getIncompressibleBytes(100));
     }
 
     @Test
@@ -172,22 +179,56 @@ public class StreamTest extends AtlasDbTestCase {
     }
 
     @Test
-    public void testStoreByteStreamFiveMegaBytes() throws IOException {
-        storeAndCheckByteStreams(5_000_000);
+    public void testStoreSmallByteStream_compressedStream() throws IOException {
+        storeAndCheckByteStreams(compressedStore, getCompressibleBytes(100));
     }
 
-    private long storeAndCheckByteStreams(int size) throws IOException {
+    @Test
+    public void testStoreByteStreamJustBiggerThanOneBlock_defaultStream() throws IOException {
+        storeAndCheckByteStreams(defaultStore,
+                getIncompressibleBytes(StreamTestStreamStore.BLOCK_SIZE_IN_BYTES + 500));
+    }
+
+    @Test
+    public void testStoreByteStreamJustBiggerThanOneBlock_compressedStream() throws IOException {
+        storeAndCheckByteStreams(compressedStore,
+                getCompressibleBytes(StreamTestStreamStore.BLOCK_SIZE_IN_BYTES + 500));
+    }
+
+    @Test
+    public void testStoreByteStreamThreeBlocksLong_defaultStream() throws IOException {
+        storeAndCheckByteStreams(defaultStore, getIncompressibleBytes(StreamTestStreamStore.BLOCK_SIZE_IN_BYTES * 3));
+    }
+
+    @Test
+    public void testStoreByteStreamThreeBlocksLong_compressedStream() throws IOException {
+        storeAndCheckByteStreams(compressedStore, getCompressibleBytes(StreamTestStreamStore.BLOCK_SIZE_IN_BYTES * 3));
+    }
+
+    @Test
+    public void testStoreByteStreamFiveMegaBytes_defaultStream() throws IOException {
+        storeAndCheckByteStreams(defaultStore, getIncompressibleBytes(5_000_000));
+    }
+
+    @Test
+    public void testStoreByteStreamFiveMegaBytes_compressedStream_compressible() throws IOException {
+        storeAndCheckByteStreams(compressedStore, getCompressibleBytes(5_000_000));
+    }
+
+    @Test
+    public void testStoreByteStreamFiveMegaBytes_compressedStream_incompressible() throws IOException {
+        storeAndCheckByteStreams(compressedStore, getIncompressibleBytes(5_000_000));
+    }
+
+    private long storeAndCheckByteStreams(PersistentStreamStore store, byte[] bytesToStore) throws IOException {
         byte[] reference = PtBytes.toBytes("ref");
-        final byte[] bytesToStore = new byte[size];
-        Random rand = new Random();
-        rand.nextBytes(bytesToStore);
 
-        final long id = storeStream(bytesToStore, reference);
+        final long id = storeStream(store, bytesToStore, reference);
 
-        verifyLoadingStreams(id, bytesToStore);
+        verifyLoadingStreams(store, id, bytesToStore);
 
         store.storeStream(new ByteArrayInputStream(bytesToStore));
-        verifyLoadingStreams(id, bytesToStore);
+        verifyLoadingStreams(store, id, bytesToStore);
 
         return id;
     }
@@ -203,24 +244,24 @@ public class StreamTest extends AtlasDbTestCase {
         return id;
     }
 
-    private void verifyLoadingStreams(long id, byte[] bytesToStore) throws IOException {
-        verifyLoadStream(id, bytesToStore);
-        verifyLoadStreams(id, bytesToStore);
-        verifyLoadStreamAsFile(id, bytesToStore);
+    private void verifyLoadingStreams(PersistentStreamStore store, long id, byte[] bytesToStore) throws IOException {
+        verifyLoadStream(store, id, bytesToStore);
+        verifyLoadStreams(store, id, bytesToStore);
+        verifyLoadStreamAsFile(store, id, bytesToStore);
     }
 
-    private void verifyLoadStreamAsFile(long id, byte[] bytesToStore) throws IOException {
+    private void verifyLoadStreamAsFile(PersistentStreamStore store, long id, byte[] bytesToStore) throws IOException {
         File file = txManager.runTaskThrowOnConflict(t -> store.loadStreamAsFile(t, id));
         Assert.assertArrayEquals(bytesToStore, FileUtils.readFileToByteArray(file));
     }
 
-    private void verifyLoadStreams(long id, byte[] bytesToStore) throws IOException {
+    private void verifyLoadStreams(PersistentStreamStore store, long id, byte[] bytesToStore) throws IOException {
         Map<Long, InputStream> streams = txManager.runTaskThrowOnConflict(t ->
                 store.loadStreams(t, ImmutableSet.of(id)));
         assertStreamHasBytes(streams.get(id), bytesToStore);
     }
 
-    private void verifyLoadStream(long id, byte[] bytesToStore) throws IOException {
+    private void verifyLoadStream(PersistentStreamStore store, long id, byte[] bytesToStore) throws IOException {
         InputStream stream = txManager.runTaskThrowOnConflict(t -> store.loadStream(t, id));
         assertStreamHasBytes(stream, bytesToStore);
     }
@@ -244,14 +285,14 @@ public class StreamTest extends AtlasDbTestCase {
 
         // Store the stream, together with a reference
         Long streamId = txManager.runTaskWithRetry(tx -> {
-            long id = storeStream(bytes1, reference);
+            long id = storeStream(defaultStore, bytes1, reference);
             KeyValueTable keyValueTable = tableFactory.getKeyValueTable(tx);
             keyValueTable.putStreamId(keyValueRow, id);
             return id;
         });
 
         // Then fetch streamId as an input stream
-        InputStream firstStream = txManager.runTaskWithRetry(tx -> store.loadStream(tx, streamId));
+        InputStream firstStream = txManager.runTaskWithRetry(tx -> defaultStore.loadStream(tx, streamId));
 
         // Then store "ref" -> some_other_stream
         final byte[] bytes2 = new byte[2 * StreamTestStreamStore.BLOCK_SIZE_IN_BYTES];
@@ -265,7 +306,7 @@ public class StreamTest extends AtlasDbTestCase {
     private void storeStreamAndReference(StreamTestTableFactory tableFactory, KeyValueTable.KeyValueRow row,
             byte[] reference, byte[] value) {
         txManager.runTaskWithRetry(tx -> {
-            long id = storeStream(value, reference);
+            long id = storeStream(defaultStore, value, reference);
             KeyValueTable keyValueTable = tableFactory.getKeyValueTable(tx);
             keyValueTable.putStreamId(row, id);
             return null;
@@ -285,14 +326,14 @@ public class StreamTest extends AtlasDbTestCase {
 
         // Store the stream, together with a reference
         Long streamId = txManager.runTaskWithRetry(tx -> {
-            long id = storeStream(bytes1, reference);
+            long id = storeStream(defaultStore, bytes1, reference);
             KeyValueTable keyValueTable = tableFactory.getKeyValueTable(tx);
             keyValueTable.putStreamId(keyValueRow, id);
             return id;
         });
 
         // Then fetch streamId as an input stream
-        InputStream stream = txManager.runTaskWithRetry(tx -> store.loadStream(tx, streamId));
+        InputStream stream = txManager.runTaskWithRetry(tx -> defaultStore.loadStream(tx, streamId));
 
         // Delete the streams
         txManager.runTaskWithRetry(tx -> {
@@ -372,9 +413,9 @@ public class StreamTest extends AtlasDbTestCase {
                 id1, new ByteArrayInputStream(bytes1),
                 id2, new ByteArrayInputStream(bytes2));
 
-        txManager.runTaskWithRetry(t -> store.storeStreams(t, streams));
+        txManager.runTaskWithRetry(t -> defaultStore.storeStreams(t, streams));
 
-        Map<Sha256Hash, Long> sha256HashLongMap = txManager.runTaskWithRetry(t -> store.lookupStreamIdsByHash(t, ImmutableSet.of(hash1, hash2, hash3)));
+        Map<Sha256Hash, Long> sha256HashLongMap = txManager.runTaskWithRetry(t -> defaultStore.lookupStreamIdsByHash(t, ImmutableSet.of(hash1, hash2, hash3)));
 
         assertEquals(id1, sha256HashLongMap.get(hash1).longValue());
         assertEquals(id2, sha256HashLongMap.get(hash2).longValue());
@@ -394,10 +435,10 @@ public class StreamTest extends AtlasDbTestCase {
                 id1, new ByteArrayInputStream(bytes),
                 id2, new ByteArrayInputStream(bytes));
 
-        txManager.runTaskWithRetry(t -> store.storeStreams(t, streams));
+        txManager.runTaskWithRetry(t -> defaultStore.storeStreams(t, streams));
 
-        Pair<Long, Sha256Hash> idAndHash1 = store.storeStream(new ByteArrayInputStream(bytes));
-        Pair<Long, Sha256Hash> idAndHash2 = store.storeStream(new ByteArrayInputStream(bytes));
+        Pair<Long, Sha256Hash> idAndHash1 = defaultStore.storeStream(new ByteArrayInputStream(bytes));
+        Pair<Long, Sha256Hash> idAndHash2 = defaultStore.storeStream(new ByteArrayInputStream(bytes));
 
         assertThat(idAndHash1.getRhSide(), equalTo(idAndHash2.getRhSide()));        //verify hashes are the same
         assertThat(idAndHash1.getLhSide(), not(equalTo(idAndHash2.getLhSide())));   //verify ids are different
@@ -416,7 +457,8 @@ public class StreamTest extends AtlasDbTestCase {
 
             @Override
             public void startSecondAndFinish(Transaction t, long streamId) {
-                DeletingStreamStore deletingStreamStore = new DeletingStreamStore(StreamTestStreamStore.of(txManager, StreamTestTableFactory.of()));
+                DeletingStreamStore deletingStreamStore =
+                        new DeletingStreamStore(StreamTestStreamStore.of(txManager, StreamTestTableFactory.of()));
                 deletingStreamStore.deleteStreams(t, ImmutableSet.of(streamId));
             }
         });
@@ -443,6 +485,28 @@ public class StreamTest extends AtlasDbTestCase {
         });
 
         assertNotNull(getStream(streamId));
+    }
+
+    @Test
+    public void testStreamCompression() throws IOException {
+        int inputBlocks = 4;
+        byte[] input = getCompressibleBytes(inputBlocks * StreamTestWithHashStreamStore.BLOCK_SIZE_IN_BYTES);
+
+        long id = storeStream(compressedStore, input, PtBytes.toBytes("ref"));
+        StreamMetadata metadata = txManager.runTaskReadOnly(t -> {
+            StreamTestWithHashStreamMetadataTable table = StreamTestTableFactory.of()
+                    .getStreamTestWithHashStreamMetadataTable(t);
+            StreamTestWithHashStreamMetadataRow row = StreamTestWithHashStreamMetadataRow.of(id);
+            return table.getRow(row).get().getMetadata();
+        });
+        long numBlocksUsed = getStreamBlockSize(metadata);
+
+        assertTrue(numBlocksUsed < inputBlocks);
+    }
+
+    private long getStreamBlockSize(StreamMetadata metadata) {
+        int blockSize = StreamTestWithHashStreamStore.BLOCK_SIZE_IN_BYTES;
+        return (metadata.getLength() + blockSize - 1) / blockSize;
     }
 
     private InputStream getStream(long streamId) {
@@ -507,6 +571,18 @@ public class StreamTest extends AtlasDbTestCase {
     abstract class TwoConflictingTasks {
         public abstract void startFirstAndFail(Transaction t, long streamId);
         public abstract void startSecondAndFinish(Transaction t, long streamId);
+    }
+
+    private byte[] getCompressibleBytes(int size) {
+        byte[] data = new byte[size];
+        Arrays.fill(data, (byte) 42);
+        return data;
+    }
+
+    private byte[] getIncompressibleBytes(int size) {
+        byte[] data = new byte[size];
+        new Random(0).nextBytes(data);
+        return data;
     }
 
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTestSchema.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTestSchema.java
@@ -54,6 +54,7 @@ public class StreamTestSchema implements AtlasSchema {
                 new StreamStoreDefinitionBuilder("stream_test_with_hash", "stream_test_with_hash", ValueType.VAR_LONG)
                     .inMemoryThreshold(4000)
                     .compressBlocksInDb()
+                    .compressStreamInClient()
                     .hashFirstRowComponent()
                     .isAppendHeavyAndReadLight()
                     .build());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
 
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +37,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
+import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingInputStream;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
@@ -371,6 +371,7 @@ public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
      * {@link Builder}
      * {@link ByteArrayIOStream}
      * {@link ByteArrayInputStream}
+     * {@link ByteStreams}
      * {@link ByteString}
      * {@link Cell}
      * {@link CheckForNull}
@@ -388,7 +389,6 @@ public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
      * {@link Generated}
      * {@link HashMultimap}
      * {@link IOException}
-     * {@link IOUtils}
      * {@link ImmutableMap}
      * {@link ImmutableSet}
      * {@link InputStream}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
@@ -21,9 +21,11 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
 
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -52,12 +54,16 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.impl.TxTask;
 import com.palantir.common.base.Throwables;
+import com.palantir.common.compression.LZ4CompressingInputStream;
 import com.palantir.common.io.ConcatenatedInputStream;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.ByteArrayIOStream;
+import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
+
+import net.jpountz.lz4.LZ4BlockInputStream;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
 public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
@@ -378,13 +384,17 @@ public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
      * {@link File}
      * {@link FileNotFoundException}
      * {@link FileOutputStream}
+     * {@link Functions}
      * {@link Generated}
      * {@link HashMultimap}
      * {@link IOException}
+     * {@link IOUtils}
      * {@link ImmutableMap}
      * {@link ImmutableSet}
      * {@link InputStream}
      * {@link Ints}
+     * {@link LZ4BlockInputStream}
+     * {@link LZ4CompressingInputStream}
      * {@link List}
      * {@link Lists}
      * {@link Logger}
@@ -395,6 +405,7 @@ public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
      * {@link Multimap}
      * {@link Multimaps}
      * {@link OutputStream}
+     * {@link Pair}
      * {@link PersistentStreamStore}
      * {@link Preconditions}
      * {@link Set}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
@@ -189,16 +189,14 @@ public final class StreamTestWithHashStreamStore extends AbstractPersistentStrea
         //Hash the data before compressing it
         MessageDigest digest = Sha256Hash.getMessageDigest();
         InputStream hashingStream = new DigestInputStream(stream, digest);
-        InputStream compressingStream;
-        try {
-            compressingStream = new LZ4CompressingInputStream(hashingStream);
+        try (InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {
+            StreamMetadata metadata = storeBlocksAndGetHashlessMetadata(t, id, compressingStream);
+            return StreamMetadata.newBuilder(metadata)
+                    .setHash(ByteString.copyFrom(digest.digest()))
+                    .build();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        StreamMetadata metadata = storeBlocksAndGetHashlessMetadata(t, id, compressingStream);
-        return StreamMetadata.newBuilder(metadata)
-                .setHash(ByteString.copyFrom(digest.digest()))
-                .build();
     }
 
     @Override

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
@@ -189,7 +189,7 @@ public final class StreamTestWithHashStreamStore extends AbstractPersistentStrea
         //Hash the data before compressing it
         MessageDigest digest = Sha256Hash.getMessageDigest();
         try (InputStream hashingStream = new DigestInputStream(stream, digest);
-            InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {
+                InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {
             StreamMetadata metadata = storeBlocksAndGetHashlessMetadata(t, id, compressingStream);
             return StreamMetadata.newBuilder(metadata)
                     .setHash(ByteString.copyFrom(digest.digest()))

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
@@ -188,8 +188,8 @@ public final class StreamTestWithHashStreamStore extends AbstractPersistentStrea
     protected StreamMetadata storeBlocksAndGetFinalMetadata(Transaction t, long id, InputStream stream) {
         //Hash the data before compressing it
         MessageDigest digest = Sha256Hash.getMessageDigest();
-        InputStream hashingStream = new DigestInputStream(stream, digest);
-        try (InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {
+        try (InputStream hashingStream = new DigestInputStream(stream, digest);
+            InputStream compressingStream = new LZ4CompressingInputStream(hashingStream)) {
             StreamMetadata metadata = storeBlocksAndGetHashlessMetadata(t, id, compressingStream);
             return StreamMetadata.newBuilder(metadata)
                     .setHash(ByteString.copyFrom(digest.digest()))

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
@@ -219,278 +219,278 @@ public final class StreamTestWithHashStreamStore extends AbstractPersistentStrea
         try {
             // Hash the data before compressing it
             compressedStream = new LZ4CompressingInputStream(new DigestInputStream(stream, digest));
-            catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            StreamMetadata metadata = storeBlocksAndGetFinalMetadata(transaction, id, compressedStream, false);
-
-            ByteString hashByteString = ByteString.copyFrom(digest.digest());
-            return StreamMetadata.newBuilder(metadata)
-                    .setHash(hashByteString)
-                    .build();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
+        StreamMetadata metadata = storeBlocksAndGetFinalMetadata(transaction, id, compressedStream, false);
 
-        @Override
-        public InputStream loadStream(Transaction t, final Long id) {
-            return new LZ4BlockInputStream(super.loadStream(t, id));
-        }
-
-        @Override
-        public Map<Long, InputStream> loadStreams(Transaction t, Set<Long> ids) {
-            Map<Long, InputStream> compressedStreams = super.loadStreams(t, ids);
-            return Maps.transformValues(compressedStreams, stream -> {
-                return new LZ4BlockInputStream(stream);
-            });
-        }
-
-        @Override
-        protected void tryWriteStreamToFile(Transaction transaction, Long id, StreamMetadata metadata, FileOutputStream fos) throws IOException {
-            try (InputStream blockStream = makeStream(id, metadata);
-                    InputStream decompressingStream = new LZ4BlockInputStream(blockStream);
-                    OutputStream fileStream = fos;) {
-                ByteStreams.copy(decompressingStream, fileStream);
-            }
-        }
-
-        @Override
-        protected Map<Long, StreamMetadata> getMetadata(Transaction t, Set<Long> streamIds) {
-            if (streamIds.isEmpty()) {
-                return ImmutableMap.of();
-            }
-            StreamTestWithHashStreamMetadataTable table = tables.getStreamTestWithHashStreamMetadataTable(t);
-            Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(getMetadataRowsForIds(streamIds));
-            Map<Long, StreamMetadata> ret = Maps.newHashMap();
-            for (Map.Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
-                ret.put(e.getKey().getId(), e.getValue());
-            }
-            return ret;
-        }
-
-        @Override
-        public Map<Sha256Hash, Long> lookupStreamIdsByHash(Transaction t, final Set<Sha256Hash> hashes) {
-            if (hashes.isEmpty()) {
-                return ImmutableMap.of();
-            }
-            StreamTestWithHashStreamHashAidxTable idx = tables.getStreamTestWithHashStreamHashAidxTable(t);
-            Set<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow> rows = getHashIndexRowsForHashes(hashes);
-
-            Multimap<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue> m = idx.getRowsMultimap(rows);
-            Map<Long, Sha256Hash> hashForStreams = Maps.newHashMap();
-            for (StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow r : m.keySet()) {
-                for (StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue v : m.get(r)) {
-                    Long streamId = v.getColumnName().getStreamId();
-                    Sha256Hash hash = r.getHash();
-                    if (hashForStreams.containsKey(streamId)) {
-                        AssertUtils.assertAndLog(hashForStreams.get(streamId).equals(hash), "(BUG) Stream ID has 2 different hashes: " + streamId);
-                    }
-                    hashForStreams.put(streamId, hash);
-                }
-            }
-            Map<Long, StreamMetadata> metadata = getMetadata(t, hashForStreams.keySet());
-
-            Map<Sha256Hash, Long> ret = Maps.newHashMap();
-            for (Map.Entry<Long, StreamMetadata> e : metadata.entrySet()) {
-                if (e.getValue().getStatus() != Status.STORED) {
-                    continue;
-                }
-                Sha256Hash hash = hashForStreams.get(e.getKey());
-                ret.put(hash, e.getKey());
-            }
-
-            return ret;
-        }
-
-        private Set<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow> getHashIndexRowsForHashes(final Set<Sha256Hash> hashes) {
-            Set<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow> rows = Sets.newHashSet();
-            for (Sha256Hash h : hashes) {
-                rows.add(StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow.of(h));
-            }
-            return rows;
-        }
-
-        private Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> getMetadataRowsForIds(final Iterable<Long> ids) {
-            Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rows = Sets.newHashSet();
-            for (Long id : ids) {
-                rows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.of(id));
-            }
-            return rows;
-        }
-
-        private void putHashIndexTask(Transaction t, Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> rowsToMetadata) {
-            Multimap<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue> indexMap = HashMultimap.create();
-            for (Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : rowsToMetadata.entrySet()) {
-                StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow row = e.getKey();
-                StreamMetadata metadata = e.getValue();
-                Preconditions.checkArgument(
-                        metadata.getStatus() == Status.STORED,
-                        "Should only index successfully stored streams.");
-
-                Sha256Hash hash = Sha256Hash.EMPTY;
-                if (metadata.getHash() != com.google.protobuf.ByteString.EMPTY) {
-                    hash = new Sha256Hash(metadata.getHash().toByteArray());
-                }
-                StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow hashRow = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow.of(hash);
-                StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn column = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn.of(row.getId());
-                StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue columnValue = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue.of(column, 0L);
-                indexMap.put(hashRow, columnValue);
-            }
-            StreamTestWithHashStreamHashAidxTable hiTable = tables.getStreamTestWithHashStreamHashAidxTable(t);
-            hiTable.put(indexMap);
-        }
-
-        /**
-         * This should only be used from the cleanup tasks.
-         */
-        void deleteStreams(Transaction t, final Set<Long> streamIds) {
-            if (streamIds.isEmpty()) {
-                return;
-            }
-            Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> smRows = Sets.newHashSet();
-            Multimap<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn> shToDelete = HashMultimap.create();
-            for (Long streamId : streamIds) {
-                smRows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.of(streamId));
-            }
-            StreamTestWithHashStreamMetadataTable table = tables.getStreamTestWithHashStreamMetadataTable(t);
-            Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(smRows);
-            Set<StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueRow> streamValueToDelete = Sets.newHashSet();
-            for (Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
-                Long streamId = e.getKey().getId();
-                long blocks = getNumberOfBlocksFromMetadata(e.getValue());
-                for (long i = 0; i < blocks; i++) {
-                    streamValueToDelete.add(StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueRow.of(streamId, i));
-                }
-                ByteString streamHash = e.getValue().getHash();
-                Sha256Hash hash = Sha256Hash.EMPTY;
-                if (streamHash != com.google.protobuf.ByteString.EMPTY) {
-                    hash = new Sha256Hash(streamHash.toByteArray());
-                } else {
-                    log.error("Empty hash for stream {}", streamId);
-                }
-                StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow hashRow = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow.of(hash);
-                StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn column = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn.of(streamId);
-                shToDelete.put(hashRow, column);
-            }
-            tables.getStreamTestWithHashStreamHashAidxTable(t).delete(shToDelete);
-            tables.getStreamTestWithHashStreamValueTable(t).delete(streamValueToDelete);
-            table.delete(smRows);
-        }
-
-        @Override
-        protected void markStreamsAsUsedInternal(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
-            if (streamIdsToReference.isEmpty()) {
-                return;
-            }
-            StreamTestWithHashStreamIdxTable index = tables.getStreamTestWithHashStreamIdxTable(t);
-            Multimap<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue> rowsToValues = HashMultimap.create();
-            for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
-                Long streamId = entry.getKey();
-                byte[] reference = entry.getValue();
-                StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn col = StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn.of(reference);
-                StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue value = StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue.of(col, 0L);
-                rowsToValues.put(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow.of(streamId), value);
-            }
-            index.put(rowsToValues);
-        }
-
-        @Override
-        public void unmarkStreamsAsUsed(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
-            if (streamIdsToReference.isEmpty()) {
-                return;
-            }
-            StreamTestWithHashStreamIdxTable index = tables.getStreamTestWithHashStreamIdxTable(t);
-            Multimap<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn> toDelete = ArrayListMultimap.create(streamIdsToReference.size(), 1);
-            for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
-                Long streamId = entry.getKey();
-                byte[] reference = entry.getValue();
-                StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn col = StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn.of(reference);
-                toDelete.put(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow.of(streamId), col);
-            }
-            index.delete(toDelete);
-        }
-
-        @Override
-        protected void touchMetadataWhileMarkingUsedForConflicts(Transaction t, Iterable<Long> ids) {
-            StreamTestWithHashStreamMetadataTable metaTable = tables.getStreamTestWithHashStreamMetadataTable(t);
-            Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rows = Sets.newHashSet();
-            for (Long id : ids) {
-                rows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.of(id));
-            }
-            Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> metadatas = metaTable.getMetadatas(rows);
-            for (Map.Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
-                StreamMetadata metadata = e.getValue();
-                Preconditions.checkState(metadata.getStatus() == Status.STORED,
-                "Stream: " + e.getKey().getId() + " has status: " + metadata.getStatus());
-                metaTable.putMetadata(e.getKey(), metadata);
-            }
-            SetView<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> missingRows = Sets.difference(rows, metadatas.keySet());
-            if (!missingRows.isEmpty()) {
-                throw new IllegalStateException("Missing metadata rows for:" + missingRows
-                + " rows: " + rows + " metadata: " + metadatas + " txn timestamp: " + t.getTimestamp());
-            }
-        }
-
-        /**
-         * This exists to avoid unused import warnings
-         * {@link AbstractPersistentStreamStore}
-         * {@link ArrayListMultimap}
-         * {@link Arrays}
-         * {@link AssertUtils}
-         * {@link BufferedInputStream}
-         * {@link Builder}
-         * {@link ByteArrayIOStream}
-         * {@link ByteArrayInputStream}
-         * {@link ByteStreams}
-         * {@link ByteString}
-         * {@link Cell}
-         * {@link CheckForNull}
-         * {@link Collection}
-         * {@link Collections2}
-         * {@link ConcatenatedInputStream}
-         * {@link CountingInputStream}
-         * {@link DeleteOnCloseFileInputStream}
-         * {@link DigestInputStream}
-         * {@link Entry}
-         * {@link File}
-         * {@link FileNotFoundException}
-         * {@link FileOutputStream}
-         * {@link Functions}
-         * {@link Generated}
-         * {@link HashMultimap}
-         * {@link IOException}
-         * {@link ImmutableMap}
-         * {@link ImmutableSet}
-         * {@link InputStream}
-         * {@link Ints}
-         * {@link LZ4BlockInputStream}
-         * {@link LZ4CompressingInputStream}
-         * {@link List}
-         * {@link Lists}
-         * {@link Logger}
-         * {@link LoggerFactory}
-         * {@link Map}
-         * {@link Maps}
-         * {@link MessageDigest}
-         * {@link Multimap}
-         * {@link Multimaps}
-         * {@link OutputStream}
-         * {@link Pair}
-         * {@link PersistentStreamStore}
-         * {@link Preconditions}
-         * {@link Set}
-         * {@link SetView}
-         * {@link Sets}
-         * {@link Sha256Hash}
-         * {@link Status}
-         * {@link StreamCleanedException}
-         * {@link StreamMetadata}
-         * {@link TempFileUtils}
-         * {@link Throwables}
-         * {@link TimeUnit}
-         * {@link Transaction}
-         * {@link TransactionFailedRetriableException}
-         * {@link TransactionManager}
-         * {@link TransactionTask}
-         * {@link TxTask}
-         */
-        static final int dummy = 0;
+        ByteString hashByteString = ByteString.copyFrom(digest.digest());
+        return StreamMetadata.newBuilder(metadata)
+                .setHash(hashByteString)
+                .build();
     }
+
+    @Override
+    public InputStream loadStream(Transaction t, final Long id) {
+        return new LZ4BlockInputStream(super.loadStream(t, id));
+    }
+
+    @Override
+    public Map<Long, InputStream> loadStreams(Transaction t, Set<Long> ids) {
+        Map<Long, InputStream> compressedStreams = super.loadStreams(t, ids);
+        return Maps.transformValues(compressedStreams, stream -> {
+            return new LZ4BlockInputStream(stream);
+        });
+    }
+
+    @Override
+    protected void tryWriteStreamToFile(Transaction transaction, Long id, StreamMetadata metadata, FileOutputStream fos) throws IOException {
+        try (InputStream blockStream = makeStream(id, metadata);
+                InputStream decompressingStream = new LZ4BlockInputStream(blockStream);
+                OutputStream fileStream = fos;) {
+            ByteStreams.copy(decompressingStream, fileStream);
+        }
+    }
+
+    @Override
+    protected Map<Long, StreamMetadata> getMetadata(Transaction t, Set<Long> streamIds) {
+        if (streamIds.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        StreamTestWithHashStreamMetadataTable table = tables.getStreamTestWithHashStreamMetadataTable(t);
+        Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(getMetadataRowsForIds(streamIds));
+        Map<Long, StreamMetadata> ret = Maps.newHashMap();
+        for (Map.Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            ret.put(e.getKey().getId(), e.getValue());
+        }
+        return ret;
+    }
+
+    @Override
+    public Map<Sha256Hash, Long> lookupStreamIdsByHash(Transaction t, final Set<Sha256Hash> hashes) {
+        if (hashes.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        StreamTestWithHashStreamHashAidxTable idx = tables.getStreamTestWithHashStreamHashAidxTable(t);
+        Set<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow> rows = getHashIndexRowsForHashes(hashes);
+
+        Multimap<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue> m = idx.getRowsMultimap(rows);
+        Map<Long, Sha256Hash> hashForStreams = Maps.newHashMap();
+        for (StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow r : m.keySet()) {
+            for (StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue v : m.get(r)) {
+                Long streamId = v.getColumnName().getStreamId();
+                Sha256Hash hash = r.getHash();
+                if (hashForStreams.containsKey(streamId)) {
+                    AssertUtils.assertAndLog(hashForStreams.get(streamId).equals(hash), "(BUG) Stream ID has 2 different hashes: " + streamId);
+                }
+                hashForStreams.put(streamId, hash);
+            }
+        }
+        Map<Long, StreamMetadata> metadata = getMetadata(t, hashForStreams.keySet());
+
+        Map<Sha256Hash, Long> ret = Maps.newHashMap();
+        for (Map.Entry<Long, StreamMetadata> e : metadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                continue;
+            }
+            Sha256Hash hash = hashForStreams.get(e.getKey());
+            ret.put(hash, e.getKey());
+        }
+
+        return ret;
+    }
+
+    private Set<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow> getHashIndexRowsForHashes(final Set<Sha256Hash> hashes) {
+        Set<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow> rows = Sets.newHashSet();
+        for (Sha256Hash h : hashes) {
+            rows.add(StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow.of(h));
+        }
+        return rows;
+    }
+
+    private Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> getMetadataRowsForIds(final Iterable<Long> ids) {
+        Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rows = Sets.newHashSet();
+        for (Long id : ids) {
+            rows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.of(id));
+        }
+        return rows;
+    }
+
+    private void putHashIndexTask(Transaction t, Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> rowsToMetadata) {
+        Multimap<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue> indexMap = HashMultimap.create();
+        for (Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : rowsToMetadata.entrySet()) {
+            StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow row = e.getKey();
+            StreamMetadata metadata = e.getValue();
+            Preconditions.checkArgument(
+                    metadata.getStatus() == Status.STORED,
+                    "Should only index successfully stored streams.");
+
+            Sha256Hash hash = Sha256Hash.EMPTY;
+            if (metadata.getHash() != com.google.protobuf.ByteString.EMPTY) {
+                hash = new Sha256Hash(metadata.getHash().toByteArray());
+            }
+            StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow hashRow = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow.of(hash);
+            StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn column = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn.of(row.getId());
+            StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue columnValue = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumnValue.of(column, 0L);
+            indexMap.put(hashRow, columnValue);
+        }
+        StreamTestWithHashStreamHashAidxTable hiTable = tables.getStreamTestWithHashStreamHashAidxTable(t);
+        hiTable.put(indexMap);
+    }
+
+    /**
+     * This should only be used from the cleanup tasks.
+     */
+    void deleteStreams(Transaction t, final Set<Long> streamIds) {
+        if (streamIds.isEmpty()) {
+            return;
+        }
+        Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> smRows = Sets.newHashSet();
+        Multimap<StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn> shToDelete = HashMultimap.create();
+        for (Long streamId : streamIds) {
+            smRows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.of(streamId));
+        }
+        StreamTestWithHashStreamMetadataTable table = tables.getStreamTestWithHashStreamMetadataTable(t);
+        Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(smRows);
+        Set<StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueRow> streamValueToDelete = Sets.newHashSet();
+        for (Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            Long streamId = e.getKey().getId();
+            long blocks = getNumberOfBlocksFromMetadata(e.getValue());
+            for (long i = 0; i < blocks; i++) {
+                streamValueToDelete.add(StreamTestWithHashStreamValueTable.StreamTestWithHashStreamValueRow.of(streamId, i));
+            }
+            ByteString streamHash = e.getValue().getHash();
+            Sha256Hash hash = Sha256Hash.EMPTY;
+            if (streamHash != com.google.protobuf.ByteString.EMPTY) {
+                hash = new Sha256Hash(streamHash.toByteArray());
+            } else {
+                log.error("Empty hash for stream {}", streamId);
+            }
+            StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow hashRow = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxRow.of(hash);
+            StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn column = StreamTestWithHashStreamHashAidxTable.StreamTestWithHashStreamHashAidxColumn.of(streamId);
+            shToDelete.put(hashRow, column);
+        }
+        tables.getStreamTestWithHashStreamHashAidxTable(t).delete(shToDelete);
+        tables.getStreamTestWithHashStreamValueTable(t).delete(streamValueToDelete);
+        table.delete(smRows);
+    }
+
+    @Override
+    protected void markStreamsAsUsedInternal(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
+        if (streamIdsToReference.isEmpty()) {
+            return;
+        }
+        StreamTestWithHashStreamIdxTable index = tables.getStreamTestWithHashStreamIdxTable(t);
+        Multimap<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue> rowsToValues = HashMultimap.create();
+        for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
+            Long streamId = entry.getKey();
+            byte[] reference = entry.getValue();
+            StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn col = StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn.of(reference);
+            StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue value = StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue.of(col, 0L);
+            rowsToValues.put(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow.of(streamId), value);
+        }
+        index.put(rowsToValues);
+    }
+
+    @Override
+    public void unmarkStreamsAsUsed(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
+        if (streamIdsToReference.isEmpty()) {
+            return;
+        }
+        StreamTestWithHashStreamIdxTable index = tables.getStreamTestWithHashStreamIdxTable(t);
+        Multimap<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn> toDelete = ArrayListMultimap.create(streamIdsToReference.size(), 1);
+        for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
+            Long streamId = entry.getKey();
+            byte[] reference = entry.getValue();
+            StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn col = StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumn.of(reference);
+            toDelete.put(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow.of(streamId), col);
+        }
+        index.delete(toDelete);
+    }
+
+    @Override
+    protected void touchMetadataWhileMarkingUsedForConflicts(Transaction t, Iterable<Long> ids) {
+        StreamTestWithHashStreamMetadataTable metaTable = tables.getStreamTestWithHashStreamMetadataTable(t);
+        Set<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rows = Sets.newHashSet();
+        for (Long id : ids) {
+            rows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.of(id));
+        }
+        Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> metadatas = metaTable.getMetadatas(rows);
+        for (Map.Entry<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            StreamMetadata metadata = e.getValue();
+            Preconditions.checkState(metadata.getStatus() == Status.STORED,
+            "Stream: " + e.getKey().getId() + " has status: " + metadata.getStatus());
+            metaTable.putMetadata(e.getKey(), metadata);
+        }
+        SetView<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> missingRows = Sets.difference(rows, metadatas.keySet());
+        if (!missingRows.isEmpty()) {
+            throw new IllegalStateException("Missing metadata rows for:" + missingRows
+            + " rows: " + rows + " metadata: " + metadatas + " txn timestamp: " + t.getTimestamp());
+        }
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbstractPersistentStreamStore}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link BufferedInputStream}
+     * {@link Builder}
+     * {@link ByteArrayIOStream}
+     * {@link ByteArrayInputStream}
+     * {@link ByteStreams}
+     * {@link ByteString}
+     * {@link Cell}
+     * {@link CheckForNull}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ConcatenatedInputStream}
+     * {@link CountingInputStream}
+     * {@link DeleteOnCloseFileInputStream}
+     * {@link DigestInputStream}
+     * {@link Entry}
+     * {@link File}
+     * {@link FileNotFoundException}
+     * {@link FileOutputStream}
+     * {@link Functions}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link IOException}
+     * {@link ImmutableMap}
+     * {@link ImmutableSet}
+     * {@link InputStream}
+     * {@link Ints}
+     * {@link LZ4BlockInputStream}
+     * {@link LZ4CompressingInputStream}
+     * {@link List}
+     * {@link Lists}
+     * {@link Logger}
+     * {@link LoggerFactory}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MessageDigest}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link OutputStream}
+     * {@link Pair}
+     * {@link PersistentStreamStore}
+     * {@link Preconditions}
+     * {@link Set}
+     * {@link SetView}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link Status}
+     * {@link StreamCleanedException}
+     * {@link StreamMetadata}
+     * {@link TempFileUtils}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TransactionFailedRetriableException}
+     * {@link TransactionManager}
+     * {@link TransactionTask}
+     * {@link TxTask}
+     */
+    static final int dummy = 0;
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,6 +65,12 @@ develop
          - Enable garbage collection logging for CircleCI builds.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1398>`__)
 
+    *    - |new|
+         - AtlasDB now supports stream store compression.
+           Streams can be compressed client-side by adding the ``compressStreamInClient`` option to the stream 
+           definition. Reads from the stream store will transparently decompress the data.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1357>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/schemas/streams.rst
+++ b/docs/source/schemas/streams.rst
@@ -44,6 +44,12 @@ this is to write a ``KeyValueService`` implementation that just
 delegates to 2 other ``KeyValueService`` impls and sends COLD tables to
 one and other tables to another.
 
+Streams can be optionally compressed to boost performance via the 
+``compressStreamsInClient`` option on the ``StreamStoreDefinitionBuilder``.
+This transparently decompresses and compresses the stream via the LZ4 
+algorithm upon reads and writes, respectively. Compression is performed client 
+side before any network communication to the underlying database.
+
 Transactionality
 ================
 

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
@@ -24,6 +24,7 @@ import javax.annotation.Generated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -36,6 +37,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
+import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingInputStream;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
@@ -52,12 +54,16 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.atlasdb.transaction.impl.TxTask;
 import com.palantir.common.base.Throwables;
+import com.palantir.common.compression.LZ4CompressingInputStream;
 import com.palantir.common.io.ConcatenatedInputStream;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.ByteArrayIOStream;
+import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 import com.palantir.util.file.DeleteOnCloseFileInputStream;
 import com.palantir.util.file.TempFileUtils;
+
+import net.jpountz.lz4.LZ4BlockInputStream;
 
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
 public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
@@ -365,6 +371,7 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link Builder}
      * {@link ByteArrayIOStream}
      * {@link ByteArrayInputStream}
+     * {@link ByteStreams}
      * {@link ByteString}
      * {@link Cell}
      * {@link CheckForNull}
@@ -378,6 +385,7 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link File}
      * {@link FileNotFoundException}
      * {@link FileOutputStream}
+     * {@link Functions}
      * {@link Generated}
      * {@link HashMultimap}
      * {@link IOException}
@@ -385,6 +393,8 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link ImmutableSet}
      * {@link InputStream}
      * {@link Ints}
+     * {@link LZ4BlockInputStream}
+     * {@link LZ4CompressingInputStream}
      * {@link List}
      * {@link Lists}
      * {@link Logger}
@@ -395,6 +405,7 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link Multimap}
      * {@link Multimaps}
      * {@link OutputStream}
+     * {@link Pair}
      * {@link PersistentStreamStore}
      * {@link Preconditions}
      * {@link Set}


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1357)
<!-- Reviewable:end -->

This PR appears much larger than it actually is because it includes commits from https://github.com/palantir/atlasdb/pull/1347 and https://github.com/palantir/atlasdb/pull/1341. All the new code is in the last commit. Hopefully the other two merge tomorrow and I can drop those changes and rebase on develop. I've applied the do not merge label since the commit includes code that will be merging in other PRs.

I'm not entirely happy with the messiness of StreamTest.java - a larger scale refactor may be in order, but it's probably outside the scope of this commit. Similarly, I've had to extend a lot of previously private methods in the stream store code, indicating that maybe a refactor is needed there as well. I defer to the atlasdb maintainers there.

The generated java files checked in represent the files rendered by StreamStoreRenderer.java.
