### PR TITLE
Feature/delete range

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -345,6 +345,13 @@ public interface KeyValueService extends AutoCloseable {
     /**
      * Deletes values in a range from the key-value store.
      *
+     * Does not guarantee an atomic delete throughout the entire range.
+     *
+     * Currently does not allow a column selection to mean only delete certain columns in a range.
+     *
+     * Some systems may require more nodes to be up to ensure that a delete is successful. If this
+     * is the case then this method may throw if the delete can't be completed on all nodes.
+     *
      * @param tableRef the name of the table to delete values from.
      * @param range the range to delete
      */

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -343,6 +343,18 @@ public interface KeyValueService extends AutoCloseable {
     void delete(@QueryParam("tableRef") TableReference tableRef, Multimap<Cell, Long> keys);
 
     /**
+     * Deletes values in a range from the key-value store.
+     *
+     * @param tableRef the name of the table to delete values from.
+     * @param range the range to delete
+     */
+    @POST
+    @Path("delete-range")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Idempotent
+    void deleteRange(@QueryParam("tableRef") TableReference tableRef, RangeRequest range);
+
+    /**
      * Truncate a table in the key-value store.
      * <p>
      * This is preferred to dropping and re-adding a table, as live schema changes can

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -212,6 +212,6 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
                 ImmutableSet.of(Cell.create(
                         tableRef.getQualifiedName().getBytes(StandardCharsets.UTF_8),
                         "m".getBytes(StandardCharsets.UTF_8))),
-                Long.MAX_VALUE).size();
+                AtlasDbConstants.MAX_TS).size();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -58,6 +58,8 @@ public class AtlasDbConstants {
     public static final int DEFAULT_TABLE_WITH_RANGESCANS_COMPRESSION_BLOCK_SIZE_KB = 64;
 
     public static final long TRANSACTION_TS = 0L;
+    public static final long MAX_TS = Long.MAX_VALUE;
+
 
     public static final Set<TableReference> hiddenTables = ImmutableSet.of(
             TransactionConstants.TRANSACTION_TABLE,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -277,7 +277,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
 
     @Override
     public void deleteRange(TableReference tableRef, RangeRequest range) {
-        try (ClosableIterator<RowResult<Set<Long>>> iterator = getRangeOfTimestamps(tableRef, range, Long.MAX_VALUE)) {
+        try (ClosableIterator<RowResult<Set<Long>>> iterator = getRangeOfTimestamps(tableRef, range, AtlasDbConstants.MAX_TS)) {
             while (iterator.hasNext()) {
                 RowResult<Set<Long>> rowResult = iterator.next();
                 Multimap<Cell, Long> cellsToDelete = HashMultimap.create();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -116,6 +116,12 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        delegate1.deleteRange(tableRef, range);
+        delegate2.deleteRange(tableRef, range);
+    }
+
+    @Override
     public void truncateTable(TableReference tableRef) {
         delegate1.truncateTable(tableRef);
         delegate2.truncateTable(tableRef);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
@@ -67,6 +67,11 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     }
 
     @Override
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        delegate().deleteRange(tableRef, range);
+    }
+
+    @Override
     public Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> keys, long timestamp) {
         return delegate().getAllTimestamps(tableRef, keys, timestamp);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -280,7 +280,7 @@ public class ProfilingKeyValueService implements KeyValueService {
         if (log.isTraceEnabled()) {
             Stopwatch stopwatch = Stopwatch.createStarted();
             ClosableIterator<RowResult<Value>> result = delegate.getRange(tableRef, rangeRequest, timestamp);
-            logTimeAndTable("getRange", tableRef.getQualifiedName(), stopwatch);
+            logTimeAndTableRange("getRange", tableRef.getQualifiedName(), rangeRequest, stopwatch);
             return result;
         } else {
             return delegate.getRange(tableRef, rangeRequest, timestamp);
@@ -292,7 +292,7 @@ public class ProfilingKeyValueService implements KeyValueService {
         if (log.isTraceEnabled()) {
             Stopwatch stopwatch = Stopwatch.createStarted();
             ClosableIterator<RowResult<Set<Long>>> result = delegate.getRangeOfTimestamps(tableRef, rangeRequest, timestamp);
-            logTimeAndTable("getRangeOfTimestamps", tableRef.getQualifiedName(), stopwatch);
+            logTimeAndTableRange("getRangeOfTimestamps", tableRef.getQualifiedName(), rangeRequest, stopwatch);
             return result;
         } else {
             return delegate.getRangeOfTimestamps(tableRef, rangeRequest, timestamp);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -92,6 +92,11 @@ public class ProfilingKeyValueService implements KeyValueService {
                 method, tableCount, stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
+    private static void logTimeAndTableRange(String method, String tableName, RangeRequest range, Stopwatch stopwatch) {
+        log.trace("Call to KVS.{} on table {} with range {} took {} ms.",
+                method, tableName, range, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+    }
+
     private final KeyValueService delegate;
 
     private ProfilingKeyValueService(KeyValueService delegate) {
@@ -140,6 +145,17 @@ public class ProfilingKeyValueService implements KeyValueService {
             logCellsAndSize("delete", tableRef.getQualifiedName(), keys.keySet().size(), byteSize(keys), stopwatch);
         } else {
             delegate.delete(tableRef, keys);
+        }
+    }
+
+    @Override
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        if (log.isTraceEnabled()) {
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            delegate.deleteRange(tableRef, range);
+            logTimeAndTableRange("deleteRange", tableRef.getQualifiedName(), range, stopwatch);
+        } else {
+            delegate.deleteRange(tableRef, range);
         }
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,7 +114,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
     @Override
     public void deleteRange(TableReference tableRef, RangeRequest rangeRequest) {
         if (!rangeRequest.getColumnNames().isEmpty()) {
-            throw new NotImplementedException(
+            throw new UnsupportedOperationException(
                     "We don't anticipate supporting deleting ranges with partial column selections.");
         }
         delegate.deleteRange(tableRef, rangeRequest);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,6 +110,15 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
             return;
         }
         delegate.delete(tableRef, keys);
+    }
+
+    @Override
+    public void deleteRange(TableReference tableRef, RangeRequest rangeRequest) {
+        if (!rangeRequest.getColumnNames().isEmpty()) {
+            throw new NotImplementedException(
+                    "We don't anticipate supporting deleting ranges with partial column selections.");
+        }
+        delegate.deleteRange(tableRef, rangeRequest);
     }
 
     @Override

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   compile project(':commons-api')
 
   testCompile project(':atlasdb-config')
+  testCompile group: 'org.hamcrest', name: 'hamcrest-library'
   testCompile group: 'org.mockito', name: 'mockito-core'
 
   processor group: 'org.immutables', name: 'value'

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -20,16 +20,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.PrimaryKeyConstraintNames;
 import com.palantir.exception.PalantirSqlException;
+import com.palantir.nexus.db.sql.BasicSQLUtils;
 import com.palantir.nexus.db.sql.ExceptionCheck;
 
 public abstract class AbstractDbWriteTable implements DbWriteTable {
@@ -142,4 +146,38 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
                 args);
     }
 
+    @Override
+    public void delete(RangeRequest range) {
+        String prefixedTableName = prefixedTableNames.get(tableRef);
+        StringBuilder query = new StringBuilder();
+        query.append(" /* DELETE_RANGE (").append(prefixedTableName).append(") */ ");
+        query.append(" DELETE FROM ").append(prefixedTableName).append(" m ");
+
+        // add where clauses to the query
+        byte[] start = range.getStartInclusive();
+        byte[] end = range.getEndExclusive();
+        Collection<byte[]> cols = range.getColumnNames();
+        List<Object> args = Lists.newArrayListWithCapacity(2 + cols.size());
+        List<String> whereClauses = Lists.newArrayListWithCapacity(3);
+        if (start.length > 0) {
+            whereClauses.add(range.isReverse() ? "m.row_name <= ?" : "m.row_name >= ?");
+            args.add(start);
+        }
+        if (end.length > 0) {
+            whereClauses.add(range.isReverse() ? "m.row_name > ?" : "m.row_name < ?");
+            args.add(end);
+        }
+        if (!cols.isEmpty()) {
+            whereClauses.add("m.col_name IN (" + BasicSQLUtils.nArguments(cols.size()) + ")");
+            args.addAll(cols);
+        }
+
+        if (!whereClauses.isEmpty()) {
+            query.append(" WHERE ");
+            Joiner.on(" AND ").appendTo(query, whereClauses);
+        }
+
+        // execute the query
+        conns.get().updateUnregisteredQuery(query.toString(), args.toArray());
+    }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -41,7 +41,7 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
     protected final TableReference tableRef;
     private final PrefixedTableNames prefixedTableNames;
 
-    public AbstractDbWriteTable(
+    protected AbstractDbWriteTable(
             DdlConfig config,
             ConnectionSupplier conns,
             TableReference tableRef,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -460,6 +460,17 @@ public class DbKvs extends AbstractKeyValueService {
     });
 
     @Override
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        runWriteForceAutocommit(tableRef, new Function<DbWriteTable, Void>() {
+            @Override
+            public Void apply(DbWriteTable table) {
+                table.delete(range);
+                return null;
+            }
+        });
+    }
+
+    @Override
     public Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
             TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbWriteTable.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.Value;
 
 public interface DbWriteTable {
@@ -29,4 +30,5 @@ public interface DbWriteTable {
     void putSentinels(Iterable<Cell> cells);
     void update(Cell cell, long ts, byte[] oldValue, byte[] newValue);
     void delete(List<Entry<Cell, Long>> partition);
+    void delete(RangeRequest range);
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/WhereClauses.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/WhereClauses.java
@@ -31,7 +31,7 @@ public final class WhereClauses {
         this.arguments = arguments;
     }
 
-    public static WhereClauses create(RangeRequest request, String... clauses) {
+    public static WhereClauses create(String tableIdentifier, RangeRequest request, String... clauses) {
         List<String> extraWhereClauses = Lists.newArrayList(clauses);
 
         byte[] start = request.getStartInclusive();
@@ -42,15 +42,15 @@ public final class WhereClauses {
         List<String> whereClauses = Lists.newArrayListWithCapacity(3 + extraWhereClauses.size());
 
         if (start.length > 0) {
-            whereClauses.add(request.isReverse() ? "i.row_name <= ?" : "i.row_name >= ?");
+            whereClauses.add(tableIdentifier + (request.isReverse() ? ".row_name <= ?" : ".row_name >= ?"));
             args.add(start);
         }
         if (end.length > 0) {
-            whereClauses.add(request.isReverse() ? "i.row_name > ?" : "i.row_name < ?");
+            whereClauses.add(tableIdentifier + (request.isReverse() ? ".row_name > ?" : ".row_name < ?"));
             args.add(end);
         }
         if (!cols.isEmpty()) {
-            whereClauses.add("i.col_name IN (" + BasicSQLUtils.nArguments(cols.size()) + ")");
+            whereClauses.add(tableIdentifier + ".col_name IN (" + BasicSQLUtils.nArguments(cols.size()) + ")");
             args.addAll(cols);
         }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/WhereClauses.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/WhereClauses.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.nexus.db.sql.BasicSQLUtils;
+
+public final class WhereClauses {
+    private final List<String> clauses;
+    private final List<Object> arguments;
+
+    private WhereClauses(List<String> clauses, List<Object> arguments) {
+        this.clauses = clauses;
+        this.arguments = arguments;
+    }
+
+    public static WhereClauses create(RangeRequest request, String... clauses) {
+        List<String> extraWhereClauses = Lists.newArrayList(clauses);
+
+        byte[] start = request.getStartInclusive();
+        byte[] end = request.getEndExclusive();
+        Collection<byte[]> cols = request.getColumnNames();
+
+        List<Object> args = Lists.newArrayListWithCapacity(2 + cols.size());
+        List<String> whereClauses = Lists.newArrayListWithCapacity(3 + extraWhereClauses.size());
+
+        if (start.length > 0) {
+            whereClauses.add(request.isReverse() ? "i.row_name <= ?" : "i.row_name >= ?");
+            args.add(start);
+        }
+        if (end.length > 0) {
+            whereClauses.add(request.isReverse() ? "i.row_name > ?" : "i.row_name < ?");
+            args.add(end);
+        }
+        if (!cols.isEmpty()) {
+            whereClauses.add("i.col_name IN (" + BasicSQLUtils.nArguments(cols.size()) + ")");
+            args.addAll(cols);
+        }
+
+        whereClauses.addAll(extraWhereClauses);
+
+        return new WhereClauses(whereClauses, args);
+    }
+
+    public List<Object> getArguments() {
+        return arguments;
+    }
+
+    public List<String> getClauses() {
+        return clauses;
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -31,6 +32,7 @@ import com.google.common.collect.Ordering;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
@@ -42,6 +44,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.UpdateExecutor;
 import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
 import com.palantir.exception.PalantirSqlException;
+import com.palantir.nexus.db.sql.BasicSQLUtils;
 import com.palantir.nexus.db.sql.ExceptionCheck;
 import com.palantir.nexus.db.sql.SqlConnection;
 
@@ -234,6 +237,60 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
                 args);
     }
 
+    @Override
+    public void delete(RangeRequest range) {
+        String shortTableName = getShortTableName();
+
+        switch (config.overflowMigrationState()) {
+            case UNSTARTED:
+                deleteOverflowRange(config.singleOverflowTable(), shortTableName, range);
+                break;
+            case IN_PROGRESS:
+                deleteOverflowRange(config.singleOverflowTable(), shortTableName, range);
+                deleteOverflowRange(getShortOverflowTableName(), shortTableName, range);
+                break;
+            case FINISHING:
+            case FINISHED:
+                deleteOverflowRange(getShortOverflowTableName(), shortTableName, range);
+                break;
+            default:
+                throw new EnumConstantNotPresentException(
+                        OverflowMigrationState.class, config.overflowMigrationState().name());
+        }
+
+        // delete from main table
+        StringBuilder query = new StringBuilder();
+        query.append(" /* DELETE_RANGE (").append(shortTableName).append(") */ ");
+        query.append(" DELETE /*+ INDEX(m pk_").append(shortTableName).append(") */ ");
+        query.append(" FROM ").append(shortTableName).append(" m ");
+
+        // add where clauses
+        byte[] start = range.getStartInclusive();
+        byte[] end = range.getEndExclusive();
+        Collection<byte[]> cols = range.getColumnNames();
+        List<Object> args = Lists.newArrayListWithCapacity(2 + cols.size());
+        List<String> whereClauses = Lists.newArrayListWithCapacity(3);
+        if (start.length > 0) {
+            whereClauses.add(range.isReverse() ? "m.row_name <= ?" : "m.row_name >= ?");
+            args.add(start);
+        }
+        if (end.length > 0) {
+            whereClauses.add(range.isReverse() ? "m.row_name > ?" : "m.row_name < ?");
+            args.add(end);
+        }
+        if (!cols.isEmpty()) {
+            whereClauses.add("m.col_name IN (" + BasicSQLUtils.nArguments(cols.size()) + ")");
+            args.addAll(cols);
+        }
+
+        if (!whereClauses.isEmpty()) {
+            query.append(" WHERE ");
+            Joiner.on(" AND ").appendTo(query, whereClauses);
+        }
+
+        conns.get().updateUnregisteredQuery(query.toString(), args.toArray());
+    }
+
     private void deleteOverflow(String overflowTable, List<Object[]> args) {
         String shortTableName = oraclePrefixedTableNames.get(tableRef);
         conns.get().updateManyUnregisteredQuery(" /* DELETE_ONE_OVERFLOW (" + overflowTable + ") */ "
@@ -247,6 +304,58 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
                 + "                    AND i.ts = ? "
                 + "                    AND i.overflow IS NOT NULL)",
                 args);
+    }
+
+    private void deleteOverflowRange(String overflowTable, String shortTableName, RangeRequest range) {
+        StringBuilder query = new StringBuilder();
+        query.append(" /* DELETE_RANGE_OVERFLOW (").append(overflowTable).append(") */ ");
+        query.append(" DELETE /*+ INDEX(m pk_").append(overflowTable).append(") */ ");
+        query.append("   FROM ").append(overflowTable).append(" m ");
+        query.append(" WHERE m.id IN (");
+
+        // subquery for finding rows in the short table
+        query.append("SELECT /*+ INDEX(i pk_").append(shortTableName).append(") */ ");
+        query.append("       i.overflow ");
+        query.append("    FROM ").append(shortTableName).append(" i ");
+
+        // add where clauses
+        byte[] start = range.getStartInclusive();
+        byte[] end = range.getEndExclusive();
+        Collection<byte[]> cols = range.getColumnNames();
+        List<Object> args = Lists.newArrayListWithCapacity(2 + cols.size());
+        List<String> whereClauses = Lists.newArrayListWithCapacity(4);
+        if (start.length > 0) {
+            whereClauses.add(range.isReverse() ? "i.row_name <= ?" : "i.row_name >= ?");
+            args.add(start);
+        }
+        if (end.length > 0) {
+            whereClauses.add(range.isReverse() ? "i.row_name > ?" : "i.row_name < ?");
+            args.add(end);
+        }
+        if (!cols.isEmpty()) {
+            whereClauses.add("i.col_name IN (" + BasicSQLUtils.nArguments(cols.size()) + ")");
+            args.addAll(cols);
+        }
+
+        whereClauses.add("i.overflow IS NOT NULL");
+
+        if (!whereClauses.isEmpty()) {
+            query.append(" WHERE ");
+            Joiner.on(" AND ").appendTo(query, whereClauses);
+        }
+
+        query.append(")");
+
+        // execute the query
+        conns.get().updateUnregisteredQuery(query.toString(), args.toArray());
+    }
+
+    private String getShortTableName() {
+        try {
+            return oracleTableNameGetter.getInternalShortTableName(conns, tableRef);
+        } catch (TableMappingNotFoundException e) {
+            throw Throwables.propagate(e);
+        }
     }
 
     private String getShortOverflowTableName() {

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/WhereClausesTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/WhereClausesTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+
+public class WhereClausesTest {
+    private static final byte[] COL1 = PtBytes.toBytes("col1");
+    private static final byte[] COL2 = PtBytes.toBytes("col2");
+    private static final byte[] COL3 = PtBytes.toBytes("col3");
+
+    private static final byte[] START = PtBytes.toBytes("start");
+    private static final byte[] END = PtBytes.toBytes("the end");
+
+    @Test
+    public void startOnly() {
+        RangeRequest request = RangeRequest.builder().startRowInclusive(START).build();
+        WhereClauses whereClauses = WhereClauses.create(request);
+
+        List<String> expectedClauses = ImmutableList.of("i.row_name >= ?");
+        assertEquals(whereClauses.getClauses(), expectedClauses);
+
+        checkWhereArguments(whereClauses, ImmutableList.of(START));
+    }
+
+    @Test
+    public void endOnly() {
+        RangeRequest request = RangeRequest.builder().endRowExclusive(END).build();
+        WhereClauses whereClauses = WhereClauses.create(request);
+
+        List<String> expectedClauses = ImmutableList.of("i.row_name < ?");
+        assertEquals(whereClauses.getClauses(), expectedClauses);
+
+        checkWhereArguments(whereClauses, ImmutableList.of(END));
+    }
+
+    @Test
+    public void whereClausesNoColumns() {
+        RangeRequest request = RangeRequest.builder().startRowInclusive(START).endRowExclusive(END).build();
+        WhereClauses whereClauses = WhereClauses.create(request);
+
+        List<String> expectedClauses = ImmutableList.of("i.row_name >= ?", "i.row_name < ?");
+        assertEquals(whereClauses.getClauses(), expectedClauses);
+
+        checkWhereArguments(whereClauses, ImmutableList.of(START, END));
+    }
+
+    @Test
+    public void withReverseRange() {
+        RangeRequest request = RangeRequest.reverseBuilder().startRowInclusive(END).endRowExclusive(START).build();
+        WhereClauses whereClauses = WhereClauses.create(request);
+
+        List<String> expectedClauses = ImmutableList.of("i.row_name <= ?", "i.row_name > ?");
+        assertEquals(whereClauses.getClauses(), expectedClauses);
+
+        checkWhereArguments(whereClauses, ImmutableList.of(END, START));
+    }
+
+    @Test
+    public void whereClausesOneColumn() {
+        RangeRequest request = RangeRequest.builder().startRowInclusive(START).endRowExclusive(END).retainColumns(
+                ColumnSelection.create(ImmutableList.of(COL1))).build();
+        WhereClauses whereClauses = WhereClauses.create(request);
+
+        List<String> expectedClauses = ImmutableList.of("i.row_name >= ?", "i.row_name < ?", "i.col_name IN (?)");
+        assertEquals(whereClauses.getClauses(), expectedClauses);
+
+        checkWhereArguments(whereClauses, ImmutableList.of(START, END, COL1));
+    }
+
+    @Test
+    public void whereClausesMultiColumn() {
+        RangeRequest request = RangeRequest.builder().startRowInclusive(START).endRowExclusive(END).retainColumns(
+                ColumnSelection.create(ImmutableList.of(COL1, COL2, COL3))).build();
+        WhereClauses whereClauses = WhereClauses.create(request);
+
+        List<String> expectedClauses = ImmutableList.of("i.row_name >= ?", "i.row_name < ?", "i.col_name IN (?,?,?)");
+        assertEquals(whereClauses.getClauses(), expectedClauses);
+
+        checkWhereArguments(whereClauses, ImmutableList.of(START, END, COL1, COL2, COL3));
+    }
+
+    @Test
+    public void whereClausesWithExtraClause() {
+        RangeRequest request = RangeRequest.builder().startRowInclusive(START).endRowExclusive(END).build();
+        String extraClause = "i.foo = bar";
+        WhereClauses whereClauses = WhereClauses.create(request, extraClause);
+
+        List<String> expectedClauses = ImmutableList.of("i.row_name >= ?", "i.row_name < ?", extraClause);
+        assertEquals(whereClauses.getClauses(), expectedClauses);
+
+        checkWhereArguments(whereClauses, ImmutableList.of(START, END));
+
+    }
+
+    private void checkWhereArguments(WhereClauses whereClauses, List<byte[]> expectedArgs) {
+        List<Object> actualArgs = whereClauses.getArguments();
+        for (int i = 0; i < actualArgs.size(); i++) {
+            assertArrayEquals(expectedArgs.get(i), (byte[]) actualArgs.get(i));
+        }
+        assertEquals(expectedArgs.size(), actualArgs.size());
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespaceMappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespaceMappingKeyValueService.java
@@ -66,6 +66,11 @@ public class NamespaceMappingKeyValueService extends ForwardingObject implements
     }
 
     @Override
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        delegate().deleteRange(tableRef, range);
+    }
+
+    @Override
     public Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> keys, long timestamp) {
         return delegate().getAllTimestamps(tableRef, keys, timestamp);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -110,6 +110,15 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        try {
+            delegate().deleteRange(tableMapper.getMappedTableName(tableRef), range);
+        } catch (TableMappingNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         dropTables(ImmutableSet.of(tableRef));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -127,6 +127,11 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        getDelegate(tableRef).deleteRange(tableRef, range);
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         getDelegate(tableRef).dropTable(tableRef);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/ThrowingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/ThrowingKeyValueService.java
@@ -125,6 +125,12 @@ public class ThrowingKeyValueService implements KeyValueService {
 
     @Override
     @Idempotent
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        throw throwEx();
+    }
+
+    @Override
+    @Idempotent
     public void truncateTable(TableReference tableRef) {
         throw throwEx();
     }

--- a/atlasdb-rocksdb/src/main/java/com/palantir/atlasdb/keyvalue/rocksdb/impl/RocksDbKeyValueService.java
+++ b/atlasdb-rocksdb/src/main/java/com/palantir/atlasdb/keyvalue/rocksdb/impl/RocksDbKeyValueService.java
@@ -50,6 +50,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -59,6 +60,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
@@ -443,6 +445,27 @@ public class RocksDbKeyValueService implements KeyValueService {
             getDb().write(options, batch);
         } catch (RocksDBException e) {
             throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void deleteRange(TableReference tableRef, RangeRequest range) {
+        try (ClosableIterator<RowResult<Set<Long>>> iterator = getRangeOfTimestamps(tableRef, range, Long.MAX_VALUE)) {
+            while (iterator.hasNext()) {
+                RowResult<Set<Long>> rowResult = iterator.next();
+
+                Multimap<Cell, Long> cellsToDelete = Multimaps.newSetMultimap(Maps.<Cell, Collection<Long>>newHashMap(), new Supplier<Set<Long>>() {
+                    @Override
+                    public Set<Long> get() {
+                        return Sets.newHashSet();
+                    }
+                });
+                for (Entry<Cell, Set<Long>> entry : rowResult.getCells()) {
+                    cellsToDelete.putAll(entry.getKey(), entry.getValue());
+                }
+
+                delete(tableRef, cellsToDelete);
+            }
         }
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -96,7 +96,6 @@ public abstract class AbstractKeyValueServiceTest {
 
     protected static final Cell TEST_CELL = Cell.create(row0, column0);
     protected static final long TEST_TIMESTAMP = 1000000L;
-    private static final long MAX_TIMESTAMP = Long.MAX_VALUE;
 
     protected static KeyValueService keyValueService = null;
 
@@ -738,59 +737,56 @@ public abstract class AbstractKeyValueServiceTest {
     }
 
     @Test
+    public void testDeleteRangeReverse() {
+        Assume.assumeTrue(reverseRangesSupported());
+        setupTestRowsZeroOneAndTwoAndDeleteFrom("row1b".getBytes(), row0, true); // should delete only row1
+        checkThatTableIsNowOnly(row0, row2);
+    }
+
+    @Test
     public void testDeleteRangeStartRowInclusivity() {
-        putTestDataForMultipleRows(); // set up rows row0,row1,row2
-
-        RangeRequest range = RangeRequest.builder()
-                .startRowInclusive(row0)
-                .endRowExclusive("row1b".getBytes())
-                .build();
-        // should delete row0 and row1
-        keyValueService.deleteRange(TEST_TABLE, range);
-
-        List<byte[]> keys = Lists.newArrayList();
-        keyValueService.getRange(TEST_TABLE, RangeRequest.all(), Long.MAX_VALUE)
-                .forEachRemaining(row -> keys.add(row.getRowName()));
-        assertTrue(Arrays.deepEquals(keys.toArray(), ImmutableList.of(row2).toArray()));
+        setupTestRowsZeroOneAndTwoAndDeleteFrom(row0, "row1b".getBytes()); // should delete row0 and row1
+        checkThatTableIsNowOnly(row2);
     }
 
     @Test
     public void testDeleteRangeEndRowExclusivity() {
-        putTestDataForMultipleRows(); // set up rows row0,row1,row2
-
-        RangeRequest range = RangeRequest.builder()
-                .startRowInclusive("row".getBytes())
-                .endRowExclusive("row1".getBytes())
-                .build();
-        // should delete row0 only
-        keyValueService.deleteRange(TEST_TABLE, range);
-
-        List<byte[]> keys = Lists.newArrayList();
-        keyValueService.getRange(TEST_TABLE, RangeRequest.all(), Long.MAX_VALUE)
-                .forEachRemaining(row -> keys.add(row.getRowName()));
-        assertTrue(Arrays.deepEquals(keys.toArray(), ImmutableList.of(row1, row2).toArray()));
+        setupTestRowsZeroOneAndTwoAndDeleteFrom("row".getBytes(), row1); // should delete row0 only
+        checkThatTableIsNowOnly(row1, row2);
     }
 
     @Test
     public void testDeleteRangeAll() {
-        putTestDataForMultipleRows(); // set up rows row0,row1,row2
+        putTestDataForRowsZeroOneAndTwo();
         keyValueService.deleteRange(TEST_TABLE, RangeRequest.all());
-        assertFalse(keyValueService.getRange(TEST_TABLE, RangeRequest.all(), Long.MAX_VALUE).hasNext());
+        checkThatTableIsNowOnly();
     }
 
     @Test
     public void testDeleteRangeNone() {
-        putTestDataForMultipleRows(); // set up rows row0,row1,row2
-        RangeRequest range = RangeRequest.builder()
-                .startRowInclusive("a".getBytes())
-                .endRowExclusive("a".getBytes())
+        setupTestRowsZeroOneAndTwoAndDeleteFrom("a".getBytes(), "a".getBytes());
+        checkThatTableIsNowOnly(row0, row1, row2);
+    }
+
+    private void setupTestRowsZeroOneAndTwoAndDeleteFrom(byte[] start, byte[] end) {
+        setupTestRowsZeroOneAndTwoAndDeleteFrom(start, end, false);
+    }
+
+    private void setupTestRowsZeroOneAndTwoAndDeleteFrom(byte[] start, byte[] end, boolean reverse) {
+        putTestDataForRowsZeroOneAndTwo();
+
+        RangeRequest range = RangeRequest.builder(reverse)
+                .startRowInclusive(start)
+                .endRowExclusive(end)
                 .build();
         keyValueService.deleteRange(TEST_TABLE, range);
+    }
 
+    private void checkThatTableIsNowOnly(byte[]... rows) {
         List<byte[]> keys = Lists.newArrayList();
-        keyValueService.getRange(TEST_TABLE, RangeRequest.all(), Long.MAX_VALUE)
+        keyValueService.getRange(TEST_TABLE, RangeRequest.all(), AtlasDbConstants.MAX_TS)
                 .forEachRemaining(row -> keys.add(row.getRowName()));
-        assertTrue(Arrays.deepEquals(keys.toArray(), ImmutableList.of(row0, row1, row2).toArray()));
+        assertTrue(Arrays.deepEquals(keys.toArray(), rows));
     }
 
     @Test
@@ -973,19 +969,19 @@ public abstract class AbstractKeyValueServiceTest {
     public void testAddGCSentinelValues() {
         putTestDataForMultipleTimestamps();
 
-        Multimap<Cell, Long> timestampsBefore = keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(TEST_CELL), MAX_TIMESTAMP);
+        Multimap<Cell, Long> timestampsBefore = keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(TEST_CELL), AtlasDbConstants.MAX_TS);
         assertEquals(2, timestampsBefore.size());
         assertTrue(!timestampsBefore.containsEntry(TEST_CELL, Value.INVALID_VALUE_TIMESTAMP));
 
         keyValueService.addGarbageCollectionSentinelValues(TEST_TABLE, ImmutableSet.of(TEST_CELL));
 
-        Multimap<Cell, Long> timestampsAfter1 = keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(TEST_CELL), MAX_TIMESTAMP);
+        Multimap<Cell, Long> timestampsAfter1 = keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(TEST_CELL), AtlasDbConstants.MAX_TS);
         assertEquals(3, timestampsAfter1.size());
         assertTrue(timestampsAfter1.containsEntry(TEST_CELL, Value.INVALID_VALUE_TIMESTAMP));
 
         keyValueService.addGarbageCollectionSentinelValues(TEST_TABLE, ImmutableSet.of(TEST_CELL));
 
-        Multimap<Cell, Long> timestampsAfter2 = keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(TEST_CELL), MAX_TIMESTAMP);
+        Multimap<Cell, Long> timestampsAfter2 = keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(TEST_CELL), AtlasDbConstants.MAX_TS);
         assertEquals(3, timestampsAfter2.size());
         assertTrue(timestampsAfter2.containsEntry(TEST_CELL, Value.INVALID_VALUE_TIMESTAMP));
     }
@@ -993,7 +989,7 @@ public abstract class AbstractKeyValueServiceTest {
     @Test
     public void testGetRangeThrowsOnError() {
         try {
-            keyValueService.getRange(TEST_NONEXISTING_TABLE, RangeRequest.all(), MAX_TIMESTAMP).hasNext();
+            keyValueService.getRange(TEST_NONEXISTING_TABLE, RangeRequest.all(), AtlasDbConstants.MAX_TS).hasNext();
             Assert.fail("getRange must throw on failure");
         } catch (RuntimeException e) {
             // Expected
@@ -1003,7 +999,7 @@ public abstract class AbstractKeyValueServiceTest {
     @Test
     public void testGetRangeOfTimestampsThrowsOnError() {
         try {
-            keyValueService.getRangeOfTimestamps(TEST_NONEXISTING_TABLE, RangeRequest.all(), MAX_TIMESTAMP).hasNext();
+            keyValueService.getRangeOfTimestamps(TEST_NONEXISTING_TABLE, RangeRequest.all(), AtlasDbConstants.MAX_TS).hasNext();
             Assert.fail("getRangeOfTimestamps must throw on failure");
         } catch (RuntimeException e) {
             // Expected
@@ -1090,7 +1086,7 @@ public abstract class AbstractKeyValueServiceTest {
         byte[] row = PtBytes.toBytes(123L);
         Cell cell = Cell.create(row, dynamicColumn(1));
 
-        Map<Cell, Long> valueToGet = ImmutableMap.of(cell, MAX_TIMESTAMP);
+        Map<Cell, Long> valueToGet = ImmutableMap.of(cell, AtlasDbConstants.MAX_TS);
 
         assertThat(keyValueService.get(DynamicColumnTable.reference(), valueToGet), is(emptyMap()));
     }
@@ -1116,7 +1112,7 @@ public abstract class AbstractKeyValueServiceTest {
                 DynamicColumnTable.reference(),
                 ImmutableList.of(row),
                 ColumnSelection.all(),
-                MAX_TIMESTAMP);
+                AtlasDbConstants.MAX_TS);
 
         assertThat(values, is(emptyMap()));
     }
@@ -1185,7 +1181,7 @@ public abstract class AbstractKeyValueServiceTest {
         return PtBytes.toBytes(columnId);
     }
 
-    protected void putTestDataForMultipleRows() {
+    protected void putTestDataForRowsZeroOneAndTwo() {
         keyValueService.put(TEST_TABLE,
                 ImmutableMap.of(Cell.create(row0, column0), value0_t0), TEST_TIMESTAMP);
         keyValueService.put(TEST_TABLE,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -49,6 +50,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -736,6 +738,62 @@ public abstract class AbstractKeyValueServiceTest {
     }
 
     @Test
+    public void testDeleteRangeStartRowInclusivity() {
+        putTestDataForMultipleRows(); // set up rows row0,row1,row2
+
+        RangeRequest range = RangeRequest.builder()
+                .startRowInclusive(row0)
+                .endRowExclusive("row1b".getBytes())
+                .build();
+        // should delete row0 and row1
+        keyValueService.deleteRange(TEST_TABLE, range);
+
+        List<byte[]> keys = Lists.newArrayList();
+        keyValueService.getRange(TEST_TABLE, RangeRequest.all(), Long.MAX_VALUE)
+                .forEachRemaining(row -> keys.add(row.getRowName()));
+        assertTrue(Arrays.deepEquals(keys.toArray(), ImmutableList.of(row2).toArray()));
+    }
+
+    @Test
+    public void testDeleteRangeEndRowExclusivity() {
+        putTestDataForMultipleRows(); // set up rows row0,row1,row2
+
+        RangeRequest range = RangeRequest.builder()
+                .startRowInclusive("row".getBytes())
+                .endRowExclusive("row1".getBytes())
+                .build();
+        // should delete row0 only
+        keyValueService.deleteRange(TEST_TABLE, range);
+
+        List<byte[]> keys = Lists.newArrayList();
+        keyValueService.getRange(TEST_TABLE, RangeRequest.all(), Long.MAX_VALUE)
+                .forEachRemaining(row -> keys.add(row.getRowName()));
+        assertTrue(Arrays.deepEquals(keys.toArray(), ImmutableList.of(row1, row2).toArray()));
+    }
+
+    @Test
+    public void testDeleteRangeAll() {
+        putTestDataForMultipleRows(); // set up rows row0,row1,row2
+        keyValueService.deleteRange(TEST_TABLE, RangeRequest.all());
+        assertFalse(keyValueService.getRange(TEST_TABLE, RangeRequest.all(), Long.MAX_VALUE).hasNext());
+    }
+
+    @Test
+    public void testDeleteRangeNone() {
+        putTestDataForMultipleRows(); // set up rows row0,row1,row2
+        RangeRequest range = RangeRequest.builder()
+                .startRowInclusive("a".getBytes())
+                .endRowExclusive("a".getBytes())
+                .build();
+        keyValueService.deleteRange(TEST_TABLE, range);
+
+        List<byte[]> keys = Lists.newArrayList();
+        keyValueService.getRange(TEST_TABLE, RangeRequest.all(), Long.MAX_VALUE)
+                .forEachRemaining(row -> keys.add(row.getRowName()));
+        assertTrue(Arrays.deepEquals(keys.toArray(), ImmutableList.of(row0, row1, row2).toArray()));
+    }
+
+    @Test
     public void testPutWithTimestamps() {
         putTestDataForMultipleTimestamps();
         final Value val1 = Value.create(value0_t1, TEST_TIMESTAMP + 1);
@@ -1125,6 +1183,15 @@ public abstract class AbstractKeyValueServiceTest {
 
     private byte[] dynamicColumn(long columnId) {
         return PtBytes.toBytes(columnId);
+    }
+
+    protected void putTestDataForMultipleRows() {
+        keyValueService.put(TEST_TABLE,
+                ImmutableMap.of(Cell.create(row0, column0), value0_t0), TEST_TIMESTAMP);
+        keyValueService.put(TEST_TABLE,
+            ImmutableMap.of(Cell.create(row1, column0), value0_t0), TEST_TIMESTAMP);
+        keyValueService.put(TEST_TABLE,
+                ImmutableMap.of(Cell.create(row2, column0), value0_t0), TEST_TIMESTAMP);
     }
 
     protected void putTestDataForMultipleTimestamps() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -332,6 +332,12 @@ v0.27.1
            See gradle-java-distribution `release notes <https://github.com/palantir/gradle-java-distribution/releases>`__ for details.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1361>`__)
 
+    *     - |new|
+          - Add KeyValueStore.deleteRange(); makes large swathes of row deletions faster,
+            like transaction sweeping. Also can be used as a fallback option for people
+            having issues with their backup solutions not allowing truncate() during a backup
+            (`Pull Request <https://github.com/palantir/atlasdb/pull/1391>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
fixes #1086 , although does not include a faster Cassandra-specific implementation that 1086 hints at. (It requires 3.0.something+ cassandra and I need to bring us up to using C* 3.7 everywhere before I want to think about it)
(It does include a fast implementation for the DbKVSs)

Anticipated usages of this feature are:
- Transaction sweeping ( #446 )
- Fallback to delete for implementation of truncate during backups ( #1351 )

@berler wrote all the business code, I just did some cleanup and added tests and such.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1391)
<!-- Reviewable:end -->
