### PR TITLE
tweak version string for develop versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,9 @@ repositories {
 apply from: 'gradle/versions.gradle'
 
 group = 'com.palantir.atlasdb'
-version = gitVersion()
+// if the version ends with a git hash, replace the 'g' with an 'r'
+// this is to get around maven regexes that considers -g<hash> a snapshot
+version = gitVersion().replaceAll('-g([a-fA-F0-9]+)$', '-r$1')
 description = 'Transactional distributed database layer'
 
 task printLastVersion {


### PR DESCRIPTION
Changes the version string to use -r<githash> instead of -g<githash>
so that internal develop publishes can be considered "releases".
This is just a workaround for internal maven regexes that flag
-g<hash> as a snapshot instead of allowing it to be a "release".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1467)
<!-- Reviewable:end -->
