### PR TITLE
Don't wait for the timelock server to be ready before starting Jepsen.

### DIFF
--- a/atlasdb-jepsen-tests/build.gradle
+++ b/atlasdb-jepsen-tests/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     processor group: 'org.immutables', name: 'value'
 
     testCompile group: 'org.assertj', name: 'assertj-core'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-library'
     testCompile group: 'org.mockito', name: 'mockito-core'
 }
 

--- a/atlasdb-jepsen-tests/build.gradle
+++ b/atlasdb-jepsen-tests/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
     compile group: 'com.google.guava', name: 'guava'
-    compile group: 'com.jayway.awaitility', name: 'awaitility'
     compile group: 'one.util', name: 'streamex'
     compile group: 'org.clojure', name: 'clojure'
     compile group: 'org.slf4j', name: 'slf4j-api'

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
@@ -22,9 +22,7 @@
         (c/upload "resources/atlasdb/timelock.yml" "/timelock-server/var/conf")
         (c/exec :sed :-i (format "s/<HOSTNAME>/%s/" (name node)) "/timelock-server/var/conf/timelock.yml")
         (info node "Starting timelock server")
-        (c/exec :env "JAVA_HOME=/usr/lib/jvm/java-8-oracle" "/timelock-server/service/bin/init.sh" "start")
-        (info node "Waiting until timelock node is ready")
-        (TimelockUtils/waitUntilHostReady (name node))))
+        (c/exec :env "JAVA_HOME=/usr/lib/jvm/java-8-oracle" "/timelock-server/service/bin/init.sh" "start")))
 
     (teardown! [_ _ node]
       (c/su

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
@@ -2,8 +2,7 @@
   (:require [clojure.tools.logging :refer :all]
             [jepsen.control :as c]
             [jepsen.db :as db]
-            [jepsen.os.debian :as debian])
-  (:import com.palantir.atlasdb.http.TimelockUtils))
+            [jepsen.os.debian :as debian]))
 
 (defn create-db
   "Creates an object that implements the db/DB protocol.

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.http;
 
-import java.net.Socket;
 import java.util.List;
 
 import javax.net.ssl.SSLSocketFactory;
@@ -46,14 +45,4 @@ public final class TimelockUtils {
                 endpointUris,
                 type);
     }
-
-    private static boolean hostIsListening(String host) {
-        try {
-            new Socket(host, PORT);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
 }

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
@@ -17,13 +17,11 @@ package com.palantir.atlasdb.http;
 
 import java.net.Socket;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import com.jayway.awaitility.Awaitility;
 
 public final class TimelockUtils {
     private static final int PORT = 8080;
@@ -31,12 +29,6 @@ public final class TimelockUtils {
     private static final String NAMESPACE = "test";
 
     private TimelockUtils() {
-    }
-
-    public static void waitUntilHostReady(String host) {
-        Awaitility.await()
-                .atMost(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .until(() -> hostIsListening(host));
     }
 
     public static <T> T createClient(List<String> hosts, Class<T> type) {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/TimelockUtils.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 
 public final class TimelockUtils {
     private static final int PORT = 8080;
-    private static final int TIMEOUT_SECONDS = 60;
     private static final String NAMESPACE = "test";
 
     private TimelockUtils() {

--- a/atlasdb-jepsen-tests/versions.lock
+++ b/atlasdb-jepsen-tests/versions.lock
@@ -1,11 +1,5 @@
 {
     "compileClasspath": {
-        "cglib:cglib-nodep": {
-            "locked": "3.1",
-            "transitive": [
-                "com.jayway.awaitility:awaitility"
-            ]
-        },
         "ch.qos.logback:logback-classic": {
             "locked": "1.1.3",
             "transitive": [
@@ -158,9 +152,6 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
             ]
-        },
-        "com.jayway.awaitility:awaitility": {
-            "locked": "1.6.5"
         },
         "com.netflix.feign:feign-core": {
             "locked": "8.6.1",
@@ -393,25 +384,6 @@
         },
         "org.clojure:clojure": {
             "locked": "1.8.0"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "com.jayway.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "com.jayway.awaitility:awaitility"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.2",
-            "transitive": [
-                "com.jayway.awaitility:awaitility"
-            ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
@@ -435,12 +407,6 @@
         }
     },
     "runtime": {
-        "cglib:cglib-nodep": {
-            "locked": "3.1",
-            "transitive": [
-                "com.jayway.awaitility:awaitility"
-            ]
-        },
         "ch.qos.logback:logback-classic": {
             "locked": "1.1.3",
             "transitive": [
@@ -593,9 +559,6 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
             ]
-        },
-        "com.jayway.awaitility:awaitility": {
-            "locked": "1.6.5"
         },
         "com.netflix.feign:feign-core": {
             "locked": "8.6.1",
@@ -828,25 +791,6 @@
         },
         "org.clojure:clojure": {
             "locked": "1.8.0"
-        },
-        "org.hamcrest:hamcrest-core": {
-            "locked": "1.3",
-            "transitive": [
-                "com.jayway.awaitility:awaitility",
-                "org.hamcrest:hamcrest-library"
-            ]
-        },
-        "org.hamcrest:hamcrest-library": {
-            "locked": "1.3",
-            "transitive": [
-                "com.jayway.awaitility:awaitility"
-            ]
-        },
-        "org.objenesis:objenesis": {
-            "locked": "2.2",
-            "transitive": [
-                "com.jayway.awaitility:awaitility"
-            ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",


### PR DESCRIPTION
The timelock server should be able to handle being pinged right from
startup. This change is even more relevant when we collect metrics on
liveness (#1359), and also may answer previous problems with
load+leadership election (#383).

<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
- Note what this change does and why it is needed
- Include details of who this change helps (without including internal product names)
- Include the Atlas release or date you need this by
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1510)
<!-- Reviewable:end -->
