### PR TITLE
link the cassandra config docs to CassandraKeyValueServiceConfig.java

### DIFF
--- a/docs/source/configuration/key_value_service_configs/cassandra_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/cassandra_key_value_service_config.rst
@@ -26,6 +26,8 @@ Configuring a Running Application to Use Cassandra
 
 An example AtlasDB configuration for running against cassandra will look like the below.
 
+For a complete list and description of the below parameters, see `CassandraKeyValueServiceConfig.java <https://github.com/palantir/atlasdb/blob/develop/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java>`__.
+
 Importantly - your lock creator must be consistent across all nodes. If you do not provide a lock creator, it will default to the first host
 in the leaders list. If you do not specify a lock creator, the leaders block should be exactly the same across all nodes.
 


### PR DESCRIPTION
Per #1423, not all Cassandra KVS configs are documented and it's not clear on where to go for the source of truth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1428)
<!-- Reviewable:end -->
