### PR TITLE
Fix stream stores with large in-memory size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ generated_testSrc/
 .factorypath
 out/
 atlasdb-cli/var/data/
+*.hprof
 
 # Common text-editor temp files
 # emacs

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinition.java
@@ -29,6 +29,9 @@ import com.palantir.atlasdb.table.description.render.StreamStoreRenderer;
 import com.palantir.common.base.Throwables;
 
 public class StreamStoreDefinition {
+    // from ArrayList.MAX_ARRAY_SIZE on 64-bit systems
+    public static final int MAX_IN_MEMORY_THRESHOLD = Integer.MAX_VALUE - 8;
+
     private final Map<String, TableDefinition> streamStoreTables;
     private final String shortName, longName;
     private final ValueType idType;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
@@ -73,6 +73,8 @@ public class StreamStoreDefinitionBuilder {
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().build()));
 
         Preconditions.checkArgument(valueType.getJavaClassName().equals("long"), "Stream ids must be a long");
+        Preconditions.checkArgument(inMemoryThreshold <= StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD,
+                "inMemoryThreshold cannot be greater than %s", StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD);
 
         return new StreamStoreDefinition(
                 tablesToCreate,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
@@ -120,8 +120,8 @@ public abstract class AbstractGenericStreamStore<ID> implements GenericStreamSto
             }
 
             @Override
