### PR TITLE
expose way to clear the timestamp cache

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -120,4 +120,10 @@ public interface TransactionManager extends AutoCloseable {
      * @throws IllegalStateException if the transaction manager has been closed.
      */
     long getUnreadableTimestamp();
+
+    /**
+     * Clear the timestamp cache. This is mostly useful for tests that perform operations that would invalidate
+     * the cache, although this can also be used to free up some memory.
+     */
+    void clearTimestampCache();
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
@@ -45,4 +45,11 @@ public class TimestampCache {
     public void putAlreadyCommittedTransaction(Long startTimestamp, Long commitTimestamp) {
         timestampCache.put(startTimestamp, commitTimestamp);
     }
+
+    /**
+     * Clear all values from the cache.
+     */
+    public void clear() {
+        timestampCache.invalidateAll();
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -97,4 +97,9 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     protected void checkOpen() {
         Preconditions.checkState(!this.closed, "Operations cannot be performed on closed TransactionManager.");
     }
+
+    @Override
+    public void clearTimestampCache() {
+        timestampValidationReadCache.clear();
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManager.java
@@ -53,6 +53,11 @@ public abstract class ForwardingTransactionManager extends ForwardingObject impl
     }
 
     @Override
+    public void clearTimestampCache() {
+        delegate().clearTimestampCache();
+    }
+
+    @Override
     public void close() throws Exception {
         delegate().close();
     }


### PR DESCRIPTION
Some internal tests perform operations that would invalidate the timestamp cache. This feature would be the easiest way for us to bump to 0.27.x internally and have tests work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1434)
<!-- Reviewable:end -->
