### PR TITLE
Add endpoint to log filtered locks on Lockserver

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/ExpiringToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/ExpiringToken.java
@@ -47,6 +47,12 @@ public interface ExpiringToken {
     @Nullable LockClient getClient();
 
     /**
+     * Returns the set of locks which were successfully acquired as a map
+     * from descriptor to lock mode.
+     */
+    SortedLockCollection<LockDescriptor> getLockDescriptors();
+
+    /**
      * Returns the amount of time that it takes for these locks to
      * expire.
      */

--- a/lock-api/src/main/java/com/palantir/lock/ForwardingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/ForwardingLockService.java
@@ -148,4 +148,9 @@ public abstract class ForwardingLockService extends ForwardingObject implements 
     public void logCurrentState() {
         delegate().logCurrentState();
     }
+
+    @Override
+    public void logCurrentHeldLocks(String descriptorRegex, boolean versionIdNecessary) {
+        delegate().logCurrentHeldLocks(descriptorRegex, versionIdNecessary);
+    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/ForwardingRemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/ForwardingRemoteLockService.java
@@ -60,4 +60,9 @@ public abstract class ForwardingRemoteLockService extends ForwardingObject imple
     public void logCurrentState() {
         delegate().logCurrentState();
     }
+
+    @Override
+    public void logCurrentHeldLocks(String descriptorRegex, boolean versionIdNecessary) {
+        delegate().logCurrentHeldLocks(descriptorRegex, versionIdNecessary);
+    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/HeldLocksGrant.java
+++ b/lock-api/src/main/java/com/palantir/lock/HeldLocksGrant.java
@@ -106,7 +106,8 @@ import com.google.common.base.Preconditions;
      * Returns the set of locks which were successfully acquired, as a mapping
      * from descriptor to lock mode.
      */
-    public SortedLockCollection<LockDescriptor> getLocks() {
+    @Override
+    public SortedLockCollection<LockDescriptor> getLockDescriptors() {
         Preconditions.checkState(!lockMap.isEmpty());
         return lockMap;
     }

--- a/lock-api/src/main/java/com/palantir/lock/HeldLocksToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/HeldLocksToken.java
@@ -112,6 +112,7 @@ import com.google.common.collect.Iterables;
      * Returns the set of locks which were successfully acquired as a map
      * from descriptor to lock mode.
      */
+    @Override
     @JsonIgnore
     public SortedLockCollection<LockDescriptor> getLockDescriptors() {
         return lockMap;

--- a/lock-api/src/main/java/com/palantir/lock/LockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockService.java
@@ -183,4 +183,6 @@ import com.palantir.common.annotation.NonIdempotent;
     @Override
     @Idempotent void logCurrentState();
 
+    @Override
+    @Idempotent void logCurrentHeldLocks(String descriptorRegex, boolean versionIdNecessary);
 }

--- a/lock-api/src/main/java/com/palantir/lock/RemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/RemoteLockService.java
@@ -23,6 +23,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.palantir.common.annotation.Idempotent;
@@ -99,4 +100,11 @@ public interface RemoteLockService {
     @POST
     @Path("log-current-state")
     void logCurrentState();
+
+    @POST
+    @Path("log-filtered-current-state")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void logCurrentHeldLocks(
+            @QueryParam("descriptor") String descriptorRegex,
+            @QueryParam("version_id_necessary") boolean versionIdNecessary);
 }

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
@@ -922,7 +922,7 @@ public abstract class LockServiceTest {
         HeldLocksGrant grant = server.convertToGrant(token);
         Assert.assertNotNull(grant);
         Assert.assertNull(grant.getClient());
-        Assert.assertEquals(request.getLockDescriptors(), grant.getLocks());
+        Assert.assertEquals(request.getLockDescriptors(), grant.getLockDescriptors());
         Thread.sleep(51);
         Assert.assertTrue(grant.getExpirationDateMs() - System.currentTimeMillis() < 450);
         grant = server.refreshGrant(grant);


### PR DESCRIPTION
This is useful for debugging. Original method dumps all tokens and only first lock of the token. This will dump every lock which satisfies regex.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1448)
<!-- Reviewable:end -->
