### PR TITLE
increase cassandra pool size to 30->100 from 20->100 connections

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -209,6 +209,6 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         Preconditions.checkNotNull(keyspace(), "'keyspace' must be specified");
         double evictionCheckProportion = proportionConnectionsToCheckPerEvictionRun();
         Preconditions.checkArgument(evictionCheckProportion > 0.01 && evictionCheckProportion <= 1,
-                "'proportionConnectionsToCheckPerEvictionRun' must be between 0 and 1");
+                "'proportionConnectionsToCheckPerEvictionRun' must be between 0.01 and 1");
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -44,7 +44,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
 
     @Value.Default
     public int poolSize() {
-        return 20;
+        return 30;
     }
 
     /**
@@ -54,7 +54,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
      */
     @Value.Default
     public int maxConnectionBurstSize() {
-        return 5 * poolSize();
+        return 100;
     }
 
     /**
@@ -208,7 +208,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         }
         Preconditions.checkNotNull(keyspace(), "'keyspace' must be specified");
         double evictionCheckProportion = proportionConnectionsToCheckPerEvictionRun();
-        Preconditions.checkArgument(evictionCheckProportion > 0 && evictionCheckProportion <= 1,
+        Preconditions.checkArgument(evictionCheckProportion > 0.01 && evictionCheckProportion <= 1,
                 "'proportionConnectionsToCheckPerEvictionRun' must be between 0 and 1");
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -66,7 +66,9 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1398>`__)
 
     *    - |improved|
-         - Increase minimum Cassandra pool size to better handle bursts in requests.
+         - Increase default Cassandra pool size from minimum of 20 and maximum of 5x the minimum (100 if minimum not modified)
+           connections to minimum of 30 and maximum of 100 connections. This allows for better handling of bursts of requests
+           that would otherwise require creating many new connections to Cassandra from the clients.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1402>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,6 +65,10 @@ develop
          - Enable garbage collection logging for CircleCI builds.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1398>`__)
 
+    *    - |improved|
+         - Increase minimum Cassandra pool size to better handle bursts in requests.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1402>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Followup to https://github.com/palantir/atlasdb/pull/1336

@jboreiko and I discussed and decided we'll bump default here and then change Atlas config in our large internal product to reflect old config to avoid screwing with anyone with overriden defaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1402)
<!-- Reviewable:end -->
