### PR TITLE
Cassandra timestamp store invalidator

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorIntegrationTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
+import com.palantir.atlasdb.containers.CassandraContainer;
+import com.palantir.atlasdb.containers.Containers;
+import com.palantir.common.base.Throwables;
+import com.palantir.timestamp.TimestampBoundStore;
+import com.palantir.timestamp.TimestampStoreInvalidator;
+
+public class CassandraTimestampStoreInvalidatorIntegrationTest {
+    @ClassRule
+    public static final Containers CONTAINERS = new Containers(CassandraTimestampStoreInvalidatorIntegrationTest.class)
+            .with(new CassandraContainer());
+
+    private static final long ZERO = 0L;
+    private static final long ONE_MILLION = 1000000L;
+    private static final long TWO_MILLION = 2000000L;
+    private static final int POOL_SIZE = 16;
+    private static final int TIMEOUT_SECONDS = 5;
+
+    private final CassandraKeyValueService kv = CassandraKeyValueService.create(
+            CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
+            CassandraContainer.LEADER_CONFIG);
+    private final TimestampStoreInvalidator invalidator = new CassandraTimestampStoreInvalidator(kv);
+
+    private TimestampBoundStore timestampBoundStore;
+    private ExecutorService executorService;
+
+    @Before
+    public void setUp() {
+        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
+        timestampBoundStore = CassandraTimestampBoundStore.create(kv);
+        executorService = Executors.newFixedThreadPool(POOL_SIZE);
+    }
+
+    @After
+    public void close() {
+        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
+        kv.close();
+    }
+
+    @Test
+    public void canInvalidateTimestampTableIfItAlreadyExistsWithData() {
+        timestampBoundStore.getUpperLimit();
+        timestampBoundStore.storeUpperLimit(ONE_MILLION);
+        invalidateAndThenCheckCannotReadBound();
+    }
+
+    @Test
+    public void canInvalidateTimestampTableIfItAlreadyExistsWithoutData() {
+        invalidateAndThenCheckCannotReadBound();
+    }
+
+    @Test
+    public void canInvalidateTimestampTableIfItDoesNotExistYet() {
+        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
+        invalidateAndThenCheckCannotReadBound();
+    }
+
+    @Test
+    public void invalidateIsIdempotent() {
+        invalidator.invalidateTimestampStore();
+        invalidateAndThenCheckCannotReadBound();
+    }
+
+    @Test
+    public void resilientToMultipleConcurrentInvalidations() {
+        executeInParallelOnExecutorService(this::invalidateAndThenCheckCannotReadBound);
+        revalidateAndThenCheckCanReadBound(ZERO);
+    }
+
+    @Test
+    public void cannotGoBackInTimeWithRevalidation() {
+        invalidateAndThenCheckCannotReadBound();
+        revalidateAndThenCheckCanReadBound(ZERO);
+        timestampBoundStore.getUpperLimit();
+        timestampBoundStore.storeUpperLimit(ONE_MILLION);
+        revalidateAndThenCheckCanReadBound(ONE_MILLION); // in particular, not ZERO
+    }
+
+    @Test
+    public void canReadTimestampTableAfterRevalidation() {
+        timestampBoundStore.getUpperLimit();
+        timestampBoundStore.storeUpperLimit(ONE_MILLION);
+        invalidateAndThenCheckCannotReadBound();
+        revalidateAndThenCheckCanReadBound(ONE_MILLION);
+    }
+
+    @Test
+    public void resilientToMultipleConcurrentRevalidations() {
+        invalidateAndThenCheckCannotReadBound();
+        executeInParallelOnExecutorService(() -> revalidateAndThenCheckCanReadBound(ZERO));
+    }
+
+    private void invalidateAndThenCheckCannotReadBound() {
+        invalidator.invalidateTimestampStore();
+        assertThatThrownBy(timestampBoundStore::getUpperLimit).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void revalidateAndThenCheckCanReadBound(long expected) {
+        invalidator.revalidateTimestampStore();
+        assertThat(timestampBoundStore.getUpperLimit()).isEqualTo(expected);
+    }
+
+    private void executeInParallelOnExecutorService(Runnable runnable) {
+        List<Future<?>> futures =
+                Stream.generate(() -> executorService.submit(runnable))
+                        .limit(POOL_SIZE)
+                        .collect(Collectors.toList());
+        futures.forEach(future -> {
+            try {
+                future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException exception) {
+                throw Throwables.rewrapAndThrowUncheckedException(exception);
+            }
+        });
+    }
+}

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorIntegrationTest.java
@@ -48,7 +48,6 @@ public class CassandraTimestampStoreInvalidatorIntegrationTest {
 
     private static final long ZERO = 0L;
     private static final long ONE_MILLION = 1000000L;
-    private static final long TWO_MILLION = 2000000L;
     private static final int POOL_SIZE = 16;
     private static final int TIMEOUT_SECONDS = 5;
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorIntegrationTest.java
@@ -74,8 +74,7 @@ public class CassandraTimestampStoreInvalidatorIntegrationTest {
 
     @Test
     public void canInvalidateTimestampTableIfItAlreadyExistsWithData() {
-        timestampBoundStore.getUpperLimit();
-        timestampBoundStore.storeUpperLimit(ONE_MILLION);
+        takeOutOneMillionTimestamps();
         invalidateAndThenCheckCannotReadBound();
     }
 
@@ -98,31 +97,36 @@ public class CassandraTimestampStoreInvalidatorIntegrationTest {
 
     @Test
     public void resilientToMultipleConcurrentInvalidations() {
+        takeOutOneMillionTimestamps();
         executeInParallelOnExecutorService(this::invalidateAndThenCheckCannotReadBound);
-        revalidateAndThenCheckCanReadBound(ZERO);
+        revalidateAndThenCheckCanReadBound(ONE_MILLION);
+    }
+
+    private void takeOutOneMillionTimestamps() {
+        timestampBoundStore.getUpperLimit();
+        timestampBoundStore.storeUpperLimit(ONE_MILLION);
     }
 
     @Test
     public void cannotGoBackInTimeWithRevalidation() {
         invalidateAndThenCheckCannotReadBound();
         revalidateAndThenCheckCanReadBound(ZERO);
-        timestampBoundStore.getUpperLimit();
-        timestampBoundStore.storeUpperLimit(ONE_MILLION);
+        takeOutOneMillionTimestamps();
         revalidateAndThenCheckCanReadBound(ONE_MILLION); // in particular, not ZERO
     }
 
     @Test
     public void canReadTimestampTableAfterRevalidation() {
-        timestampBoundStore.getUpperLimit();
-        timestampBoundStore.storeUpperLimit(ONE_MILLION);
+        takeOutOneMillionTimestamps();
         invalidateAndThenCheckCannotReadBound();
         revalidateAndThenCheckCanReadBound(ONE_MILLION);
     }
 
     @Test
     public void resilientToMultipleConcurrentRevalidations() {
+        takeOutOneMillionTimestamps();
         invalidateAndThenCheckCannotReadBound();
-        executeInParallelOnExecutorService(() -> revalidateAndThenCheckCanReadBound(ZERO));
+        executeInParallelOnExecutorService(() -> revalidateAndThenCheckCanReadBound(ONE_MILLION));
     }
 
     private void invalidateAndThenCheckCannotReadBound() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -65,7 +65,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                         ColumnValueDescription.forType(ValueType.FIXED_LONG)))),
             ConflictHandler.IGNORE_ALL);
 
