### PR TITLE
Remove dangling rocksdb dependency found in atlasdb-cli

### DIFF
--- a/atlasdb-cli/build.gradle
+++ b/atlasdb-cli/build.gradle
@@ -8,8 +8,5 @@ dependencies {
     compile project(path: ':atlasdb-dagger', configuration: 'shadow')
     compile 'io.airlift:airline:0.7'
 
-    runtime project(':atlasdb-rocksdb')
-
-    testCompile project(':atlasdb-rocksdb')
     testCompile group: 'org.assertj', name: 'assertj-core', version: libVersions.assertj
 }

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -1,18 +1,10 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 ideaSetModuleLevel(idea, targetCompatibility)
 
-repositories {
-    mavenCentral()
-}
-
-libsDirName = file('build/artifacts')
 dependencies {
     compile group: 'com.google.code.findbugs', name: 'jsr305'
     compile group: 'com.google.guava', name: 'guava'

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,12 +49,12 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1402>`__)
 
     *    - |fixed|
-         - Allow tables declared with SweepStrategy.THOROUGH to be migrated.
+         - Allow tables declared with ``SweepStrategy.THOROUGH`` to be migrated.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1410>`__)
 
     *    - |improved|
-         - atlasdb-rocksdb is no longer required by atlasdb-cli and therefore will no longer be packaged with AtlasDB clients
-           pulling in the atlasdb-dropwizard-bundle.
+         - ``atlasdb-rocksdb`` is no longer required by ``atlasdb-cli`` and therefore will no longer be packaged with AtlasDB clients
+           pulling in ``atlasdb-dropwizard-bundle``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1439>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,6 +52,11 @@ develop
          - Allow tables declared with SweepStrategy.THOROUGH to be migrated.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1410>`__)
 
+    *    - |improved|
+         - atlasdb-rocksdb is no longer required by atlasdb-cli and therefore will no longer be packaged with AtlasDB clients
+           pulling in the atlasdb-dropwizard-bundle.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1439>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
This is a solution to https://github.com/palantir/atlasdb/issues/1401.

RocksDB KVS was incorrectly included as part of atlasdb-cli.  This dependency was removed.  If you wish to use the cli directly now rocks is bundled as part of atlasdb-cli-distribution.

This PR also includes some misc clean up of unnecessary gradle logic in atlasdb-commons (it's all included in shared.gradle now).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1439)
<!-- Reviewable:end -->
