### PR TITLE
Log successful transaction if we've retried

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -53,7 +53,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
                     log.warn("Failing after {} tries.", failureCount, e);
                     throw Throwables.rewrap(String.format("Failing after %d tries.", failureCount), e);
                 }
-                log.info("Retrying transaction.", e);
+                log.info("Retrying transaction after {} failure(s).", failureCount, e);
             } catch (RuntimeException e) {
                 log.warn("RuntimeException while processing transaction.", e);
                 throw e;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -16,6 +16,8 @@
 package com.palantir.atlasdb.transaction.impl;
 
 
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,27 +37,28 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     @Override
     public <T, E extends Exception> T runTaskWithRetry(TransactionTask<T, E> task) throws E {
         int failureCount = 0;
+        UUID runId = UUID.randomUUID();
         while (true) {
             checkOpen();
             try {
                 T result = runTaskThrowOnConflict(task);
                 if (failureCount > 0) {
-                    log.info("Successfully completed transaction after {} retries.", failureCount);
+                    log.info("[{}] Successfully completed transaction after {} retries.", runId, failureCount);
                 }
                 return result;
             } catch (TransactionFailedException e) {
                 if (!e.canTransactionBeRetried()) {
-                    log.warn("Non-retriable exception while processing transaction.", e);
+                    log.warn("[{}] Non-retriable exception while processing transaction.", runId, e);
                     throw e;
                 }
                 failureCount++;
                 if (shouldStopRetrying(failureCount)) {
-                    log.warn("Failing after {} tries.", failureCount, e);
+                    log.warn("[{}] Failing after {} tries.", runId, failureCount, e);
                     throw Throwables.rewrap(String.format("Failing after %d tries.", failureCount), e);
                 }
-                log.info("Retrying transaction after {} failure(s).", failureCount, e);
+                log.info("[{}] Retrying transaction after {} failure(s).", runId, failureCount, e);
             } catch (RuntimeException e) {
-                log.warn("RuntimeException while processing transaction.", e);
+                log.warn("[{}] RuntimeException while processing transaction.", runId, e);
                 throw e;
             }
             sleepForBackoff(failureCount);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
@@ -73,9 +73,13 @@ public abstract class AbstractLockAwareTransactionManager
 
             try {
                 if (lockToken == null) {
-                    return runTaskWithLocksThrowOnConflict(lockTokens, task);
+                    T result = runTaskWithLocksThrowOnConflict(lockTokens, task);
+                    logSuccess(runId, failureCount);
+                    return result;
                 } else {
-                    return runTaskWithLocksThrowOnConflict(IterableUtils.append(lockTokens, lockToken), task);
+                    T result = runTaskWithLocksThrowOnConflict(IterableUtils.append(lockTokens, lockToken), task);
+                    logSuccess(runId, failureCount);
+                    return result;
                 }
             } catch (TransactionFailedException e) {
                 if (!e.canTransactionBeRetried()) {
@@ -102,6 +106,10 @@ public abstract class AbstractLockAwareTransactionManager
 
             sleepForBackoff(failureCount);
         }
+    }
+
+    private void logSuccess(UUID runId, int failureCount) {
+        log.info("[{}] Successfully completed transaction after {} retries.", runId, failureCount);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -46,6 +47,7 @@ public abstract class AbstractLockAwareTransactionManager
             Supplier<LockRequest> lockSupplier,
             LockAwareTransactionTask<T, E> task) throws E, InterruptedException {
         int failureCount = 0;
+        UUID runId = UUID.randomUUID();
         while (true) {
             checkOpen();
             LockRequest lockRequest = lockSupplier.get();
@@ -57,10 +59,10 @@ public abstract class AbstractLockAwareTransactionManager
                 if (response == null) {
                     RuntimeException ex = new LockAcquisitionException(
                             "Failed to lock using the provided lock request: " + lockRequest);
-                    log.warn("Could not lock successfully", ex);
+                    log.warn("[{}] Could not lock successfully", runId, ex);
                     failureCount++;
                     if (shouldStopRetrying(failureCount)) {
-                        log.warn("Failing after {} tries", failureCount, ex);
+                        log.warn("[{}] Failing after {} tries", runId, failureCount, ex);
                         throw ex;
                     }
                     sleepForBackoff(failureCount);
@@ -77,7 +79,7 @@ public abstract class AbstractLockAwareTransactionManager
                 }
             } catch (TransactionFailedException e) {
                 if (!e.canTransactionBeRetried()) {
-                    log.warn("Non-retriable exception while processing transaction.", e);
+                    log.warn("[{}] Non-retriable exception while processing transaction.", runId, e);
                     throw e;
                 }
                 if (e instanceof TransactionLockTimeoutException) {
@@ -85,12 +87,12 @@ public abstract class AbstractLockAwareTransactionManager
                 }
                 failureCount++;
                 if (shouldStopRetrying(failureCount)) {
-                    log.warn("Failing after {} tries", failureCount, e);
+                    log.warn("[{}] Failing after {} tries", runId, failureCount, e);
                     throw e;
                 }
-                log.info("retrying transaction", e);
+                log.info("[{}] Retrying transaction", runId, e);
             } catch (RuntimeException e) {
-                log.warn("RuntimeException while processing transaction.", e);
+                log.warn("[{}] RuntimeException while processing transaction.", runId, e);
                 throw e;
             } finally {
                 if (lockToken != null) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,6 +58,12 @@ develop
          - Don't retry interrupted remote calls, shut down the scrubber immediately when interrupted.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1488>`__)
 
+    *    - |improved|
+         - More informative logging around retrying of transactions.
+           If a transaction succeeds after being retried, we log the success (at the INFO level).
+           If a transaction failed, but will be retried, we now also log the number of failures so far (at INFO).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1376>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -228,7 +234,8 @@ v0.27.1
 
     *    - |improved|
          - ``StreamStore.loadStream`` now actually streams data if it does not fit in memory.
-           This means that getting the first byte of the stream now has constant-time performance, rather than linear in terms of stream length as it was previously.
+           This means that getting the first byte of the stream now has constant-time performance, rather than
+           linear in terms of stream length as it was previously.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1341>`__)
 
     *    - |improved|


### PR DESCRIPTION
Note that if multiple transactions are in flight simultaneously, it
won't be clear *which* transaction completed after the retry.

To do:

- [x] ensure the logging / logic is shared between this and the other txMgr retry loop (AbstractLockAwareTransactionManager#runTaskWithLocksWithRetry)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1376)
<!-- Reviewable:end -->