-    private static final long INITIAL_VALUE = 10000L;
+    public static final long INITIAL_VALUE = 10000L;
 
     @GuardedBy("this")
     private long currentLimit = -1;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
@@ -36,9 +36,10 @@ public class CassandraTimestampCqlExecutor {
     private static final Logger log = LoggerFactory.getLogger(CassandraTimestampCqlExecutor.class);
 
     private static final String ROW_AND_COLUMN_NAME = "ts";
-    public static final byte[] ROW_AND_COLUMN_NAME_BYTES = PtBytes.toBytes(ROW_AND_COLUMN_NAME);
     private static final String BACKUP_COLUMN_NAME = "oldTs";
-    public static final byte[] BACKUP_COLUMN_NAME_BYTES = PtBytes.toBytes(BACKUP_COLUMN_NAME);
+
+    static final byte[] ROW_AND_COLUMN_NAME_BYTES = PtBytes.toBytes(ROW_AND_COLUMN_NAME);
+    static final byte[] BACKUP_COLUMN_NAME_BYTES = PtBytes.toBytes(BACKUP_COLUMN_NAME);
 
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
@@ -81,16 +82,16 @@ public class CassandraTimestampCqlExecutor {
                 .stream()
                 .map(entry -> constructCqlInsertCommandForTimestampTable(entry.getKey(), entry.getValue()))
                 .collect(Collectors.joining());
-        return "BEGIN BATCH\n" +
-                insertions +
-                "APPLY BATCH;";
+        return "BEGIN BATCH\n"
+                + insertions
+                + "APPLY BATCH;";
     }
 
     private String constructCqlInsertCommandForTimestampTable(byte[] rowAndColumnName, byte[] value) {
         String hexName = encodeCassandraHexValue(rowAndColumnName);
         String hexValue = encodeCassandraHexValue(value);
         return String.format(
-                "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, -1, %s);\n",
+                "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, -1, %s);%n",
                 "\"" + AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName() + "\"",
                 hexName,
                 hexName,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
@@ -90,7 +90,10 @@ public class CassandraTimestampCqlExecutor {
     private String constructCqlBatchInsertCommand(Map<byte[], byte[]> rowsToValues) {
         String insertions = rowsToValues.entrySet()
                 .stream()
-                .map(entry -> constructCqlInsertCommandForTimestampTable(entry.getKey(), entry.getValue()))
+                .map(entry -> constructCqlInsertCommandForTimestampTable(
+                        ROW_AND_COLUMN_NAME_BYTES,
+                        entry.getKey(),
+                        entry.getValue()))
                 .collect(Collectors.joining());
         return "BEGIN BATCH\n"
                 + insertions
@@ -98,15 +101,13 @@ public class CassandraTimestampCqlExecutor {
     }
 
     @SuppressFBWarnings("VA_FORMAT_STRING_USES_NEWLINE")
-    private String constructCqlInsertCommandForTimestampTable(byte[] rowAndColumnName, byte[] value) {
-        String hexName = encodeCassandraHexValue(rowAndColumnName);
-        String hexValue = encodeCassandraHexValue(value);
+    private String constructCqlInsertCommandForTimestampTable(byte[] rowName, byte[] columnName, byte[] value) {
         return String.format(
                 "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, -1, %s);\n",
                 wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
-                hexName,
-                hexName,
-                hexValue);
+                encodeCassandraHexValue(rowName),
+                encodeCassandraHexValue(columnName),
+                encodeCassandraHexValue(value));
     }
 
     private String wrapInQuotes(String tableName) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
@@ -92,10 +92,14 @@ public class CassandraTimestampCqlExecutor {
         String hexValue = encodeCassandraHexValue(value);
         return String.format(
                 "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, -1, %s);%n",
-                "\"" + AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName() + "\"",
+                wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
                 hexName,
                 hexName,
                 hexValue);
+    }
+
+    private String wrapInQuotes(String tableName) {
+        return "\"" + tableName + "\"";
     }
 
     private String encodeCassandraHexValue(byte[] value) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
@@ -58,6 +58,7 @@ public class CassandraTimestampCqlExecutor {
     public void restoreBoundFromBackup(long bound) {
         executeCqlBatchInsertOnTimestampTable(ImmutableMap.<byte[], byte[]>builder()
                 .put(ROW_AND_COLUMN_NAME_BYTES, PtBytes.toBytes(bound))
+                .put(BACKUP_COLUMN_NAME_BYTES, EMPTY_BYTE_ARRAY) // else 2x revalidate will mean we go back in time
                 .build());
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampCqlExecutor.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.common.base.Throwables;
+
+public class CassandraTimestampCqlExecutor {
+    private static final Logger log = LoggerFactory.getLogger(CassandraTimestampCqlExecutor.class);
+
+    private static final String ROW_AND_COLUMN_NAME = "ts";
+    public static final byte[] ROW_AND_COLUMN_NAME_BYTES = PtBytes.toBytes(ROW_AND_COLUMN_NAME);
+    private static final String BACKUP_COLUMN_NAME = "oldTs";
+    public static final byte[] BACKUP_COLUMN_NAME_BYTES = PtBytes.toBytes(BACKUP_COLUMN_NAME);
+
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
+    private final CassandraKeyValueService rawCassandraKvs;
+
+    public CassandraTimestampCqlExecutor(CassandraKeyValueService rawCassandraKvs) {
+        this.rawCassandraKvs = rawCassandraKvs;
+    }
+
+    public void backupBound(long bound) {
+        executeCqlBatchInsertOnTimestampTable(ImmutableMap.<byte[], byte[]>builder()
+                .put(ROW_AND_COLUMN_NAME_BYTES, EMPTY_BYTE_ARRAY)
+                .put(BACKUP_COLUMN_NAME_BYTES, PtBytes.toBytes(bound))
+                .build());
+    }
+
+    public void restoreBoundFromBackup(long bound) {
+        executeCqlBatchInsertOnTimestampTable(ImmutableMap.<byte[], byte[]>builder()
+                .put(ROW_AND_COLUMN_NAME_BYTES, PtBytes.toBytes(bound))
+                .build());
+    }
+
+    private void executeCqlBatchInsertOnTimestampTable(Map<byte[], byte[]> rowsToValues) {
+        rawCassandraKvs.clientPool.runWithRetry(client -> {
+            try {
+                String queryString = constructCqlBatchInsertCommand(rowsToValues);
+                ByteBuffer queryBuffer = ByteBuffer.wrap(PtBytes.toBytes(queryString));
+                client.execute_cql3_query(queryBuffer, Compression.NONE, ConsistencyLevel.QUORUM);
+            } catch (TException e) {
+                log.error("An error occurred whilst trying to write to Cassandra:", e);
+                throw Throwables.rewrapAndThrowUncheckedException(e);
+            }
+            return null;
+        });
+    }
+
+    private String constructCqlBatchInsertCommand(Map<byte[], byte[]> rowsToValues) {
+        String insertions = rowsToValues.entrySet()
+                .stream()
+                .map(entry -> constructCqlInsertCommandForTimestampTable(entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining());
+        return "BEGIN BATCH\n" +
+                insertions +
+                "APPLY BATCH;";
+    }
+
+    private String constructCqlInsertCommandForTimestampTable(byte[] rowAndColumnName, byte[] value) {
+        String hexName = encodeCassandraHexValue(rowAndColumnName);
+        String hexValue = encodeCassandraHexValue(value);
+        return String.format(
+                "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, -1, %s);\n",
+                "\"" + AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName() + "\"",
+                hexName,
+                hexName,
+                hexValue);
+    }
+
+    private String encodeCassandraHexValue(byte[] value) {
+        return "0x" + DatatypeConverter.printHexBinary(value);
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
@@ -15,17 +15,8 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
-
-import javax.xml.bind.DatatypeConverter;
-
-import org.apache.cassandra.thrift.Compression;
-import org.apache.cassandra.thrift.ConsistencyLevel;
-import org.apache.thrift.TException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -33,81 +24,57 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.common.base.Throwables;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 
 public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalidator {
-    private static final Logger log = LoggerFactory.getLogger(CassandraTimestampStoreInvalidator.class);
-    private static final long CASSANDRA_TIMESTAMP = 0L;
-
-    private static final String ROW_AND_COLUMN_NAME = "ts";
-    private static final byte[] ROW_AND_COLUMN_NAME_BYTES = PtBytes.toBytes(ROW_AND_COLUMN_NAME);
-    private static final Cell TIMESTAMP_CELL = Cell.create(ROW_AND_COLUMN_NAME_BYTES, ROW_AND_COLUMN_NAME_BYTES);
-
-    private static final String BACKUP_COLUMN_NAME = "oldTs";
-    private static final byte[] BACKUP_COLUMN_NAME_BYTES = PtBytes.toBytes(BACKUP_COLUMN_NAME);
-
-    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+    private static final long DEFAULT_TIMESTAMP_BOUND = 0L;
 
     private final CassandraKeyValueService rawCassandraKvs;
+    private final CassandraTimestampCqlExecutor cassandraTimestampCqlExecutor;
 
     public CassandraTimestampStoreInvalidator(CassandraKeyValueService rawCassandraKvs) {
         this.rawCassandraKvs = rawCassandraKvs;
+        this.cassandraTimestampCqlExecutor = new CassandraTimestampCqlExecutor(rawCassandraKvs);
     }
 
     @Override
     public void invalidateTimestampStore() {
         Optional<Long> bound = getCurrentTimestampBound();
-        bound.ifPresent(this::backupBound);
-    }
-
-    private Optional<Long> getCurrentTimestampBound() {
-        Map<Cell, Value> result = rawCassandraKvs.get(
-                AtlasDbConstants.TIMESTAMP_TABLE,
-                ImmutableMap.of(TIMESTAMP_CELL, Long.MAX_VALUE));
-        Value value = Iterables.getOnlyElement(result.values(), Value.create(PtBytes.toBytes(0L), CASSANDRA_TIMESTAMP));
-        try {
-            return Optional.of(PtBytes.toLong(value.getContents()));
-        } catch (IllegalArgumentException exception) {
-            // This can occur if the timestamp table was already invalidated.
-            return Optional.empty();
-        }
-    }
-
-    private void backupBound(long bound) {
-        rawCassandraKvs.clientPool.runWithRetry(client -> {
-            try {
-                String queryString = "BEGIN BATCH\n" +
-                        constructCqlInsertCommandForTimestampTable(BACKUP_COLUMN_NAME_BYTES, PtBytes.toBytes(bound)) +
-                        constructCqlInsertCommandForTimestampTable(ROW_AND_COLUMN_NAME_BYTES, EMPTY_BYTE_ARRAY) +
-                        "APPLY BATCH;";
-                ByteBuffer query = ByteBuffer.wrap(PtBytes.toBytes(queryString));
-                client.execute_cql3_query(query, Compression.NONE, ConsistencyLevel.QUORUM);
-            } catch (TException e) {
-                log.error("An error occurred whilst trying to write to Cassandra:", e);
-                throw Throwables.rewrapAndThrowUncheckedException(e);
-            }
-            return null;
-        });
-    }
-
-    private String constructCqlInsertCommandForTimestampTable(byte[] rowAndColumnName, byte[] value) {
-        String hexName = encodeCassandraHexValue(rowAndColumnName);
-        String hexValue = encodeCassandraHexValue(value);
-        return String.format(
-                "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, -1, %s);\n",
-                "\"" + AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName() + "\"",
-                hexName,
-                hexName,
-                hexValue);
-    }
-
-    private String encodeCassandraHexValue(byte[] value) {
-        return "0x" + DatatypeConverter.printHexBinary(value);
+        bound.ifPresent(cassandraTimestampCqlExecutor::backupBound);
     }
 
     @Override
     public void revalidateTimestampStore() {
+        Optional<Long> bound = getBackupTimestampBound();
+        bound.ifPresent(cassandraTimestampCqlExecutor::restoreBoundFromBackup);
+    }
 
+    private Optional<Long> getCurrentTimestampBound() {
+        return getBoundFromKvs(CassandraTimestampCqlExecutor.ROW_AND_COLUMN_NAME_BYTES);
+    }
+
+    private Optional<Long> getBackupTimestampBound() {
+        return getBoundFromKvs(CassandraTimestampCqlExecutor.BACKUP_COLUMN_NAME_BYTES);
+    }
+
+    private Optional<Long> getBoundFromKvs(byte[] timestampCellName) {
+        Cell timestampCell = Cell.create(timestampCellName, timestampCellName);
+        Map<Cell, Value> result = rawCassandraKvs.get(
+                AtlasDbConstants.TIMESTAMP_TABLE,
+                ImmutableMap.of(timestampCell, Long.MAX_VALUE));
+        if (result.isEmpty()) {
+            return Optional.of(DEFAULT_TIMESTAMP_BOUND);
+        }
+
+        Value value = Iterables.getOnlyElement(result.values());
+        return getLongFromValue(value);
+    }
+
+    private Optional<Long> getLongFromValue(Value value) {
+        byte[] contents = value.getContents();
+        if (contents.length == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(PtBytes.toLong(contents));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
@@ -70,7 +70,8 @@ public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalid
     }
 
     private Optional<Long> getBoundFromKvs(byte[] timestampCellName) {
-        Cell timestampCell = Cell.create(timestampCellName, timestampCellName);
+        Cell timestampCell = Cell.create(
+                CassandraTimestampCqlExecutor.ROW_AND_COLUMN_NAME_BYTES, timestampCellName);
         Map<Cell, Value> result = rawCassandraKvs.get(
                 AtlasDbConstants.TIMESTAMP_TABLE,
                 ImmutableMap.of(timestampCell, Long.MAX_VALUE));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
@@ -39,6 +39,9 @@ public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalid
 
     @Override
     public void invalidateTimestampStore() {
+        // Avoid Cassandra exploding on later reads if the table happens not to exist yet.
+        rawCassandraKvs.createTable(AtlasDbConstants.TIMESTAMP_TABLE,
+                CassandraTimestampBoundStore.TIMESTAMP_TABLE_METADATA.persistToBytes());
         Optional<Long> bound = getCurrentTimestampBound();
         bound.ifPresent(cassandraTimestampCqlExecutor::backupBound);
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.util.Map;
 import java.util.Optional;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -33,8 +34,14 @@ public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalid
     private final CassandraTimestampCqlExecutor cassandraTimestampCqlExecutor;
 
     public CassandraTimestampStoreInvalidator(CassandraKeyValueService rawCassandraKvs) {
+        this(rawCassandraKvs, new CassandraTimestampCqlExecutor(rawCassandraKvs));
+    }
+
+    @VisibleForTesting
+    CassandraTimestampStoreInvalidator(CassandraKeyValueService rawCassandraKvs,
+            CassandraTimestampCqlExecutor cassandraTimestampCqlExecutor) {
         this.rawCassandraKvs = rawCassandraKvs;
-        this.cassandraTimestampCqlExecutor = new CassandraTimestampCqlExecutor(rawCassandraKvs);
+        this.cassandraTimestampCqlExecutor = cassandraTimestampCqlExecutor;
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.common.base.Throwables;
+import com.palantir.timestamp.TimestampStoreInvalidator;
+
+public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalidator {
+    private static final Logger log = LoggerFactory.getLogger(CassandraTimestampStoreInvalidator.class);
+    private static final long CASSANDRA_TIMESTAMP = 0L;
+
+    private static final String ROW_AND_COLUMN_NAME = "ts";
+    private static final byte[] ROW_AND_COLUMN_NAME_BYTES = PtBytes.toBytes(ROW_AND_COLUMN_NAME);
+    private static final Cell TIMESTAMP_CELL = Cell.create(ROW_AND_COLUMN_NAME_BYTES, ROW_AND_COLUMN_NAME_BYTES);
+
+    private static final String BACKUP_COLUMN_NAME = "oldTs";
+    private static final byte[] BACKUP_COLUMN_NAME_BYTES = PtBytes.toBytes(BACKUP_COLUMN_NAME);
+
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
+    private final CassandraKeyValueService rawCassandraKvs;
+
+    public CassandraTimestampStoreInvalidator(CassandraKeyValueService rawCassandraKvs) {
+        this.rawCassandraKvs = rawCassandraKvs;
+    }
+
+    @Override
+    public void invalidateTimestampStore() {
+        Optional<Long> bound = getCurrentTimestampBound();
+        bound.ifPresent(this::backupBound);
+    }
+
+    private Optional<Long> getCurrentTimestampBound() {
+        Map<Cell, Value> result = rawCassandraKvs.get(
+                AtlasDbConstants.TIMESTAMP_TABLE,
+                ImmutableMap.of(TIMESTAMP_CELL, Long.MAX_VALUE));
+        Value value = Iterables.getOnlyElement(result.values(), Value.create(PtBytes.toBytes(0L), CASSANDRA_TIMESTAMP));
+        try {
+            return Optional.of(PtBytes.toLong(value.getContents()));
+        } catch (IllegalArgumentException exception) {
+            // This can occur if the timestamp table was already invalidated.
+            return Optional.empty();
+        }
+    }
+
+    private void backupBound(long bound) {
+        rawCassandraKvs.clientPool.runWithRetry(client -> {
+            try {
+                String queryString = "BEGIN BATCH\n" +
+                        constructCqlInsertCommandForTimestampTable(BACKUP_COLUMN_NAME_BYTES, PtBytes.toBytes(bound)) +
+                        constructCqlInsertCommandForTimestampTable(ROW_AND_COLUMN_NAME_BYTES, EMPTY_BYTE_ARRAY) +
+                        "APPLY BATCH;";
+                ByteBuffer query = ByteBuffer.wrap(PtBytes.toBytes(queryString));
+                client.execute_cql3_query(query, Compression.NONE, ConsistencyLevel.QUORUM);
+            } catch (TException e) {
+                log.error("An error occurred whilst trying to write to Cassandra:", e);
+                throw Throwables.rewrapAndThrowUncheckedException(e);
+            }
+            return null;
+        });
+    }
+
+    private String constructCqlInsertCommandForTimestampTable(byte[] rowAndColumnName, byte[] value) {
+        String hexName = encodeCassandraHexValue(rowAndColumnName);
+        String hexValue = encodeCassandraHexValue(value);
+        return String.format(
+                "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, -1, %s);\n",
+                "\"" + AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName() + "\"",
+                hexName,
+                hexName,
+                hexValue);
+    }
+
+    private String encodeCassandraHexValue(byte[] value) {
+        return "0x" + DatatypeConverter.printHexBinary(value);
+    }
+
+    @Override
+    public void revalidateTimestampStore() {
+
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
@@ -46,17 +46,21 @@ public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalid
 
     @Override
     public void invalidateTimestampStore() {
-        // Avoid Cassandra exploding on later reads if the table happens not to exist yet.
-        rawCassandraKvs.createTable(AtlasDbConstants.TIMESTAMP_TABLE,
-                CassandraTimestampBoundStore.TIMESTAMP_TABLE_METADATA.persistToBytes());
+        ensureTimestampTableExists();
         Optional<Long> bound = getCurrentTimestampBound();
         bound.ifPresent(cassandraTimestampCqlExecutor::backupBound);
     }
 
     @Override
     public void revalidateTimestampStore() {
+        ensureTimestampTableExists();
         Optional<Long> bound = getBackupTimestampBound();
         bound.ifPresent(cassandraTimestampCqlExecutor::restoreBoundFromBackup);
+    }
+
+    private void ensureTimestampTableExists() {
+        rawCassandraKvs.createTable(AtlasDbConstants.TIMESTAMP_TABLE,
+                CassandraTimestampBoundStore.TIMESTAMP_TABLE_METADATA.persistToBytes());
     }
 
     private Optional<Long> getCurrentTimestampBound() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
@@ -28,8 +28,6 @@ import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 
 public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalidator {
-    private static final long DEFAULT_TIMESTAMP_BOUND = 0L;
-
     private final CassandraKeyValueService rawCassandraKvs;
     private final CassandraTimestampCqlExecutor cassandraTimestampCqlExecutor;
 
@@ -77,7 +75,7 @@ public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalid
                 AtlasDbConstants.TIMESTAMP_TABLE,
                 ImmutableMap.of(timestampCell, Long.MAX_VALUE));
         if (result.isEmpty()) {
-            return Optional.of(DEFAULT_TIMESTAMP_BOUND);
+            return Optional.of(CassandraTimestampBoundStore.INITIAL_VALUE);
         }
 
         Value value = Iterables.getOnlyElement(result.values());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidator.java
@@ -84,7 +84,7 @@ public class CassandraTimestampStoreInvalidator implements TimestampStoreInvalid
 
     private Optional<Long> getLongFromValue(Value value) {
         byte[] contents = value.getContents();
-        if (contents.length == 0) {
+        if (contents.length < Long.BYTES) {
             return Optional.empty();
         }
         return Optional.of(PtBytes.toLong(contents));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorTest.java
@@ -69,7 +69,7 @@ public class CassandraTimestampStoreInvalidatorTest {
     }
 
     @Test
-    public void revalidatePassesBackupValueFromKvsToBeBackedUp() {
+    public void revalidatePassesBackupValueFromKvsToBeRestored() {
         invalidator.revalidateTimestampStore();
         verify(cqlExecutor, times(1)).restoreBoundFromBackup(eq(FORTY_THREE));
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorTest.java
@@ -54,13 +54,13 @@ public class CassandraTimestampStoreInvalidatorTest {
         Map<Cell, Long> queries = (Map<Cell, Long>) invocation.getArguments()[1];
         Cell cell = queries.keySet().iterator().next();
 
-        byte[] bytesToReturn = isTimestampRow(cell) ? PtBytes.toBytes(BACKUP_VALUE) : PtBytes.toBytes(RESTORE_VALUE);
+        byte[] bytesToReturn = isTimestampColumn(cell) ? PtBytes.toBytes(BACKUP_VALUE) : PtBytes.toBytes(RESTORE_VALUE);
         Value valueToReturn = Value.create(bytesToReturn, CASSANDRA_TIMESTAMP);
         return ImmutableMap.of(cell, valueToReturn);
     }
 
-    private boolean isTimestampRow(Cell cell) {
-        return Arrays.equals(cell.getRowName(), CassandraTimestampCqlExecutor.ROW_AND_COLUMN_NAME_BYTES);
+    private boolean isTimestampColumn(Cell cell) {
+        return Arrays.equals(cell.getColumnName(), CassandraTimestampCqlExecutor.ROW_AND_COLUMN_NAME_BYTES);
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Value;
+
+public class CassandraTimestampStoreInvalidatorTest {
+    private static final long CASSANDRA_TIMESTAMP = 0L;
+    private static final long FORTY_TWO = 42L;
+    private static final byte[] FORTY_TWO_IN_BYTES = PtBytes.toBytes(FORTY_TWO);
+    private static final long FORTY_THREE = 43L;
+    private static final byte[] FORTY_THREE_IN_BYTES = PtBytes.toBytes(FORTY_THREE);
+
+    private final CassandraKeyValueService kvs = mock(CassandraKeyValueService.class);
+    private final CassandraTimestampCqlExecutor cqlExecutor = mock(CassandraTimestampCqlExecutor.class);
+    private final CassandraTimestampStoreInvalidator invalidator =
+            new CassandraTimestampStoreInvalidator(kvs, cqlExecutor);
+
+    @Before
+    public void setUp() {
+        when(kvs.get(any(), any())).thenAnswer(this::constructKeyValueStoreReply);
+    }
+
+    private Map<Cell, Value> constructKeyValueStoreReply(InvocationOnMock invocation) {
+        Map<Cell, Long> queries = (Map<Cell, Long>) invocation.getArguments()[1];
+        Cell cell = queries.keySet().iterator().next();
+
+        Value valueToReturn = Value.create(FORTY_THREE_IN_BYTES, CASSANDRA_TIMESTAMP);
+        if (Arrays.equals(cell.getRowName(), CassandraTimestampCqlExecutor.ROW_AND_COLUMN_NAME_BYTES)) {
+            valueToReturn = Value.create(FORTY_TWO_IN_BYTES, CASSANDRA_TIMESTAMP);
+        }
+        return ImmutableMap.of(cell, valueToReturn);
+    }
+
+    @Test
+    public void invalidatePassesCurrentTimestampValueFromKvsToBeBackedUp() {
+        invalidator.invalidateTimestampStore();
+        verify(cqlExecutor, times(1)).backupBound(eq(FORTY_TWO));
+    }
+
+    @Test
+    public void revalidatePassesBackupValueFromKvsToBeBackedUp() {
+        invalidator.revalidateTimestampStore();
+        verify(cqlExecutor, times(1)).restoreBoundFromBackup(eq(FORTY_THREE));
+    }
+}

--- a/timestamp-api/build.gradle
+++ b/timestamp-api/build.gradle
@@ -2,6 +2,8 @@ apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
 dependencies {
-  compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
-  compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
+    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
+
+    testCompile group: 'org.assertj', name: 'assertj-core'
 }

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampStoreInvalidator.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampStoreInvalidator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.timestamp;
+
+public interface TimestampStoreInvalidator {
+    /**
+     * This method corrupts the data in an underlying timestamp bound store. This is important for the safety of
+     * timestamp store migrations; if one migrates AtlasDB to a different timestamp bound store, then the
+     * original timestamp bound store must not be used again if it is not updated with information about what
+     * timestamps the new store has given out.
+     *
+     * As this method performs corruption, it should only be called *after* the migration of the existing timestamp
+     * bound to the new timestamp bound store has been carried out successfully.
+     *
+     * Of course, this is not strictly needed if no one ever uses the original timestamp bound store again.
+     * However, we find this to be a safety precaution worth taking, especially if AtlasDB is subsequently downgraded.
+     */
+    void invalidateTimestampStore();
+
+    /**
+     * This method performs the inverse of invalidateTimestampStore().
+     *
+     * It is not safe to use a revalidated timestamp store directly, *unless* we can guarantee that no timestamps
+     * have been taken out for the relevant data since invalidation.
+     */
+    default void revalidateTimestampStore() {
+        throw new UnsupportedOperationException("This timestamp store does not support revalidation!");
+    }
+}

--- a/timestamp-api/src/test/java/com/palantir/timestamp/TimestampStoreInvalidatorTest.java
+++ b/timestamp-api/src/test/java/com/palantir/timestamp/TimestampStoreInvalidatorTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.timestamp;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class TimestampStoreInvalidatorTest {
+    @Test
+    public void revalidateTimestampStoreThrowsByDefault() {
+        TimestampStoreInvalidator nopInvalidator = () -> { /* nop */ };
+        assertThatThrownBy(nopInvalidator::revalidateTimestampStore).isInstanceOf(UnsupportedOperationException.class);
+    }
+}


### PR DESCRIPTION
Part one of #1513 - adds some infrastructure for invalidating the existing timestamp tables, plus an impl for Cassandra. This is required for automatic migrations in #1511, which we want to do.

**Not** included:
* Postgres and Oracle impls.
* Wiring any of this up to TransactionManagers. (So as far as users are concerned this should currently never be used.)

Changes:
* Introduces TimestampStoreInvalidator interface, and CassandraTimestampStoreInvalidator (an impl for Cassandra). The latter uses a CassandraTimestampCqlExecutor.
* Mock and integration tests for the above.

Sorry, a little long-ish owing to a fair chunk of tests, and 6 new classes = 90 lines of licenses.

- [ ] Fix change in behaviour after MRTSE #1515 merges
- [ ] CassandraTimestampStore class to handle all writes to the kvs
- [x] Change to use the same row key for both the timestamp and the timestamp backup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1514)
<!-- Reviewable:end -->
