### PR TITLE
Apply java plugin to identify sourceSets [no release notes]

### DIFF
--- a/gradle/publish-jars.gradle
+++ b/gradle/publish-jars.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'java'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'


### PR DESCRIPTION
The publications will be empty if sourceSets are not identified. This comes from the java plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1397)
<!-- Reviewable:end -->
