### PR TITLE
include the cause of truncate errors for oracle

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -188,7 +188,8 @@ public final class OracleDdlTable implements DbDdlTable {
             throw new IllegalStateException(
                     String.format(
                         "Truncate called on a table (%s) that did not exist",
-                        oracleTableNameGetter.getPrefixedTableName(tableRef)));
+                        oracleTableNameGetter.getPrefixedTableName(tableRef)),
+                    e);
         }
         truncateOverflowTableIfItExists();
     }
@@ -206,7 +207,8 @@ public final class OracleDdlTable implements DbDdlTable {
                                 "Truncate called on a table (%s) that was supposed to have an overflow table (%s),"
                                 + " but that overflow table appears to not exist",
                                 oracleTableNameGetter.getPrefixedTableName(tableRef),
-                                oracleTableNameGetter.getPrefixedOverflowTableName(tableRef)));
+                                oracleTableNameGetter.getPrefixedOverflowTableName(tableRef)),
+                        e);
             }
         }
     }


### PR DESCRIPTION
Currently internal products cannot determine what the underlying error
actually is when a truncate fails because the original exception is
caught and rethrown. This will make it easier to determine the actual
cause of these errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1496)
<!-- Reviewable:end -->
