### PR TITLE
Update gradle-java-distribution to 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.3.1'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.4'
-        classpath 'com.palantir.gradle.javadist:gradle-java-distribution:1.2.0'
+        classpath 'com.palantir.gradle.javadist:gradle-java-distribution:1.3.0'
         classpath 'com.palantir:gradle-baseline-java:0.7.1'
         classpath 'com.palantir:jacoco-coverage:0.4.0'
         classpath "com.netflix.nebula:gradle-dependency-lock-plugin:4.3.2"

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,7 +49,7 @@ develop
     *    - |fixed|
          - Prevent deadlocks during parallel reads from DB KVS.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1468>`__)
-           
+
     *    - |improved|
          - Added support for benchmarking custom Key Value Stores; see `documentation <http://palantir.github.io/atlasdb/html/performance/writing.html>`__.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1459>`__)
@@ -57,6 +57,11 @@ develop
     *    - |fixed|
          - Don't retry interrupted remote calls, shut down the scrubber immediately when interrupted.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1488>`__)
+
+    *    - |improved|
+         - Updated our dependency on ``gradle-java-distribution`` from 1.2.0 to 1.3.0.
+           See gradle-java-distribution `release notes <https://github.com/palantir/gradle-java-distribution/releases>`__ for details.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1500>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
Recommended update.

Release notes: "Check scripts no longer contain GC-related JVM options. This reduces pollution of the log directory with GC logs."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1500)
<!-- Reviewable:end -->
