### PR TITLE
Small refactor of Jepsen tests

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
@@ -1,0 +1,37 @@
+(ns jepsen.atlasdb.timelock
+  (:require [clojure.tools.logging :refer :all]
+            [jepsen.control :as c]
+            [jepsen.db :as db]
+            [jepsen.os.debian :as debian])
+  (:import com.palantir.atlasdb.http.TimelockUtils))
+
+(defn create-db
+  "Creates an object that implements the db/DB protocol.
+   This object defines how to setup and teardown a timelock server on a given node, and specifies where the log files
+   can be found.
+  "
+  []
+  (reify db/DB
+    (setup! [_ _ node]
+      (c/su
+        (debian/install-jdk8!)
+        (info node "Uploading and unpacking timelock server")
+        (c/upload "resources/atlasdb/atlasdb-timelock-server.tgz" "/")
+        (c/exec :mkdir "/atlasdb-timelock-server")
+        (c/exec :tar :xf "/atlasdb-timelock-server.tgz" "-C" "/atlasdb-timelock-server" "--strip-components" "1")
+        (c/upload "resources/atlasdb/timelock.yml" "/atlasdb-timelock-server/var/conf")
+        (c/exec :sed :-i (format "s/<HOSTNAME>/%s/" (name node)) "/atlasdb-timelock-server/var/conf/timelock.yml")
+        (info node "Starting timelock server")
+        (c/exec :env "JAVA_HOME=/usr/lib/jvm/java-8-oracle" "/atlasdb-timelock-server/service/bin/init.sh" "start")
+        (info node "Waiting until timelock node is ready")
+        (TimelockUtils/waitUntilHostReady (name node))))
+
+    (teardown! [_ _ node]
+      (c/su
+        (try (c/exec "/atlasdb-timelock-server/service/bin/init.sh" "stop") (catch Exception _))
+        (try (c/exec :rm :-rf "/atlasdb-timelock-server") (catch Exception _))
+        (try (c/exec :rm :-f "/atlasdb-timelock-server.tgz") (catch Exception _))))
+
+    db/LogFiles
+    (log-files [_ test node]
+      ["/atlasdb-timelock-server/var/log/atlasdb-timelock-server-startup.log"])))

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import java.net.Socket;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.jayway.awaitility.Awaitility;
+
+public final class TimelockUtils {
+    private static final int PORT = 8080;
+    private static final int TIMEOUT_SECONDS = 60;
+    private static final String NAMESPACE = "test";
+
+    private TimelockUtils() {
+    }
+
+    public static void waitUntilHostReady(String host) {
+        Awaitility.await()
+                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .until(() -> hostIsListening(host));
+    }
+
+    public static <T> T createClient(List<String> hosts, Class<T> type) {
+        List<String> endpointUris = hostnamesToEndpointUris(hosts);
+        return createFromUris(endpointUris, type);
+    }
+
+    private static List<String> hostnamesToEndpointUris(List<String> hosts) {
+        return Lists.transform(hosts, host -> String.format("http://%s:%d/%s", host, PORT, NAMESPACE));
+    }
+
+    private static <T> T createFromUris(List<String> endpointUris, Class<T> type) {
+        return AtlasDbHttpClients.createProxyWithQuickFailoverForTesting(
+                Optional.<SSLSocketFactory>absent(),
+                endpointUris,
+                type);
+    }
+
+    private static boolean hostIsListening(String host) {
+        try {
+            new Socket(host, PORT);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimestampClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimestampClient.java
@@ -15,69 +15,15 @@
  */
 package com.palantir.atlasdb.http;
 
-import java.net.Socket;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.SSLSocketFactory;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.jayway.awaitility.Awaitility;
 import com.palantir.timestamp.TimestampService;
 
 public final class TimestampClient {
-    private static final int PORT = 8080;
-    private static final String NAMESPACE = "test";
-    private static final int TIMEOUT_SECONDS = 60;
-
     private TimestampClient() {
     }
 
     public static TimestampService create(List<String> hosts) {
-        List<String> endpointUris = hostnamesToEndpointUris(hosts);
-        return createFromUris(endpointUris);
-    }
-
-    public static void waitUntilHostReady(String host) {
-        Awaitility.await()
-                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .until(() -> hostIsListening(host));
-    }
-
-    public static void waitUntilTimestampClusterReady(List<String> hosts) {
-        Awaitility.await()
-                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .until(() -> clusterReturnsTimestamp(hosts));
-    }
-
-    private static List<String> hostnamesToEndpointUris(List<String> hosts) {
-        return Lists.transform(hosts, host -> String.format("http://%s:%d/%s", host, PORT, NAMESPACE));
-    }
-
-    private static TimestampService createFromUris(List<String> endpointUris) {
-        return AtlasDbHttpClients.createProxyWithQuickFailoverForTesting(
-                Optional.<SSLSocketFactory>absent(),
-                endpointUris,
-                TimestampService.class);
-    }
-
-    private static boolean hostIsListening(String host) {
-        try {
-            new Socket(host, PORT);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    private static boolean clusterReturnsTimestamp(List<String> hosts) {
-        try {
-            TimestampService service = create(hosts);
-            service.getFreshTimestamp();
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
+        return TimelockUtils.createClient(hosts, TimestampService.class);
     }
 }

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -1,9 +1,9 @@
 (ns jepsen.atlasdb-test
   (:require [clojure.test :refer :all]
-            [jepsen.core :as jepsen]
-            [jepsen.atlasdb :as atlasdb]))
+            [jepsen.atlasdb.timestamp :as timestamp]
+            [jepsen.core :as jepsen]))
 
 ;; Using Clojure's testing framework, we initiate a run of atlasdb-test
 ;; The test is successful iff the value for the key ":valid?" is truthy
-(deftest atlasdb-test
-   (is (:valid? (:results (jepsen/run! (atlasdb/atlasdb-test))))))
+(deftest timestamp-test
+   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test))))))


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

A refactor of the Jepsen tests to allow for the addition of a test of the lock server:

• Move some of `TimestampClient` into a `TimelockUtils` class, so that it can be later accessed by a `LockClient`
• Move the timelock server setup and teardown from `timestamp.clj` into `timelock.clj`, so that it be later used by the Jepsen test of the lock server
• When setting up the timelock server, only wait until it's listening on its ports, not until it can issue timestamps. Practically the second wait doesn't make a difference, and isn't worth the complexity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1399)
<!-- Reviewable:end -->
