### PR TITLE
Highlight that DebugLogger was moved.

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,7 +56,12 @@ develop
          - There is now a ``TimestampMigrationService`` with the ``fast-forward`` method that can be used to migrate between timestamp services.
            You will simply need to fast-forward the new timestamp service using the latest timestamp from the old service.
            This can be done using the :ref:`timestamp forward cli <offline-clis>` when your AtlasDB services are offline.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/?>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1445>`__)
+
+    *    - |devbreak|
+         - The ``DebugLogger`` class was moved from package ``com.palantir.timestamp`` in project ``timestamp-impl``
+           to ``com.palantir.util`` in project ``atlasdb-commons``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1445>`__)
 
     *    - |fixed|
          - Allow tables declared with ``SweepStrategy.THOROUGH`` to be migrated.


### PR DESCRIPTION
This causes a compile-time break in an internal product that pulls in the DebugLogger.

FYI @diogoholanda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1452)
<!-- Reviewable:end -->
