### PR TITLE
Fix migration for thoroughly swept tables

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TransactionRangeMigrator.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TransactionRangeMigrator.java
@@ -74,27 +74,24 @@ public class TransactionRangeMigrator implements RangeMigrator {
         return row == null || RangeRequests.isLastRowName(row);
     }
 
-    /**
-     * The write transaction wraps the read transaction because the write transaction can be
-     * aborted, and the read transaction should be new.
-     */
     private byte[] copyOneTransaction(final RangeRequest range, final long rangeId) {
         return txManager.runTaskWithRetry(new TransactionTask<byte[], RuntimeException>() {
             @Override
             public byte[] execute(final Transaction writeT) {
-                return copyOneTransactionWithReadTransaction(range, rangeId, writeT);
+                return copyOneTransactionFromReadTxManager(range, rangeId, writeT);
             }
         });
     }
 
-    private byte[] copyOneTransactionWithReadTransaction(final RangeRequest range,
-                                                         final long rangeId,
-                                                         final Transaction writeT) {
+    private byte[] copyOneTransactionFromReadTxManager(final RangeRequest range,
+                                                       final long rangeId,
+                                                       final Transaction writeT) {
         if (readTxManager == txManager) {
             // don't wrap
             return copyOneTransactionInternal(range, rangeId, writeT, writeT);
         } else {
-            return readTxManager.runTaskReadOnly(new TransactionTask<byte[], RuntimeException>() {
+            // read only, but need to use a write tx in case the source table has SweepStrategy.THOROUGH
+            return readTxManager.runTaskWithRetry(new TransactionTask<byte[], RuntimeException>() {
                 @Override
                 public byte[] execute(Transaction readT) {
                     return copyOneTransactionInternal(range, rangeId, readT, writeT);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
@@ -120,7 +120,8 @@ public class KeyValueServiceValidator {
 
     private void validateTable(final TableReference table) {
         final int limit = getBatchSize(table);
-        validationFromTransactionManager.runTaskReadOnly(
+        // read only, but need to use a write tx in case the source table has SweepStrategy.THOROUGH
+        validationFromTransactionManager.runTaskWithRetry(
                 new TransactionTask<Map<Cell, byte[]>, RuntimeException>() {
                     @Override
                     public Map<Cell, byte[]> execute(Transaction t1) {
@@ -132,7 +133,8 @@ public class KeyValueServiceValidator {
     }
 
     private void validateTable(final TableReference table, final int limit, final Transaction t1) {
-        validationToTransactionManager.runTaskReadOnly(
+        // read only, but need to use a write tx in case the source table has SweepStrategy.THOROUGH
+        validationToTransactionManager.runTaskWithRetry(
                 new TransactionTask<Map<Cell, byte[]>, RuntimeException>() {
                     @Override
                     public Map<Cell, byte[]> execute(Transaction t2) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,6 +65,10 @@ develop
          - Enable garbage collection logging for CircleCI builds.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1398>`__)
 
+    *    - |fixed|
+         - Allow tables declared with SweepStrategy.THOROUGH to be migrated.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1410>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Migration currently uses read-only transactions to read from source tables, but this fails when those tables are declared with SweepStrategy.THOROUGH, which prohibits read-only transactions. This commit replaces all occurrences of runTaskReadOnly with runTaskWithRetry on the migration codepaths. This should only have a negligible performance impact.
It would be nice to get this in asap, into 0.27.0 or 0.28.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1410)
<!-- Reviewable:end -->
