### PR TITLE
Timestamp Service Docs (Timelock Docs, Part 2, in a sense)

### DIFF
--- a/docs/source/services/index.rst
+++ b/docs/source/services/index.rst
@@ -15,4 +15,5 @@ external timestamp and lock service. Please consult the relevant section of the 
 
    key_value_services/index
    lock_service/index
+   timestamp_service/index
    timelock_service/index

--- a/docs/source/services/lock_service/index.rst
+++ b/docs/source/services/lock_service/index.rst
@@ -1,9 +1,11 @@
+.. _lock-service:
+
 ============
 Lock Service
 ============
 
 The AtlasDB Lock Service exposes an API to lock clients for acquiring read and read/write locks on data in AtlasDB.
-The Lock Service also supports clustering. When multiple lock services are clustered, they will collaborate to elect a leader
+The Lock Service also supports clustering. When a Lock service is clustered, the nodes will collaborate to elect a leader
 via the Paxos algorithm.
 
 A description of Paxos can be found on `Wikipedia <https://en.wikipedia.org/wiki/Paxos_(computer_science)>`__

--- a/docs/source/services/lock_service/installation.rst
+++ b/docs/source/services/lock_service/installation.rst
@@ -6,5 +6,10 @@ How to choose a number of lock servers
 --------------------------------------
 
 Distributed consensus is not useful for clusters of size one and two.
-It's generally advisable to choose 3-6 lock servers, because too many lock servers will negatively impact performance.
-You should not see much of a performance difference within the range [3, 4, 5, 6]
+It's generally advisable to choose 3-6 lock servers, because too many lock servers will negatively impact performance
+owing to the overhead of distributed consensus and leader election.
+You should not see much of a performance difference within the range [3, 4, 5, 6].
+
+Note that we usually prefer to select an odd number of servers, because as far as obtaining a quorum is concerned,
+that has the same tolerance to node failures as the next higher even number. However, selecting an even number does
+have advantages under certain circumstances, such as tolerance to node failures with loss of disk logs.

--- a/docs/source/services/timelock_service/index.rst
+++ b/docs/source/services/timelock_service/index.rst
@@ -16,9 +16,9 @@ External Timelock Service
     installation
     migration
 