-            public int expectedLength() {
-                return BLOCK_SIZE_IN_BYTES * blocksInMemory;
+            public int expectedBlockLength() {
+                return BLOCK_SIZE_IN_BYTES;
             }
         };
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockConsumingInputStream.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockConsumingInputStream.java
@@ -20,9 +20,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.schema.stream.StreamStoreDefinition;
 
 public final class BlockConsumingInputStream extends InputStream {
-    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8; // ArrayList.MAX_ARRAY_SIZE on 64-bit systems
     private final BlockGetter blockGetter;
     private final long numBlocks;
     private final int blocksInMemory;
@@ -44,13 +44,13 @@ public final class BlockConsumingInputStream extends InputStream {
 
     private static void ensureExpectedArraySizeDoesNotOverflow(BlockGetter blockGetter, int blocksInMemory) {
         int expectedBlockLength = blockGetter.expectedBlockLength();
-        int maxBlocksInMemory = MAX_ARRAY_SIZE / expectedBlockLength;
+        int maxBlocksInMemory = StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD / expectedBlockLength;
         long expectedBufferSize = (long) expectedBlockLength * (long) blocksInMemory;
         Preconditions.checkArgument(blocksInMemory <= maxBlocksInMemory,
                 "Promised to load too many blocks into memory. The underlying buffer is stored as a byte array, "
                         + "so can only fit %s bytes. The supplied BlockGetter expected to produce "
                         + "blocks of %s bytes, so %s of them (requested size %s) would cause the array to overflow.",
-                MAX_ARRAY_SIZE,
+                StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD,
                 expectedBlockLength,
                 blocksInMemory,
                 expectedBufferSize);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockConsumingInputStream.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockConsumingInputStream.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.schema.stream.StreamStoreDefinition;
 
@@ -42,7 +43,9 @@ public final class BlockConsumingInputStream extends InputStream {
         return stream;
     }
 
-    private static void ensureExpectedArraySizeDoesNotOverflow(BlockGetter blockGetter, int blocksInMemory) {
+    // we don't want to actually create a very large array in tests, as the external test VM would run out of memory.
+    @VisibleForTesting
+    protected static void ensureExpectedArraySizeDoesNotOverflow(BlockGetter blockGetter, int blocksInMemory) {
         int expectedBlockLength = blockGetter.expectedBlockLength();
         int maxBlocksInMemory = StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD / expectedBlockLength;
         long expectedBufferSize = (long) expectedBlockLength * (long) blocksInMemory;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockGetter.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockGetter.java
@@ -32,5 +32,5 @@ interface BlockGetter {
     /**
      * @return the expected length of a block of data.
      */
-    int expectedLength();
+    int expectedBlockLength();
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockGetter.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockGetter.java
@@ -30,7 +30,7 @@ interface BlockGetter {
     void get(long firstBlock, long numBlocks, OutputStream destination);
 
     /**
-     * @return the expected length of a block of data.
+     * @return the expected length of a block of data in bytes.
      */
     int expectedBlockLength();
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilderTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilderTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.schema.stream;
+
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.table.description.ValueType;
+
+public class StreamStoreDefinitionBuilderTest {
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testTooBigInMemoryThreshold() {
+        new StreamStoreDefinitionBuilder("test", "test", ValueType.VAR_LONG)
+                .inMemoryThreshold(StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD + 1)
+                .build();
+    }
+
+    @Test
+    public void testMaxInMemoryThreshold() {
+        new StreamStoreDefinitionBuilder("test", "test", ValueType.VAR_LONG)
+                .inMemoryThreshold(StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD)
+                .build();
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/stream/BlockConsumingInputStreamTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/stream/BlockConsumingInputStreamTest.java
@@ -236,7 +236,7 @@ public class BlockConsumingInputStreamTest {
         };
 
         // Should succeed, because bigGetter.expectedBlockLength() * blocksInMemory = Integer.MAX_VALUE - 8.
-        BlockConsumingInputStream.create(bigGetter, 2, 1);
+        BlockConsumingInputStream.ensureExpectedArraySizeDoesNotOverflow(bigGetter, 1);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/stream/BlockConsumingInputStreamTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/stream/BlockConsumingInputStreamTest.java
@@ -50,7 +50,7 @@ public class BlockConsumingInputStreamTest {
         }
 
         @Override
-        public int expectedLength() {
+        public int expectedBlockLength() {
             return data.length;
         }
     };
@@ -66,7 +66,7 @@ public class BlockConsumingInputStreamTest {
         }
 
         @Override
-        public int expectedLength() {
+        public int expectedBlockLength() {
             return data.length;
         }
     };
@@ -83,7 +83,7 @@ public class BlockConsumingInputStreamTest {
         }
 
         @Override
-        public int expectedLength() {
+        public int expectedBlockLength() {
             return data.length;
         }
     };
@@ -227,12 +227,12 @@ public class BlockConsumingInputStreamTest {
             }
 
             @Override
-            public int expectedLength() {
+            public int expectedBlockLength() {
                 return 1_000_000;
             }
         };
 
-        // Should fail, because bigGetter.expectedLength() * blocksInMemory > Integer.MAX_VALUE.
+        // Should fail, because bigGetter.expectedBlockLength() * blocksInMemory > Integer.MAX_VALUE.
         BlockConsumingInputStream.create(bigGetter, 9001, 2148);
     }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/stream/BlockConsumingInputStreamTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/stream/BlockConsumingInputStreamTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.stream;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -32,6 +33,8 @@ import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import com.palantir.atlasdb.schema.stream.StreamStoreDefinition;
 
 @SuppressWarnings("ResultOfMethodCallIgnored")
 public class BlockConsumingInputStreamTest {
@@ -251,7 +254,11 @@ public class BlockConsumingInputStreamTest {
         };
 
         // Should fail, because reallyBigGetter.expectedBlockLength() * blocksInMemory = Integer.MAX_VALUE - 7.
-        BlockConsumingInputStream.create(reallyBigGetter, 9, 8);
+        int blocksInMemory = 8;
+        assertTrue("Test assumption violated: expectedBlockLength() * blocksInMemory > MAX_IN_MEMORY_THRESHOLD.",
+                (long) reallyBigGetter.expectedBlockLength() * (long) blocksInMemory
+                        > StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD);
+        BlockConsumingInputStream.create(reallyBigGetter, 9, blocksInMemory);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,6 +30,15 @@ import com.palantir.common.concurrent.PTExecutors;
 public class TransactionManagerTest extends TransactionTestSetup {
     @Rule
     public ExpectedException exception = ExpectedException.none();
+
+    @Override
+    @After
+    public void tearDown() {
+        // these tests close the txMgr, so we need to also close the keyValueService
+        // and null it out so that it gets recreated for the next test
+        keyValueService.close();
+        keyValueService = null;
+    }
 
     @Test
     public void shouldSuccessfullyCloseTransactionManagerMultipleTimes() throws Exception {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTest.java
@@ -58,6 +58,7 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
 import com.palantir.atlasdb.schema.stream.generated.DeletingStreamStore;
 import com.palantir.atlasdb.schema.stream.generated.KeyValueTable;
+import com.palantir.atlasdb.schema.stream.generated.StreamTestMaxMemStreamStore;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestStreamHashAidxTable;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestStreamMetadataTable;
 import com.palantir.atlasdb.schema.stream.generated.StreamTestStreamStore;
@@ -81,6 +82,7 @@ import com.palantir.util.crypto.Sha256Hash;
 public class StreamTest extends AtlasDbTestCase {
     private PersistentStreamStore defaultStore;
     private PersistentStreamStore compressedStore;
+    private PersistentStreamStore maxMemStore;
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -92,6 +94,7 @@ public class StreamTest extends AtlasDbTestCase {
 
         defaultStore = StreamTestStreamStore.of(txManager, StreamTestTableFactory.of());
         compressedStore = StreamTestWithHashStreamStore.of(txManager, StreamTestTableFactory.of());
+        maxMemStore = StreamTestMaxMemStreamStore.of(txManager, StreamTestTableFactory.of());
     }
 
     @Test
@@ -218,6 +221,16 @@ public class StreamTest extends AtlasDbTestCase {
     @Test
     public void testStoreByteStreamFiveMegaBytes_compressedStream_incompressible() throws IOException {
         storeAndCheckByteStreams(compressedStore, getIncompressibleBytes(5_000_000));
+    }
+
+    @Test
+    public void testStoreToMaxMemStream() throws IOException {
+        storeAndCheckByteStreams(maxMemStore, getIncompressibleBytes(100));
+    }
+
+    @Test
+    public void testStoreHugeToMaxMemStream() throws IOException {
+        storeAndCheckByteStreams(maxMemStore, getIncompressibleBytes(20_000_000));
     }
 
     private long storeAndCheckByteStreams(PersistentStreamStore store, byte[] bytesToStore) throws IOException {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTestSchema.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTestSchema.java
@@ -59,10 +59,9 @@ public class StreamTestSchema implements AtlasSchema {
                     .isAppendHeavyAndReadLight()
                     .build());
 
-        // streams can have up to Integer.MAX_VALUE as the inMemoryThreshold
         schema.addStreamStoreDefinition(
                 new StreamStoreDefinitionBuilder("stream_test_max_mem", "stream_test_max_mem", ValueType.VAR_LONG)
-                    .inMemoryThreshold(Integer.MAX_VALUE)
+                    .inMemoryThreshold(StreamStoreDefinition.MAX_IN_MEMORY_THRESHOLD)
                     .build());
 
         return schema;

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTestSchema.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTestSchema.java
@@ -59,6 +59,12 @@ public class StreamTestSchema implements AtlasSchema {
                     .isAppendHeavyAndReadLight()
                     .build());
 
+        // streams can have up to Integer.MAX_VALUE as the inMemoryThreshold
+        schema.addStreamStoreDefinition(
+                new StreamStoreDefinitionBuilder("stream_test_max_mem", "stream_test_max_mem", ValueType.VAR_LONG)
+                    .inMemoryThreshold(Integer.MAX_VALUE)
+                    .build());
+
         return schema;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemIndexCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemIndexCleanupTask.java
@@ -1,0 +1,36 @@
+package com.palantir.atlasdb.schema.stream.generated;
+
+import java.util.Set;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class StreamTestMaxMemIndexCleanupTask implements OnCleanupTask {
+
+    private final StreamTestTableFactory tables;
+
+    public StreamTestMaxMemIndexCleanupTask(Namespace namespace) {
+        tables = StreamTestTableFactory.of(namespace);
+    }
+
+    @Override
+    public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
+        StreamTestMaxMemStreamIdxTable usersIndex = tables.getStreamTestMaxMemStreamIdxTable(t);
+        Set<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
+        for (Cell cell : cells) {
+            rows.add(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+        }
+        Multimap<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue> rowsInDb = usersIndex.getRowsMultimap(rows);
+        Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.keySet().size());
+        for (StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow rowToDelete : Sets.difference(rows, rowsInDb.keySet())) {
+            toDelete.add(rowToDelete.getId());
+        }
+        StreamTestMaxMemStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
@@ -1,0 +1,42 @@
+package com.palantir.atlasdb.schema.stream.generated;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
+
+    private final StreamTestTableFactory tables;
+
+    public StreamTestMaxMemMetadataCleanupTask(Namespace namespace) {
+        tables = StreamTestTableFactory.of(namespace);
+    }
+
+    @Override
+    public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
+        StreamTestMaxMemStreamMetadataTable metaTable = tables.getStreamTestMaxMemStreamMetadataTable(t);
+        Collection<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        for (Cell cell : cells) {
+            rows.add(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+        }
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
+        for (Map.Entry<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                toDelete.add(e.getKey().getId());
+            }
+        }
+        StreamTestMaxMemStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -1,0 +1,770 @@
+package com.palantir.atlasdb.schema.stream.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedExpiringSet;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.common.proxy.AsyncProxy;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+public final class StreamTestMaxMemStreamHashAidxTable implements
+        AtlasDbDynamicMutablePersistentTable<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow,
+                                                StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumn,
+                                                StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue,
+                                                StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRowResult> {
+    private final Transaction t;
+    private final List<StreamTestMaxMemStreamHashAidxTrigger> triggers;
+    private final static String rawTableName = "stream_test_max_mem_stream_hash_aidx";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = ColumnSelection.all();
+
+    static StreamTestMaxMemStreamHashAidxTable of(Transaction t, Namespace namespace) {
+        return new StreamTestMaxMemStreamHashAidxTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamHashAidxTrigger>of());
+    }
+
+    static StreamTestMaxMemStreamHashAidxTable of(Transaction t, Namespace namespace, StreamTestMaxMemStreamHashAidxTrigger trigger, StreamTestMaxMemStreamHashAidxTrigger... triggers) {
+        return new StreamTestMaxMemStreamHashAidxTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamHashAidxTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static StreamTestMaxMemStreamHashAidxTable of(Transaction t, Namespace namespace, List<StreamTestMaxMemStreamHashAidxTrigger> triggers) {
+        return new StreamTestMaxMemStreamHashAidxTable(t, namespace, triggers);
+    }
+
+    private StreamTestMaxMemStreamHashAidxTable(Transaction t, Namespace namespace, List<StreamTestMaxMemStreamHashAidxTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * StreamTestMaxMemStreamHashAidxRow {
+     *   {@literal Sha256Hash hash};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestMaxMemStreamHashAidxRow implements Persistable, Comparable<StreamTestMaxMemStreamHashAidxRow> {
+        private final Sha256Hash hash;
+
+        public static StreamTestMaxMemStreamHashAidxRow of(Sha256Hash hash) {
+            return new StreamTestMaxMemStreamHashAidxRow(hash);
+        }
+
+        private StreamTestMaxMemStreamHashAidxRow(Sha256Hash hash) {
+            this.hash = hash;
+        }
+
+        public Sha256Hash getHash() {
+            return hash;
+        }
+
+        public static Function<StreamTestMaxMemStreamHashAidxRow, Sha256Hash> getHashFun() {
+            return new Function<StreamTestMaxMemStreamHashAidxRow, Sha256Hash>() {
+                @Override
+                public Sha256Hash apply(StreamTestMaxMemStreamHashAidxRow row) {
+                    return row.hash;
+                }
+            };
+        }
+
+        public static Function<Sha256Hash, StreamTestMaxMemStreamHashAidxRow> fromHashFun() {
+            return new Function<Sha256Hash, StreamTestMaxMemStreamHashAidxRow>() {
+                @Override
+                public StreamTestMaxMemStreamHashAidxRow apply(Sha256Hash row) {
+                    return StreamTestMaxMemStreamHashAidxRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] hashBytes = hash.getBytes();
+            return EncodingUtils.add(hashBytes);
+        }
+
+        public static final Hydrator<StreamTestMaxMemStreamHashAidxRow> BYTES_HYDRATOR = new Hydrator<StreamTestMaxMemStreamHashAidxRow>() {
+            @Override
+            public StreamTestMaxMemStreamHashAidxRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
+                __index += 32;
+                return new StreamTestMaxMemStreamHashAidxRow(hash);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("hash", hash)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestMaxMemStreamHashAidxRow other = (StreamTestMaxMemStreamHashAidxRow) obj;
+            return Objects.equal(hash, other.hash);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(hash);
+        }
+
+        @Override
+        public int compareTo(StreamTestMaxMemStreamHashAidxRow o) {
+            return ComparisonChain.start()
+                .compare(this.hash, o.hash)
+                .result();
+        }
+    }
+
+    /**
+     * <pre>
+     * StreamTestMaxMemStreamHashAidxColumn {
+     *   {@literal Long streamId};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestMaxMemStreamHashAidxColumn implements Persistable, Comparable<StreamTestMaxMemStreamHashAidxColumn> {
+        private final long streamId;
+
+        public static StreamTestMaxMemStreamHashAidxColumn of(long streamId) {
+            return new StreamTestMaxMemStreamHashAidxColumn(streamId);
+        }
+
+        private StreamTestMaxMemStreamHashAidxColumn(long streamId) {
+            this.streamId = streamId;
+        }
+
+        public long getStreamId() {
+            return streamId;
+        }
+
+        public static Function<StreamTestMaxMemStreamHashAidxColumn, Long> getStreamIdFun() {
+            return new Function<StreamTestMaxMemStreamHashAidxColumn, Long>() {
+                @Override
+                public Long apply(StreamTestMaxMemStreamHashAidxColumn row) {
+                    return row.streamId;
+                }
+            };
+        }
+
+        public static Function<Long, StreamTestMaxMemStreamHashAidxColumn> fromStreamIdFun() {
+            return new Function<Long, StreamTestMaxMemStreamHashAidxColumn>() {
+                @Override
+                public StreamTestMaxMemStreamHashAidxColumn apply(Long row) {
+                    return StreamTestMaxMemStreamHashAidxColumn.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] streamIdBytes = EncodingUtils.encodeUnsignedVarLong(streamId);
+            return EncodingUtils.add(streamIdBytes);
+        }
+
+        public static final Hydrator<StreamTestMaxMemStreamHashAidxColumn> BYTES_HYDRATOR = new Hydrator<StreamTestMaxMemStreamHashAidxColumn>() {
+            @Override
+            public StreamTestMaxMemStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                return new StreamTestMaxMemStreamHashAidxColumn(streamId);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("streamId", streamId)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestMaxMemStreamHashAidxColumn other = (StreamTestMaxMemStreamHashAidxColumn) obj;
+            return Objects.equal(streamId, other.streamId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(streamId);
+        }
+
+        @Override
+        public int compareTo(StreamTestMaxMemStreamHashAidxColumn o) {
+            return ComparisonChain.start()
+                .compare(this.streamId, o.streamId)
+                .result();
+        }
+    }
+
+    public interface StreamTestMaxMemStreamHashAidxTrigger {
+        public void putStreamTestMaxMemStreamHashAidx(Multimap<StreamTestMaxMemStreamHashAidxRow, ? extends StreamTestMaxMemStreamHashAidxColumnValue> newRows);
+    }
+
+    /**
+     * <pre>
+     * Column name description {
+     *   {@literal Long streamId};
+     * }
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class StreamTestMaxMemStreamHashAidxColumnValue implements ColumnValue<Long> {
+        private final StreamTestMaxMemStreamHashAidxColumn columnName;
+        private final Long value;
+
+        public static StreamTestMaxMemStreamHashAidxColumnValue of(StreamTestMaxMemStreamHashAidxColumn columnName, Long value) {
+            return new StreamTestMaxMemStreamHashAidxColumnValue(columnName, value);
+        }
+
+        private StreamTestMaxMemStreamHashAidxColumnValue(StreamTestMaxMemStreamHashAidxColumn columnName, Long value) {
+            this.columnName = columnName;
+            this.value = value;
+        }
+
+        public StreamTestMaxMemStreamHashAidxColumn getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return columnName.persistToBytes();
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        public static Long hydrateValue(byte[] bytes) {
+            bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+            return EncodingUtils.decodeUnsignedVarLong(bytes, 0);
+        }
+
+        public static Function<StreamTestMaxMemStreamHashAidxColumnValue, StreamTestMaxMemStreamHashAidxColumn> getColumnNameFun() {
+            return new Function<StreamTestMaxMemStreamHashAidxColumnValue, StreamTestMaxMemStreamHashAidxColumn>() {
+                @Override
+                public StreamTestMaxMemStreamHashAidxColumn apply(StreamTestMaxMemStreamHashAidxColumnValue columnValue) {
+                    return columnValue.getColumnName();
+                }
+            };
+        }
+
+        public static Function<StreamTestMaxMemStreamHashAidxColumnValue, Long> getValueFun() {
+            return new Function<StreamTestMaxMemStreamHashAidxColumnValue, Long>() {
+                @Override
+                public Long apply(StreamTestMaxMemStreamHashAidxColumnValue columnValue) {
+                    return columnValue.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("ColumnName", this.columnName)
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public static final class StreamTestMaxMemStreamHashAidxRowResult implements TypedRowResult {
+        private final StreamTestMaxMemStreamHashAidxRow rowName;
+        private final ImmutableSet<StreamTestMaxMemStreamHashAidxColumnValue> columnValues;
+
+        public static StreamTestMaxMemStreamHashAidxRowResult of(RowResult<byte[]> rowResult) {
+            StreamTestMaxMemStreamHashAidxRow rowName = StreamTestMaxMemStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<StreamTestMaxMemStreamHashAidxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                StreamTestMaxMemStreamHashAidxColumn col = StreamTestMaxMemStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long value = StreamTestMaxMemStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                columnValues.add(StreamTestMaxMemStreamHashAidxColumnValue.of(col, value));
+            }
+            return new StreamTestMaxMemStreamHashAidxRowResult(rowName, ImmutableSet.copyOf(columnValues));
+        }
+
+        private StreamTestMaxMemStreamHashAidxRowResult(StreamTestMaxMemStreamHashAidxRow rowName, ImmutableSet<StreamTestMaxMemStreamHashAidxColumnValue> columnValues) {
+            this.rowName = rowName;
+            this.columnValues = columnValues;
+        }
+
+        @Override
+        public StreamTestMaxMemStreamHashAidxRow getRowName() {
+            return rowName;
+        }
+
+        public Set<StreamTestMaxMemStreamHashAidxColumnValue> getColumnValues() {
+            return columnValues;
+        }
+
+        public static Function<StreamTestMaxMemStreamHashAidxRowResult, StreamTestMaxMemStreamHashAidxRow> getRowNameFun() {
+            return new Function<StreamTestMaxMemStreamHashAidxRowResult, StreamTestMaxMemStreamHashAidxRow>() {
+                @Override
+                public StreamTestMaxMemStreamHashAidxRow apply(StreamTestMaxMemStreamHashAidxRowResult rowResult) {
+                    return rowResult.rowName;
+                }
+            };
+        }
+
+        public static Function<StreamTestMaxMemStreamHashAidxRowResult, ImmutableSet<StreamTestMaxMemStreamHashAidxColumnValue>> getColumnValuesFun() {
+            return new Function<StreamTestMaxMemStreamHashAidxRowResult, ImmutableSet<StreamTestMaxMemStreamHashAidxColumnValue>>() {
+                @Override
+                public ImmutableSet<StreamTestMaxMemStreamHashAidxColumnValue> apply(StreamTestMaxMemStreamHashAidxRowResult rowResult) {
+                    return rowResult.columnValues;
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("ColumnValues", getColumnValues())
+                .toString();
+        }
+    }
+
+    @Override
+    public void delete(StreamTestMaxMemStreamHashAidxRow row, StreamTestMaxMemStreamHashAidxColumn column) {
+        delete(ImmutableMultimap.of(row, column));
+    }
+
+    @Override
+    public void delete(Iterable<StreamTestMaxMemStreamHashAidxRow> rows) {
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> toRemove = HashMultimap.create();
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> result = getRowsMultimap(rows);
+        for (Entry<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> e : result.entries()) {
+            toRemove.put(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toRemove);
+    }
+
+    @Override
+    public void delete(Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> values) {
+        t.delete(tableRef, ColumnValues.toCells(values));
+    }
+
+    @Override
+    public void put(StreamTestMaxMemStreamHashAidxRow rowName, Iterable<StreamTestMaxMemStreamHashAidxColumnValue> values) {
+        put(ImmutableMultimap.<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(StreamTestMaxMemStreamHashAidxRow rowName, StreamTestMaxMemStreamHashAidxColumnValue... values) {
+        put(ImmutableMultimap.<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(Multimap<StreamTestMaxMemStreamHashAidxRow, ? extends StreamTestMaxMemStreamHashAidxColumnValue> values) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(values));
+        for (StreamTestMaxMemStreamHashAidxTrigger trigger : triggers) {
+            trigger.putStreamTestMaxMemStreamHashAidx(values);
+        }
+    }
+
+    @Override
+    public void putUnlessExists(StreamTestMaxMemStreamHashAidxRow rowName, Iterable<StreamTestMaxMemStreamHashAidxColumnValue> values) {
+        putUnlessExists(ImmutableMultimap.<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void putUnlessExists(StreamTestMaxMemStreamHashAidxRow rowName, StreamTestMaxMemStreamHashAidxColumnValue... values) {
+        putUnlessExists(ImmutableMultimap.<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void putUnlessExists(Multimap<StreamTestMaxMemStreamHashAidxRow, ? extends StreamTestMaxMemStreamHashAidxColumnValue> rows) {
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, StreamTestMaxMemStreamHashAidxColumnValue.getColumnNameFun());
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> existing = get(toGet);
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> toPut = HashMultimap.create();
+        for (Entry<StreamTestMaxMemStreamHashAidxRow, ? extends StreamTestMaxMemStreamHashAidxColumnValue> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    @Override
+    public void touch(Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> values) {
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> currentValues = get(values);
+        put(currentValues);
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> e : currentValues.entries()) {
+            toDelete.remove(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toDelete);
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<StreamTestMaxMemStreamHashAidxColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
+    }
+
+    public static ColumnSelection getColumnSelection(StreamTestMaxMemStreamHashAidxColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> get(Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> cells) {
+        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> rowMap = HashMultimap.create();
+        for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
+            if (e.getValue().length > 0) {
+                StreamTestMaxMemStreamHashAidxRow row = StreamTestMaxMemStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                StreamTestMaxMemStreamHashAidxColumn col = StreamTestMaxMemStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                Long val = StreamTestMaxMemStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, StreamTestMaxMemStreamHashAidxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getAsync(final Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> cells, ExecutorService exec) {
+        Callable<Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>> c =
+                new Callable<Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>>() {
+            @Override
+            public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> call() {
+                return get(cells);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), Multimap.class);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamHashAidxColumnValue> getRowColumns(StreamTestMaxMemStreamHashAidxRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamHashAidxColumnValue> getRowColumns(StreamTestMaxMemStreamHashAidxRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<StreamTestMaxMemStreamHashAidxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                StreamTestMaxMemStreamHashAidxColumn col = StreamTestMaxMemStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = StreamTestMaxMemStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                ret.add(StreamTestMaxMemStreamHashAidxColumnValue.of(col, val));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestMaxMemStreamHashAidxRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestMaxMemStreamHashAidxRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getAsyncRowsMultimap(Iterable<StreamTestMaxMemStreamHashAidxRow> rows, ExecutorService exec) {
+        return getAsyncRowsMultimap(rows, allColumns, exec);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getAsyncRowsMultimap(final Iterable<StreamTestMaxMemStreamHashAidxRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>> c =
+                new Callable<Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>>() {
+            @Override
+            public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> call() {
+                return getRowsMultimapInternal(rows, columns);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), Multimap.class);
+    }
+
+    private Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<StreamTestMaxMemStreamHashAidxRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            StreamTestMaxMemStreamHashAidxRow row = StreamTestMaxMemStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                StreamTestMaxMemStreamHashAidxColumn col = StreamTestMaxMemStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = StreamTestMaxMemStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, StreamTestMaxMemStreamHashAidxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<StreamTestMaxMemStreamHashAidxRow, BatchingVisitable<StreamTestMaxMemStreamHashAidxColumnValue>> getRowsColumnRange(Iterable<StreamTestMaxMemStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestMaxMemStreamHashAidxRow, BatchingVisitable<StreamTestMaxMemStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestMaxMemStreamHashAidxRow row = StreamTestMaxMemStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<StreamTestMaxMemStreamHashAidxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                StreamTestMaxMemStreamHashAidxColumn col = StreamTestMaxMemStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestMaxMemStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return StreamTestMaxMemStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>> getRowsColumnRange(Iterable<StreamTestMaxMemStreamHashAidxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            StreamTestMaxMemStreamHashAidxRow row = StreamTestMaxMemStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            StreamTestMaxMemStreamHashAidxColumn col = StreamTestMaxMemStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            Long val = StreamTestMaxMemStreamHashAidxColumnValue.hydrateValue(e.getValue());
+            StreamTestMaxMemStreamHashAidxColumnValue colValue = StreamTestMaxMemStreamHashAidxColumnValue.of(col, val);
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<StreamTestMaxMemStreamHashAidxRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<StreamTestMaxMemStreamHashAidxRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, StreamTestMaxMemStreamHashAidxRowResult>() {
+            @Override
+            public StreamTestMaxMemStreamHashAidxRowResult apply(RowResult<byte[]> input) {
+                return StreamTestMaxMemStreamHashAidxRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AsyncProxy}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutableExpiringTable}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutableExpiringTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedExpiringSet}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link ExecutorService}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "6KjHR4/i7R8TPVeWh0VB6Q==";
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -1,0 +1,770 @@
+package com.palantir.atlasdb.schema.stream.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedExpiringSet;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.common.proxy.AsyncProxy;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+public final class StreamTestMaxMemStreamIdxTable implements
+        AtlasDbDynamicMutablePersistentTable<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow,
+                                                StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumn,
+                                                StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue,
+                                                StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRowResult> {
+    private final Transaction t;
+    private final List<StreamTestMaxMemStreamIdxTrigger> triggers;
+    private final static String rawTableName = "stream_test_max_mem_stream_idx";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = ColumnSelection.all();
+
+    static StreamTestMaxMemStreamIdxTable of(Transaction t, Namespace namespace) {
+        return new StreamTestMaxMemStreamIdxTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamIdxTrigger>of());
+    }
+
+    static StreamTestMaxMemStreamIdxTable of(Transaction t, Namespace namespace, StreamTestMaxMemStreamIdxTrigger trigger, StreamTestMaxMemStreamIdxTrigger... triggers) {
+        return new StreamTestMaxMemStreamIdxTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamIdxTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static StreamTestMaxMemStreamIdxTable of(Transaction t, Namespace namespace, List<StreamTestMaxMemStreamIdxTrigger> triggers) {
+        return new StreamTestMaxMemStreamIdxTable(t, namespace, triggers);
+    }
+
+    private StreamTestMaxMemStreamIdxTable(Transaction t, Namespace namespace, List<StreamTestMaxMemStreamIdxTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * StreamTestMaxMemStreamIdxRow {
+     *   {@literal Long id};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestMaxMemStreamIdxRow implements Persistable, Comparable<StreamTestMaxMemStreamIdxRow> {
+        private final long id;
+
+        public static StreamTestMaxMemStreamIdxRow of(long id) {
+            return new StreamTestMaxMemStreamIdxRow(id);
+        }
+
+        private StreamTestMaxMemStreamIdxRow(long id) {
+            this.id = id;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public static Function<StreamTestMaxMemStreamIdxRow, Long> getIdFun() {
+            return new Function<StreamTestMaxMemStreamIdxRow, Long>() {
+                @Override
+                public Long apply(StreamTestMaxMemStreamIdxRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<Long, StreamTestMaxMemStreamIdxRow> fromIdFun() {
+            return new Function<Long, StreamTestMaxMemStreamIdxRow>() {
+                @Override
+                public StreamTestMaxMemStreamIdxRow apply(Long row) {
+                    return StreamTestMaxMemStreamIdxRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = EncodingUtils.encodeUnsignedVarLong(id);
+            return EncodingUtils.add(idBytes);
+        }
+
+        public static final Hydrator<StreamTestMaxMemStreamIdxRow> BYTES_HYDRATOR = new Hydrator<StreamTestMaxMemStreamIdxRow>() {
+            @Override
+            public StreamTestMaxMemStreamIdxRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                return new StreamTestMaxMemStreamIdxRow(id);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestMaxMemStreamIdxRow other = (StreamTestMaxMemStreamIdxRow) obj;
+            return Objects.equal(id, other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(id);
+        }
+
+        @Override
+        public int compareTo(StreamTestMaxMemStreamIdxRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .result();
+        }
+    }
+
+    /**
+     * <pre>
+     * StreamTestMaxMemStreamIdxColumn {
+     *   {@literal byte[] reference};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestMaxMemStreamIdxColumn implements Persistable, Comparable<StreamTestMaxMemStreamIdxColumn> {
+        private final byte[] reference;
+
+        public static StreamTestMaxMemStreamIdxColumn of(byte[] reference) {
+            return new StreamTestMaxMemStreamIdxColumn(reference);
+        }
+
+        private StreamTestMaxMemStreamIdxColumn(byte[] reference) {
+            this.reference = reference;
+        }
+
+        public byte[] getReference() {
+            return reference;
+        }
+
+        public static Function<StreamTestMaxMemStreamIdxColumn, byte[]> getReferenceFun() {
+            return new Function<StreamTestMaxMemStreamIdxColumn, byte[]>() {
+                @Override
+                public byte[] apply(StreamTestMaxMemStreamIdxColumn row) {
+                    return row.reference;
+                }
+            };
+        }
+
+        public static Function<byte[], StreamTestMaxMemStreamIdxColumn> fromReferenceFun() {
+            return new Function<byte[], StreamTestMaxMemStreamIdxColumn>() {
+                @Override
+                public StreamTestMaxMemStreamIdxColumn apply(byte[] row) {
+                    return StreamTestMaxMemStreamIdxColumn.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] referenceBytes = EncodingUtils.encodeSizedBytes(reference);
+            return EncodingUtils.add(referenceBytes);
+        }
+
+        public static final Hydrator<StreamTestMaxMemStreamIdxColumn> BYTES_HYDRATOR = new Hydrator<StreamTestMaxMemStreamIdxColumn>() {
+            @Override
+            public StreamTestMaxMemStreamIdxColumn hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
+                __index += EncodingUtils.sizeOfSizedBytes(reference);
+                return new StreamTestMaxMemStreamIdxColumn(reference);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("reference", reference)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestMaxMemStreamIdxColumn other = (StreamTestMaxMemStreamIdxColumn) obj;
+            return Arrays.equals(reference, other.reference);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(reference);
+        }
+
+        @Override
+        public int compareTo(StreamTestMaxMemStreamIdxColumn o) {
+            return ComparisonChain.start()
+                .compare(this.reference, o.reference, UnsignedBytes.lexicographicalComparator())
+                .result();
+        }
+    }
+
+    public interface StreamTestMaxMemStreamIdxTrigger {
+        public void putStreamTestMaxMemStreamIdx(Multimap<StreamTestMaxMemStreamIdxRow, ? extends StreamTestMaxMemStreamIdxColumnValue> newRows);
+    }
+
+    /**
+     * <pre>
+     * Column name description {
+     *   {@literal byte[] reference};
+     * }
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class StreamTestMaxMemStreamIdxColumnValue implements ColumnValue<Long> {
+        private final StreamTestMaxMemStreamIdxColumn columnName;
+        private final Long value;
+
+        public static StreamTestMaxMemStreamIdxColumnValue of(StreamTestMaxMemStreamIdxColumn columnName, Long value) {
+            return new StreamTestMaxMemStreamIdxColumnValue(columnName, value);
+        }
+
+        private StreamTestMaxMemStreamIdxColumnValue(StreamTestMaxMemStreamIdxColumn columnName, Long value) {
+            this.columnName = columnName;
+            this.value = value;
+        }
+
+        public StreamTestMaxMemStreamIdxColumn getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return columnName.persistToBytes();
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        public static Long hydrateValue(byte[] bytes) {
+            bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+            return EncodingUtils.decodeUnsignedVarLong(bytes, 0);
+        }
+
+        public static Function<StreamTestMaxMemStreamIdxColumnValue, StreamTestMaxMemStreamIdxColumn> getColumnNameFun() {
+            return new Function<StreamTestMaxMemStreamIdxColumnValue, StreamTestMaxMemStreamIdxColumn>() {
+                @Override
+                public StreamTestMaxMemStreamIdxColumn apply(StreamTestMaxMemStreamIdxColumnValue columnValue) {
+                    return columnValue.getColumnName();
+                }
+            };
+        }
+
+        public static Function<StreamTestMaxMemStreamIdxColumnValue, Long> getValueFun() {
+            return new Function<StreamTestMaxMemStreamIdxColumnValue, Long>() {
+                @Override
+                public Long apply(StreamTestMaxMemStreamIdxColumnValue columnValue) {
+                    return columnValue.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("ColumnName", this.columnName)
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public static final class StreamTestMaxMemStreamIdxRowResult implements TypedRowResult {
+        private final StreamTestMaxMemStreamIdxRow rowName;
+        private final ImmutableSet<StreamTestMaxMemStreamIdxColumnValue> columnValues;
+
+        public static StreamTestMaxMemStreamIdxRowResult of(RowResult<byte[]> rowResult) {
+            StreamTestMaxMemStreamIdxRow rowName = StreamTestMaxMemStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<StreamTestMaxMemStreamIdxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long value = StreamTestMaxMemStreamIdxColumnValue.hydrateValue(e.getValue());
+                columnValues.add(StreamTestMaxMemStreamIdxColumnValue.of(col, value));
+            }
+            return new StreamTestMaxMemStreamIdxRowResult(rowName, ImmutableSet.copyOf(columnValues));
+        }
+
+        private StreamTestMaxMemStreamIdxRowResult(StreamTestMaxMemStreamIdxRow rowName, ImmutableSet<StreamTestMaxMemStreamIdxColumnValue> columnValues) {
+            this.rowName = rowName;
+            this.columnValues = columnValues;
+        }
+
+        @Override
+        public StreamTestMaxMemStreamIdxRow getRowName() {
+            return rowName;
+        }
+
+        public Set<StreamTestMaxMemStreamIdxColumnValue> getColumnValues() {
+            return columnValues;
+        }
+
+        public static Function<StreamTestMaxMemStreamIdxRowResult, StreamTestMaxMemStreamIdxRow> getRowNameFun() {
+            return new Function<StreamTestMaxMemStreamIdxRowResult, StreamTestMaxMemStreamIdxRow>() {
+                @Override
+                public StreamTestMaxMemStreamIdxRow apply(StreamTestMaxMemStreamIdxRowResult rowResult) {
+                    return rowResult.rowName;
+                }
+            };
+        }
+
+        public static Function<StreamTestMaxMemStreamIdxRowResult, ImmutableSet<StreamTestMaxMemStreamIdxColumnValue>> getColumnValuesFun() {
+            return new Function<StreamTestMaxMemStreamIdxRowResult, ImmutableSet<StreamTestMaxMemStreamIdxColumnValue>>() {
+                @Override
+                public ImmutableSet<StreamTestMaxMemStreamIdxColumnValue> apply(StreamTestMaxMemStreamIdxRowResult rowResult) {
+                    return rowResult.columnValues;
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("ColumnValues", getColumnValues())
+                .toString();
+        }
+    }
+
+    @Override
+    public void delete(StreamTestMaxMemStreamIdxRow row, StreamTestMaxMemStreamIdxColumn column) {
+        delete(ImmutableMultimap.of(row, column));
+    }
+
+    @Override
+    public void delete(Iterable<StreamTestMaxMemStreamIdxRow> rows) {
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> toRemove = HashMultimap.create();
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> result = getRowsMultimap(rows);
+        for (Entry<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> e : result.entries()) {
+            toRemove.put(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toRemove);
+    }
+
+    @Override
+    public void delete(Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> values) {
+        t.delete(tableRef, ColumnValues.toCells(values));
+    }
+
+    @Override
+    public void put(StreamTestMaxMemStreamIdxRow rowName, Iterable<StreamTestMaxMemStreamIdxColumnValue> values) {
+        put(ImmutableMultimap.<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(StreamTestMaxMemStreamIdxRow rowName, StreamTestMaxMemStreamIdxColumnValue... values) {
+        put(ImmutableMultimap.<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(Multimap<StreamTestMaxMemStreamIdxRow, ? extends StreamTestMaxMemStreamIdxColumnValue> values) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(values));
+        for (StreamTestMaxMemStreamIdxTrigger trigger : triggers) {
+            trigger.putStreamTestMaxMemStreamIdx(values);
+        }
+    }
+
+    @Override
+    public void putUnlessExists(StreamTestMaxMemStreamIdxRow rowName, Iterable<StreamTestMaxMemStreamIdxColumnValue> values) {
+        putUnlessExists(ImmutableMultimap.<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void putUnlessExists(StreamTestMaxMemStreamIdxRow rowName, StreamTestMaxMemStreamIdxColumnValue... values) {
+        putUnlessExists(ImmutableMultimap.<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void putUnlessExists(Multimap<StreamTestMaxMemStreamIdxRow, ? extends StreamTestMaxMemStreamIdxColumnValue> rows) {
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> toGet = Multimaps.transformValues(rows, StreamTestMaxMemStreamIdxColumnValue.getColumnNameFun());
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> existing = get(toGet);
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> toPut = HashMultimap.create();
+        for (Entry<StreamTestMaxMemStreamIdxRow, ? extends StreamTestMaxMemStreamIdxColumnValue> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    @Override
+    public void touch(Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> values) {
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> currentValues = get(values);
+        put(currentValues);
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> e : currentValues.entries()) {
+            toDelete.remove(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toDelete);
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<StreamTestMaxMemStreamIdxColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
+    }
+
+    public static ColumnSelection getColumnSelection(StreamTestMaxMemStreamIdxColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> get(Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> cells) {
+        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> rowMap = HashMultimap.create();
+        for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
+            if (e.getValue().length > 0) {
+                StreamTestMaxMemStreamIdxRow row = StreamTestMaxMemStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                Long val = StreamTestMaxMemStreamIdxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, StreamTestMaxMemStreamIdxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getAsync(final Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> cells, ExecutorService exec) {
+        Callable<Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>> c =
+                new Callable<Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>>() {
+            @Override
+            public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> call() {
+                return get(cells);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), Multimap.class);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamIdxColumnValue> getRowColumns(StreamTestMaxMemStreamIdxRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamIdxColumnValue> getRowColumns(StreamTestMaxMemStreamIdxRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<StreamTestMaxMemStreamIdxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = StreamTestMaxMemStreamIdxColumnValue.hydrateValue(e.getValue());
+                ret.add(StreamTestMaxMemStreamIdxColumnValue.of(col, val));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowsMultimap(Iterable<StreamTestMaxMemStreamIdxRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowsMultimap(Iterable<StreamTestMaxMemStreamIdxRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getAsyncRowsMultimap(Iterable<StreamTestMaxMemStreamIdxRow> rows, ExecutorService exec) {
+        return getAsyncRowsMultimap(rows, allColumns, exec);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getAsyncRowsMultimap(final Iterable<StreamTestMaxMemStreamIdxRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>> c =
+                new Callable<Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>>() {
+            @Override
+            public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> call() {
+                return getRowsMultimapInternal(rows, columns);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), Multimap.class);
+    }
+
+    private Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowsMultimapInternal(Iterable<StreamTestMaxMemStreamIdxRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            StreamTestMaxMemStreamIdxRow row = StreamTestMaxMemStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = StreamTestMaxMemStreamIdxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, StreamTestMaxMemStreamIdxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<StreamTestMaxMemStreamIdxRow, BatchingVisitable<StreamTestMaxMemStreamIdxColumnValue>> getRowsColumnRange(Iterable<StreamTestMaxMemStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestMaxMemStreamIdxRow, BatchingVisitable<StreamTestMaxMemStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestMaxMemStreamIdxRow row = StreamTestMaxMemStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<StreamTestMaxMemStreamIdxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestMaxMemStreamIdxColumnValue.hydrateValue(result.getValue());
+                return StreamTestMaxMemStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>> getRowsColumnRange(Iterable<StreamTestMaxMemStreamIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            StreamTestMaxMemStreamIdxRow row = StreamTestMaxMemStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            Long val = StreamTestMaxMemStreamIdxColumnValue.hydrateValue(e.getValue());
+            StreamTestMaxMemStreamIdxColumnValue colValue = StreamTestMaxMemStreamIdxColumnValue.of(col, val);
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<StreamTestMaxMemStreamIdxRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<StreamTestMaxMemStreamIdxRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, StreamTestMaxMemStreamIdxRowResult>() {
+            @Override
+            public StreamTestMaxMemStreamIdxRowResult apply(RowResult<byte[]> input) {
+                return StreamTestMaxMemStreamIdxRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AsyncProxy}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutableExpiringTable}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutableExpiringTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedExpiringSet}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link ExecutorService}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "HTDDCKZJoVbnP2nQipqeHA==";
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -1,0 +1,747 @@
+package com.palantir.atlasdb.schema.stream.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedExpiringSet;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.common.proxy.AsyncProxy;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+public final class StreamTestMaxMemStreamMetadataTable implements
+        AtlasDbMutablePersistentTable<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow,
+                                         StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataNamedColumnValue<?>,
+                                         StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRowResult>,
+        AtlasDbNamedMutableTable<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow,
+                                    StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataNamedColumnValue<?>,
+                                    StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRowResult> {
+    private final Transaction t;
+    private final List<StreamTestMaxMemStreamMetadataTrigger> triggers;
+    private final static String rawTableName = "stream_test_max_mem_stream_metadata";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(StreamTestMaxMemStreamMetadataNamedColumn.values());
+
+    static StreamTestMaxMemStreamMetadataTable of(Transaction t, Namespace namespace) {
+        return new StreamTestMaxMemStreamMetadataTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamMetadataTrigger>of());
+    }
+
+    static StreamTestMaxMemStreamMetadataTable of(Transaction t, Namespace namespace, StreamTestMaxMemStreamMetadataTrigger trigger, StreamTestMaxMemStreamMetadataTrigger... triggers) {
+        return new StreamTestMaxMemStreamMetadataTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamMetadataTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static StreamTestMaxMemStreamMetadataTable of(Transaction t, Namespace namespace, List<StreamTestMaxMemStreamMetadataTrigger> triggers) {
+        return new StreamTestMaxMemStreamMetadataTable(t, namespace, triggers);
+    }
+
+    private StreamTestMaxMemStreamMetadataTable(Transaction t, Namespace namespace, List<StreamTestMaxMemStreamMetadataTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * StreamTestMaxMemStreamMetadataRow {
+     *   {@literal Long id};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestMaxMemStreamMetadataRow implements Persistable, Comparable<StreamTestMaxMemStreamMetadataRow> {
+        private final long id;
+
+        public static StreamTestMaxMemStreamMetadataRow of(long id) {
+            return new StreamTestMaxMemStreamMetadataRow(id);
+        }
+
+        private StreamTestMaxMemStreamMetadataRow(long id) {
+            this.id = id;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public static Function<StreamTestMaxMemStreamMetadataRow, Long> getIdFun() {
+            return new Function<StreamTestMaxMemStreamMetadataRow, Long>() {
+                @Override
+                public Long apply(StreamTestMaxMemStreamMetadataRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<Long, StreamTestMaxMemStreamMetadataRow> fromIdFun() {
+            return new Function<Long, StreamTestMaxMemStreamMetadataRow>() {
+                @Override
+                public StreamTestMaxMemStreamMetadataRow apply(Long row) {
+                    return StreamTestMaxMemStreamMetadataRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = EncodingUtils.encodeUnsignedVarLong(id);
+            return EncodingUtils.add(idBytes);
+        }
+
+        public static final Hydrator<StreamTestMaxMemStreamMetadataRow> BYTES_HYDRATOR = new Hydrator<StreamTestMaxMemStreamMetadataRow>() {
+            @Override
+            public StreamTestMaxMemStreamMetadataRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                return new StreamTestMaxMemStreamMetadataRow(id);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestMaxMemStreamMetadataRow other = (StreamTestMaxMemStreamMetadataRow) obj;
+            return Objects.equal(id, other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(id);
+        }
+
+        @Override
+        public int compareTo(StreamTestMaxMemStreamMetadataRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .result();
+        }
+    }
+
+    public interface StreamTestMaxMemStreamMetadataNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+     *   name: "StreamMetadata"
+     *   field {
+     *     name: "status"
+     *     number: 1
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_ENUM
+     *     type_name: ".com.palantir.atlasdb.protos.generated.Status"
+     *   }
+     *   field {
+     *     name: "length"
+     *     number: 2
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_INT64
+     *   }
+     *   field {
+     *     name: "hash"
+     *     number: 3
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_BYTES
+     *   }
+     * }
+     * </pre>
+     */
+    public static final class Metadata implements StreamTestMaxMemStreamMetadataNamedColumnValue<com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> {
+        private final com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value;
+
+        public static Metadata of(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+            return new Metadata(value);
+        }
+
+        private Metadata(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "metadata";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "md";
+        }
+
+        @Override
+        public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = value.toByteArray();
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("md");
+        }
+
+        public static final Hydrator<Metadata> BYTES_HYDRATOR = new Hydrator<Metadata>() {
+            @Override
+            public Metadata hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                try {
+                    return of(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata.parseFrom(bytes));
+                } catch (InvalidProtocolBufferException e) {
+                    throw Throwables.throwUncheckedException(e);
+                }
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface StreamTestMaxMemStreamMetadataTrigger {
+        public void putStreamTestMaxMemStreamMetadata(Multimap<StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>> newRows);
+    }
+
+    public static final class StreamTestMaxMemStreamMetadataRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static StreamTestMaxMemStreamMetadataRowResult of(RowResult<byte[]> row) {
+            return new StreamTestMaxMemStreamMetadataRowResult(row);
+        }
+
+        private StreamTestMaxMemStreamMetadataRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public StreamTestMaxMemStreamMetadataRow getRowName() {
+            return StreamTestMaxMemStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<StreamTestMaxMemStreamMetadataRowResult, StreamTestMaxMemStreamMetadataRow> getRowNameFun() {
+            return new Function<StreamTestMaxMemStreamMetadataRowResult, StreamTestMaxMemStreamMetadataRow>() {
+                @Override
+                public StreamTestMaxMemStreamMetadataRow apply(StreamTestMaxMemStreamMetadataRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, StreamTestMaxMemStreamMetadataRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, StreamTestMaxMemStreamMetadataRowResult>() {
+                @Override
+                public StreamTestMaxMemStreamMetadataRowResult apply(RowResult<byte[]> rowResult) {
+                    return new StreamTestMaxMemStreamMetadataRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasMetadata() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("md"));
+        }
+
+        public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata getMetadata() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("md"));
+            if (bytes == null) {
+                return null;
+            }
+            Metadata value = Metadata.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<StreamTestMaxMemStreamMetadataRowResult, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> getMetadataFun() {
+            return new Function<StreamTestMaxMemStreamMetadataRowResult, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>() {
+                @Override
+                public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata apply(StreamTestMaxMemStreamMetadataRowResult rowResult) {
+                    return rowResult.getMetadata();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Metadata", getMetadata())
+                .toString();
+        }
+    }
+
+    public enum StreamTestMaxMemStreamMetadataNamedColumn {
+        METADATA {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("md");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<StreamTestMaxMemStreamMetadataNamedColumn, byte[]> toShortName() {
+            return new Function<StreamTestMaxMemStreamMetadataNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(StreamTestMaxMemStreamMetadataNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<StreamTestMaxMemStreamMetadataNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, StreamTestMaxMemStreamMetadataNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(StreamTestMaxMemStreamMetadataNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>>>builder()
+                .put("md", Metadata.BYTES_HYDRATOR)
+                .build();
+
+    public Map<StreamTestMaxMemStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> getMetadatas(Collection<StreamTestMaxMemStreamMetadataRow> rows) {
+        Map<Cell, StreamTestMaxMemStreamMetadataRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (StreamTestMaxMemStreamMetadataRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("md")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<StreamTestMaxMemStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata val = Metadata.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putMetadata(StreamTestMaxMemStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+        put(ImmutableMultimap.of(row, Metadata.of(value)));
+    }
+
+    public void putMetadata(Map<StreamTestMaxMemStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
+        Map<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<StreamTestMaxMemStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
+            toPut.put(e.getKey(), Metadata.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    public void putMetadataUnlessExists(StreamTestMaxMemStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
+    }
+
+    public void putMetadataUnlessExists(Map<StreamTestMaxMemStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
+        Map<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<StreamTestMaxMemStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
+            toPut.put(e.getKey(), Metadata.of(e.getValue()));
+        }
+        putUnlessExists(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (StreamTestMaxMemStreamMetadataTrigger trigger : triggers) {
+            trigger.putStreamTestMaxMemStreamMetadata(rows);
+        }
+    }
+
+    @Override
+    public void putUnlessExists(Multimap<StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>> rows) {
+        Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    public void deleteMetadata(StreamTestMaxMemStreamMetadataRow row) {
+        deleteMetadata(ImmutableSet.of(row));
+    }
+
+    public void deleteMetadata(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("md");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(StreamTestMaxMemStreamMetadataRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public Optional<StreamTestMaxMemStreamMetadataRowResult> getRow(StreamTestMaxMemStreamMetadataRow row) {
+        return getRow(row, allColumns);
+    }
+
+    @Override
+    public Optional<StreamTestMaxMemStreamMetadataRowResult> getRow(StreamTestMaxMemStreamMetadataRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.absent();
+        } else {
+            return Optional.of(StreamTestMaxMemStreamMetadataRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamMetadataRowResult> getRows(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamMetadataRowResult> getRows(Iterable<StreamTestMaxMemStreamMetadataRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<StreamTestMaxMemStreamMetadataRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(StreamTestMaxMemStreamMetadataRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamMetadataRowResult> getAsyncRows(Iterable<StreamTestMaxMemStreamMetadataRow> rows, ExecutorService exec) {
+        return getAsyncRows(rows, allColumns, exec);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamMetadataRowResult> getAsyncRows(final Iterable<StreamTestMaxMemStreamMetadataRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<List<StreamTestMaxMemStreamMetadataRowResult>> c =
+                new Callable<List<StreamTestMaxMemStreamMetadataRowResult>>() {
+            @Override
+            public List<StreamTestMaxMemStreamMetadataRowResult> call() {
+                return getRows(rows, columns);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), List.class);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowColumns(StreamTestMaxMemStreamMetadataRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowColumns(StreamTestMaxMemStreamMetadataRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<StreamTestMaxMemStreamMetadataNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestMaxMemStreamMetadataRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getAsyncRowsMultimap(Iterable<StreamTestMaxMemStreamMetadataRow> rows, ExecutorService exec) {
+        return getAsyncRowsMultimap(rows, allColumns, exec);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getAsyncRowsMultimap(final Iterable<StreamTestMaxMemStreamMetadataRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>>> c =
+                new Callable<Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>>>() {
+            @Override
+            public Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> call() {
+                return getRowsMultimapInternal(rows, columns);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), Multimap.class);
+    }
+
+    private Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestMaxMemStreamMetadataRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            StreamTestMaxMemStreamMetadataRow row = StreamTestMaxMemStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<StreamTestMaxMemStreamMetadataRow, BatchingVisitable<StreamTestMaxMemStreamMetadataNamedColumnValue<?>>> getRowsColumnRange(Iterable<StreamTestMaxMemStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestMaxMemStreamMetadataRow, BatchingVisitable<StreamTestMaxMemStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestMaxMemStreamMetadataRow row = StreamTestMaxMemStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<StreamTestMaxMemStreamMetadataNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>>> getRowsColumnRange(Iterable<StreamTestMaxMemStreamMetadataRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            StreamTestMaxMemStreamMetadataRow row = StreamTestMaxMemStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            StreamTestMaxMemStreamMetadataNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<StreamTestMaxMemStreamMetadataRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<StreamTestMaxMemStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, StreamTestMaxMemStreamMetadataRowResult>() {
+            @Override
+            public StreamTestMaxMemStreamMetadataRowResult apply(RowResult<byte[]> input) {
+                return StreamTestMaxMemStreamMetadataRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AsyncProxy}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutableExpiringTable}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutableExpiringTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedExpiringSet}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link ExecutorService}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "Y8NItHMaLM/2KnItdzyQ7A==";
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
@@ -68,7 +68,7 @@ import net.jpountz.lz4.LZ4BlockInputStream;
 @Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
 public final class StreamTestMaxMemStreamStore extends AbstractPersistentStreamStore {
     public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
-    public static final int IN_MEMORY_THRESHOLD = 2147483647; // streams under this size are kept in memory when loaded
+    public static final int IN_MEMORY_THRESHOLD = 2147483639; // streams under this size are kept in memory when loaded
     public static final String STREAM_FILE_PREFIX = "StreamTestMaxMem_stream_";
     public static final String STREAM_FILE_SUFFIX = ".tmp";
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
@@ -1,0 +1,428 @@
+package com.palantir.atlasdb.schema.stream.generated;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Generated;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.CountingInputStream;
+import com.google.common.primitives.Ints;
+import com.google.protobuf.ByteString;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata.Builder;
+import com.palantir.atlasdb.stream.AbstractPersistentStreamStore;
+import com.palantir.atlasdb.stream.PersistentStreamStore;
+import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.TxTask;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.compression.LZ4CompressingInputStream;
+import com.palantir.common.io.ConcatenatedInputStream;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.ByteArrayIOStream;
+import com.palantir.util.Pair;
+import com.palantir.util.crypto.Sha256Hash;
+import com.palantir.util.file.DeleteOnCloseFileInputStream;
+import com.palantir.util.file.TempFileUtils;
+
+import net.jpountz.lz4.LZ4BlockInputStream;
+
+@Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
+public final class StreamTestMaxMemStreamStore extends AbstractPersistentStreamStore {
+    public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
+    public static final int IN_MEMORY_THRESHOLD = 2147483647; // streams under this size are kept in memory when loaded
+    public static final String STREAM_FILE_PREFIX = "StreamTestMaxMem_stream_";
+    public static final String STREAM_FILE_SUFFIX = ".tmp";
+
+    private static final Logger log = LoggerFactory.getLogger(StreamTestMaxMemStreamStore.class);
+
+    private final StreamTestTableFactory tables;
+
+    private StreamTestMaxMemStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
+        super(txManager);
+        this.tables = tables;
+    }
+
+    public static StreamTestMaxMemStreamStore of(TransactionManager txManager, StreamTestTableFactory tables) {
+        return new StreamTestMaxMemStreamStore(txManager, tables);
+    }
+
+    /**
+     * This should only be used by test code or as a performance optimization.
+     */
+    static StreamTestMaxMemStreamStore of(StreamTestTableFactory tables) {
+        return new StreamTestMaxMemStreamStore(null, tables);
+    }
+
+    @Override
+    protected long getInMemoryThreshold() {
+        return IN_MEMORY_THRESHOLD;
+    }
+
+    @Override
+    protected void storeBlock(Transaction t, long id, long blockNumber, final byte[] block) {
+        Preconditions.checkArgument(block.length <= BLOCK_SIZE_IN_BYTES, "Block to store in DB must be less than BLOCK_SIZE_IN_BYTES");
+        final StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow row = StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow.of(id, blockNumber);
+        try {
+            // Do a touch operation on this table to ensure we get a conflict if someone cleans it up.
+            touchMetadataWhileStoringForConflicts(t, row.getId(), row.getBlockId());
+            tables.getStreamTestMaxMemStreamValueTable(t).putValue(row, block);
+        } catch (RuntimeException e) {
+            log.error("Error storing block {} for stream id {}", row.getBlockId(), row.getId(), e);
+            throw e;
+        }
+    }
+
+    private void touchMetadataWhileStoringForConflicts(Transaction t, Long id, long blockNumber) {
+        StreamTestMaxMemStreamMetadataTable metaTable = tables.getStreamTestMaxMemStreamMetadataTable(t);
+        StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow row = StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of(id);
+        StreamMetadata metadata = metaTable.getMetadatas(ImmutableSet.of(row)).values().iterator().next();
+        Preconditions.checkState(metadata.getStatus() == Status.STORING, "This stream is being cleaned up while storing blocks: " + id);
+        Builder builder = StreamMetadata.newBuilder(metadata);
+        builder.setLength(blockNumber * BLOCK_SIZE_IN_BYTES + 1);
+        metaTable.putMetadata(row, builder.build());
+    }
+
+    @Override
+    protected void putMetadataAndHashIndexTask(Transaction t, Map<Long, StreamMetadata> streamIdsToMetadata) {
+        StreamTestMaxMemStreamMetadataTable mdTable = tables.getStreamTestMaxMemStreamMetadataTable(t);
+        Map<Long, StreamMetadata> prevMetadatas = getMetadata(t, streamIdsToMetadata.keySet());
+
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> rowsToStoredMetadata = Maps.newHashMap();
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> rowsToUnstoredMetadata = Maps.newHashMap();
+        for (Entry<Long, StreamMetadata> e : streamIdsToMetadata.entrySet()) {
+            long streamId = e.getKey();
+            StreamMetadata metadata = e.getValue();
+            StreamMetadata prevMetadata = prevMetadatas.get(streamId);
+            if (metadata.getStatus() == Status.STORED) {
+                if (prevMetadata == null || prevMetadata.getStatus() != Status.STORING) {
+                    // This can happen if we cleanup old streams.
+                    throw new TransactionFailedRetriableException("Cannot mark a stream as stored that isn't currently storing: " + prevMetadata);
+                }
+                rowsToStoredMetadata.put(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of(streamId), metadata);
+            } else if (metadata.getStatus() == Status.STORING) {
+                // This will prevent two users trying to store the same id.
+                if (prevMetadata != null) {
+                    throw new TransactionFailedRetriableException("Cannot reuse the same stream id: " + streamId);
+                }
+                rowsToUnstoredMetadata.put(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of(streamId), metadata);
+            }
+        }
+        putHashIndexTask(t, rowsToStoredMetadata);
+
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> rowsToMetadata = Maps.newHashMap();
+        rowsToMetadata.putAll(rowsToStoredMetadata);
+        rowsToMetadata.putAll(rowsToUnstoredMetadata);
+        mdTable.putMetadata(rowsToMetadata);
+    }
+
+    private long getNumberOfBlocksFromMetadata(StreamMetadata metadata) {
+        return (metadata.getLength() + BLOCK_SIZE_IN_BYTES - 1) / BLOCK_SIZE_IN_BYTES;
+    }
+
+    @Override
+    protected File createTempFile(Long id) throws IOException {
+        File file = TempFileUtils.createTempFile(STREAM_FILE_PREFIX + id, STREAM_FILE_SUFFIX);
+        file.deleteOnExit();
+        return file;
+    }
+
+    @Override
+    protected void loadSingleBlockToOutputStream(Transaction t, Long streamId, long blockId, OutputStream os) {
+        StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow row = StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow.of(streamId, blockId);
+        try {
+            os.write(getBlock(t, row));
+        } catch (RuntimeException e) {
+            log.error("Error storing block {} for stream id {}", row.getBlockId(), row.getId(), e);
+            throw e;
+        } catch (IOException e) {
+            log.error("Error writing block {} to file when getting stream id {}", row.getBlockId(), row.getId(), e);
+            throw Throwables.rewrapAndThrowUncheckedException("Error writing blocks to file when creating stream.", e);
+        }
+    }
+
+    private byte[] getBlock(Transaction t, StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow row) {
+        StreamTestMaxMemStreamValueTable valueTable = tables.getStreamTestMaxMemStreamValueTable(t);
+        return valueTable.getValues(ImmutableSet.of(row)).get(row);
+    }
+
+    @Override
+    protected Map<Long, StreamMetadata> getMetadata(Transaction t, Set<Long> streamIds) {
+        if (streamIds.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        StreamTestMaxMemStreamMetadataTable table = tables.getStreamTestMaxMemStreamMetadataTable(t);
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(getMetadataRowsForIds(streamIds));
+        Map<Long, StreamMetadata> ret = Maps.newHashMap();
+        for (Map.Entry<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            ret.put(e.getKey().getId(), e.getValue());
+        }
+        return ret;
+    }
+
+    @Override
+    public Map<Sha256Hash, Long> lookupStreamIdsByHash(Transaction t, final Set<Sha256Hash> hashes) {
+        if (hashes.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        StreamTestMaxMemStreamHashAidxTable idx = tables.getStreamTestMaxMemStreamHashAidxTable(t);
+        Set<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow> rows = getHashIndexRowsForHashes(hashes);
+
+        Multimap<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue> m = idx.getRowsMultimap(rows);
+        Map<Long, Sha256Hash> hashForStreams = Maps.newHashMap();
+        for (StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow r : m.keySet()) {
+            for (StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue v : m.get(r)) {
+                Long streamId = v.getColumnName().getStreamId();
+                Sha256Hash hash = r.getHash();
+                if (hashForStreams.containsKey(streamId)) {
+                    AssertUtils.assertAndLog(hashForStreams.get(streamId).equals(hash), "(BUG) Stream ID has 2 different hashes: " + streamId);
+                }
+                hashForStreams.put(streamId, hash);
+            }
+        }
+        Map<Long, StreamMetadata> metadata = getMetadata(t, hashForStreams.keySet());
+
+        Map<Sha256Hash, Long> ret = Maps.newHashMap();
+        for (Map.Entry<Long, StreamMetadata> e : metadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                continue;
+            }
+            Sha256Hash hash = hashForStreams.get(e.getKey());
+            ret.put(hash, e.getKey());
+        }
+
+        return ret;
+    }
+
+    private Set<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow> getHashIndexRowsForHashes(final Set<Sha256Hash> hashes) {
+        Set<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow> rows = Sets.newHashSet();
+        for (Sha256Hash h : hashes) {
+            rows.add(StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow.of(h));
+        }
+        return rows;
+    }
+
+    private Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> getMetadataRowsForIds(final Iterable<Long> ids) {
+        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rows = Sets.newHashSet();
+        for (Long id : ids) {
+            rows.add(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of(id));
+        }
+        return rows;
+    }
+
+    private void putHashIndexTask(Transaction t, Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> rowsToMetadata) {
+        Multimap<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue> indexMap = HashMultimap.create();
+        for (Entry<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> e : rowsToMetadata.entrySet()) {
+            StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow row = e.getKey();
+            StreamMetadata metadata = e.getValue();
+            Preconditions.checkArgument(
+                    metadata.getStatus() == Status.STORED,
+                    "Should only index successfully stored streams.");
+
+            Sha256Hash hash = Sha256Hash.EMPTY;
+            if (metadata.getHash() != com.google.protobuf.ByteString.EMPTY) {
+                hash = new Sha256Hash(metadata.getHash().toByteArray());
+            }
+            StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow hashRow = StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow.of(hash);
+            StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumn column = StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumn.of(row.getId());
+            StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue columnValue = StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue.of(column, 0L);
+            indexMap.put(hashRow, columnValue);
+        }
+        StreamTestMaxMemStreamHashAidxTable hiTable = tables.getStreamTestMaxMemStreamHashAidxTable(t);
+        hiTable.put(indexMap);
+    }
+
+    /**
+     * This should only be used from the cleanup tasks.
+     */
+    void deleteStreams(Transaction t, final Set<Long> streamIds) {
+        if (streamIds.isEmpty()) {
+            return;
+        }
+        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> smRows = Sets.newHashSet();
+        Multimap<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumn> shToDelete = HashMultimap.create();
+        for (Long streamId : streamIds) {
+            smRows.add(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of(streamId));
+        }
+        StreamTestMaxMemStreamMetadataTable table = tables.getStreamTestMaxMemStreamMetadataTable(t);
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(smRows);
+        Set<StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow> streamValueToDelete = Sets.newHashSet();
+        for (Entry<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            Long streamId = e.getKey().getId();
+            long blocks = getNumberOfBlocksFromMetadata(e.getValue());
+            for (long i = 0; i < blocks; i++) {
+                streamValueToDelete.add(StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow.of(streamId, i));
+            }
+            ByteString streamHash = e.getValue().getHash();
+            Sha256Hash hash = Sha256Hash.EMPTY;
+            if (streamHash != com.google.protobuf.ByteString.EMPTY) {
+                hash = new Sha256Hash(streamHash.toByteArray());
+            } else {
+                log.error("Empty hash for stream {}", streamId);
+            }
+            StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow hashRow = StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow.of(hash);
+            StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumn column = StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumn.of(streamId);
+            shToDelete.put(hashRow, column);
+        }
+        tables.getStreamTestMaxMemStreamHashAidxTable(t).delete(shToDelete);
+        tables.getStreamTestMaxMemStreamValueTable(t).delete(streamValueToDelete);
+        table.delete(smRows);
+    }
+
+    @Override
+    protected void markStreamsAsUsedInternal(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
+        if (streamIdsToReference.isEmpty()) {
+            return;
+        }
+        StreamTestMaxMemStreamIdxTable index = tables.getStreamTestMaxMemStreamIdxTable(t);
+        Multimap<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue> rowsToValues = HashMultimap.create();
+        for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
+            Long streamId = entry.getKey();
+            byte[] reference = entry.getValue();
+            StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumn.of(reference);
+            StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue value = StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue.of(col, 0L);
+            rowsToValues.put(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow.of(streamId), value);
+        }
+        index.put(rowsToValues);
+    }
+
+    @Override
+    public void unmarkStreamsAsUsed(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
+        if (streamIdsToReference.isEmpty()) {
+            return;
+        }
+        StreamTestMaxMemStreamIdxTable index = tables.getStreamTestMaxMemStreamIdxTable(t);
+        Multimap<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumn> toDelete = ArrayListMultimap.create(streamIdsToReference.size(), 1);
+        for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
+            Long streamId = entry.getKey();
+            byte[] reference = entry.getValue();
+            StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumn col = StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumn.of(reference);
+            toDelete.put(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow.of(streamId), col);
+        }
+        index.delete(toDelete);
+    }
+
+    @Override
+    protected void touchMetadataWhileMarkingUsedForConflicts(Transaction t, Iterable<Long> ids) {
+        StreamTestMaxMemStreamMetadataTable metaTable = tables.getStreamTestMaxMemStreamMetadataTable(t);
+        Set<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rows = Sets.newHashSet();
+        for (Long id : ids) {
+            rows.add(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of(id));
+        }
+        Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> metadatas = metaTable.getMetadatas(rows);
+        for (Map.Entry<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            StreamMetadata metadata = e.getValue();
+            Preconditions.checkState(metadata.getStatus() == Status.STORED,
+            "Stream: " + e.getKey().getId() + " has status: " + metadata.getStatus());
+            metaTable.putMetadata(e.getKey(), metadata);
+        }
+        SetView<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> missingRows = Sets.difference(rows, metadatas.keySet());
+        if (!missingRows.isEmpty()) {
+            throw new IllegalStateException("Missing metadata rows for:" + missingRows
+            + " rows: " + rows + " metadata: " + metadatas + " txn timestamp: " + t.getTimestamp());
+        }
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbstractPersistentStreamStore}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link BufferedInputStream}
+     * {@link Builder}
+     * {@link ByteArrayIOStream}
+     * {@link ByteArrayInputStream}
+     * {@link ByteStreams}
+     * {@link ByteString}
+     * {@link Cell}
+     * {@link CheckForNull}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ConcatenatedInputStream}
+     * {@link CountingInputStream}
+     * {@link DeleteOnCloseFileInputStream}
+     * {@link DigestInputStream}
+     * {@link Entry}
+     * {@link File}
+     * {@link FileNotFoundException}
+     * {@link FileOutputStream}
+     * {@link Functions}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link IOException}
+     * {@link ImmutableMap}
+     * {@link ImmutableSet}
+     * {@link InputStream}
+     * {@link Ints}
+     * {@link LZ4BlockInputStream}
+     * {@link LZ4CompressingInputStream}
+     * {@link List}
+     * {@link Lists}
+     * {@link Logger}
+     * {@link LoggerFactory}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MessageDigest}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link OutputStream}
+     * {@link Pair}
+     * {@link PersistentStreamStore}
+     * {@link Preconditions}
+     * {@link Set}
+     * {@link SetView}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link Status}
+     * {@link StreamCleanedException}
+     * {@link StreamMetadata}
+     * {@link TempFileUtils}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TransactionFailedRetriableException}
+     * {@link TransactionManager}
+     * {@link TransactionTask}
+     * {@link TxTask}
+     */
+    static final int dummy = 0;
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -1,0 +1,735 @@
+package com.palantir.atlasdb.schema.stream.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedExpiringSet;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.common.proxy.AsyncProxy;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+public final class StreamTestMaxMemStreamValueTable implements
+        AtlasDbMutablePersistentTable<StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow,
+                                         StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueNamedColumnValue<?>,
+                                         StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRowResult>,
+        AtlasDbNamedMutableTable<StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow,
+                                    StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueNamedColumnValue<?>,
+                                    StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRowResult> {
+    private final Transaction t;
+    private final List<StreamTestMaxMemStreamValueTrigger> triggers;
+    private final static String rawTableName = "stream_test_max_mem_stream_value";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(StreamTestMaxMemStreamValueNamedColumn.values());
+
+    static StreamTestMaxMemStreamValueTable of(Transaction t, Namespace namespace) {
+        return new StreamTestMaxMemStreamValueTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamValueTrigger>of());
+    }
+
+    static StreamTestMaxMemStreamValueTable of(Transaction t, Namespace namespace, StreamTestMaxMemStreamValueTrigger trigger, StreamTestMaxMemStreamValueTrigger... triggers) {
+        return new StreamTestMaxMemStreamValueTable(t, namespace, ImmutableList.<StreamTestMaxMemStreamValueTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static StreamTestMaxMemStreamValueTable of(Transaction t, Namespace namespace, List<StreamTestMaxMemStreamValueTrigger> triggers) {
+        return new StreamTestMaxMemStreamValueTable(t, namespace, triggers);
+    }
+
+    private StreamTestMaxMemStreamValueTable(Transaction t, Namespace namespace, List<StreamTestMaxMemStreamValueTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * StreamTestMaxMemStreamValueRow {
+     *   {@literal Long id};
+     *   {@literal Long blockId};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestMaxMemStreamValueRow implements Persistable, Comparable<StreamTestMaxMemStreamValueRow> {
+        private final long id;
+        private final long blockId;
+
+        public static StreamTestMaxMemStreamValueRow of(long id, long blockId) {
+            return new StreamTestMaxMemStreamValueRow(id, blockId);
+        }
+
+        private StreamTestMaxMemStreamValueRow(long id, long blockId) {
+            this.id = id;
+            this.blockId = blockId;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public long getBlockId() {
+            return blockId;
+        }
+
+        public static Function<StreamTestMaxMemStreamValueRow, Long> getIdFun() {
+            return new Function<StreamTestMaxMemStreamValueRow, Long>() {
+                @Override
+                public Long apply(StreamTestMaxMemStreamValueRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<StreamTestMaxMemStreamValueRow, Long> getBlockIdFun() {
+            return new Function<StreamTestMaxMemStreamValueRow, Long>() {
+                @Override
+                public Long apply(StreamTestMaxMemStreamValueRow row) {
+                    return row.blockId;
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = EncodingUtils.encodeUnsignedVarLong(id);
+            byte[] blockIdBytes = EncodingUtils.encodeUnsignedVarLong(blockId);
+            return EncodingUtils.add(idBytes, blockIdBytes);
+        }
+
+        public static final Hydrator<StreamTestMaxMemStreamValueRow> BYTES_HYDRATOR = new Hydrator<StreamTestMaxMemStreamValueRow>() {
+            @Override
+            public StreamTestMaxMemStreamValueRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                return new StreamTestMaxMemStreamValueRow(id, blockId);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .add("blockId", blockId)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestMaxMemStreamValueRow other = (StreamTestMaxMemStreamValueRow) obj;
+            return Objects.equal(id, other.id) && Objects.equal(blockId, other.blockId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.deepHashCode(new Object[]{ id, blockId });
+        }
+
+        @Override
+        public int compareTo(StreamTestMaxMemStreamValueRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .compare(this.blockId, o.blockId)
+                .result();
+        }
+    }
+
+    public interface StreamTestMaxMemStreamValueNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: byte[];
+     * }
+     * </pre>
+     */
+    public static final class Value implements StreamTestMaxMemStreamValueNamedColumnValue<byte[]> {
+        private final byte[] value;
+
+        public static Value of(byte[] value) {
+            return new Value(value);
+        }
+
+        private Value(byte[] value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "value";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "v";
+        }
+
+        @Override
+        public byte[] getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = value;
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("v");
+        }
+
+        public static final Hydrator<Value> BYTES_HYDRATOR = new Hydrator<Value>() {
+            @Override
+            public Value hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                return of(EncodingUtils.getBytesFromOffsetToEnd(bytes, 0));
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface StreamTestMaxMemStreamValueTrigger {
+        public void putStreamTestMaxMemStreamValue(Multimap<StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueNamedColumnValue<?>> newRows);
+    }
+
+    public static final class StreamTestMaxMemStreamValueRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static StreamTestMaxMemStreamValueRowResult of(RowResult<byte[]> row) {
+            return new StreamTestMaxMemStreamValueRowResult(row);
+        }
+
+        private StreamTestMaxMemStreamValueRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public StreamTestMaxMemStreamValueRow getRowName() {
+            return StreamTestMaxMemStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<StreamTestMaxMemStreamValueRowResult, StreamTestMaxMemStreamValueRow> getRowNameFun() {
+            return new Function<StreamTestMaxMemStreamValueRowResult, StreamTestMaxMemStreamValueRow>() {
+                @Override
+                public StreamTestMaxMemStreamValueRow apply(StreamTestMaxMemStreamValueRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, StreamTestMaxMemStreamValueRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, StreamTestMaxMemStreamValueRowResult>() {
+                @Override
+                public StreamTestMaxMemStreamValueRowResult apply(RowResult<byte[]> rowResult) {
+                    return new StreamTestMaxMemStreamValueRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasValue() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("v"));
+        }
+
+        public byte[] getValue() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("v"));
+            if (bytes == null) {
+                return null;
+            }
+            Value value = Value.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<StreamTestMaxMemStreamValueRowResult, byte[]> getValueFun() {
+            return new Function<StreamTestMaxMemStreamValueRowResult, byte[]>() {
+                @Override
+                public byte[] apply(StreamTestMaxMemStreamValueRowResult rowResult) {
+                    return rowResult.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Value", getValue())
+                .toString();
+        }
+    }
+
+    public enum StreamTestMaxMemStreamValueNamedColumn {
+        VALUE {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("v");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<StreamTestMaxMemStreamValueNamedColumn, byte[]> toShortName() {
+            return new Function<StreamTestMaxMemStreamValueNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(StreamTestMaxMemStreamValueNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<StreamTestMaxMemStreamValueNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, StreamTestMaxMemStreamValueNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(StreamTestMaxMemStreamValueNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends StreamTestMaxMemStreamValueNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends StreamTestMaxMemStreamValueNamedColumnValue<?>>>builder()
+                .put("v", Value.BYTES_HYDRATOR)
+                .build();
+
+    public Map<StreamTestMaxMemStreamValueRow, byte[]> getValues(Collection<StreamTestMaxMemStreamValueRow> rows) {
+        Map<Cell, StreamTestMaxMemStreamValueRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (StreamTestMaxMemStreamValueRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("v")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<StreamTestMaxMemStreamValueRow, byte[]> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            byte[] val = Value.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putValue(StreamTestMaxMemStreamValueRow row, byte[] value) {
+        put(ImmutableMultimap.of(row, Value.of(value)));
+    }
+
+    public void putValue(Map<StreamTestMaxMemStreamValueRow, byte[]> map) {
+        Map<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<StreamTestMaxMemStreamValueRow, byte[]> e : map.entrySet()) {
+            toPut.put(e.getKey(), Value.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    public void putValueUnlessExists(StreamTestMaxMemStreamValueRow row, byte[] value) {
+        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
+    }
+
+    public void putValueUnlessExists(Map<StreamTestMaxMemStreamValueRow, byte[]> map) {
+        Map<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<StreamTestMaxMemStreamValueRow, byte[]> e : map.entrySet()) {
+            toPut.put(e.getKey(), Value.of(e.getValue()));
+        }
+        putUnlessExists(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (StreamTestMaxMemStreamValueTrigger trigger : triggers) {
+            trigger.putStreamTestMaxMemStreamValue(rows);
+        }
+    }
+
+    @Override
+    public void putUnlessExists(Multimap<StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueNamedColumnValue<?>> rows) {
+        Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueNamedColumnValue<?>> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    public void deleteValue(StreamTestMaxMemStreamValueRow row) {
+        deleteValue(ImmutableSet.of(row));
+    }
+
+    public void deleteValue(Iterable<StreamTestMaxMemStreamValueRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("v");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(StreamTestMaxMemStreamValueRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<StreamTestMaxMemStreamValueRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public Optional<StreamTestMaxMemStreamValueRowResult> getRow(StreamTestMaxMemStreamValueRow row) {
+        return getRow(row, allColumns);
+    }
+
+    @Override
+    public Optional<StreamTestMaxMemStreamValueRowResult> getRow(StreamTestMaxMemStreamValueRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.absent();
+        } else {
+            return Optional.of(StreamTestMaxMemStreamValueRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamValueRowResult> getRows(Iterable<StreamTestMaxMemStreamValueRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamValueRowResult> getRows(Iterable<StreamTestMaxMemStreamValueRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<StreamTestMaxMemStreamValueRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(StreamTestMaxMemStreamValueRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamValueRowResult> getAsyncRows(Iterable<StreamTestMaxMemStreamValueRow> rows, ExecutorService exec) {
+        return getAsyncRows(rows, allColumns, exec);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamValueRowResult> getAsyncRows(final Iterable<StreamTestMaxMemStreamValueRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<List<StreamTestMaxMemStreamValueRowResult>> c =
+                new Callable<List<StreamTestMaxMemStreamValueRowResult>>() {
+            @Override
+            public List<StreamTestMaxMemStreamValueRowResult> call() {
+                return getRows(rows, columns);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), List.class);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowColumns(StreamTestMaxMemStreamValueRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowColumns(StreamTestMaxMemStreamValueRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<StreamTestMaxMemStreamValueNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestMaxMemStreamValueRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestMaxMemStreamValueRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getAsyncRowsMultimap(Iterable<StreamTestMaxMemStreamValueRow> rows, ExecutorService exec) {
+        return getAsyncRowsMultimap(rows, allColumns, exec);
+    }
+
+    @Override
+    public Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getAsyncRowsMultimap(final Iterable<StreamTestMaxMemStreamValueRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>>> c =
+                new Callable<Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>>>() {
+            @Override
+            public Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> call() {
+                return getRowsMultimapInternal(rows, columns);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), Multimap.class);
+    }
+
+    private Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestMaxMemStreamValueRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            StreamTestMaxMemStreamValueRow row = StreamTestMaxMemStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<StreamTestMaxMemStreamValueRow, BatchingVisitable<StreamTestMaxMemStreamValueNamedColumnValue<?>>> getRowsColumnRange(Iterable<StreamTestMaxMemStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestMaxMemStreamValueRow, BatchingVisitable<StreamTestMaxMemStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestMaxMemStreamValueRow row = StreamTestMaxMemStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<StreamTestMaxMemStreamValueNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>>> getRowsColumnRange(Iterable<StreamTestMaxMemStreamValueRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            StreamTestMaxMemStreamValueRow row = StreamTestMaxMemStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            StreamTestMaxMemStreamValueNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<StreamTestMaxMemStreamValueRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<StreamTestMaxMemStreamValueRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, StreamTestMaxMemStreamValueRowResult>() {
+            @Override
+            public StreamTestMaxMemStreamValueRowResult apply(RowResult<byte[]> input) {
+                return StreamTestMaxMemStreamValueRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AsyncProxy}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutableExpiringTable}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutableExpiringTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedExpiringSet}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link ExecutorService}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "2j377xCs8IEMzZtkvEqrKw==";
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestTableFactory.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestTableFactory.java
@@ -42,6 +42,22 @@ public final class StreamTestTableFactory {
         return KeyValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
+    public StreamTestMaxMemStreamHashAidxTable getStreamTestMaxMemStreamHashAidxTable(Transaction t, StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxTrigger... triggers) {
+        return StreamTestMaxMemStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public StreamTestMaxMemStreamIdxTable getStreamTestMaxMemStreamIdxTable(Transaction t, StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxTrigger... triggers) {
+        return StreamTestMaxMemStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public StreamTestMaxMemStreamMetadataTable getStreamTestMaxMemStreamMetadataTable(Transaction t, StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataTrigger... triggers) {
+        return StreamTestMaxMemStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public StreamTestMaxMemStreamValueTable getStreamTestMaxMemStreamValueTable(Transaction t, StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueTrigger... triggers) {
+        return StreamTestMaxMemStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
     public StreamTestStreamHashAidxTable getStreamTestStreamHashAidxTable(Transaction t, StreamTestStreamHashAidxTable.StreamTestStreamHashAidxTrigger... triggers) {
         return StreamTestStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
@@ -76,6 +92,10 @@ public final class StreamTestTableFactory {
 
     public interface SharedTriggers extends
             KeyValueTable.KeyValueTrigger,
+            StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxTrigger,
+            StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxTrigger,
+            StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataTrigger,
+            StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueTrigger,
             StreamTestStreamHashAidxTable.StreamTestStreamHashAidxTrigger,
             StreamTestStreamIdxTable.StreamTestStreamIdxTrigger,
             StreamTestStreamMetadataTable.StreamTestStreamMetadataTrigger,
@@ -90,6 +110,26 @@ public final class StreamTestTableFactory {
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
         public void putKeyValue(Multimap<KeyValueTable.KeyValueRow, ? extends KeyValueTable.KeyValueNamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putStreamTestMaxMemStreamHashAidx(Multimap<StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxRow, ? extends StreamTestMaxMemStreamHashAidxTable.StreamTestMaxMemStreamHashAidxColumnValue> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putStreamTestMaxMemStreamIdx(Multimap<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, ? extends StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putStreamTestMaxMemStreamMetadata(Multimap<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataNamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putStreamTestMaxMemStreamValue(Multimap<StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueTable.StreamTestMaxMemStreamValueNamedColumnValue<?>> newRows) {
             // do nothing
         }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -32,7 +32,27 @@ Changelog
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
-develop
+v0.27.2
+=======
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |fixed|
+         - Fixed an issue with ``StreamStore.loadStream``'s underlying ``BlockGetter`` where, for non-default block size and in-memory thresholds,
+           we would incorrectly throw an exception instead of allowing the stream to be created.
+           This caused an issue when the in-memory threshold was many times larger than the default (47MB for the default block size),
+           or when the block size was many times smaller (7KB for the default in-memory threshold).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1422>`__)
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
+v0.27.0
 =======
 
 .. list-table::
@@ -67,7 +87,7 @@ develop
 
     *    - |new|
          - AtlasDB now supports stream store compression.
-           Streams can be compressed client-side by adding the ``compressStreamInClient`` option to the stream 
+           Streams can be compressed client-side by adding the ``compressStreamInClient`` option to the stream
            definition. Reads from the stream store will transparently decompress the data.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1357>`__)
 


### PR DESCRIPTION
This fixes several issues with the current StreamStore implementation.

The implementation on the BlockGetter was inconsistent in how it used
expectedLength(). In some places it assumed it was the size of a single
block, and in others it assumed it was the maximum memory size for the
stream buffer. I have renamed this to expectedBlockLength and made the
usage consistent to be just the block size (and also match the javadoc).

The BlockConsumingInputStream was always allocating a buffer with a size
of the maximum number of blocks allowed in memory rather than the size
corresponding to the actual number of blocks that were going to be
loaded.

Added StreamTests that actually test the case where the
inMemoryThreshold is Integer.MAX_VALUE (as it is in some product code).
These tests fail without the corresponding fixes mentioned above.

[no release notes]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1422)
<!-- Reviewable:end -->
