### PR TITLE
Install sphinx when publishing docs

### DIFF
--- a/scripts/circle-ci/publish-github-page.sh
+++ b/scripts/circle-ci/publish-github-page.sh
@@ -2,6 +2,9 @@
 
 set -x -e
 
+# Just-in-time install of sphinx so that docs build
+sudo pip install sphinx sphinx_rtd_theme
+
 # Clone gh-pages into build
 cd docs/
 rm -rf build/


### PR DESCRIPTION
A previous build performance optimisation (#1379, commit 889a42a) sped
things up by installing sphinx only when checking that docs build.

However, this meant that sphinx wasn't installed when we come to
actually building the docs (which doesn't happen on pre-merge builds).

This addition should mean we can publish docs again.
[no release notes]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1404)
<!-- Reviewable:end -->
