### PR TITLE
Prevent double-newlines when the last block contains no imports

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/ImportRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/ImportRenderer.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
 
 public class ImportRenderer extends Renderer {
     private static final List<String> IMPORT_PREFIXES = ImmutableList.of("java.", "javax.", "org.", "com.");
@@ -41,7 +40,7 @@ public class ImportRenderer extends Renderer {
     void renderImports() {
         for (String prefix : IMPORT_PREFIXES) {
             boolean anyImportsRendered = renderImportsWithPrefix(prefix);
-            if (anyImportsRendered && !prefix.equals(Iterables.getLast(IMPORT_PREFIXES))) {
+            if (anyImportsRendered) {
                 line();
             }
         }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -134,7 +134,6 @@ public class StreamStoreRenderer {
                 line("package ", packageName, ";");
                 line();
                 importRenderer.renderImports();
-                line();
                 line("@Generated(\"",  StreamStoreRenderer.class.getName(), "\")");
                 line("public final class ", StreamStore, " extends AbstractPersistentStreamStore", " {"); {
                     fields();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -199,7 +199,6 @@ public class TableRenderer {
                 line("package ", packageName, ";");
                 line();
                 importRenderer.renderImports();
-                line();
             }
             line("@Generated(\"",  TableRenderer.class.getName(), "\")");
             line("public ", isNestedIndex ? "static " : "", "final class ", Table, " implements");


### PR DESCRIPTION
Previously, if there were imports in some types, but not in the last
block, we would end up with a blank line at the end of the
`renderImports` part of the buffer.

This never occurred in practice, but a parallel PR, #1357, adds an
import type ".net", which doesn't usually have any matching imports.
Regenerating schemas lead to many undesirable blank lines.

We passed the responsibility of adding the line between imports and the
class declaration to ImportRenderer, because otherwise we'd need
omniscient logic along the lines of "only add a blank line if we just
rendered some imports *and* there will be more imports to come".

[no release notes]

Adding @SerialVelocity for SA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1413)
<!-- Reviewable:end -->
