### PR TITLE
Add trustStorePassword to AtomixSslConfiguration

### DIFF
--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServer.java
@@ -32,9 +32,9 @@ import com.palantir.atlasdb.timelock.atomix.DistributedValues;
 import com.palantir.atlasdb.timelock.atomix.ImmutableLeaderAndTerm;
 import com.palantir.atlasdb.timelock.atomix.InvalidatingLeaderProxy;
 import com.palantir.atlasdb.timelock.atomix.LeaderAndTerm;
+import com.palantir.atlasdb.timelock.config.AtomixSslConfiguration;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 import com.palantir.lock.impl.LockServiceImpl;
-import com.palantir.remoting1.config.ssl.SslConfiguration;
 import com.palantir.remoting1.servers.jersey.HttpRemotingJerseyFeature;
 
 import io.atomix.AtomixReplica;
@@ -150,23 +150,24 @@ public class TimeLockServer extends Application<TimeLockServerConfiguration> {
                 TimeLockServices.class);
     }
 
-    private static Transport createTransport(Optional<SslConfiguration> optionalSecurity) {
+    private static Transport createTransport(Optional<AtomixSslConfiguration> optionalSecurity) {
         NettyTransport.Builder transport = NettyTransport.builder();
 
         if (!optionalSecurity.isPresent()) {
             return transport.build();
         }
 
-        SslConfiguration security = optionalSecurity.get();
+        AtomixSslConfiguration security = optionalSecurity.get();
         transport.withSsl()
-                .withTrustStorePath(security.trustStorePath().toString());
+                .withTrustStorePath(security.sslConfiguration().trustStorePath().toString())
+                .withTrustStorePassword(security.trustStorePassword());
 
-        if (security.keyStorePath().isPresent()) {
-            transport.withKeyStorePath(security.keyStorePath().get().toString());
+        if (security.sslConfiguration().keyStorePath().isPresent()) {
+            transport.withKeyStorePath(security.sslConfiguration().keyStorePath().get().toString());
         }
 
-        if (security.keyStorePassword().isPresent()) {
-            transport.withKeyStorePassword(security.keyStorePassword().get());
+        if (security.sslConfiguration().keyStorePassword().isPresent()) {
+            transport.withKeyStorePassword(security.sslConfiguration().keyStorePassword().get());
         }
 
         return transport.build();

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/AtomixSslConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/AtomixSslConfiguration.java
@@ -15,30 +15,17 @@
  */
 package com.palantir.atlasdb.timelock.config;
 
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.remoting1.config.ssl.SslConfiguration;
 
-import io.atomix.copycat.server.storage.StorageLevel;
-
-@JsonSerialize(as = ImmutableAtomixConfiguration.class)
-@JsonDeserialize(as = ImmutableAtomixConfiguration.class)
+@JsonSerialize(as = ImmutableAtomixSslConfiguration.class)
+@JsonDeserialize(as = ImmutableAtomixSslConfiguration.class)
 @Value.Immutable
-public abstract class AtomixConfiguration {
-    public static final AtomixConfiguration DEFAULT = ImmutableAtomixConfiguration.builder().build();
+public abstract class AtomixSslConfiguration {
+    public abstract SslConfiguration sslConfiguration();
 
-    public abstract Optional<AtomixSslConfiguration> security();
-
-    @Value.Default
-    public StorageLevel storageLevel() {
-        return StorageLevel.DISK;
-    }
-
-    @Value.Default
-    public String storageDirectory() {
-        return "var/data/atomix";
-    }
+    public abstract String trustStorePassword();
 }


### PR DESCRIPTION
Netty requires a trustStore password to read the trustStore. However SslConfiguration doesnt have the field (https://github.com/palantir/http-remoting/issues/312) and hence the config should be modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1394)
<!-- Reviewable:end -->
