### PR TITLE
Fix/oracle name

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
@@ -332,7 +332,7 @@ public class DbKvsGetRanges {
     }
 
     private String getPrefixedTableName(TableReference tableRef) {
-        return new PrefixedTableNames(config).get(tableRef);
+        return prefixedTableNames.get(tableRef);
     }
 
     private static final String SIMPLE_ROW_SELECT_TEMPLATE =

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -44,6 +44,8 @@ import com.palantir.docker.compose.execution.DockerComposeRunArgument;
 import com.palantir.docker.compose.execution.DockerComposeRunOption;
 import com.palantir.docker.compose.logging.LogDirectory;
 
+// **** Important: Some internal tests depend on this class,
+// please recompile them if any breaking changes are made to the setup ***
 public class EteSetup {
     private static final Gradle GRADLE_PREPARE_TASK = Gradle.ensureTaskHasRun(":atlasdb-ete-tests:prepareForEteTests");
     private static final Optional<SSLSocketFactory> NO_SSL = Optional.absent();


### PR DESCRIPTION
The oracle table names should be retrieved from the prefixedTableNames. Internal tests are happy with this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1396)
<!-- Reviewable:end -->
