### PR TITLE
fix off by 1 in check for max blocks

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockConsumingInputStream.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockConsumingInputStream.java
@@ -43,7 +43,7 @@ public final class BlockConsumingInputStream extends InputStream {
 
     private static void ensureExpectedArraySizeDoesNotOverflow(BlockGetter blockGetter, int blocksInMemory) {
         int expectedLength = blockGetter.expectedLength();
-        Preconditions.checkArgument(blocksInMemory < Integer.MAX_VALUE / expectedLength,
+        Preconditions.checkArgument(blocksInMemory <= Integer.MAX_VALUE / expectedLength,
                 "Promised to load too many blocks into memory. The underlying buffer is stored as a byte array, "
                         + "so can only fit Integer.MAX_VALUE bytes. The supplied BlockGetter expected to produce "
                         + "blocks of %s bytes, so %s of them would cause the array to overflow.",


### PR DESCRIPTION
Use <= comparison to allow it when we have the exact maximum number of
blocks instead of requiring 1 less. I doubt this ever actually happens,
but we have internal tests that hit this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1411)
<!-- Reviewable:end -->
