### PR TITLE
fail faster when shutting down

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -110,7 +110,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
 
         checkAndHandleFailure(ex);
         if (!isFastFailoverException) {
-            pauseForBackOff();
+            pauseForBackOff(ex);
         }
     }
 
@@ -137,7 +137,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     }
 
 
-    private void pauseForBackOff() {
+    private void pauseForBackOff(RetryableException ex) {
         double pow = Math.pow(
                 GOLDEN_RATIO,
                 numSwitches.get() * failuresBeforeSwitching + failuresSinceLastSwitch.get());
@@ -148,6 +148,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
             Thread.sleep(timeout);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            throw ex;
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -198,22 +198,18 @@ public final class Scrubber {
                         log.debug("Sleeping {} millis until next execution of scrub task", sleepDuration);
                         Thread.sleep(sleepDuration);
                     } catch (InterruptedException e) {
-                        if (service.isShutdown()) {
-                            break;
-                        } else {
-                            log.error("Interrupted unexpectedly during background scrub task,"
-                                    + " but continuing anyway", e);
-                        }
+                        break;
                     } catch (Throwable t) { // (authorized)
+                        if (Thread.interrupted()) {
+                            break;
+                        }
                         log.error("Encountered the following error during background scrub task,"
                                 + " but continuing anyway", t);
                         numberOfAttempts++;
                         try {
                             Thread.sleep(RETRY_SLEEP_INTERVAL_IN_MILLIS);
                         } catch (InterruptedException e) {
-                            log.error("Interrupted while waiting to retry, but continuing anyway.", e);
-                            // Restore interrupt
-                            Thread.currentThread().interrupt();
+                            break;
                         }
                     }
                 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
          - Prevent deadlocks during parallel reads from DB KVS.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1468>`__)
 
+    *    - |fixed|
+         - Don't retry interrupted remote calls, shut down the scrubber immediately when interrupted.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1488>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
If a remote call is interrupted, it should not retry, it should fail
immediately and propogate the interrupted flag to the caller.

If the background scrub task is interrupted it should shut down
immediately. The only way to interrupt it is to close the scrubber.

<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
- Note what this change does and why it is needed
- Include details of who this change helps (without including internal product names)
- Include the Atlas release or date you need this by
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1488)
<!-- Reviewable:end -->
