### PR TITLE
Don't preload buffer when creating a BlockConsumingInputStream

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockConsumingInputStream.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/BlockConsumingInputStream.java
@@ -38,9 +38,7 @@ public final class BlockConsumingInputStream extends InputStream {
             long numBlocks,
             int blocksInMemory) throws IOException {
         ensureExpectedArraySizeDoesNotOverflow(blockGetter, blocksInMemory);
-        BlockConsumingInputStream stream = new BlockConsumingInputStream(blockGetter, numBlocks, blocksInMemory);
-        stream.refillBuffer();
-        return stream;
+        return new BlockConsumingInputStream(blockGetter, numBlocks, blocksInMemory);
     }
 
     // we don't want to actually create a very large array in tests, as the external test VM would run out of memory.
@@ -65,6 +63,7 @@ public final class BlockConsumingInputStream extends InputStream {
         this.blocksInMemory = blocksInMemory;
         this.nextBlockToRead = 0L;
         this.positionInBuffer = 0;
+        this.buffer = new byte[0];
     }
 
     @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,11 @@ develop
          - Allow tables declared with ``SweepStrategy.THOROUGH`` to be migrated.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1410>`__)
 
+    *    - |fixed|
+         - Fix an issue with stream store, where pre-loading the first block of an input stream caused us to create a transaction inside another transaction.
+           To avoid this issue, it is now the caller's responsibility to ensure that ``InputStream.read()`` is not called within the transaction used to fetch the stream.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1447>`__)
+
     *    - |improved|
          - ``atlasdb-rocksdb`` is no longer required by ``atlasdb-cli`` and therefore will no longer be packaged with AtlasDB clients
            pulling in ``atlasdb-dropwizard-bundle``.


### PR DESCRIPTION
Fixes #1443.

The usage of this stream is in `AbstractGenericStreamStore.makeStream`.
Crucially, `refillBuffer` creates a transaction, and
`BlockConsumingInputStream.create` is itself called inside a transaction.

Having one transaction entirely inside another is not desirable because
of the potential for deadlock situations to occur, so this broke our
own best practices.

It will now be the caller's responsibility to close the "load stream"
transaction before reading the stream data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1447)
<!-- Reviewable:end -->
