### PR TITLE
Move debug logger back to original location and replace usage with class name loggers

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -25,9 +25,9 @@ import com.palantir.atlasdb.keyvalue.cassandra.CassandraTimestampBoundStore;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.versions.AtlasDbVersion;
+import com.palantir.timestamp.DebugLogger;
 import com.palantir.timestamp.PersistentTimestampService;
 import com.palantir.timestamp.TimestampService;
-import com.palantir.util.DebugLogger;
 
 @AutoService(AtlasDbFactory.class)
 public class CassandraAtlasDbFactory implements AtlasDbFactory {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -44,9 +44,9 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
+import com.palantir.timestamp.DebugLogger;
 import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 import com.palantir.timestamp.TimestampBoundStore;
-import com.palantir.util.DebugLogger;
 import com.palantir.util.debug.ThreadDumps;
 
 public final class CassandraTimestampBoundStore implements TimestampBoundStore {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -26,6 +26,9 @@ import java.util.ServiceLoader;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
@@ -35,10 +38,10 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.timestamp.TimestampService;
-import com.palantir.util.DebugLogger;
 import com.palantir.util.debug.ThreadDumps;
 
 public class ServiceDiscoveringAtlasSupplier {
+    private static final Logger log = LoggerFactory.getLogger(ServiceDiscoveringAtlasSupplier.class);
     private static final ServiceLoader<AtlasDbFactory> loader = ServiceLoader.load(AtlasDbFactory.class);
 
     private static String timestampServiceCreationInfo = null;
@@ -68,7 +71,7 @@ public class ServiceDiscoveringAtlasSupplier {
     }
 
     public synchronized TimestampService getTimestampService() {
-        DebugLogger.logger.info("Fetching timestamp service from thread {}. This should only happen once.",
+        log.info("Fetching timestamp service from thread {}. This should only happen once.",
                 Thread.currentThread().getName());
 
         if (timestampServiceCreationInfo == null) {
@@ -85,7 +88,7 @@ public class ServiceDiscoveringAtlasSupplier {
             String threadDumpFile = saveThreadDumps();
             reportMultipleTimestampFetch(threadDumpFile);
         } catch (IOException e) {
-            DebugLogger.logger.error("The timestamp service was fetched for a second time. We tried to output thread "
+            log.error("The timestamp service was fetched for a second time. We tried to output thread "
                     + "dumps to a temporary file, but encountered an error.", e);
         }
     }
@@ -118,13 +121,13 @@ public class ServiceDiscoveringAtlasSupplier {
 
     private void reportMultipleTimestampFetch(String path) {
         if (!leaderConfig.isPresent()) {
-            DebugLogger.logger.warn("Timestamp service fetched for a second time, and there is no leader config. "
+            log.warn("Timestamp service fetched for a second time, and there is no leader config. "
                     + "This means that you may soon encounter the MultipleRunningTimestampServices error. "
                     + "Thread dumps from both fetches of the timestamp service have been outputted to {}. "
                     + "If you encounter a MultipleRunningTimestampServices error, please send this file to "
                     + "support.", path);
         } else {
-            DebugLogger.logger.warn("Timestamp service fetched for a second time. This is only OK if you are "
+            log.warn("Timestamp service fetched for a second time. This is only OK if you are "
                     + "running in an HA configuration and have just had a leadership election. "
                     + "You do have a leader config, but we're outputting thread dumps from both fetches of the "
                     + "timestamp service, in case this second service was created in error. "

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -71,8 +71,8 @@ public class ServiceDiscoveringAtlasSupplier {
     }
 
     public synchronized TimestampService getTimestampService() {
-        log.info("Fetching timestamp service from thread {}. This should only happen once.",
-                Thread.currentThread().getName());
+        log.info("[timestamp-service-creation] Fetching timestamp service from "
+                        + "thread {}. This should only happen once.", Thread.currentThread().getName());
 
         if (timestampServiceCreationInfo == null) {
             timestampServiceCreationInfo = ThreadDumps.programmaticThreadDump();
@@ -88,8 +88,8 @@ public class ServiceDiscoveringAtlasSupplier {
             String threadDumpFile = saveThreadDumps();
             reportMultipleTimestampFetch(threadDumpFile);
         } catch (IOException e) {
-            log.error("The timestamp service was fetched for a second time. We tried to output thread "
-                    + "dumps to a temporary file, but encountered an error.", e);
+            log.error("[timestamp-service-creation] The timestamp service was fetched for a second time. "
+                    + "We tried to output thread dumps to a temporary file, but encountered an error.", e);
         }
     }
 
@@ -121,14 +121,14 @@ public class ServiceDiscoveringAtlasSupplier {
 
     private void reportMultipleTimestampFetch(String path) {
         if (!leaderConfig.isPresent()) {
-            log.warn("Timestamp service fetched for a second time, and there is no leader config. "
-                    + "This means that you may soon encounter the MultipleRunningTimestampServices error. "
+            log.warn("[timestamp-service-creation] Timestamp service fetched for a second time, and there is no leader "
+                    + "config. This means that you may soon encounter the MultipleRunningTimestampServices error. "
                     + "Thread dumps from both fetches of the timestamp service have been outputted to {}. "
                     + "If you encounter a MultipleRunningTimestampServices error, please send this file to "
                     + "support.", path);
         } else {
-            log.warn("Timestamp service fetched for a second time. This is only OK if you are "
-                    + "running in an HA configuration and have just had a leadership election. "
+            log.warn("[timestamp-service-creation] Timestamp service fetched for a second time. This is only OK if "
+                    + "you are running in an HA configuration and have just had a leadership election. "
                     + "You do have a leader config, but we're outputting thread dumps from both fetches of the "
                     + "timestamp service, in case this second service was created in error. "
                     + "Thread dumps from both fetches of the timestamp service have been outputted to {}. "

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -75,9 +77,9 @@ import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.remoting.ssl.SslConfiguration;
 import com.palantir.remoting.ssl.SslSocketFactories;
 import com.palantir.timestamp.TimestampService;
-import com.palantir.util.DebugLogger;
 
 public final class TransactionManagers {
+    private static final Logger log = LoggerFactory.getLogger(TransactionManagers.class);
     private static final ServiceLoader<AtlasDbFactory> loader = ServiceLoader.load(AtlasDbFactory.class);
     public static final LockClient LOCK_CLIENT = LockClient.of("atlas instance");
 
@@ -106,7 +108,7 @@ public final class TransactionManagers {
             Set<Schema> schemas,
             Environment env,
             boolean allowHiddenTableAccess) {
-        DebugLogger.logger.info("Called TransactionManagers.create on thread {}. This should only happen once.",
+        log.info("Called TransactionManagers.create on thread {}. This should only happen once.",
                 Thread.currentThread().getName());
         return create(config, schemas, env, LockServerOptions.DEFAULT, allowHiddenTableAccess);
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,6 +63,9 @@ develop
            ``checkAndSet`` is **not** supported for RocksDB or JDBC. However, it will only be used in a future release.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1435>`__)
 
+    *    - |fixed|
+         - Fixed the |devbreak| below by returning the ``DebugLogger`` to it's original location.
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -77,7 +80,8 @@ v0.28.0
          - Change
 
     *    - |devbreak|
-         - The ``DebugLogger`` class was moved from package ``com.palantir.timestamp`` in project ``timestamp-impl`` to ``com.palantir.util`` in project ``atlasdb-commons``.
+         - The ``DebugLogger`` class was moved from package ``com.palantir.timestamp`` in project ``timestamp-impl`` to ``com.palantir.util`` in project ``atlasdb-commons``.  This is
+           fixed in the next release 0.29.0.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1445>`__)
 
     *    - |improved|

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
@@ -19,8 +19,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.palantir.util.DebugLogger;
-
 public class AvailableTimestamps {
     static final long ALLOCATION_BUFFER_SIZE = 1000 * 1000;
     private static final long MINIMUM_BUFFER = ALLOCATION_BUFFER_SIZE / 2;

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/DebugLogger.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/DebugLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Palantir Technologies
+ * Copyright 2017 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.util;
+package com.palantir.timestamp;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+/**
+ * This is a logger intended for use tracking down problems arising from
+ * https://github.com/palantir/atlasdb/issues/1000.  To activate this logging
+ * please follow instructions on
+ * http://palantir.github.io/atlasdb/html/configuration/logging.html#debug-logging-for-multiple-timestamp-services-error
+ */
 @SuppressFBWarnings("SLF4J_LOGGER_SHOULD_BE_PRIVATE")
 public final class DebugLogger {
     public static final Logger logger = LoggerFactory.getLogger(DebugLogger.class);

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -21,7 +21,6 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.base.Preconditions;
 import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.util.DebugLogger;
 
 @ThreadSafe
 public class PersistentTimestampService implements TimestampService, TimestampManagementService {

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
@@ -24,7 +24,6 @@ import javax.annotation.concurrent.GuardedBy;
 import com.palantir.common.time.Clock;
 import com.palantir.common.time.SystemClock;
 import com.palantir.exception.PalantirInterruptedException;
-import com.palantir.util.DebugLogger;
 
 public class PersistentUpperLimit {
     private final TimestampBoundStore tbs;


### PR DESCRIPTION
Coming in response to discussion on #1445.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1469)
<!-- Reviewable:end -->
