### PR TITLE
Add generateMapToFullTableNames in TableMappingService

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/TableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/TableMappingService.java
@@ -28,4 +28,5 @@ public interface TableMappingService {
     <T> Map<TableReference, T> mapToShortTableNames(Map<TableReference, T> tableMap)
             throws TableMappingNotFoundException;
     Set<TableReference> mapToFullTableNames(Set<TableReference> tableNames);
+    Map<TableReference, TableReference> generateMapToFullTableNames(Set<TableReference> tableNames);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -22,7 +22,6 @@ import java.util.Set;
 
 import com.google.common.collect.ForwardingObject;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -207,13 +206,15 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
 
     @Override
     public Map<TableReference, byte[]> getMetadataForTables() {
-        Map<TableReference, byte[]> tableRefToBytes = Maps.newHashMap();
-        for (Entry<TableReference, byte[]> entry : delegate().getMetadataForTables().entrySet()) {
-            tableRefToBytes.put(
-                    Iterables.getOnlyElement(tableMapper.mapToFullTableNames(ImmutableSet.of(entry.getKey()))),
-                    entry.getValue());
+        Map<TableReference, byte[]> tableMetadata = delegate().getMetadataForTables();
+        Map<TableReference, TableReference> metadataNamesToFullTableNames = tableMapper.generateMapToFullTableNames(
+                tableMetadata.keySet());
+        Map<TableReference, byte[]> fullTableNameToBytes = Maps.newHashMapWithExpectedSize(
+                metadataNamesToFullTableNames.size());
+        for (Entry<TableReference, byte[]> entry : tableMetadata.entrySet()) {
+            fullTableNameToBytes.put(metadataNamesToFullTableNames.get(entry.getKey()), entry.getValue());
         }
-        return tableRefToBytes;
+        return fullTableNameToBytes;
     }
 
     @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -31,8 +31,18 @@ Changelog
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
-develop
+v0.25.1
 =======
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |improved|
+         - Improve performance by preventing excessive reads from the _namespace table when initializing SweepStrategyManager.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1486>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
This is a duplicate of #1486 to be merged into 0.25.x and then tagged as a new 0.25.1 release. After merging here we need to ensure this makes it into develop as well.

Description from #1486: 
_This should fix issue #1485, which was causing
excessive reads from the DB during initialization
of the SweepStrategyManager._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1492)
<!-- Reviewable:end -->
