### PR TITLE
remove java8 nicety from java6 package

### DIFF
--- a/atlasdb-commons/src/test/java/com/palantir/common/compression/LZ4CompressionTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/compression/LZ4CompressionTests.java
@@ -65,7 +65,7 @@ public class LZ4CompressionTests {
         initializeStreams(uncompressedData);
         int value = decompressingStream.read();
 
-        assertEquals(Byte.toUnsignedInt(uncompressedData[0]), value);
+        assertEquals(uncompressedData[0] & 0xFF, value);
         assertStreamIsEmpty(decompressingStream);
     }
 
@@ -97,7 +97,7 @@ public class LZ4CompressionTests {
 
         for (int i = 0; i < uncompressedData.length; ++i) {
             int value = decompressingStream.read();
-            assertEquals(Byte.toUnsignedInt(uncompressedData[i]), value);
+            assertEquals(uncompressedData[i] & 0xFF, value);
         }
         assertStreamIsEmpty(decompressingStream);
     }


### PR DESCRIPTION
this causes intellij build break but not gradle or eclipse build break (sandor is a dirty eclipse user)

It's java8 code in a package marked as java 6. Technically it's test-only code so it should work and really should be okay, but it's just easier to not have it at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1367)
<!-- Reviewable:end -->
