### PR TITLE
Jepsen test of the lock server (no nemeses, no checker)

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -1,0 +1,108 @@
+(ns jepsen.atlasdb.lock
+  (:require [jepsen.atlasdb.timelock :as timelock]
+            [jepsen.checker :as checker]
+            [jepsen.client :as client]
+            [jepsen.generator :as gen]
+            [jepsen.tests :as tests]
+            [jepsen.os.debian :as debian]
+            [jepsen.util :refer [timeout]]
+            [knossos.history :as history]
+            [clojure.java.io :refer [writer]])
+    (:import com.palantir.atlasdb.jepsen.JepsenHistoryChecker)
+    (:import com.palantir.atlasdb.http.LockClient))
+
+(def lock-names ["bob" "sarah" "alfred" "shelly"])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Client creation and invocations (i.e. locking, unlocking refreshing)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defn nullable-to-string    [obj] (if (nil? obj) "" (.toString obj)))
+(defn create-token-store    [] (atom {}))
+(defn replace-token         [store key obj] (swap! store assoc key obj))
+(defn assoc-ok-value
+  "Associate the map with ':ok', meaning that the server response was 200.
+   Also capture the server response and the query parameters we used."
+  [op response query-params]
+  (assoc op :type :ok
+            :value (nullable-to-string response)
+            :query-params (nullable-to-string query-params)))
+
+(defn create-client
+  "Creates an object that implements the client/Client protocol.
+   The object defines how you create a timestamp client, and how to request timestamps from it. The first call to this
+   function will return an invalid object: you should call 'setup' on the returned object to get a valid one.
+  "
+  [lock-service, client-name, token-store]
+  (reify client/Client
+    (setup!
+      [this test node]
+      "Factory that returns an object implementing client/Client"
+        (create-client
+          (LockClient/create '("n1" "n2" "n3" "n4" "n5"))
+          (name node)
+          (create-token-store)))
+
+    (invoke!
+      [this test op]
+      "Run an operation on our client"
+      (timeout (* 30 1000)
+          (assoc op :type :fail :error :timeout)
+          (try
+            (let [lock-name (:value op)
+                  token-store-key (str client-name lock-name)]
+              (case (:f op)
+                :lock
+                  (let [response (LockClient/lock lock-service client-name lock-name)]
+                    (do (replace-token token-store token-store-key response)
+                        (assoc-ok-value op response [client-name lock-name])))
+                :unlock
+                  (let [token (@token-store token-store-key)
+                        response (LockClient/unlock lock-service token)]
+                    (do (replace-token token-store token-store-key nil)
+                        (assoc-ok-value op response token)))
+                :refresh
+                  (let [token (@token-store token-store-key)
+                        response (LockClient/refresh lock-service token)]
+                    (do (replace-token token-store token-store-key token)
+                        (assoc-ok-value op response token)))))
+          (catch Exception e
+            (assoc op :type :fail :error (.toString e))))))
+
+    (teardown! [_ test])))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; How to check the validity of a run of the Jepsen test. Hard-coded to succeed for now.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(def checker
+  (reify checker/Checker
+    (check [this test model history opts]
+      {:valid? true})))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; How to generate test events. We randomly mix refreshes, locks, and unlocks.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(def generator
+  (reify gen/Generator
+    (op [generator test process]
+      (let [random-lock-name (rand-nth lock-names)]
+        (condp < (rand)
+          ;; 70% chance of a refresh
+          0.30 {:type :invoke   :f :refresh   :value random-lock-name}
+          ;; 15% chance of a lock
+          0.15 {:type :invoke   :f :lock      :value random-lock-name}
+          ;; 15% chance of an unlock
+               {:type :invoke   :f :unlock    :value random-lock-name})))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Defining the Jepsen test
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defn lock-test
+  []
+  (assoc tests/noop-test
+    :client (create-client nil nil nil)
+    :generator (->> generator
+                    (gen/stagger 0.1)
+                    (gen/clients)
+                    (gen/time-limit 30))
+    :db (timelock/create-db)
+    :checker checker))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
@@ -28,7 +28,9 @@
 
     (teardown! [_ _ node]
       (c/su
-        (try (c/exec "/atlasdb-timelock-server/service/bin/init.sh" "stop") (catch Exception _))
+        (info node "Forcibly killing all Java processes")
+        (try (c/exec :pkill "-9" "java") (catch Exception _))
+        (info node "Removing any timelock server files")
         (try (c/exec :rm :-rf "/atlasdb-timelock-server") (catch Exception _))
         (try (c/exec :rm :-f "/atlasdb-timelock-server.tgz") (catch Exception _))))
 

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/LockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/LockClient.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Lists;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.TimeDuration;
+
+public final class LockClient {
+    private LockClient() {
+    }
+
+    public static RemoteLockService create(List<String> hosts) {
+        return TimelockUtils.createClient(hosts, RemoteLockService.class);
+    }
+
+    public static LockRefreshToken lock(RemoteLockService service, String client, String lock) throws InterruptedException {
+        LockDescriptor descriptor = StringLockDescriptor.of(lock);
+        LockRequest request = LockRequest.builder(ImmutableSortedMap.of(descriptor, LockMode.WRITE))
+                .doNotBlock()
+                .build();
+        return service.lock(client, request);
+    }
+
+    public static boolean unlock(RemoteLockService service, LockRefreshToken token) throws InterruptedException {
+        if (token == null) {
+            return false;
+        }
+        return service.unlock(token);
+    }
+
+    public static LockRefreshToken refresh(RemoteLockService service, LockRefreshToken token) {
+        if (token == null) {
+            return null;
+        }
+        Set<LockRefreshToken> validTokens = service.refreshLockRefreshTokens(ImmutableList.of(token));
+        if (validTokens.isEmpty()) {
+            return null;
+        } else {
+            return validTokens.iterator().next();
+        }
+    }
+}

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -1,9 +1,14 @@
 (ns jepsen.atlasdb-test
   (:require [clojure.test :refer :all]
+            [jepsen.atlasdb.lock :as lock]
             [jepsen.atlasdb.timestamp :as timestamp]
             [jepsen.core :as jepsen]))
 
-;; Using Clojure's testing framework, we initiate a run of atlasdb-test
-;; The test is successful iff the value for the key ":valid?" is truthy
+;; Using Clojure's testing framework, we initiate our test runs
+;; Tests successful iff the value for the key ":valid?" is truthy
+
 (deftest timestamp-test
    (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test))))))
+
+;;(deftest lock-test
+;;   (is (:valid? (:results (jepsen/run! (lock/lock-test))))))


### PR DESCRIPTION
This Jepsen test uses five clients ("n1" through to "n5"), all operating on the "test" namespace. They randomly issue lock, unlock, and refresh events, for a lock chosen from a random list of four ("bob", "sarah", "alfred", "shelly"). Refreshes are chosen 70% of the time, locks 15% of the time, and unlocks 15% of the time.

The client for this test is a little bit complicated because we need to keep the token returned on lock requests available for subsequent refresh calls. This is done by maintaining a map of ``(client-name, lock-name) -> token``. Thanks to @JacekLach for helping me out with this!

This PR also changes the teardown of the timelock server from being "init.sh stop" to "kill -9". This makes it quicker to re-run the tests locally, and also removes an odd flake where the server sometimes fails to re-start.

<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
- Note what this change does and why it is needed
- Include details of who this change helps (without including internal product names)
- Include the Atlas release or date you need this by
--->
