### PR TITLE
Jepsen: partition events by lock name

### DIFF
--- a/atlasdb-jepsen-tests/src/integTest/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckerIntegrationTest.java
+++ b/atlasdb-jepsen-tests/src/integTest/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckerIntegrationTest.java
@@ -66,13 +66,13 @@ public class JepsenHistoryCheckerIntegrationTest {
 
         Map<Keyword, ?> nemesisStartEventMap = ImmutableMap.of(
                 Keyword.intern("f"), "start",
-                Keyword.intern("process"), "nemesis",
+                Keyword.intern("process"), JepsenConstants.NEMESIS_PROCESS,
                 Keyword.intern("type"), "info",
                 Keyword.intern("value"), "start!",
                 Keyword.intern("time"), 18784227842L);
         Map<Keyword, ?> nemesisStopEventMap = ImmutableMap.of(
                 Keyword.intern("f"), "stop",
-                Keyword.intern("process"), "nemesis",
+                Keyword.intern("process"), JepsenConstants.NEMESIS_PROCESS,
                 Keyword.intern("type"), "info",
                 Keyword.intern("value"), "stop!",
                 Keyword.intern("time"), 18805796986L);

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenConstants.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenConstants.java
@@ -16,7 +16,8 @@
 package com.palantir.atlasdb.jepsen;
 
 public final class JepsenConstants {
-    public static final String NEMESIS_PROCESS = "nemesis";
+    public static final int NEMESIS_PROCESS = -1;
+    public static final String NEMESIS_PROCESS_NAME = "nemesis";
 
     public static final String START_FUNCTION = "start";
     public static final String STOP_FUNCTION = "stop";

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
@@ -46,7 +46,7 @@ public final class JepsenHistoryCheckers {
     @VisibleForTesting
     static final List<Supplier<Checker>> LOCK_CHECKERS = ImmutableList.of(
             IsolatedProcessCorrectnessChecker::new,
-            LockCorrectnessChecker::new,
+            () -> new PartitionByInvokeNameCheckerHelper(LockCorrectnessChecker::new),
             RefreshCorrectnessChecker::new);
 
     public static JepsenHistoryChecker createWithTimestampCheckers() {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckers.java
@@ -45,9 +45,9 @@ public final class JepsenHistoryCheckers {
 
     @VisibleForTesting
     static final List<Supplier<Checker>> LOCK_CHECKERS = ImmutableList.of(
-            IsolatedProcessCorrectnessChecker::new,
+            () -> new PartitionByInvokeNameCheckerHelper(IsolatedProcessCorrectnessChecker::new),
             () -> new PartitionByInvokeNameCheckerHelper(LockCorrectnessChecker::new),
-            RefreshCorrectnessChecker::new);
+            () -> new PartitionByInvokeNameCheckerHelper(RefreshCorrectnessChecker::new));
 
     public static JepsenHistoryChecker createWithTimestampCheckers() {
         return createWithCheckers(TIMESTAMP_CHECKERS);

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelper.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelper.java
@@ -25,13 +25,14 @@ import java.util.stream.Collectors;
 
 import com.palantir.atlasdb.jepsen.events.Checker;
 import com.palantir.atlasdb.jepsen.events.Event;
+import com.palantir.atlasdb.jepsen.events.InfoEvent;
 import com.palantir.atlasdb.jepsen.events.InvokeEvent;
 
 public class PartitionByInvokeNameCheckerHelper implements Checker {
 
     private Supplier<Checker> checkerSupplier;
 
-    PartitionByInvokeNameCheckerHelper(Supplier<Checker> checkerSupplier) {
+    public PartitionByInvokeNameCheckerHelper(Supplier<Checker> checkerSupplier) {
         this.checkerSupplier = checkerSupplier;
     }
 
@@ -52,8 +53,12 @@ public class PartitionByInvokeNameCheckerHelper implements Checker {
                 lastInvokeValueForProcess.put(process, invokeEvent.value());
             }
             String key = lastInvokeValueForProcess.getOrDefault(process, null);
+            if (event instanceof InfoEvent) {
+                key = null;
+            }
             List<Event> history = partitionedEvents.getOrDefault(key, new ArrayList<>());
             history.add(event);
+            partitionedEvents.put(key, history);
         }
         return partitionedEvents;
     }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelper.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelper.java
@@ -73,7 +73,8 @@ public class PartitionByInvokeNameCheckerHelper implements Checker {
     }
 
     private CheckerResult combineResults(List<CheckerResult> results) {
-        List<Event> allErrors = results.stream().flatMap(result -> result.errors().stream()).collect(Collectors.toList());
+        List<Event> allErrors = results.stream().flatMap(result ->
+                result.errors().stream()).collect(Collectors.toList());
         boolean allValid = results.stream().allMatch(CheckerResult::valid);
         return ImmutableCheckerResult.builder()
                 .valid(allValid)

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelper.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelper.java
@@ -30,7 +30,7 @@ import com.palantir.atlasdb.jepsen.events.InvokeEvent;
 
 public class PartitionByInvokeNameCheckerHelper implements Checker {
 
-    private Supplier<Checker> checkerSupplier;
+    private final Supplier<Checker> checkerSupplier;
 
     public PartitionByInvokeNameCheckerHelper(Supplier<Checker> checkerSupplier) {
         this.checkerSupplier = checkerSupplier;
@@ -73,7 +73,7 @@ public class PartitionByInvokeNameCheckerHelper implements Checker {
     }
 
     private CheckerResult combineResults(List<CheckerResult> results) {
-        List<Event> allErrors = results.stream().flatMap(r -> r.errors().stream()).collect(Collectors.toList());
+        List<Event> allErrors = results.stream().flatMap(result -> result.errors().stream()).collect(Collectors.toList());
         boolean allValid = results.stream().allMatch(CheckerResult::valid);
         return ImmutableCheckerResult.builder()
                 .valid(allValid)

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelper.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelper.java
@@ -29,7 +29,6 @@ import com.palantir.atlasdb.jepsen.events.InfoEvent;
 import com.palantir.atlasdb.jepsen.events.InvokeEvent;
 
 public class PartitionByInvokeNameCheckerHelper implements Checker {
-
     private final Supplier<Checker> checkerSupplier;
 
     public PartitionByInvokeNameCheckerHelper(Supplier<Checker> checkerSupplier) {
@@ -53,6 +52,9 @@ public class PartitionByInvokeNameCheckerHelper implements Checker {
                 lastInvokeValueForProcess.put(process, invokeEvent.value());
             }
             String key = lastInvokeValueForProcess.getOrDefault(process, null);
+            /*
+             * Note that all InfoEvents get mapped to null
+             */
             if (event instanceof InfoEvent) {
                 key = null;
             }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.palantir.atlasdb.jepsen.utils.EventUtils;
 
 import clojure.lang.Keyword;
 import one.util.streamex.EntryStream;
@@ -42,8 +43,9 @@ public interface Event {
             .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
 
     static Event fromKeywordMap(Map<Keyword, ?> map) {
+        Map<Keyword, ?> encodedMap = EventUtils.encodeNemesis(map);
         Map<String, Object> convertedMap = new HashMap<>();
-        EntryStream.of(map)
+        EntryStream.of(encodedMap)
                 .mapKeys(Keyword::getName)
                 .mapValues(value -> value != null && value instanceof Keyword ? ((Keyword) value).getName() : value)
                 .forKeyValue(convertedMap::put);

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/Event.java
@@ -60,5 +60,7 @@ public interface Event {
 
     long time();
 
+    int process();
+
     void accept(EventVisitor visitor);
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/InfoEvent.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/events/InfoEvent.java
@@ -36,7 +36,7 @@ public abstract class InfoEvent implements Event {
     @JsonProperty("f")
     public abstract String function();
 
-    public abstract String process();
+    public abstract int process();
 
     public abstract long time();
 

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/IsolatedProcessCorrectnessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/IsolatedProcessCorrectnessChecker.java
@@ -77,8 +77,6 @@ public class IsolatedProcessCorrectnessChecker implements Checker {
         @Override
         public void visit(OkEvent event) {
             int currentProcess = event.process();
-            //String lockName = pendingForProcess.get(currentProcess).value();
-            //Pair<Integer, String> processLock = new Pair(currentProcess, lockName);
 
             switch (event.function()) {
                 case RequestType.LOCK:

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessChecker.java
@@ -94,7 +94,7 @@ public class LockCorrectnessChecker implements Checker {
 
         @Override
         public void visit(InvokeEvent event) {
-            Integer process = event.process();
+            int process = event.process();
             pendingForProcess.put(process, event);
             this.lockName = event.value();
         }
@@ -105,7 +105,7 @@ public class LockCorrectnessChecker implements Checker {
                 return;
             }
 
-            Integer process = event.process();
+            int process = event.process();
             InvokeEvent invokeEvent = pendingForProcess.get(process);
 
             switch (event.function()) {
@@ -137,14 +137,6 @@ public class LockCorrectnessChecker implements Checker {
             }
         }
 
-        public boolean valid() {
-            return errors.isEmpty();
-        }
-
-        public List<Event> errors() {
-            return ImmutableList.copyOf(errors);
-        }
-
         private void verifyLockCorrectness() {
             for (Pair<InvokeEvent, OkEvent> eventPair : locksAtSomePoint) {
                 InvokeEvent invokeEvent = eventPair.getLhSide();
@@ -162,6 +154,14 @@ public class LockCorrectnessChecker implements Checker {
         private boolean intervalCovered(InvokeEvent invokeEvent, OkEvent okEvent) {
             Range<Long> interval = Range.closed(invokeEvent.time(), okEvent.time());
             return locksHeld.encloses(interval);
+        }
+
+        public boolean valid() {
+            return errors.isEmpty();
+        }
+
+        public List<Event> errors() {
+            return ImmutableList.copyOf(errors);
         }
 
     }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessChecker.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessChecker.java
@@ -129,8 +129,7 @@ public class LockCorrectnessChecker implements Checker {
                     if (lastHeldLock.containsKey(process)) {
                         long lastLockTime = lastHeldLock.get(process).time();
                         if (lastLockTime < invokeEvent.time()) {
-                            locksHeld.add(
-                                    Range.open(lastLockTime, invokeEvent.time()));
+                            locksHeld.add(Range.open(lastLockTime, invokeEvent.time()));
                         }
                     }
                     break;

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/utils/EventUtils.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/jepsen/utils/EventUtils.java
@@ -15,8 +15,14 @@
  */
 package com.palantir.atlasdb.jepsen.utils;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.palantir.atlasdb.jepsen.JepsenConstants;
 import com.palantir.atlasdb.jepsen.events.OkEvent;
 import com.palantir.atlasdb.jepsen.events.RequestType;
+
+import clojure.lang.Keyword;
 
 public final class EventUtils {
     private EventUtils() {
@@ -36,5 +42,18 @@ public final class EventUtils {
             default:
                 return false;
         }
+    }
+
+    public static Map<Keyword, ?> encodeNemesis(Map<Keyword, ?> clojureEvent) {
+        Map<Keyword, Object> convertedEvent = new HashMap<>();
+        for (Map.Entry<Keyword, ?> entry : clojureEvent.entrySet()) {
+            if (entry.getKey().equals(Keyword.intern("process"))
+                    && entry.getValue().equals(Keyword.intern(JepsenConstants.NEMESIS_PROCESS_NAME))) {
+                convertedEvent.put(entry.getKey(), -1);
+            } else {
+                convertedEvent.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return convertedEvent;
     }
 }

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/NemesisResilienceCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/NemesisResilienceCheckerTest.java
@@ -30,7 +30,7 @@ public class NemesisResilienceCheckerTest {
     private static final int PROCESS_1 = 1;
     private static final int PROCESS_2 = 2;
 
-    private static final String IMPOSTOR_PROCESS = "impostor";
+    private static final int IMPOSTOR_PROCESS = -2;
     private static final String VALUE_1 = "value1";
     private static final String VALUE_2 = "value2";
 

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelperTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelperTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.jepsen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.jepsen.events.Checker;
+import com.palantir.atlasdb.jepsen.events.Event;
+import com.palantir.atlasdb.jepsen.events.InfoEvent;
+import com.palantir.atlasdb.jepsen.events.InvokeEvent;
+import com.palantir.atlasdb.jepsen.events.OkEvent;
+import com.palantir.atlasdb.jepsen.events.RequestType;
+import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
+import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
+
+public class PartitionByInvokeNameCheckerHelperTest {
+
+    private static final int PROCESS_1 = 1;
+    private static final int PROCESS_2 = 2;
+    private static final int PROCESS_3 = 3;
+    private static final String LOCK_1 = "lock1";
+    private static final String LOCK_2 = "lock2";
+
+    private static List<Event> eventList = ImmutableList.<Event>builder()
+            .add(TestEventUtils.invokeLock(0, PROCESS_1, LOCK_1))
+            .add(TestEventUtils.invokeRefresh(1, PROCESS_2, LOCK_1))
+            .add(TestEventUtils.lockSuccess(2, PROCESS_1))
+            .add(TestEventUtils.invokeUnlock(3, PROCESS_1, LOCK_2))
+            .add(TestEventUtils.createInfoEvent(3, PROCESS_3, RequestType.LOCK))
+            .add(TestEventUtils.unlockSuccess(4, PROCESS_1))
+            .add(TestEventUtils.refreshFailure(5, PROCESS_2))
+            .add(TestEventUtils.invokeLock(6, PROCESS_2, LOCK_2))
+            .add(TestEventUtils.lockSuccess(7, PROCESS_2))
+            .build();
+
+    private static List<Event> onlyLock2EventList = ImmutableList.<Event>builder()
+            .add(TestEventUtils.invokeUnlock(3, PROCESS_1, LOCK_2))
+            .add(TestEventUtils.unlockSuccess(4, PROCESS_1))
+            .add(TestEventUtils.invokeLock(6, PROCESS_2, LOCK_2))
+            .add(TestEventUtils.lockSuccess(7, PROCESS_2))
+            .build();
+
+    private static CheckerResult validResult = ImmutableCheckerResult.builder()
+            .valid(true)
+            .errors(new ArrayList<>())
+            .build();
+
+    /**
+     * This checker always fails, returning the entire list of events as the error list. This is useful to verify how
+     * PartitionByInvokeNameCheckerHelper manipulates the list. The value of the valid parameter is set to false purely
+     * for consistency reasons (since the list of errors is not empty).
+     */
+    private static Checker identityChecker = Mockito.mock(Checker.class);
+
+    static {
+        Mockito.when(identityChecker.check(Matchers.anyListOf(Event.class))).then(
+                list -> ImmutableCheckerResult.builder()
+                        .valid(false)
+                        .errors((List) list.getArguments()[0])
+                        .build()
+        );
+    }
+
+    @Test
+    public void universalSuccessCheckerShouldSucceedOnNoEvents() {
+        Checker universalChecker = Mockito.mock(Checker.class);
+        Mockito.when(universalChecker.check(Matchers.anyList())).thenReturn(validResult);
+
+        assertNoError(() -> universalChecker, ImmutableList.<Event>of());
+    }
+
+    @Test
+    public void universalSuccessCheckerShouldSucceed() {
+        Checker universalChecker = Mockito.mock(Checker.class);
+        Mockito.when(universalChecker.check(Matchers.anyList())).thenReturn(validResult);
+
+        assertNoError(() -> universalChecker, eventList);
+    }
+
+    @Test
+    public void infoEventsAreNotLost() {
+        InfoEvent infoEvent = TestEventUtils.createInfoEvent(0, PROCESS_1, RequestType.LOCK);
+
+        CheckerResult checkerResult = runPartitionChecker(() -> identityChecker,
+                ImmutableList.<Event>of(infoEvent));
+
+        assertThat(checkerResult.valid()).isFalse();
+        assertThat(checkerResult.errors()).containsExactly(infoEvent);
+    }
+
+    @Test
+    public void universalFailureCheckerShouldFail() {
+        InvokeEvent invokeEvent = TestEventUtils.invokeLock(0, PROCESS_1, LOCK_1);
+        OkEvent okEvent = TestEventUtils.lockSuccess(1, PROCESS_1);
+
+        CheckerResult checkerResult = runPartitionChecker(() -> identityChecker,
+                ImmutableList.of(invokeEvent, okEvent));
+
+        assertThat(checkerResult.valid()).isFalse();
+        assertThat(checkerResult.errors()).containsExactly(invokeEvent, okEvent);
+    }
+
+    @Test
+    public void partitioningOnlyReordersEvents() {
+        CheckerResult checkerResult = runPartitionChecker(() -> identityChecker, eventList);
+
+        assertThat(checkerResult.valid()).isFalse();
+        assertThat(checkerResult.errors().size()).isEqualTo(eventList.size());
+        assertThat(checkerResult.errors()).containsOnlyElementsOf(eventList);
+    }
+
+    @Test
+    public void partitionsRetainRelativeOrdering() {
+        CheckerResult checkerResult = runPartitionChecker(() -> filterChecker(LOCK_2), eventList);
+
+        assertThat(checkerResult.valid()).isFalse();
+        assertThat(checkerResult.errors()).containsExactlyElementsOf(onlyLock2EventList);
+    }
+
+    @Test
+    public void infoEventsAreLockIndependent() {
+        InvokeEvent invokeEvent = TestEventUtils.invokeLock(0, PROCESS_1, LOCK_1);
+        OkEvent okEvent = TestEventUtils.lockSuccess(1, PROCESS_1);
+
+        List<Event> infoEventList = ImmutableList.<Event>builder()
+                .add(TestEventUtils.createInfoEvent(0, PROCESS_1, RequestType.LOCK))
+                .add(invokeEvent)
+                .add(okEvent)
+                .add(TestEventUtils.createInfoEvent(2, PROCESS_1, RequestType.LOCK))
+                .build();
+
+        CheckerResult checkerResult = runPartitionChecker(() -> filterChecker(LOCK_1), infoEventList);
+
+        assertThat(checkerResult.valid()).isFalse();
+        assertThat(checkerResult.errors()).containsExactlyElementsOf(ImmutableList.of(invokeEvent, okEvent));
+    }
+
+    /**
+     * This method generates a mocked Checker that returns the entire list of Events if and only if all Events in the
+     * list are related to the specified lock name, and there is at least one InvokeEvent.
+     * @param lockName The lock name to filter for
+     * @return mocked Checker
+     */
+    private Checker filterChecker(String lockName) {
+        Checker mockChecker = Mockito.mock(Checker.class);
+        Mockito.when(mockChecker.check(Matchers.anyListOf(Event.class))).then(
+                args -> {
+                    List<Event> events = (List) args.getArguments()[0];
+                    boolean noOtherLock = true;
+                    boolean atLeatOneInvoke = false;
+                    for (Event event : events) {
+                        if (event instanceof InvokeEvent) {
+                            atLeatOneInvoke = true;
+                            InvokeEvent invokeEvent = (InvokeEvent) event;
+                            if (!invokeEvent.value().equals(lockName)) {
+                                noOtherLock = false;
+                            }
+                        }
+                    }
+                    if (noOtherLock && atLeatOneInvoke) {
+                        return ImmutableCheckerResult.builder()
+                                .valid(false)
+                                .errors(events)
+                                .build();
+                    } else {
+                        return ImmutableCheckerResult.builder()
+                                .valid(true)
+                                .errors(new ArrayList<>())
+                                .build();
+                    }
+                });
+        return mockChecker;
+    }
+
+    private static CheckerResult runPartitionChecker(Supplier<Checker> checker, List<Event> events) {
+        PartitionByInvokeNameCheckerHelper partitionByInvokeNameCheckerHelper =
+                new PartitionByInvokeNameCheckerHelper(checker);
+        return partitionByInvokeNameCheckerHelper.check(events);
+    }
+
+    private static void assertNoError(Supplier<Checker> checker, List<Event> events) {
+        CheckerTestUtils.assertNoErrors(() -> new PartitionByInvokeNameCheckerHelper(checker), events);
+    }
+}

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/events/EventTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/events/EventTest.java
@@ -40,7 +40,7 @@ public class EventTest {
         Map<Keyword, Object> keywordMap = new HashMap<>();
         keywordMap.put(Keyword.intern("type"), Keyword.intern("info"));
         keywordMap.put(Keyword.intern("f"), Keyword.intern(JepsenConstants.START_FUNCTION));
-        keywordMap.put(Keyword.intern("process"), Keyword.intern(JepsenConstants.NEMESIS_PROCESS));
+        keywordMap.put(Keyword.intern("process"), Keyword.intern(JepsenConstants.NEMESIS_PROCESS_NAME));
         keywordMap.put(Keyword.intern("time"), SOME_TIME);
         keywordMap.put(Keyword.intern("value"), null);
 
@@ -55,7 +55,7 @@ public class EventTest {
         Map<Keyword, Object> keywordMap = new HashMap<>();
         keywordMap.put(Keyword.intern("type"), Keyword.intern("info"));
         keywordMap.put(Keyword.intern("f"), Keyword.intern(JepsenConstants.START_FUNCTION));
-        keywordMap.put(Keyword.intern("process"), Keyword.intern(JepsenConstants.NEMESIS_PROCESS));
+        keywordMap.put(Keyword.intern("process"), Keyword.intern(JepsenConstants.NEMESIS_PROCESS_NAME));
         keywordMap.put(Keyword.intern("time"), SOME_TIME);
 
         Event event = Event.fromKeywordMap(keywordMap);
@@ -68,7 +68,7 @@ public class EventTest {
         Map<Keyword, Object> keywordMap = new HashMap<>();
         keywordMap.put(Keyword.intern("type"), Keyword.intern("info"));
         keywordMap.put(Keyword.intern("f"), Keyword.intern(JepsenConstants.START_FUNCTION));
-        keywordMap.put(Keyword.intern("process"), Keyword.intern(JepsenConstants.NEMESIS_PROCESS));
+        keywordMap.put(Keyword.intern("process"), Keyword.intern(JepsenConstants.NEMESIS_PROCESS_NAME));
         keywordMap.put(Keyword.intern("time"), SOME_TIME);
         keywordMap.put(Keyword.intern("value"), Keyword.intern(SOME_LONG_AS_STRING));
 
@@ -237,7 +237,7 @@ public class EventTest {
     public void canSerialiseInfoEventWithValue() {
         Event infoEvent = ImmutableInfoEvent.builder()
                 .function("foo")
-                .process(String.valueOf(SOME_PROCESS))
+                .process(SOME_PROCESS)
                 .time(SOME_TIME)
                 .value("bar")
                 .build();
@@ -245,7 +245,7 @@ public class EventTest {
         Map<Keyword, Object> expected = ImmutableMap.of(
                 Keyword.intern("type"), "info",
                 Keyword.intern("f"), "foo",
-                Keyword.intern("process"), String.valueOf(SOME_PROCESS),
+                Keyword.intern("process"), SOME_PROCESS,
                 Keyword.intern("time"), SOME_TIME,
                 Keyword.intern("value"), "bar");
 
@@ -256,14 +256,14 @@ public class EventTest {
     public void canSerialiseInfoEventWithoutValue() {
         Event infoEvent = ImmutableInfoEvent.builder()
                 .function("foo")
-                .process(String.valueOf(SOME_PROCESS))
+                .process(SOME_PROCESS)
                 .time(SOME_TIME)
                 .build();
 
         Map<Keyword, Object> expected = ImmutableMap.of(
                 Keyword.intern("type"), "info",
                 Keyword.intern("f"), "foo",
-                Keyword.intern("process"), String.valueOf(SOME_PROCESS),
+                Keyword.intern("process"), SOME_PROCESS,
                 Keyword.intern("time"), SOME_TIME);
 
         assertThat(Event.toKeywordMap(infoEvent)).isEqualTo(expected);

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/IsolatedProcessCorrectnessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/IsolatedProcessCorrectnessCheckerTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.jepsen.CheckerResult;
+import com.palantir.atlasdb.jepsen.PartitionByInvokeNameCheckerHelper;
+import com.palantir.atlasdb.jepsen.events.Checker;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
@@ -226,11 +228,13 @@ public class IsolatedProcessCorrectnessCheckerTest {
     }
 
     private static CheckerResult runIsolatedProcessRefreshSuccessChecker(List<Event> events) {
-        IsolatedProcessCorrectnessChecker isolatedProcessCorrectnessChecker = new IsolatedProcessCorrectnessChecker();
+        Checker isolatedProcessCorrectnessChecker =
+                new PartitionByInvokeNameCheckerHelper(IsolatedProcessCorrectnessChecker::new);
         return isolatedProcessCorrectnessChecker.check(events);
     }
 
     private static void assertNoError(List<Event> events) {
-        CheckerTestUtils.assertNoErrors(IsolatedProcessCorrectnessChecker::new, events);
+        CheckerTestUtils.assertNoErrors(() ->
+                new PartitionByInvokeNameCheckerHelper(IsolatedProcessCorrectnessChecker::new), events);
     }
 }

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessCheckerTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.jepsen.CheckerResult;
+import com.palantir.atlasdb.jepsen.PartitionByInvokeNameCheckerHelper;
+import com.palantir.atlasdb.jepsen.events.Checker;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
@@ -190,11 +192,12 @@ public class LockCorrectnessCheckerTest {
     }
 
     private static CheckerResult runLockCorrectnessChecker(ImmutableList<Event> events) {
-        LockCorrectnessChecker lockCorrectnessChecker = new LockCorrectnessChecker();
+        Checker lockCorrectnessChecker = new PartitionByInvokeNameCheckerHelper(LockCorrectnessChecker::new);
         return lockCorrectnessChecker.check(events);
     }
 
     private static void assertNoError(List<Event> events) {
-        CheckerTestUtils.assertNoErrors(LockCorrectnessChecker::new, events);
+        CheckerTestUtils.assertNoErrors(() -> new PartitionByInvokeNameCheckerHelper(LockCorrectnessChecker::new),
+                events);
     }
 }

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/utils/TestEventUtils.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/utils/TestEventUtils.java
@@ -105,11 +105,11 @@ public abstract class TestEventUtils {
                 .build();
     }
 
-    public static FailEvent createFailEvent(long time, String process) {
+    public static FailEvent createFailEvent(long time, int process) {
         return createFailEvent(time, process, "unknown");
     }
 
-    public static FailEvent createFailEvent(long time, String process, String error) {
+    public static FailEvent createFailEvent(long time, int process, String error) {
         return ImmutableFailEvent.builder()
                 .time(time)
                 .process(process)
@@ -117,7 +117,7 @@ public abstract class TestEventUtils {
                 .build();
     }
 
-    public static InfoEvent createInfoEvent(long time, String process, String requestType) {
+    public static InfoEvent createInfoEvent(long time, int process, String requestType) {
         return ImmutableInfoEvent.builder()
                 .time(time)
                 .process(process)
@@ -125,7 +125,7 @@ public abstract class TestEventUtils {
                 .build();
     }
 
-    public static InfoEvent createInfoEvent(long time, String process, String requestType, String value) {
+    public static InfoEvent createInfoEvent(long time, int process, String requestType, String value) {
         return ImmutableInfoEvent.builder()
                 .time(time)
                 .process(process)

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/utils/TestEventUtils.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/utils/TestEventUtils.java
@@ -105,11 +105,11 @@ public abstract class TestEventUtils {
                 .build();
     }
 
-    public static FailEvent createFailEvent(long time, int process) {
+    public static FailEvent createFailEvent(long time, String process) {
         return createFailEvent(time, process, "unknown");
     }
 
-    public static FailEvent createFailEvent(long time, int process, String error) {
+    public static FailEvent createFailEvent(long time, String process, String error) {
         return ImmutableFailEvent.builder()
                 .time(time)
                 .process(process)


### PR DESCRIPTION
I started writing a class to partition events by lock name, so that we could simplify some lock checkers by working under the assumption that only one lock was being treated at one time.

However, I hit a snag. I need access to the process number in `Event`, so that I can send all non-invoke events to the last lock name that was used in a request by that process. This requires me to add an `int process()` to the `Event` class; but this clashes with the `String process()` of `InfoEvent`. That's because of the `"nemesis"` process.

Some options to move forwards:

1. convert the `"nemesis"` process to `-1`, and have `InfoEvent.process` be an `int`
2. write an event visitor inside `PartitionByInvokeNameCheckerHelper`
3. abandon this PR entirely and just leave the lock checkers slightly more complicated

I'm not in favour of 3.: I think we should simplify the lock checkers as much as possible for future people reading the code. With 2. we might forget/mess up when if a new event type gets added.

I'm leaning towards 1. as a low-priority task which shouldn't be blocking for #1473.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1493)
<!-- Reviewable:end -->
