### PR TITLE
Timelock Refactoring for Alternative Implementations

### DIFF
--- a/atlasdb-timelock-server/src/integTest/resources/singleTestServer.yml
+++ b/atlasdb-timelock-server/src/integTest/resources/singleTestServer.yml
@@ -1,4 +1,5 @@
-atomix:
+algorithm:
+  type: atomix
   storageLevel: memory
 
 cluster:

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/ServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/ServerImplementation.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.timelock;
+
+import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
+
+public interface ServerImplementation {
+    void onStart(TimeLockServerConfiguration configuration);
+
+    void onStop();
+
+    void onFail();
+
+    TimeLockServices createInvalidatingTimeLockServices(String client);
+}

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/ServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/ServerImplementation.java
@@ -39,7 +39,7 @@ public interface ServerImplementation {
 
     /**
      * Creates timestamp and lock services for the given client. It is expected that for each client there should
-     * only be one active timestamp service, and one active lock service at any time.
+     * only be (up to) one active timestamp service, and one active lock service at any time.
      * @param client Client namespace to create the services for
      * @return Invalidating timestamp and lock services
      */

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/ServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/ServerImplementation.java
@@ -23,11 +23,11 @@ public interface ServerImplementation {
      * are accepted from clients.
      * @param configuration Timelock Server configuration; may be useful for initialisation
      */
-    void onStart(TimeLockServerConfiguration configuration);
+    void onStartup(TimeLockServerConfiguration configuration);
 
     /**
      * Called when the Timelock Server is shut down after a successful start, whether normally or because
-     * of an exception. In the event the server fails to start, onFail() will be called, not this method.
+     * of an exception. In the event the server fails to start, onStartupFailure() will be called, not this method.
      */
     void onStop();
 
@@ -35,7 +35,7 @@ public interface ServerImplementation {
      * Called when the Timelock Server fails to start up. Note that this only applies to startup failures;
      * in the event the Timelock Server is shut down due to an exception, onStop() will be called, not this method.
      */
-    void onFail();
+    void onStartupFailure();
 
     /**
      * Creates timestamp and lock services for the given client. It is expected that for each client there should

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/ServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/ServerImplementation.java
@@ -18,11 +18,30 @@ package com.palantir.atlasdb.timelock;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 
 public interface ServerImplementation {
+    /**
+     * Called when the Timelock Server is started up, and is guaranteed to run before any requests
+     * are accepted from clients.
+     * @param configuration Timelock Server configuration; may be useful for initialisation
+     */
     void onStart(TimeLockServerConfiguration configuration);
 
+    /**
+     * Called when the Timelock Server is shut down after a successful start, whether normally or because
+     * of an exception. In the event the server fails to start, onFail() will be called, not this method.
+     */
     void onStop();
 
+    /**
+     * Called when the Timelock Server fails to start up. Note that this only applies to startup failures;
+     * in the event the Timelock Server is shut down due to an exception, onStop() will be called, not this method.
+     */
     void onFail();
 
+    /**
+     * Creates timestamp and lock services for the given client. It is expected that for each client there should
+     * only be one active timestamp service, and one active lock service at any time.
+     * @param client Client namespace to create the services for
+     * @return Invalidating timestamp and lock services
+     */
     TimeLockServices createInvalidatingTimeLockServices(String client);
 }

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServer.java
@@ -39,7 +39,7 @@ public class TimeLockServer extends Application<TimeLockServerConfiguration> {
         ServerImplementation serverImpl = new AtomixServerImplementation();
         try {
             serverImpl.onStart(configuration);
-            run(configuration, environment, serverImpl);
+            registerResources(configuration, environment, serverImpl);
         } catch (Exception e) {
             serverImpl.onFail();
             throw e;
@@ -53,7 +53,7 @@ public class TimeLockServer extends Application<TimeLockServerConfiguration> {
         });
     }
 
-    private static void run(
+    private static void registerResources(
             TimeLockServerConfiguration configuration,
             Environment environment,
             ServerImplementation serverImpl) {

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServer.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.timelock.atomix.AtomixServerImplementation;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 import com.palantir.remoting1.servers.jersey.HttpRemotingJerseyFeature;
 
@@ -36,7 +35,7 @@ public class TimeLockServer extends Application<TimeLockServerConfiguration> {
 
     @Override
     public void run(TimeLockServerConfiguration configuration, Environment environment) {
-        ServerImplementation serverImpl = new AtomixServerImplementation();
+        ServerImplementation serverImpl = configuration.algorithm().createServerImpl();
         try {
             serverImpl.onStart(configuration);
             registerResources(configuration, environment, serverImpl);

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServer.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServer.java
@@ -37,10 +37,10 @@ public class TimeLockServer extends Application<TimeLockServerConfiguration> {
     public void run(TimeLockServerConfiguration configuration, Environment environment) {
         ServerImplementation serverImpl = configuration.algorithm().createServerImpl();
         try {
-            serverImpl.onStart(configuration);
+            serverImpl.onStartup(configuration);
             registerResources(configuration, environment, serverImpl);
         } catch (Exception e) {
-            serverImpl.onFail();
+            serverImpl.onStartupFailure();
             throw e;
         }
 

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.timelock.ServerImplementation;
 import com.palantir.atlasdb.timelock.TimeLockServices;
+import com.palantir.atlasdb.timelock.config.AtomixConfiguration;
 import com.palantir.atlasdb.timelock.config.AtomixSslConfiguration;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 import com.palantir.lock.impl.LockServiceImpl;
@@ -47,12 +48,13 @@ public class AtomixServerImplementation implements ServerImplementation {
 
     @Override
     public void onStart(TimeLockServerConfiguration configuration) {
+        AtomixConfiguration atomix = ((AtomixConfiguration) configuration.algorithm());
         replica = AtomixReplica.builder(new Address(configuration.cluster().localServer()))
                 .withStorage(Storage.builder()
-                        .withDirectory(configuration.atomix().storageDirectory())
-                        .withStorageLevel(configuration.atomix().storageLevel())
+                        .withDirectory(atomix.storageDirectory())
+                        .withStorageLevel(atomix.storageLevel())
                         .build())
-                .withTransport(createTransport(configuration.atomix().security()))
+                .withTransport(createTransport(atomix.security()))
                 .build();
         AtomixRetryer.getWithRetry(() -> replica.bootstrap(
                 configuration.cluster()

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
@@ -48,7 +48,7 @@ public class AtomixServerImplementation implements ServerImplementation {
 
     @Override
     public void onStart(TimeLockServerConfiguration configuration) {
-        AtomixConfiguration atomix = ((AtomixConfiguration) configuration.algorithm());
+        AtomixConfiguration atomix = (AtomixConfiguration) configuration.algorithm();
         replica = AtomixReplica.builder(new Address(configuration.cluster().localServer()))
                 .withStorage(Storage.builder()
                         .withDirectory(atomix.storageDirectory())

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
@@ -47,7 +47,7 @@ public class AtomixServerImplementation implements ServerImplementation {
     private LocalMember localMember;
 
     @Override
-    public void onStart(TimeLockServerConfiguration configuration) {
+    public void onStartup(TimeLockServerConfiguration configuration) {
         AtomixConfiguration atomix = (AtomixConfiguration) configuration.algorithm();
         replica = AtomixReplica.builder(new Address(configuration.cluster().localServer()))
                 .withStorage(Storage.builder()
@@ -94,7 +94,7 @@ public class AtomixServerImplementation implements ServerImplementation {
     }
 
     @Override
-    public void onFail() {
+    public void onStartupFailure() {
         onStop();
     }
 

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
@@ -56,6 +56,11 @@ public class AtomixServerImplementation implements ServerImplementation {
                         .build())
                 .withTransport(createTransport(atomix.security()))
                 .build();
+
+        startAtomix(configuration);
+    }
+
+    private void startAtomix(TimeLockServerConfiguration configuration) {
         AtomixRetryer.getWithRetry(() -> replica.bootstrap(
                 configuration.cluster()
                         .servers()

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/atomix/AtomixServerImplementation.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.timelock.atomix;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.atlasdb.timelock.ServerImplementation;
+import com.palantir.atlasdb.timelock.TimeLockServices;
+import com.palantir.atlasdb.timelock.config.AtomixSslConfiguration;
+import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
+import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.remoting1.config.ssl.SslConfiguration;
+
+import io.atomix.AtomixReplica;
+import io.atomix.catalyst.transport.Transport;
+import io.atomix.catalyst.transport.netty.NettyTransport;
+import io.atomix.copycat.server.storage.Storage;
+import io.atomix.group.DistributedGroup;
+import io.atomix.group.LocalMember;
+import io.atomix.variables.DistributedLong;
+import io.atomix.variables.DistributedValue;
+
+public class AtomixServerImplementation implements ServerImplementation {
+    private static final Logger log = LoggerFactory.getLogger(AtomixServerImplementation.class);
+
+    private AtomixReplica replica;
+    private LocalMember localMember;
+
+    @Override
+    public void onStart(TimeLockServerConfiguration configuration) {
+        replica = AtomixReplica.builder(configuration.cluster().localServer())
+                .withStorage(Storage.builder()
+                        .withDirectory(configuration.atomix().storageDirectory())
+                        .withStorageLevel(configuration.atomix().storageLevel())
+                        .build())
+                .withTransport(createTransport(configuration.atomix().security()))
+                .build();
+        AtomixRetryer.getWithRetry(() -> replica.bootstrap(configuration.cluster().servers()));
+
+        DistributedGroup timeLockGroup = DistributedValues.getTimeLockGroup(replica);
+        localMember = AtomixRetryer.getWithRetry(timeLockGroup::join);
+
+        DistributedValue<LeaderAndTerm> leaderInfo = DistributedValues.getLeaderInfo(replica);
+        timeLockGroup.election().onElection(term -> {
+            LeaderAndTerm newLeaderInfo = ImmutableLeaderAndTerm.of(term.term(), term.leader().id());
+            while (true) {
+                LeaderAndTerm currentLeaderInfo = AtomixRetryer.getWithRetry(leaderInfo::get);
+                if (currentLeaderInfo != null && newLeaderInfo.term() <= currentLeaderInfo.term()) {
+                    log.info("Not setting the leader to {} since it is not newer than the current leader {}",
+                            newLeaderInfo, currentLeaderInfo);
+                    break;
+                }
+                log.debug("Updating the leader from {} to {}", currentLeaderInfo, newLeaderInfo);
+                if (leaderInfo.compareAndSet(currentLeaderInfo, newLeaderInfo).join()) {
+                    log.info("Leader has been set to {}", newLeaderInfo);
+                    break;
+                }
+            }
+        });
+    }
+
+    @Override
+    public void onStop() {
+        if (replica != null) {
+            AtomixRetryer.getWithRetry(replica::shutdown);
+            replica = null;
+        }
+    }
+
+    @Override
+    public void onFail() {
+        onStop();
+    }
+
+    @Override
+    public TimeLockServices createInvalidatingTimeLockServices(String client) {
+        DistributedValue<LeaderAndTerm> leaderInfo = DistributedValues.getLeaderInfo(replica);
+        DistributedLong timestamp = DistributedValues.getTimestampForClient(replica, client);
+        Supplier<TimeLockServices> timeLockSupplier = () -> TimeLockServices.create(
+                new AtomixTimestampService(timestamp),
+                LockServiceImpl.create());
+        return InvalidatingLeaderProxy.create(
+                localMember,
+                leaderInfo,
+                timeLockSupplier,
+                TimeLockServices.class);
+    }
+
+    private static Transport createTransport(Optional<AtomixSslConfiguration> optionalSecurity) {
+        NettyTransport.Builder transport = NettyTransport.builder();
+
+        if (!optionalSecurity.isPresent()) {
+            return transport.build();
+        }
+
+        AtomixSslConfiguration security = optionalSecurity.get();
+        SslConfiguration baseSslConfiguration = security.sslConfiguration();
+        transport.withSsl()
+                .withTrustStorePath(baseSslConfiguration.trustStorePath().toString())
+                .withTrustStorePassword(security.trustStorePassword());
+
+        if (isKeystoreSpecified(baseSslConfiguration)) {
+            transport.withKeyStorePath(baseSslConfiguration.keyStorePath().get().toString());
+            transport.withKeyStorePassword(baseSslConfiguration.keyStorePassword().get());
+        }
+
+        return transport.build();
+    }
+
+    private static boolean isKeystoreSpecified(SslConfiguration baseSslConfiguration) {
+        return baseSslConfiguration.keyStorePath().isPresent() && baseSslConfiguration.keyStorePassword().isPresent();
+    }
+}

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/AlgorithmConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/AlgorithmConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.timelock.config;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.palantir.atlasdb.timelock.ServerImplementation;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AtomixConfiguration.class, name = "atomix")})
+public interface AlgorithmConfiguration {
+    ServerImplementation createServerImpl();
+}

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/AtomixConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/AtomixConfiguration.java
@@ -21,13 +21,15 @@ import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.atlasdb.timelock.ServerImplementation;
+import com.palantir.atlasdb.timelock.atomix.AtomixServerImplementation;
 
 import io.atomix.copycat.server.storage.StorageLevel;
 
 @JsonSerialize(as = ImmutableAtomixConfiguration.class)
 @JsonDeserialize(as = ImmutableAtomixConfiguration.class)
 @Value.Immutable
-public abstract class AtomixConfiguration {
+public abstract class AtomixConfiguration implements AlgorithmConfiguration {
     public static final AtomixConfiguration DEFAULT = ImmutableAtomixConfiguration.builder().build();
 
     public abstract Optional<AtomixSslConfiguration> security();
@@ -40,5 +42,10 @@ public abstract class AtomixConfiguration {
     @Value.Default
     public String storageDirectory() {
         return "var/data/atomix";
+    }
+
+    @Override
+    public ServerImplementation createServerImpl() {
+        return new AtomixServerImplementation();
     }
 }

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/AtomixConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/AtomixConfiguration.java
@@ -29,7 +29,7 @@ import io.atomix.copycat.server.storage.StorageLevel;
 @JsonSerialize(as = ImmutableAtomixConfiguration.class)
 @JsonDeserialize(as = ImmutableAtomixConfiguration.class)
 @Value.Immutable
-public abstract class AtomixConfiguration implements AlgorithmConfiguration {
+public abstract class AtomixConfiguration implements TimeLockAlgorithmConfiguration {
     public static final AtomixConfiguration DEFAULT = ImmutableAtomixConfiguration.builder().build();
 
     public abstract Optional<AtomixSslConfiguration> security();

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/ClusterConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/ClusterConfiguration.java
@@ -25,16 +25,14 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 
-import io.atomix.catalyst.transport.Address;
-
 @JsonSerialize(as = ImmutableClusterConfiguration.class)
 @JsonDeserialize(as = ImmutableClusterConfiguration.class)
 @Value.Immutable
 public abstract class ClusterConfiguration {
-    public abstract Address localServer();
+    public abstract String localServer();
 
     @Size(min = 1)
-    public abstract Set<Address> servers();
+    public abstract Set<String> servers();
 
     @Value.Check
     protected void check() {

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/ClusterConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/ClusterConfiguration.java
@@ -24,6 +24,7 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
+import com.google.common.net.HostAndPort;
 
 @JsonSerialize(as = ImmutableClusterConfiguration.class)
 @JsonDeserialize(as = ImmutableClusterConfiguration.class)
@@ -38,5 +39,15 @@ public abstract class ClusterConfiguration {
     protected void check() {
         Preconditions.checkArgument(servers().contains(localServer()),
                 "The localServer '%s' must be included in the server entries %s.", localServer(), servers());
+        checkServersAreWellFormed();
+    }
+
+    private void checkServersAreWellFormed() {
+        servers().forEach(ClusterConfiguration::checkHostPortString);
+    }
+
+    private static void checkHostPortString(String server) {
+        HostAndPort hostAndPort = HostAndPort.fromString(server);
+        Preconditions.checkArgument(hostAndPort.hasPort(), "Port not present: '%s'", server);
     }
 }

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/ClusterConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/ClusterConfiguration.java
@@ -23,6 +23,7 @@ import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 
@@ -46,7 +47,8 @@ public abstract class ClusterConfiguration {
         servers().forEach(ClusterConfiguration::checkHostPortString);
     }
 
-    private static void checkHostPortString(String server) {
+    @VisibleForTesting
+    static void checkHostPortString(String server) {
         HostAndPort hostAndPort = HostAndPort.fromString(server);
         Preconditions.checkArgument(hostAndPort.hasPort(), "Port not present: '%s'", server);
     }

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockAlgorithmConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockAlgorithmConfiguration.java
@@ -24,6 +24,6 @@ import com.palantir.atlasdb.timelock.ServerImplementation;
         property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = AtomixConfiguration.class, name = "atomix")})
-public interface AlgorithmConfiguration {
+public interface TimeLockAlgorithmConfiguration {
     ServerImplementation createServerImpl();
 }

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
@@ -24,18 +24,18 @@ import com.google.common.base.Preconditions;
 import io.dropwizard.Configuration;
 
 public class TimeLockServerConfiguration extends Configuration {
-    private final AtomixConfiguration atomix;
+    private final AlgorithmConfiguration algorithm;
     private final ClusterConfiguration cluster;
     private final Set<String> clients;
 
     public TimeLockServerConfiguration(
-            @JsonProperty(value = "atomix", required = false) AtomixConfiguration atomix,
+            @JsonProperty(value = "algorithm", required = false) AlgorithmConfiguration algorithm,
             @JsonProperty(value = "cluster", required = true) ClusterConfiguration cluster,
             @JsonProperty(value = "clients", required = true) Set<String> clients) {
         Preconditions.checkState(!clients.isEmpty(), "'clients' should have at least one entry");
         checkClientNames(clients);
 
-        this.atomix = MoreObjects.firstNonNull(atomix, AtomixConfiguration.DEFAULT);
+        this.algorithm = MoreObjects.firstNonNull(algorithm, AtomixConfiguration.DEFAULT);
         this.cluster = cluster;
         this.clients = clients;
     }
@@ -47,8 +47,8 @@ public class TimeLockServerConfiguration extends Configuration {
                         + "'%s' does not.", client)));
     }
 
-    public AtomixConfiguration atomix() {
-        return atomix;
+    public AlgorithmConfiguration algorithm() {
+        return algorithm;
     }
 
     public ClusterConfiguration cluster() {

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
@@ -24,12 +24,12 @@ import com.google.common.base.Preconditions;
 import io.dropwizard.Configuration;
 
 public class TimeLockServerConfiguration extends Configuration {
-    private final AlgorithmConfiguration algorithm;
+    private final TimeLockAlgorithmConfiguration algorithm;
     private final ClusterConfiguration cluster;
     private final Set<String> clients;
 
     public TimeLockServerConfiguration(
-            @JsonProperty(value = "algorithm", required = false) AlgorithmConfiguration algorithm,
+            @JsonProperty(value = "algorithm", required = false) TimeLockAlgorithmConfiguration algorithm,
             @JsonProperty(value = "cluster", required = true) ClusterConfiguration cluster,
             @JsonProperty(value = "clients", required = true) Set<String> clients) {
         Preconditions.checkState(!clients.isEmpty(), "'clients' should have at least one entry");
@@ -47,7 +47,7 @@ public class TimeLockServerConfiguration extends Configuration {
                         + "'%s' does not.", client)));
     }
 
-    public AlgorithmConfiguration algorithm() {
+    public TimeLockAlgorithmConfiguration algorithm() {
         return algorithm;
     }
 

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
@@ -40,8 +40,8 @@ public class TimeLockServerConfiguration extends Configuration {
         this.clients = clients;
     }
 
-    private void checkClientNames(Set<String> clients) {
-        clients.forEach(client -> Preconditions.checkState(
+    private void checkClientNames(Set<String> clientNames) {
+        clientNames.forEach(client -> Preconditions.checkState(
                 client.matches("[a-zA-Z0-9_-]+"),
                 String.format("Client names must consist of alphanumeric characters, underscores or dashes only; "
                         + "'%s' does not.", client)));

--- a/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
+++ b/atlasdb-timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
@@ -33,10 +33,18 @@ public class TimeLockServerConfiguration extends Configuration {
             @JsonProperty(value = "cluster", required = true) ClusterConfiguration cluster,
             @JsonProperty(value = "clients", required = true) Set<String> clients) {
         Preconditions.checkState(!clients.isEmpty(), "'clients' should have at least one entry");
+        checkClientNames(clients);
 
         this.atomix = MoreObjects.firstNonNull(atomix, AtomixConfiguration.DEFAULT);
         this.cluster = cluster;
         this.clients = clients;
+    }
+
+    private void checkClientNames(Set<String> clients) {
+        clients.forEach(client -> Preconditions.checkState(
+                client.matches("[a-zA-Z0-9_-]+"),
+                String.format("Client names must consist of alphanumeric characters, underscores or dashes only; "
+                        + "'%s' does not.", client)));
     }
 
     public AtomixConfiguration atomix() {

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/TimeLockServerTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/TimeLockServerTest.java
@@ -47,14 +47,15 @@ import io.dropwizard.setup.Environment;
 @Ignore("Observed ConcurrentModificationException-related flakes (e.g. build #5407 on CircleCI)."
         + "Fixed in atomix/copycat#231, but not part of Copycat 1.1.4 which we use.")
 public class TimeLockServerTest {
-    private static final Address LOCAL_ADDRESS = new Address("localhost:12345");
+    private static final String LOCAL_ADDRESS_STRING = "localhost:12345";
+    private static final Address LOCAL_ADDRESS = new Address(LOCAL_ADDRESS_STRING);
     private static final TimeLockServerConfiguration TIMELOCK_CONFIG = new TimeLockServerConfiguration(
             ImmutableAtomixConfiguration.builder()
                     .storageLevel(StorageLevel.MEMORY)
                     .build(),
             ImmutableClusterConfiguration.builder()
-                    .localServer(LOCAL_ADDRESS)
-                    .addServers(LOCAL_ADDRESS)
+                    .localServer(LOCAL_ADDRESS_STRING)
+                    .addServers(LOCAL_ADDRESS_STRING)
                     .build(),
             ImmutableSet.of(String.format("%s:%s", LOCAL_ADDRESS.host(), LOCAL_ADDRESS.port())));
 

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/ClusterConfigurationTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/ClusterConfigurationTest.java
@@ -45,4 +45,43 @@ public class ClusterConfigurationTest {
                 ::build)
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    public void shouldAcceptValidHostPortString() {
+        assertAddressValid(ADDRESS_1);
+    }
+
+    @Test
+    public void shouldAcceptHostSpecifiedAsIpAddress() {
+        assertAddressValid("1.2.3.4:1");
+    }
+
+    @Test
+    public void shouldThrowIfServerHasNoPort() {
+        assertAddressNotValid("localhost");
+    }
+
+    @Test
+    public void shouldThrowIfServerHasInvalidPort() {
+        assertAddressNotValid("localhost:1234567");
+    }
+
+    @Test
+    public void shouldThrowIfStringIncludesProtocol() {
+        assertAddressNotValid("http://palantir.com:8080");
+    }
+
+    @Test
+    public void shouldThrowIfPortUnparseable() {
+        assertAddressNotValid("localhost:foo");
+    }
+
+    private void assertAddressValid(String address) {
+        ClusterConfiguration.checkHostPortString(address);
+    }
+
+    private void assertAddressNotValid(String address) {
+        assertThatThrownBy(() -> ClusterConfiguration.checkHostPortString(address))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/ClusterConfigurationTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/ClusterConfigurationTest.java
@@ -19,11 +19,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
-import io.atomix.catalyst.transport.Address;
-
 public class ClusterConfigurationTest {
-    private static final Address ADDRESS_1 = new Address("localhost:1");
-    private static final Address ADDRESS_2 = new Address("localhost:2");
+    private static final String ADDRESS_1 = "localhost:2";
+    private static final String ADDRESS_2 = "localhost:1";
 
     @Test
     public void shouldThrowIfLocalServerNotSpecified() {

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/ClusterConfigurationTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/ClusterConfigurationTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.Test;
 
 public class ClusterConfigurationTest {
-    private static final String ADDRESS_1 = "localhost:2";
-    private static final String ADDRESS_2 = "localhost:1";
+    private static final String ADDRESS_1 = "localhost:1";
+    private static final String ADDRESS_2 = "localhost:2";
 
     @Test
     public void shouldThrowIfLocalServerNotSpecified() {

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfigurationTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfigurationTest.java
@@ -35,7 +35,7 @@ public class TimeLockServerConfigurationTest {
     @Test
     public void shouldAddDefaultConfigurationIfNotIncluded() {
         TimeLockServerConfiguration configuration = new TimeLockServerConfiguration(null, CLUSTER, CLIENTS);
-        assertThat(configuration.atomix()).isEqualTo(ImmutableAtomixConfiguration.DEFAULT);
+        assertThat(configuration.algorithm()).isEqualTo(ImmutableAtomixConfiguration.DEFAULT);
     }
 
     @Test

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfigurationTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfigurationTest.java
@@ -24,12 +24,10 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
 
-import io.atomix.catalyst.transport.Address;
-
 public class TimeLockServerConfigurationTest {
-    private static final Address ADDRESS = new Address("localhost:8700");
+    private static final String ADDRESS = "localhost:8701";
     private static final ClusterConfiguration CLUSTER = ImmutableClusterConfiguration.builder()
-            .localServer(new Address(ADDRESS))
+            .localServer(ADDRESS)
             .addServers(ADDRESS)
             .build();
     private static final Set<String> CLIENTS = ImmutableSet.of("client1", "client2");

--- a/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfigurationTest.java
+++ b/atlasdb-timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfigurationTest.java
@@ -43,4 +43,16 @@ public class TimeLockServerConfigurationTest {
         assertThatThrownBy(() -> new TimeLockServerConfiguration(null, CLUSTER, ImmutableSet.of()))
                 .isInstanceOf(IllegalStateException.class);
     }
+
+    @Test
+    public void shouldRejectClientsWithInvalidCharacters() {
+        assertThatThrownBy(() -> new TimeLockServerConfiguration(null, CLUSTER, ImmutableSet.of("/")))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void shouldRejectClientsWithEmptyName() {
+        assertThatThrownBy(() -> new TimeLockServerConfiguration(null, CLUSTER, ImmutableSet.of("")))
+                .isInstanceOf(IllegalStateException.class);
+    }
 }


### PR DESCRIPTION
This change integrates and builds upon @SerialVelocity's work on a `ServerImplementation` abstraction, which will be useful if we want to support alternative or additional implementations. Specifically:

* Introduces general `ServerImplementation`; refactors Atomix-specific logic to `AtomixServerImplementation`
* Refactors configuration: eliminates explicit dependency on Atomix's `Address` class, and introduces an `AlgorithmConfiguration` interface allowing for more general implementation-specific configs.
* Adds additional test that client names conform to the allowed paths (`[0-9a-zA-Z_-]+`)
* Adds a bit of detail on the semantics of the various methods in `ServerImplementation`

This will be required for future Timelock work that involves introducing an alternative algorithm for distributing the timestamp and lock services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1417)
<!-- Reviewable:end -->
