### PR TITLE
Feature/timelock client config

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
@@ -140,8 +140,8 @@ public final class AtlasDbConfigs {
         //noinspection ConstantConditions - function returns an existing ServerListConfig, maybe with different SSL.
         return config.transform(clientConfig -> ImmutableTimeLockClientConfig.builder()
                 .from(clientConfig)
-                .servers(addSslConfigurationToServerListFunction(sslConfiguration)
-                        .apply(clientConfig.servers()))
+                .serversList(addSslConfigurationToServerListFunction(sslConfiguration)
+                        .apply(clientConfig.serversList()))
                 .build());
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
@@ -28,4 +28,3 @@ public abstract class TimeLockClientConfig {
 
     public abstract ServerListConfig serversList();
 }
-

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.config;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize(as = ImmutableTimeLockClientConfig.class)
+@JsonDeserialize(as = ImmutableTimeLockClientConfig.class)
+@Value.Immutable
+public abstract class TimeLockClientConfig {
+    public abstract String client();
+
+    public abstract ServerListConfig servers();
+}
+

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
@@ -26,6 +26,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public abstract class TimeLockClientConfig {
     public abstract String client();
 
-    public abstract ServerListConfig servers();
+    public abstract ServerListConfig serversList();
 }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -17,11 +17,13 @@ package com.palantir.atlasdb.factory;
 
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLSocketFactory;
 
 import org.immutables.value.Value;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
@@ -32,8 +34,10 @@ import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.ServerListConfig;
+import com.palantir.atlasdb.config.TimeLockClientConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.NamespacedKeyValueServices;
@@ -231,9 +235,36 @@ public final class TransactionManagers {
             return createRawLeaderServices(config.leader().get(), env, lock, time);
         } else if (config.timestamp().isPresent() && config.lock().isPresent()) {
             return createRawRemoteServices(config);
+        } else if (config.timelock().isPresent()) {
+            return createNamespacedRawRemoteServices(config.timelock().get());
         } else {
             return createRawEmbeddedServices(env, lock, time);
         }
+    }
+
+    private static LockAndTimestampServices createNamespacedRawRemoteServices(TimeLockClientConfig config) {
+        ServerListConfig namespacedServerListConfig = getNamespacedServerListConfig(config);
+        return getLockAndTimestampServices(namespacedServerListConfig);
+    }
+
+    @VisibleForTesting
+    static ServerListConfig getNamespacedServerListConfig(TimeLockClientConfig config) {
+        return ImmutableServerListConfig.copyOf(config.serversList())
+                .withServers(config.serversList()
+                        .servers()
+                        .stream()
+                        .map(serverAddress -> serverAddress.replaceAll("/$", "") + "/" + config.client())
+                        .collect(Collectors.toSet()));
+    }
+
+    private static LockAndTimestampServices getLockAndTimestampServices(ServerListConfig timelockServerListConfig) {
+        RemoteLockService lockService = new ServiceCreator<>(RemoteLockService.class).apply(timelockServerListConfig);
+        TimestampService timeService = new ServiceCreator<>(TimestampService.class).apply(timelockServerListConfig);
+
+        return ImmutableLockAndTimestampServices.builder()
+                .lock(lockService)
+                .time(timeService)
+                .build();
     }
 
     private static LockAndTimestampServices createRawLeaderServices(

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -37,7 +37,7 @@ public class AtlasDbConfigTest {
     private static final ServerListConfig DEFAULT_SERVER_LIST = ImmutableServerListConfig.builder()
             .addServers("server")
             .build();
-    public static final ImmutableTimeLockClientConfig TIMELOCK_CONFIG = ImmutableTimeLockClientConfig.builder()
+    public static final TimeLockClientConfig TIMELOCK_CONFIG = ImmutableTimeLockClientConfig.builder()
             .client("testClient")
             .servers(DEFAULT_SERVER_LIST)
             .build();

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -164,6 +164,16 @@ public class AtlasDbConfigTest {
     }
 
     @Test
+    public void addingFallbackSslAddsItToTimelockServersBlock() {
+        AtlasDbConfig withoutSsl = ImmutableAtlasDbConfig.builder()
+                .keyValueService(KVS_CONFIG)
+                .timelock(TIMELOCK_CONFIG)
+                .build();
+        AtlasDbConfig withSsl = AtlasDbConfigs.addFallbackSslConfigurationToAtlasDbConfig(withoutSsl, SSL_CONFIG);
+        assertThat(withSsl.timelock().get().servers().sslConfiguration(), is(SSL_CONFIG));
+    }
+
+    @Test
     public void addingFallbackSslAddsItToTimestampBlock() {
         AtlasDbConfig withoutSsl = ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG)

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -37,6 +37,10 @@ public class AtlasDbConfigTest {
     private static final ServerListConfig DEFAULT_SERVER_LIST = ImmutableServerListConfig.builder()
             .addServers("server")
             .build();
+    public static final ImmutableTimeLockClientConfig TIMELOCK_CONFIG = ImmutableTimeLockClientConfig.builder()
+            .client("testClient")
+            .servers(DEFAULT_SERVER_LIST)
+            .build();
     private static final Optional<SslConfiguration> SSL_CONFIG = Optional.of(mock(SslConfiguration.class));
     private static final Optional<SslConfiguration> OTHER_SSL_CONFIG = Optional.of(mock(SslConfiguration.class));
     private static final Optional<SslConfiguration> NO_SSL_CONFIG = Optional.absent();
@@ -80,6 +84,27 @@ public class AtlasDbConfigTest {
                 .leader(LEADER_CONFIG)
                 .lock(DEFAULT_SERVER_LIST)
                 .timestamp(DEFAULT_SERVER_LIST)
+                .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void timelockBlockNotPermittedWithLockAndTimestampBlocks() {
+        ImmutableAtlasDbConfig.builder()
+                .keyValueService(KVS_CONFIG)
+                .timelock(ImmutableTimeLockClientConfig.builder()
+                        .client("testClient")
+                        .servers(DEFAULT_SERVER_LIST).build())
+                .lock(DEFAULT_SERVER_LIST)
+                .timestamp(DEFAULT_SERVER_LIST)
+                .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void timelockBlockNotPermittedWithLeaderBlock() {
+        ImmutableAtlasDbConfig.builder()
+                .keyValueService(KVS_CONFIG)
+                .timelock(TIMELOCK_CONFIG)
+                .leader(LEADER_CONFIG)
                 .build();
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -39,7 +39,7 @@ public class AtlasDbConfigTest {
             .build();
     public static final TimeLockClientConfig TIMELOCK_CONFIG = ImmutableTimeLockClientConfig.builder()
             .client("testClient")
-            .servers(DEFAULT_SERVER_LIST)
+            .serversList(DEFAULT_SERVER_LIST)
             .build();
     private static final Optional<SslConfiguration> SSL_CONFIG = Optional.of(mock(SslConfiguration.class));
     private static final Optional<SslConfiguration> OTHER_SSL_CONFIG = Optional.of(mock(SslConfiguration.class));
@@ -93,7 +93,7 @@ public class AtlasDbConfigTest {
                 .keyValueService(KVS_CONFIG)
                 .timelock(ImmutableTimeLockClientConfig.builder()
                         .client("testClient")
-                        .servers(DEFAULT_SERVER_LIST).build())
+                        .serversList(DEFAULT_SERVER_LIST).build())
                 .lock(DEFAULT_SERVER_LIST)
                 .timestamp(DEFAULT_SERVER_LIST)
                 .build();
@@ -170,7 +170,7 @@ public class AtlasDbConfigTest {
                 .timelock(TIMELOCK_CONFIG)
                 .build();
         AtlasDbConfig withSsl = AtlasDbConfigs.addFallbackSslConfigurationToAtlasDbConfig(withoutSsl, SSL_CONFIG);
-        assertThat(withSsl.timelock().get().servers().sslConfiguration(), is(SSL_CONFIG));
+        assertThat(withSsl.timelock().get().serversList().sslConfiguration(), is(SSL_CONFIG));
     }
 
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -68,6 +68,14 @@ public class AtlasDbConfigTest {
     }
 
     @Test
+    public void configWithTimelockBlockIsValid() {
+        AtlasDbConfig config = ImmutableAtlasDbConfig.builder()
+                .keyValueService(KVS_CONFIG)
+                .timelock(TIMELOCK_CONFIG)
+                .build();
+        assertThat(config, not(nullValue()));
+    }
+    @Test
     public void remoteLockAndTimestampConfigIsValid() {
         AtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG)

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -75,6 +75,7 @@ public class AtlasDbConfigTest {
                 .build();
         assertThat(config, not(nullValue()));
     }
+
     @Test
     public void remoteLockAndTimestampConfigIsValid() {
         AtlasDbConfig config = ImmutableAtlasDbConfig.builder()

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.factory;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.config.ImmutableServerListConfig;
+import com.palantir.atlasdb.config.ImmutableTimeLockClientConfig;
+import com.palantir.atlasdb.config.ServerListConfig;
+import com.palantir.atlasdb.config.TimeLockClientConfig;
+
+public class TransactionManagersTest {
+    private static final String CLIENT = "testClient";
+    private static final String SERVER_1 = "http://localhost:8080";
+    private static final String SERVER_2 = "http://palantir.com:8080";
+
+    private static final TimeLockClientConfig CLIENT_CONFIG = ImmutableTimeLockClientConfig.builder()
+            .client(CLIENT)
+            .serversList(ImmutableServerListConfig.builder()
+                    .addServers(SERVER_1, SERVER_2)
+                    .build())
+            .build();
+
+    @Test
+    public void canGetNamespacedConfigsFromTimelockBlock() {
+        ServerListConfig namespacedConfig = TransactionManagers.getNamespacedServerListConfig(CLIENT_CONFIG);
+        assertThat(namespacedConfig.servers(), hasItems(SERVER_1 + "/" + CLIENT, SERVER_2 + "/" + CLIENT));
+    }
+}

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -12,6 +12,7 @@ Configuration
    cassandra_config
    enabling_cassandra_tracing
    leader_config
+   timelock_config
    logging
 
 The AtlasDB configuration has two main parts - keyValueService and leader.

--- a/docs/source/configuration/timelock_config.rst
+++ b/docs/source/configuration/timelock_config.rst
@@ -1,0 +1,82 @@
+.. _timelock-config:
+
+======================
+Timelock Configuration
+======================
+
+Overview
+========
+
+The timelock block is where you specify configurations related to the timelock server of your AtlasDB clients.
+If your product uses the timelock server, you should specify the timelock block. The leader block and the timestamp/lock
+blocks must be absent from the config.
+
+Timelock
+========
+
+Required parameters:
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Property
+         - Description
+
+    *    - client
+         - The name of your client, generally the same as your application name.
+
+    *    - serversList::servers
+         - A list of all hosts. The hosts must be specified as addresses i.e. ``host:port``.
+
+Optional parameters:
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Property
+         - Description
+
+    *    - serversList::sslConfiguration
+         - The SSL configuration of the service.
+
+.. _timelock-config-examples:
+
+Timelock Configuration Examples
+===============================
+
+Here is an example of an AtlasDB configuration with the  timelock block.
+
+You must ensure that you have migrated to the timelock server before adding a timelock block to the config.
+
+.. code-block:: yaml
+
+    atlasdb:
+      keyValueService:
+        type: cassandra
+        servers:
+          - cassandra:9160
+        poolSize: 20
+        keyspace: yourapp
+        credentials:
+          username: cassandra
+          password: cassandra
+        sslConfiguration:
+          trustStorePath: var/security/truststore.jks
+        replicationFactor: 1
+        mutationBatchCount: 10000
+        mutationBatchSizeBytes: 10000000
+        fetchBatchCount: 1000
+        safetyDisabled: false
+        autoRefreshNodes: false
+
+      timelock:
+        client: yourapp
+        serversList:
+          servers:
+            - "host1:3828"
+            - "host2:3828"
+            - "host3:3828"
+          sslConfiguration:
+            trustStorePath: var/security/truststore.jks


### PR DESCRIPTION
This PR adds an optional timelock block to the atlasdb config for clients and exposes the appropriate endpoints for timestamp and lock services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1427)
<!-- Reviewable:end -->
