### PR TITLE
Rename PersistentTimestampServiceTest

### DIFF
--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
@@ -29,7 +29,9 @@ import java.util.concurrent.Executors;
 
 import org.junit.Test;
 
-public class PersistentTimestampServiceTest {
+// Mock AvailableTimestamps to test PersistentTimestampService.
+// See also PersistentTimestampServiceTests for end-to-end style tests.
+public class PersistentTimestampServiceMockingTest {
 
     private static final long INITIAL_TIMESTAMP = 12345L;
     private static final long TIMESTAMP = 100 * 1000;

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTests.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTests.java
@@ -26,6 +26,8 @@ import org.junit.rules.ExpectedException;
 import com.palantir.atlasdb.timestamp.AbstractTimestampServiceTests;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 
+// Test PersistentTimestampService by fully instantiating it with an InMemoryTimestampBoundStore.
+// See also PersistentTimestampServiceMockingTest that mocks AvailableTimestamps instead.
 public class PersistentTimestampServiceTests extends AbstractTimestampServiceTests {
     @Rule
     public ExpectedException exception = ExpectedException.none();


### PR DESCRIPTION
PersistentTimestampServiceTest being a prefix of PersistentTimestampServiceTests causes issues with the internal test infra.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1477)
<!-- Reviewable:end -->
