### PR TITLE
Clarify project license as BSD 3-Clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ We use [ZenHub](https://www.zenhub.com/) for tracking our work inside GitHub. If
 Please see our docs on [Contributing to AtlasDB](https://palantir.github.io/atlasdb/html/miscellaneous/contributing.html)
 
 ## License
-This project is made available under the [BSD License](https://github.com/palantir/atlasdb/blob/develop/LICENSE.txt).
+This project is made available under the [BSD 3-Clause License](https://github.com/palantir/atlasdb/blob/develop/LICENSE.txt).


### PR DESCRIPTION
Our license.txt and each Java class file uses BSD 3-Clause but README.md was unclear on which variation of BSD we use.  Updating README.md to avoid confusion.

[no release notes]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1382)
<!-- Reviewable:end -->
