### PR TITLE
In the Jepsen framework, pass values as strings

### DIFF
--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/MonotonicChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/MonotonicChecker.java
@@ -47,7 +47,9 @@ public class MonotonicChecker implements Checker {
 
             if (latestEventPerProcess.containsKey(process)) {
                 OkEvent previousEvent = latestEventPerProcess.get(process);
-                if (event.value() <= previousEvent.value()) {
+                Long previousTimestamp = Long.parseLong(previousEvent.value());
+                Long timestamp = Long.parseLong(event.value());
+                if (timestamp <= previousTimestamp) {
                     errors.add(previousEvent);
                     errors.add(event);
                 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/MonotonicChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/MonotonicChecker.java
@@ -47,8 +47,8 @@ public class MonotonicChecker implements Checker {
 
             if (latestEventPerProcess.containsKey(process)) {
                 OkEvent previousEvent = latestEventPerProcess.get(process);
-                Long previousTimestamp = Long.parseLong(previousEvent.value());
-                Long timestamp = Long.parseLong(event.value());
+                long previousTimestamp = Long.parseLong(previousEvent.value());
+                long timestamp = Long.parseLong(event.value());
                 if (timestamp <= previousTimestamp) {
                     errors.add(previousEvent);
                     errors.add(event);

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/NonOverlappingReadsMonotonicChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/NonOverlappingReadsMonotonicChecker.java
@@ -43,7 +43,7 @@ public class NonOverlappingReadsMonotonicChecker implements Checker {
     }
 
     private static class Visitor implements EventVisitor {
-        private static final long DUMMY_VALUE = -1L;
+        private static final String DUMMY_VALUE = "-1";
         private static final int DUMMY_PROCESS = -1;
 
         private final Map<Integer, InvokeEvent> pendingReadForProcess = new HashMap<>();
@@ -87,10 +87,14 @@ public class NonOverlappingReadsMonotonicChecker implements Checker {
 
         private void validateTimestampHigherThanReadsCompletedBeforeInvoke(InvokeEvent invoke, OkEvent event) {
             OkEvent lastAcknowledgedRead = lastAcknowledgedReadBefore(invoke.time());
-            if (lastAcknowledgedRead != null && lastAcknowledgedRead.value() >= event.value()) {
-                errors.add(lastAcknowledgedRead);
-                errors.add(invoke);
-                errors.add(event);
+            if (lastAcknowledgedRead != null) {
+                Long timestamp = Long.parseLong(event.value());
+                Long lastAcknowledgedTimestamp = Long.parseLong(lastAcknowledgedRead.value());
+                if (lastAcknowledgedTimestamp >= timestamp) {
+                    errors.add(lastAcknowledgedRead);
+                    errors.add(invoke);
+                    errors.add(event);
+                }
             }
         }
 

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/NonOverlappingReadsMonotonicChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/NonOverlappingReadsMonotonicChecker.java
@@ -88,8 +88,8 @@ public class NonOverlappingReadsMonotonicChecker implements Checker {
         private void validateTimestampHigherThanReadsCompletedBeforeInvoke(InvokeEvent invoke, OkEvent event) {
             OkEvent lastAcknowledgedRead = lastAcknowledgedReadBefore(invoke.time());
             if (lastAcknowledgedRead != null) {
-                Long timestamp = Long.parseLong(event.value());
-                Long lastAcknowledgedTimestamp = Long.parseLong(lastAcknowledgedRead.value());
+                long timestamp = Long.parseLong(event.value());
+                long lastAcknowledgedTimestamp = Long.parseLong(lastAcknowledgedRead.value());
                 if (lastAcknowledgedTimestamp >= timestamp) {
                     errors.add(lastAcknowledgedRead);
                     errors.add(invoke);

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/UniquenessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/UniquenessChecker.java
@@ -40,11 +40,11 @@ public class UniquenessChecker implements Checker {
 
     private static class Visitor implements EventVisitor {
         private final List<Event> errors = new ArrayList<>();
-        private final Map<Long, OkEvent> valuesAlreadySeen = new HashMap<>();
+        private final Map<String, OkEvent> valuesAlreadySeen = new HashMap<>();
 
         @Override
         public void visit(OkEvent event) {
-            long value = event.value();
+            String value = event.value();
 
             if (valuesAlreadySeen.containsKey(value)) {
                 OkEvent previousEvent = valuesAlreadySeen.get(value);

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/OkEvent.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/OkEvent.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.jepsen.events;
 
+import javax.annotation.Nullable;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -34,7 +36,8 @@ public abstract class OkEvent implements Event {
 
     public abstract int process();
 
-    public abstract long value();
+    @Nullable
+    public abstract String value();
 
     @Override
     public void accept(EventVisitor visitor) {

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/MonotonicCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/MonotonicCheckerTest.java
@@ -28,7 +28,8 @@ public class MonotonicCheckerTest {
     private static final Long ZERO_TIME = 0L;
     private static final int PROCESS_0 = 0;
     private static final int PROCESS_1 = 1;
-    private static final Long INT_MAX_PLUS_ONE = 1L + Integer.MAX_VALUE;
+    private static final String INT_MAX_PLUS_ONE = String.valueOf(1L + Integer.MAX_VALUE);
+    private static final String NOOP = "noop";
 
     @Test
     public void shouldSucceedOnNoEvents() {
@@ -108,16 +109,16 @@ public class MonotonicCheckerTest {
         Event event1 = ImmutableOkEvent.builder()
                 .time(ZERO_TIME)
                 .process(PROCESS_0)
-                .value("noop")
+                .value(NOOP)
                 .build();
         Event event2 = ImmutableOkEvent.builder()
                 .time(ZERO_TIME)
                 .process(PROCESS_0)
-                .value("noop")
+                .value(NOOP)
                 .build();
 
         assertThatThrownBy(() -> runMonotonicChecker(event1, event2))
-                .isInstanceOf(Exception.class);
+                .isInstanceOf(NumberFormatException.class);
     }
 
     @Test
@@ -125,13 +126,11 @@ public class MonotonicCheckerTest {
         Event event1 = ImmutableOkEvent.builder()
                 .time(ZERO_TIME)
                 .process(PROCESS_0)
-                .value(INT_MAX_PLUS_ONE.toString())
+                .value(INT_MAX_PLUS_ONE)
                 .build();
 
-        CheckerResult result = runMonotonicChecker(event1);
-
-        assertThat(result.valid()).isTrue();
-        assertThat(result.errors()).isEmpty();
+        CheckerTestUtils.assertNoErrors(MonotonicChecker::new,
+                event1);
     }
 
     private static CheckerResult runMonotonicChecker(Event... events) {

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/NemesisResilienceCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/NemesisResilienceCheckerTest.java
@@ -47,12 +47,12 @@ public class NemesisResilienceCheckerTest {
     private static final Event OK_1 = ImmutableOkEvent.builder()
             .time(ZERO_TIME)
             .process(PROCESS_1)
-            .value(0L)
+            .value("0")
             .build();
     private static final Event OK_2 = ImmutableOkEvent.builder()
             .time(ZERO_TIME)
             .process(PROCESS_2)
-            .value(0L)
+            .value("0")
             .build();
 
     private static final Event ERROR_1 = ImmutableFailEvent.builder()

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/NonOverlappingReadsMonotonicCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/NonOverlappingReadsMonotonicCheckerTest.java
@@ -140,7 +140,7 @@ public class NonOverlappingReadsMonotonicCheckerTest {
 
         NonOverlappingReadsMonotonicChecker checker = new NonOverlappingReadsMonotonicChecker();
         assertThatThrownBy(() -> checker.check(ImmutableList.of(event1, event2, event3, event4)))
-                .isInstanceOf(Exception.class);
+                .isInstanceOf(NumberFormatException.class);
     }
 
     @Test

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/UniquenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/UniquenessCheckerTest.java
@@ -27,8 +27,8 @@ public class UniquenessCheckerTest {
     private static final long ZERO_TIME = 0L;
     private static final int PROCESS_0 = 0;
     private static final int PROCESS_1 = 1;
-    private static final long VALUE_A = 0L;
-    private static final long VALUE_B = 1L;
+    private static final String VALUE_A = "0";
+    private static final String VALUE_B = "1";
 
     @Test
     public void shouldSuceeedOnNoEvents() {

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/events/EventTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/events/EventTest.java
@@ -28,7 +28,7 @@ import com.palantir.atlasdb.jepsen.JepsenConstants;
 import clojure.lang.Keyword;
 
 public class EventTest {
-    public static final String SOME_INTEGER_AS_STRING = "136";
+    public static final String SOME_LONG_AS_STRING = "136";
     public static final String SOME_STRING = "SOME_STRING";
     public static final Long SOME_LONG = 987L;
     public static final long SOME_TIME = 3029699376L;
@@ -69,7 +69,7 @@ public class EventTest {
         keywordMap.put(Keyword.intern("f"), Keyword.intern(JepsenConstants.START_FUNCTION));
         keywordMap.put(Keyword.intern("process"), Keyword.intern(JepsenConstants.NEMESIS_PROCESS));
         keywordMap.put(Keyword.intern("time"), SOME_TIME);
-        keywordMap.put(Keyword.intern("value"), Keyword.intern(String.valueOf(SOME_INTEGER_AS_STRING)));
+        keywordMap.put(Keyword.intern("value"), Keyword.intern(SOME_LONG_AS_STRING));
 
         Event event = Event.fromKeywordMap(keywordMap);
 
@@ -99,14 +99,14 @@ public class EventTest {
         Map<Keyword, Object> keywordMap = new HashMap<>();
         keywordMap.put(Keyword.intern("type"), Keyword.intern("ok"));
         keywordMap.put(Keyword.intern("f"), Keyword.intern("read-operation"));
-        keywordMap.put(Keyword.intern("value"), SOME_INTEGER_AS_STRING);
+        keywordMap.put(Keyword.intern("value"), SOME_LONG_AS_STRING);
         keywordMap.put(Keyword.intern("process"), SOME_PROCESS);
         keywordMap.put(Keyword.intern("time"), SOME_TIME);
 
         Event event = Event.fromKeywordMap(keywordMap);
 
         OkEvent expectedEvent = ImmutableOkEvent.builder()
-                .value(SOME_INTEGER_AS_STRING)
+                .value(SOME_LONG_AS_STRING)
                 .process(SOME_PROCESS)
                 .time(SOME_TIME)
                 .build();

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/events/EventTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/events/EventTest.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.jepsen.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +28,9 @@ import com.palantir.atlasdb.jepsen.JepsenConstants;
 import clojure.lang.Keyword;
 
 public class EventTest {
-    public static final long SOME_VALUE = 136L;
+    public static final String SOME_INTEGER_AS_STRING = "136";
+    public static final String SOME_STRING = "SOME_STRING";
+    public static final Long SOME_LONG = 987L;
     public static final long SOME_TIME = 3029699376L;
     public static final int SOME_PROCESS = 1;
 
@@ -68,7 +69,7 @@ public class EventTest {
         keywordMap.put(Keyword.intern("f"), Keyword.intern(JepsenConstants.START_FUNCTION));
         keywordMap.put(Keyword.intern("process"), Keyword.intern(JepsenConstants.NEMESIS_PROCESS));
         keywordMap.put(Keyword.intern("time"), SOME_TIME);
-        keywordMap.put(Keyword.intern("value"), Keyword.intern(String.valueOf(SOME_VALUE)));
+        keywordMap.put(Keyword.intern("value"), Keyword.intern(String.valueOf(SOME_INTEGER_AS_STRING)));
 
         Event event = Event.fromKeywordMap(keywordMap);
 
@@ -94,18 +95,75 @@ public class EventTest {
     }
 
     @Test
-    public void canDeserialiseOkRead() {
+    public void canDeserialiseOkReadWithValueAsStringOfLong() {
         Map<Keyword, Object> keywordMap = new HashMap<>();
         keywordMap.put(Keyword.intern("type"), Keyword.intern("ok"));
         keywordMap.put(Keyword.intern("f"), Keyword.intern("read-operation"));
-        keywordMap.put(Keyword.intern("value"), SOME_VALUE);
+        keywordMap.put(Keyword.intern("value"), SOME_INTEGER_AS_STRING);
         keywordMap.put(Keyword.intern("process"), SOME_PROCESS);
         keywordMap.put(Keyword.intern("time"), SOME_TIME);
 
         Event event = Event.fromKeywordMap(keywordMap);
 
         OkEvent expectedEvent = ImmutableOkEvent.builder()
-                .value(SOME_VALUE)
+                .value(SOME_INTEGER_AS_STRING)
+                .process(SOME_PROCESS)
+                .time(SOME_TIME)
+                .build();
+        assertThat(event).isEqualTo(expectedEvent);
+    }
+
+    @Test
+    public void canDeserialiseOkReadWithValueAsAnyString() {
+        Map<Keyword, Object> keywordMap = new HashMap<>();
+        keywordMap.put(Keyword.intern("type"), Keyword.intern("ok"));
+        keywordMap.put(Keyword.intern("f"), Keyword.intern("read-operation"));
+        keywordMap.put(Keyword.intern("value"), SOME_STRING);
+        keywordMap.put(Keyword.intern("process"), SOME_PROCESS);
+        keywordMap.put(Keyword.intern("time"), SOME_TIME);
+
+        Event event = Event.fromKeywordMap(keywordMap);
+
+        OkEvent expectedEvent = ImmutableOkEvent.builder()
+                .value(SOME_STRING)
+                .process(SOME_PROCESS)
+                .time(SOME_TIME)
+                .build();
+        assertThat(event).isEqualTo(expectedEvent);
+    }
+
+    @Test
+    public void canDeserialiseOkReadWithValueAsLong() {
+        Map<Keyword, Object> keywordMap = new HashMap<>();
+        keywordMap.put(Keyword.intern("type"), Keyword.intern("ok"));
+        keywordMap.put(Keyword.intern("f"), Keyword.intern("read-operation"));
+        keywordMap.put(Keyword.intern("value"), SOME_LONG);
+        keywordMap.put(Keyword.intern("process"), SOME_PROCESS);
+        keywordMap.put(Keyword.intern("time"), SOME_TIME);
+
+        Event event = Event.fromKeywordMap(keywordMap);
+
+        OkEvent expectedEvent = ImmutableOkEvent.builder()
+                .value(SOME_LONG.toString())
+                .process(SOME_PROCESS)
+                .time(SOME_TIME)
+                .build();
+        assertThat(event).isEqualTo(expectedEvent);
+    }
+
+    @Test
+    public void canDeserialiseOkReadWithNullValue() {
+        Map<Keyword, Object> keywordMap = new HashMap<>();
+        keywordMap.put(Keyword.intern("type"), Keyword.intern("ok"));
+        keywordMap.put(Keyword.intern("f"), Keyword.intern("read-operation"));
+        keywordMap.put(Keyword.intern("value"), null);
+        keywordMap.put(Keyword.intern("process"), SOME_PROCESS);
+        keywordMap.put(Keyword.intern("time"), SOME_TIME);
+
+        Event event = Event.fromKeywordMap(keywordMap);
+
+        OkEvent expectedEvent = ImmutableOkEvent.builder()
+                .value(null)
                 .process(SOME_PROCESS)
                 .time(SOME_TIME)
                 .build();
@@ -151,26 +209,21 @@ public class EventTest {
     }
 
     @Test
-    public void cannotDeserialiseOkReadWhenValueIsMissing() {
+    public void canDeserialiseOkReadWhenValueIsMissing() {
         Map<Keyword, Object> keywordMap = new HashMap<>();
         keywordMap.put(Keyword.intern("type"), Keyword.intern("ok"));
         keywordMap.put(Keyword.intern("f"), Keyword.intern("read-operation"));
         keywordMap.put(Keyword.intern("process"), SOME_PROCESS);
         keywordMap.put(Keyword.intern("time"), SOME_TIME);
 
-        assertThatThrownBy(() -> Event.fromKeywordMap(keywordMap)).isInstanceOf(IllegalArgumentException.class);
-    }
+        Event event = Event.fromKeywordMap(keywordMap);
 
-    @Test
-    public void cannotDeserialiseOkReadWhenValueIsNull() {
-        Map<Keyword, Object> keywordMap = new HashMap<>();
-        keywordMap.put(Keyword.intern("type"), Keyword.intern("ok"));
-        keywordMap.put(Keyword.intern("f"), Keyword.intern("read-operation"));
-        keywordMap.put(Keyword.intern("process"), SOME_PROCESS);
-        keywordMap.put(Keyword.intern("time"), SOME_TIME);
-        keywordMap.put(Keyword.intern("value"), null);
-
-        assertThatThrownBy(() -> Event.fromKeywordMap(keywordMap)).isInstanceOf(IllegalArgumentException.class);
+        OkEvent expectedEvent = ImmutableOkEvent.builder()
+                .process(SOME_PROCESS)
+                .time(SOME_TIME)
+                .value(null)
+                .build();
+        assertThat(event).isEqualTo(expectedEvent);
     }
 
     @Test


### PR DESCRIPTION
Previously we would pass the values returned by :ok events of our Jepsen
tests as longs. This was fine when our Jepsen tests were just for
timestamps, but since we want to extend the testing to locks, we need to
handle a wider variety of responses from the timelock server.

I've opted to use nullable strings, rather than Objects, since we really
don't need the extra complexity of fully-fledged objects.

[no release notes]

<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1403)
<!-- Reviewable:end -->
