### PR TITLE
backoff on cassandra connection exception and add randomness to backoff

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -130,6 +130,8 @@ public class CassandraClientPoolIntegrationTest {
         assertTrue(CassandraClientPool.isRetriableWithBackoffException(new NoSuchElementException()));
         assertTrue(CassandraClientPool.isRetriableWithBackoffException(new UnavailableException()));
         assertTrue(CassandraClientPool.isRetriableWithBackoffException(
+                new TTransportException(new SocketTimeoutException())));
+        assertTrue(CassandraClientPool.isRetriableWithBackoffException(
                 new TTransportException(new UnavailableException())));
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -518,7 +518,7 @@ public class CassandraClientPool {
                 if (isRetriableWithBackoffException(e)) {
                     log.warn("Retrying with backoff a query intended for host {}.", hostPool.getHost(), e);
                     try {
-                        Thread.sleep(numTries * 1000);
+                        Thread.sleep(numTries * ThreadLocalRandom.current().nextInt(1000));
                     } catch (InterruptedException i) {
                         throw new RuntimeException(i);
                     }
@@ -653,6 +653,8 @@ public class CassandraClientPool {
                 && (ex instanceof NoSuchElementException
                 // remote cassandra node couldn't talk to enough other remote cassandra nodes to answer
                 || ex instanceof UnavailableException
+                // tcp socket timeout, possibly indicating network flake, long GC, or restarting server
+                || isConnectionException(ex)
                 || isRetriableWithBackoffException(ex.getCause()));
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -518,7 +518,8 @@ public class CassandraClientPool {
                 if (isRetriableWithBackoffException(e)) {
                     log.warn("Retrying with backoff a query intended for host {}.", hostPool.getHost(), e);
                     try {
-                        Thread.sleep(numTries * ThreadLocalRandom.current().nextInt(1000));
+                        // And value between -500 and +500ms to backoff to better spread load on failover
+                        Thread.sleep(numTries * 1000 + (ThreadLocalRandom.current().nextInt(1000) - 500));
                     } catch (InterruptedException i) {
                         throw new RuntimeException(i);
                     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -41,7 +41,7 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.common.base.FunctionCheckedException;
 
 public class CassandraClientPoolTest {
-    public static final int POOL_REFRESH_INTERVAL_SECONDS = 10;
+    public static final int POOL_REFRESH_INTERVAL_SECONDS = 3 * 60;
     public static final int TIME_BETWEEN_EVICTION_RUNS_SECONDS = 20;
     public static final int DEFAULT_PORT = 5000;
     public static final int OTHER_PORT = 6000;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,6 +52,11 @@ develop
          - Don't retry transactions when the locks are invalid. Previously, AtlasDB tried repeatedly to run a transaction when the external locks are already invalid.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1323>`__)
 
+    *    - |improved|
+         - Backoff when receiving a socket timeout to Cassandra to put back pressure on client and to spread out load incurred
+           on remaining servers when a failover occurs.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1420>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Counts connection exceptions (primarily socket and connect timeouts) as retriable and adds a bit of randomness to the backoff time. 

\+ @clockfort and @tpetracca for thoughts. My assumption is that socket timeouts will primarily be due to heavy load on a server (in the case that process isn't just straight killed at least), and therefore this helps push back on the client a bit and spreads out the failover time in the case that it is actually down so we don't cascade load onto the remaining healthy servers. Does that seem reasonable? If a node actually goes down this would add up to 5 seconds (on average about 3) of additional wait time until failover, but it'll get blacklisted in that case so seems worth the small wait time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1420)
<!-- Reviewable:end -->