-The AtlasDB Timelock Service is an external implementation of the Timestamp and Lock services. Running an external
-Timelock Service (as opposed to running timestamp and lock services embedded within one's clients) provides several
-benefits:
+The AtlasDB Timelock Service is an external implementation of the :ref:`Timestamp <timestamp-service>` and
+:ref:`Lock <lock-service>` services. Running an external Timelock Service (as opposed to running timestamp and lock
+services embedded within one's clients) provides several benefits:
 
 - Additional reliability; we have subjected our new implementation to Jepsen testing, and do not rely on the
   consistency of the user's key-value services.

--- a/docs/source/services/timestamp_service/clustering.rst
+++ b/docs/source/services/timestamp_service/clustering.rst
@@ -12,7 +12,8 @@ issues timestamps (other nodes will return a 503). The leader also writes an upp
 it has given out to a persistent store; in practice, we write this to a timestamp table in the key-value store.
 
 Note that the leader still needs to talk to a quorum of nodes before entertaining a timestamp request, to check
-that it is still the leader. However, this only requires one round trip as opposed to two for Paxos.
+that it is still the leader. This was a deliberate design decision to maintain safety in the face of clock drift.
+However, this only requires one round trip to a quorum of nodes, as opposed to two for Paxos.
 
 Safety
 ======

--- a/docs/source/services/timestamp_service/clustering.rst
+++ b/docs/source/services/timestamp_service/clustering.rst
@@ -1,0 +1,30 @@
+========
+Clusters
+========
+
+The Timestamp Service can be run in clustered mode. The main benefit of this is that you get high availability;
+timestamps can be issued as long as a majority of nodes in a cluster are available and can communicate. It may
+be worth noting that there is a performance tradeoff involved here, as distributed consensus requires us to communicate
+with the other servers in the cluster quite frequently (and thus becomes more costly as more servers are added).
+
+The cluster will agree on a leader using leader election. Thereafter, the leader will be the only node that actually
+issues timestamps (other nodes will return a 503). The leader also writes an upper bound for the timestamps that
+it has given out to a persistent store; in practice, we write this to a timestamp table in the key-value store.
+
+Note that the leader still needs to talk to a quorum of nodes before entertaining a timestamp request, to check
+that it is still the leader. However, this only requires one round trip as opposed to two for Paxos.
+
+Safety
+======
+
+Our leader election allows us to guarantee that there will only be one leader at any time. Since only this leader
+is allowed to give out timestamps, and we require that it writes an upper bound *before* it is allowed to issue any
+timestamps that would take it past the previous upper bound, this is safe. Should the current leader fail mid-way and
+then recover, the cluster will have elected a new leader which would have seen the current leader's upper bound.
+
+Liveness
+========
+
+We rely on the resilience of our leader election algorithm here. The guarantees our implementation of Paxos gives
+include that as long as a majority quorum (strictly more than half) of the nodes are able to communicate with each
+other, the protocol can make progress (and in that way decide on a leader).

--- a/docs/source/services/timestamp_service/index.rst
+++ b/docs/source/services/timestamp_service/index.rst
@@ -14,3 +14,4 @@ collaborate to elect a leader via the Paxos algorithm.
 
    overview
    clustering
+   management

--- a/docs/source/services/timestamp_service/index.rst
+++ b/docs/source/services/timestamp_service/index.rst
@@ -1,0 +1,15 @@
+=================
+Timestamp Service
+=================
+
+AtlasDB relies on timestamps for its multi-version concurrency control protocols. The Timestamp Service API
+allows clients to request fresh timestamps.
+
+The Timestamp Service also supports clustering; when multiple timestamp services are clustered, they will
+collaborate to elect a leader via the Paxos algorithm.
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   overview

--- a/docs/source/services/timestamp_service/index.rst
+++ b/docs/source/services/timestamp_service/index.rst
@@ -1,3 +1,5 @@
+.. _timestamp-service:
+
 =================
 Timestamp Service
 =================

--- a/docs/source/services/timestamp_service/index.rst
+++ b/docs/source/services/timestamp_service/index.rst
@@ -13,3 +13,4 @@ collaborate to elect a leader via the Paxos algorithm.
    :titlesonly:
 
    overview
+   clustering

--- a/docs/source/services/timestamp_service/management.rst
+++ b/docs/source/services/timestamp_service/management.rst
@@ -1,0 +1,24 @@
+==================
+Service Management
+==================
+
+Fast Forward
+============
+
+.. warning::
+
+   In general, caution should be used when using Fast Forward, especially with user input data (since fast forwarding
+   to ``Long.MAX_VALUE`` will cause the AtlasDB cluster to become corrupted and require complex manual recovery).
+
+There may be instances where we need to fast forward the Timestamp Service - that is, ensure that all timestamps
+given out by the Timestamp Service are after a certain timestamp. Examples include restoring an AtlasDB cluster
+from a backup, or migrating an existing cluster from embedded timestamp services to external Timelock services.
+
+More precisely, the guarantee we offer is that after a fast forward to timestamp TS has returned, future requests sent
+to the Timestamp Service will return a timestamp greater than TS.
+
+Typically, fast forwards are carried out through the AtlasDB :ref:`clis`, or through the ``fast-forward`` endpoint
+on the Timelock Server. Fast forward operates by updating the last known issued timestamp to the maximum of that and
+TS.
+
+Note that fast forward is idempotent, since we use maximums. Also, fast forwarding to the past is a no-op.

--- a/docs/source/services/timestamp_service/overview.rst
+++ b/docs/source/services/timestamp_service/overview.rst
@@ -22,7 +22,7 @@ see will necessarily be monotonically increasing. The following sequence of even
 7. Node A becomes functional again
 8. Node A hands out timestamp X and its client receives it
 
-However, this sequence of events is not allowed:
+However, we guarantee the following sequence of events will not happen:
 
 1. Node A is the Leader
 2. Node A receives request for timestamp

--- a/docs/source/services/timestamp_service/overview.rst
+++ b/docs/source/services/timestamp_service/overview.rst
@@ -1,0 +1,51 @@
+========
+Overview
+========
+
+The Timestamp Service exposes an API that allows for clients to request fresh timestamps, which are required by the
+AtlasDB transaction protocol. These timestamps are *logical timestamps* (that is, they have no relationship to actual
+wall-clock time), and are returned as signed 64-bit integers.
+
+Guarantees
+==========
+
+We guarantee that a request for a fresh timestamp will return a strictly greater timestamp than any other timestamp
+that may be observed before the request was initiated. In particular, this does *not* mean that the timestamps clients
+see will necessarily be monotonically increasing. The following sequence of events is allowed:
+
+1. Node A is the Leader
+2. Node A receives request for timestamp
+3. Node A enters bad GC cycle / JVM goes to sleep etc.
+4. Node B becomes the Leader
+5. Node B receives request for timestamp
+6. Node B hands out timestamp X+1 and its client receives it
+7. Node A becomes functional again
+8. Node A hands out timestamp X and its client receives it
+
+Furthermore, there are also no guarantees that the timestamps issued will be consecutive.
+
+We guarantee the above ordering across system restarts as well.
+
+Contiguous Blocks
+=================
+
+Users are allowed to make requests for contiguous blocks of timestamps using the ``getFreshTimestamps`` endpoint.
+This may be useful if one knows it is the only client and/or wishes to have bespoke complex concurrency semantics.
+
+The endpoint will return a contiguous block of timestamps; this is indicated by a lower and upper bound (inclusive
+on both ends). However, we do not guarantee that the size of the timestamp range will be equal to the number of
+timestamps requested for; the onus to check this is on the client. We do guarantee that the range returned will
+consist of at least 1 timestamp.
+
+Caching
+=======
+
+To guarantee that timestamps still increase across system restarts, we need to persist some kind of a record of
+what timestamps we've issued to stable storage. However, doing this on each timestamp request is unperformant, as
+we would need a database operation, and in clustered mode we would also need to achieve distributed consensus.
+
+Thus, instead of updating this record on every timestamp, the Timestamp Service will "reserve" a large number of
+timestamps (currently 1,000,000) and update the bound to be the end of that range. When clients talk to the
+Timestamp Service, it will issue timestamps from the range it knows it has, requesting more if necessary. We thus only
+have one "persist" action every million timestamps. This can lead to there being gaps in timestamps when servers
+are restarted and/or there is a leadership change in clustered mode, but that's allowed by our guarantees.

--- a/docs/source/services/timestamp_service/overview.rst
+++ b/docs/source/services/timestamp_service/overview.rst
@@ -33,9 +33,9 @@ Users are allowed to make requests for contiguous blocks of timestamps using the
 This may be useful if one knows it is the only client and/or wishes to have bespoke complex concurrency semantics.
 
 The endpoint will return a contiguous block of timestamps; this is indicated by a lower and upper bound (inclusive
-on both ends). However, we do not guarantee that the size of the timestamp range will be equal to the number of
-timestamps requested for; the onus to check this is on the client. We do guarantee that the range returned will
-consist of at least 1 timestamp.
+on both ends). We guarantee that the range returned will consist of at least 1 timestamp, and will have *at most*
+as many timestamps as the number requested. However, we do not guarantee that the size of the timestamp range will be
+equal to the number of timestamps requested for; the onus to check this is on the client.
 
 Caching
 =======

--- a/docs/source/services/timestamp_service/overview.rst
+++ b/docs/source/services/timestamp_service/overview.rst
@@ -10,7 +10,7 @@ Guarantees
 ==========
 
 We guarantee that a request for a fresh timestamp will return a strictly greater timestamp than any other timestamp
-that may be observed before the request was initiated. In particular, this does *not* mean that the timestamps clients
+already returned by an earlier request. In particular, this does *not* mean that the timestamps clients
 see will necessarily be monotonically increasing. The following sequence of events is allowed:
 
 1. Node A is the Leader
@@ -21,6 +21,15 @@ see will necessarily be monotonically increasing. The following sequence of even
 6. Node B hands out timestamp X+1 and its client receives it
 7. Node A becomes functional again
 8. Node A hands out timestamp X and its client receives it
+
+However, this sequence of events is not allowed:
+
+1. Node A is the Leader
+2. Node A receives request for timestamp
+3. Node A hands out timestamp X+1 and its client receives it
+4. Node B becomes the Leader
+5. Node B receives request for timestamp
+6. Node B hands out timestamp X and its client receives it
 
 Furthermore, there are also no guarantees that the timestamps issued will be consecutive.
 


### PR DESCRIPTION
* Added a section on the timestamp service, usage and its guarantees.
* Added a bit of detail on how to choose a number of servers.

This is a docs change. I found this useful to help me clarify my thinking about timelock and what kinds of invariants we can demand from Jepsen, and I think it would be good to get this merged (though not as high of a priority).

Also we have in the docs "AtlasDB relies on three distinct services. They are the Key Value Service, the Lock Service, and the Timestamp Service. Each of the services is described in detail below." with no docs on Timestamp, which is not great.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1519)
<!-- Reviewable:end -->
