### PR TITLE
Enable GC logs for builds as CircleCI artifacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
     version:
       oraclejdk8
   environment:
-    _JAVA_OPTIONS: "-Xmx512M -XX:+HeapDumpOnOutOfMemoryError"
+    _JAVA_OPTIONS: "-Xmx512M -XX:+HeapDumpOnOutOfMemoryError -verbose:gc -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:-TraceClassUnloading -Xloggc:build-%t-%p.gc.log"
     TERM: dumb
   services:
     - docker
@@ -58,7 +58,7 @@ test:
         parallel: true
     - mkdir -p $CIRCLE_ARTIFACTS/heapdumps:
         parallel: true
-    - find . -type f -regex ".*\.hprof" -exec cp {} $CIRCLE_ARTIFACTS/heapdumps \;:
+    - find . -type f -name "*.hprof" -o -name "*.gc.log" -exec cp {} $CIRCLE_ARTIFACTS/heapdumps \;:
         parallel: true
 
 deployment:

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -61,6 +61,10 @@ develop
          - We now publish a runnable distribution of AtlasCli that is available for download directly from Bintray
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1345>`__)
 
+    *    - |improved|
+         - Enable garbage collection logging for CircleCI builds.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1398>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Adds GC logs to CircleCI artifacts, e.g. `build-2017-01-04_14-51-31-pid11879.gc.log`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1398)
<!-- Reviewable:end -->
