### PR TITLE
Fix Java 8 optionals in Schema code

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -1027,12 +1027,10 @@ public final class SweepPriorityTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<SweepPriorityRowResult> getRow(SweepPriorityRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<SweepPriorityRowResult> getRow(SweepPriorityRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -1275,5 +1273,5 @@ public final class SweepPriorityTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "vCEOH0g8QatgT/jpEZEk5w==";
+    static String __CLASS_HASH = "URN0DNH5wLcp9bwsNvieGQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
@@ -1027,12 +1027,10 @@ public final class SweepProgressTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<SweepProgressRowResult> getRow(SweepProgressRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<SweepProgressRowResult> getRow(SweepProgressRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -1275,5 +1273,5 @@ public final class SweepProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/I2gV/xLpiGWuzDf+9UF1g==";
+    static String __CLASS_HASH = "D+ku3UNbkHgU75aRsw008A==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbNamedImmutableTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbNamedImmutableTable.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.table.api;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import com.google.common.base.Optional;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 
 /*
@@ -26,8 +25,6 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
  */
 public interface AtlasDbNamedImmutableTable<ROW, COLUMN_VALUE, ROW_RESULT> extends
             AtlasDbImmutableTable<ROW, COLUMN_VALUE, ROW_RESULT> {
-    Optional<ROW_RESULT> getRow(ROW row);
-    Optional<ROW_RESULT> getRow(ROW row, ColumnSelection columnSelection);
     List<ROW_RESULT> getRows(Iterable<ROW> rows);
     List<ROW_RESULT> getRows(Iterable<ROW> rows, ColumnSelection columnSelection);
     List<ROW_RESULT> getAsyncRows(Iterable<ROW> rows, ExecutorService exec);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -1043,12 +1043,10 @@ public class TableRenderer {
         }
 
         private void renderNamedGetRow() {
-            line("@Override");
             line("public ", "Optional<", RowResult, ">", " getRow(", Row, " row) {"); {
                 line("return getRow(row, allColumns);");
             } line("}");
             line();
-            line("@Override");
             line("public ", "Optional<", RowResult, ">", " getRow(", Row, " row, ColumnSelection columns) {"); {
                 line("byte[] bytes = row.persistToBytes();");
                 line("RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);");

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -4,6 +4,10 @@ apply from: "../gradle/shared.gradle"
 apply plugin: 'com.palantir.java-distribution'
 apply plugin: 'org.inferred.processors'
 
+schemas = [
+        'com.palantir.atlasdb.cas.CheckAndSetSchema'
+]
+
 dependencies {
     compile project(':lock-impl')
     compile project(':leader-election-impl')

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
@@ -471,12 +471,10 @@ public final class CheckAndSetTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<CheckAndSetRowResult> getRow(CheckAndSetRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<CheckAndSetRowResult> getRow(CheckAndSetRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
@@ -717,5 +717,5 @@ public final class CheckAndSetTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Liq886F85D4YKwyuaXZmRg==";
+    static String __CLASS_HASH = "vRzK/r2VXST+puDjpkcKPA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -610,12 +610,10 @@ public final class DataTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<DataRowResult> getRow(DataRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<DataRowResult> getRow(DataRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -3638,5 +3636,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "6v6D3OWztYAGUBd3y4QSBw==";
+    static String __CLASS_HASH = "UfX2BLcIzo66QOV+PDQVSg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -678,12 +678,10 @@ public final class TwoColumnsTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<TwoColumnsRowResult> getRow(TwoColumnsRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<TwoColumnsRowResult> getRow(TwoColumnsRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -2293,5 +2291,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "CoGTujrSWASTbNC1oi69+w==";
+    static String __CLASS_HASH = "UpDk9nRzPSLNVC6dlfbS7g==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
@@ -471,12 +471,10 @@ public final class KeyValueTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<KeyValueRowResult> getRow(KeyValueRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<KeyValueRowResult> getRow(KeyValueRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -719,5 +717,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "SMiJwwtb7UOGyQ5QanH9sg==";
+    static String __CLASS_HASH = "26REEPuBZ5/GeJc3UVRfug==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -495,12 +495,10 @@ public final class StreamTestMaxMemStreamMetadataTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<StreamTestMaxMemStreamMetadataRowResult> getRow(StreamTestMaxMemStreamMetadataRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<StreamTestMaxMemStreamMetadataRowResult> getRow(StreamTestMaxMemStreamMetadataRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -743,5 +741,5 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Y8NItHMaLM/2KnItdzyQ7A==";
+    static String __CLASS_HASH = "ovKBuFSKXhb5ELOhaS04Gw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -483,12 +483,10 @@ public final class StreamTestMaxMemStreamValueTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<StreamTestMaxMemStreamValueRowResult> getRow(StreamTestMaxMemStreamValueRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<StreamTestMaxMemStreamValueRowResult> getRow(StreamTestMaxMemStreamValueRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -731,5 +729,5 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "2j377xCs8IEMzZtkvEqrKw==";
+    static String __CLASS_HASH = "YN3vYMkZLfm4msMBJmEanw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -495,12 +495,10 @@ public final class StreamTestStreamMetadataTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<StreamTestStreamMetadataRowResult> getRow(StreamTestStreamMetadataRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<StreamTestStreamMetadataRowResult> getRow(StreamTestStreamMetadataRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -743,5 +741,5 @@ public final class StreamTestStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "jp+VE/Vn2d/3IzCP3P5OVA==";
+    static String __CLASS_HASH = "3ojwsIhrTIviW11wySPLxA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -483,12 +483,10 @@ public final class StreamTestStreamValueTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<StreamTestStreamValueRowResult> getRow(StreamTestStreamValueRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<StreamTestStreamValueRowResult> getRow(StreamTestStreamValueRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -731,5 +729,5 @@ public final class StreamTestStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "QKcLUySpgG4UCchkSoGqXQ==";
+    static String __CLASS_HASH = "bGruW2fk4ePTtlzh25i7mA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -504,12 +504,10 @@ public final class StreamTestWithHashStreamMetadataTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<StreamTestWithHashStreamMetadataRowResult> getRow(StreamTestWithHashStreamMetadataRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<StreamTestWithHashStreamMetadataRowResult> getRow(StreamTestWithHashStreamMetadataRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -752,5 +750,5 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "qsxulwRUqqMed0UPvTgBjQ==";
+    static String __CLASS_HASH = "oplV0XBNSDiuh+BC+uOnmg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
@@ -492,12 +492,10 @@ public final class StreamTestWithHashStreamValueTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<StreamTestWithHashStreamValueRowResult> getRow(StreamTestWithHashStreamValueRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<StreamTestWithHashStreamValueRowResult> getRow(StreamTestWithHashStreamValueRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -740,5 +738,5 @@ public final class StreamTestWithHashStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "8IRhcqBIePRPBqc0EBPnRw==";
+    static String __CLASS_HASH = "f9j87h9bCmX57DOhXfUplw==";
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -43,6 +43,15 @@ develop
          - Change
 
     *    - |fixed|
+         - Fixed schema generation with Java 8 optionals.
+           To use Java8 optionals, supply ``OptionalType.JAVA8`` as an additional constructor argument when creating your ``Schema`` object.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1501>`__)
+
+    *    - |devbreak|
+         - The above fix requires all projects to regenerate their schemas, even if not using Java 8 optionals.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1501>`__)
+
+    *    - |fixed|
          - Make fetch size bounded from above in ``DbKvs.getRowsColumnRange()``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1478>`__)
 

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/ProfileSchema.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/ProfileSchema.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.schema.AtlasSchema;
 import com.palantir.atlasdb.schema.stream.StreamStoreDefinitionBuilder;
 import com.palantir.atlasdb.table.description.IndexDefinition;
 import com.palantir.atlasdb.table.description.IndexDefinition.IndexType;
+import com.palantir.atlasdb.table.description.OptionalType;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
@@ -40,7 +41,8 @@ public class ProfileSchema implements AtlasSchema {
     private static Schema generateSchema() {
         Schema schema = new Schema("Profile",
                 ProfileSchema.class.getPackage().getName() + ".generated",
-                Namespace.DEFAULT_NAMESPACE);
+                Namespace.DEFAULT_NAMESPACE,
+                OptionalType.JAVA8);
 
         schema.addTableDefinition("user_profile", new TableDefinition() {{
             rowName();

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Callable;
@@ -20,7 +21,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -766,5 +766,5 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "WO7sUdURgoIbJTeCMGXAQw==";
+    static String __CLASS_HASH = "dQJo6NvMXsoKhKg3Vq7GNg==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Callable;
@@ -20,7 +21,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -766,5 +766,5 @@ public final class UserPhotosStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "DMbXUaZKuYz1R0VKvAxEqQ==";
+    static String __CLASS_HASH = "0BCwlfLHYV5Htu8FCwnBXA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Callable;
@@ -20,7 +21,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -503,7 +503,7 @@ public final class UserPhotosStreamMetadataTable implements
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
-            return Optional.absent();
+            return Optional.empty();
         } else {
             return Optional.of(UserPhotosStreamMetadataRowResult.of(rowResult));
         }
@@ -741,5 +741,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UQj42m9mYJTK6OKcxim6nQ==";
+    static String __CLASS_HASH = "pF65FiYhkVyYcSGzmQXwbQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -495,12 +495,10 @@ public final class UserPhotosStreamMetadataTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<UserPhotosStreamMetadataRowResult> getRow(UserPhotosStreamMetadataRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<UserPhotosStreamMetadataRowResult> getRow(UserPhotosStreamMetadataRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -743,5 +741,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "gDn9bIqWsbm3u8PlbY7obQ==";
+    static String __CLASS_HASH = "UQj42m9mYJTK6OKcxim6nQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -483,12 +483,10 @@ public final class UserPhotosStreamValueTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<UserPhotosStreamValueRowResult> getRow(UserPhotosStreamValueRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<UserPhotosStreamValueRowResult> getRow(UserPhotosStreamValueRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -731,5 +729,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "OO3xJ1Ch3BBeCGrTup0MCQ==";
+    static String __CLASS_HASH = "BInQoHB4vz+x4jZjtnCynQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Callable;
@@ -20,7 +21,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -491,7 +491,7 @@ public final class UserPhotosStreamValueTable implements
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
-            return Optional.absent();
+            return Optional.empty();
         } else {
             return Optional.of(UserPhotosStreamValueRowResult.of(rowResult));
         }
@@ -729,5 +729,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "BInQoHB4vz+x4jZjtnCynQ==";
+    static String __CLASS_HASH = "lp86MkgeeTISottbieOOIA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Callable;
@@ -20,7 +21,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -1017,7 +1017,7 @@ public final class UserProfileTable implements
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
-            return Optional.absent();
+            return Optional.empty();
         } else {
             return Optional.of(UserProfileRowResult.of(rowResult));
         }
@@ -3386,5 +3386,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Gnev0ttdbs293RjM7Vexew==";
+    static String __CLASS_HASH = "twWonBYvnCo3eLx7bSPHnw==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -1009,12 +1009,10 @@ public final class UserProfileTable implements
         t.delete(tableRef, cells);
     }
 
-    @Override
     public Optional<UserProfileRowResult> getRow(UserProfileRow row) {
         return getRow(row, allColumns);
     }
 
-    @Override
     public Optional<UserProfileRowResult> getRow(UserProfileRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
@@ -3388,5 +3386,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "BAWiFRjPo3iiz4ifhWSE8g==";
+    static String __CLASS_HASH = "Gnev0ttdbs293RjM7Vexew==";
 }


### PR DESCRIPTION
- Removed the unused interfaces AtlasDbNamedMutableTable and
AtlasDbNamedImmutableTable.
- Made the ProfileSchema use Java 8 optionals as a proof of concept
that this can work.

Fixes #1249

@ellisjoe for SA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1501)
<!-- Reviewable:end -->
