### PR TITLE
Noticed these checks weren't being applied to all gets in ReadTransac…

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -15,11 +15,14 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
@@ -68,6 +71,20 @@ public class ReadTransaction extends ForwardingTransaction {
                                                                     Iterable<RangeRequest> rangeRequests) {
         checkTableName(tableRef);
         return delegate().getRanges(tableRef, rangeRequests);
+    }
+
+    @Override
+    public Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> getRowsColumnRange(TableReference tableRef,
+            Iterable<byte[]> rows, BatchColumnRangeSelection columnRangeSelection) {
+        checkTableName(tableRef);
+        return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection);
+    }
+
+    @Override
+    public Iterator<Map.Entry<Cell, byte[]>> getRowsColumnRange(TableReference tableRef, Iterable<byte[]> rows,
+            ColumnRangeSelection columnRangeSelection, int batchHint) {
+        checkTableName(tableRef);
+        return delegate().getRowsColumnRange(tableRef, rows, columnRangeSelection, batchHint);
     }
 
     private void checkTableName(TableReference tableRef) {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.transaction.impl;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.common.base.Throwables;
+
+public class ReadTransactionShould {
+
+    private static final TableReference DUMMY_CONSERVATIVE_TABLE =
+            TableReference.createWithEmptyNamespace("dummy-conservative");
+    private static final TableReference DUMMY_THOROUGH_TABLE =
+            TableReference.createWithEmptyNamespace("dummy-thorough");
+    private static final Cell DUMMY_CELL = Cell.create("row".getBytes(), "col".getBytes());
+    private static final byte[] EMPTY_BYTES = "".getBytes();
+
+    private static final Map<String, Object[]> simpleGets = ImmutableMap.<String, Object[]>builder()
+            .put("get", new Object[] {DUMMY_THOROUGH_TABLE, ImmutableSet.of(DUMMY_CELL)})
+            .put("getRows", new Object[] {DUMMY_THOROUGH_TABLE, ImmutableList.of(EMPTY_BYTES), ColumnSelection.all()})
+            .put("getRange", new Object[] {DUMMY_THOROUGH_TABLE, RangeRequest.all()})
+            .put("getRanges", new Object[] {DUMMY_THOROUGH_TABLE, ImmutableList.of(RangeRequest.all())})
+            .build();
+
+    private ReadTransaction readTransaction;
+    private AbstractTransaction delegateTransaction;
+
+    @Before
+    public void setUp() throws Exception {
+        delegateTransaction = Mockito.mock(AbstractTransaction.class);
+        SweepStrategyManager sweepStrategies = Mockito.mock(SweepStrategyManager.class);
+        when(sweepStrategies.get()).thenReturn(ImmutableMap.of(
+                DUMMY_CONSERVATIVE_TABLE,
+                TableMetadataPersistence.SweepStrategy.CONSERVATIVE,
+                DUMMY_THOROUGH_TABLE,
+                TableMetadataPersistence.SweepStrategy.THOROUGH));
+        readTransaction = new ReadTransaction(delegateTransaction, sweepStrategies);
+    }
+
+    @Test
+    public void notAllowPuts() {
+        checkThrowsAndNoInteraction(() -> readTransaction.put(
+                DUMMY_CONSERVATIVE_TABLE,
+                ImmutableMap.of(DUMMY_CELL, "value".getBytes())),
+                IllegalArgumentException.class,
+                "is a read only transaction");
+    }
+
+    @Test
+    public void notAllowDeletes() {
+        checkThrowsAndNoInteraction(() -> readTransaction.delete(
+                DUMMY_CONSERVATIVE_TABLE,
+                ImmutableSet.of(DUMMY_CELL)),
+                IllegalArgumentException.class,
+                "is a read only transaction");
+    }
+
+    @Test
+    public void allowGetsOnConservativeTables() {
+        ImmutableSet<Cell> cellToGet = ImmutableSet.of(DUMMY_CELL);
+        readTransaction.get(DUMMY_CONSERVATIVE_TABLE, cellToGet);
+        Mockito.verify(delegateTransaction, times(1)).get(eq(DUMMY_CONSERVATIVE_TABLE), eq(cellToGet));
+    }
+
+    @Test
+    public void notAllowGetsOnThoroughTables() {
+        ImmutableSet<Cell> cellToGet = ImmutableSet.of(DUMMY_CELL);
+        checkThrowsAndNoInteraction(() -> readTransaction.get(DUMMY_THOROUGH_TABLE, cellToGet),
+                IllegalStateException.class,
+                "Cannot read");
+    }
+
+    @Test
+    public void notAllowSimpleGets() throws IllegalAccessException {
+        Method[] declaredMethods = ReadTransaction.class.getDeclaredMethods();
+
+        for (Method m : declaredMethods) {
+            if (simpleGets.containsKey(m.getName())) {
+                checkThrowsAndNoInteraction(() -> {
+                            try {
+                                m.invoke(readTransaction, simpleGets.get(m.getName()));
+                            } catch (InvocationTargetException e) {
+                                Throwables.throwIfInstance(e.getCause(), IllegalStateException.class);
+                            } catch (IllegalAccessException e) {
+                                Throwables.throwUncheckedException(e);
+                            }
+                        },
+                        IllegalStateException.class,
+                        "Cannot read");
+            }
+        }
+    }
+
+    @Test
+    public void notAllowColumnRangeGets() {
+        checkThrowsAndNoInteraction(() -> readTransaction.getRowsColumnRange(
+                DUMMY_THOROUGH_TABLE,
+                ImmutableList.of(EMPTY_BYTES),
+                BatchColumnRangeSelection.create(EMPTY_BYTES, EMPTY_BYTES, 1)),
+                IllegalStateException.class,
+                "Cannot read");
+    }
+
+    @Test
+    public void notAllowColumnRangeGets2() {
+        checkThrowsAndNoInteraction(() -> readTransaction.getRowsColumnRange(
+                DUMMY_THOROUGH_TABLE,
+                ImmutableList.of(EMPTY_BYTES),
+                new ColumnRangeSelection(EMPTY_BYTES, EMPTY_BYTES),
+                1),
+                IllegalStateException.class,
+                "Cannot read");
+    }
+
+    private void checkThrowsAndNoInteraction(Runnable thrower,
+            Class<? extends Exception> exception,
+            String errorMessage) {
+        try {
+            thrower.run();
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertThat(e, is(instanceOf(exception)));
+            Assert.assertThat(e.getMessage(), containsString(errorMessage));
+            verifyZeroInteractions(delegateTransaction);
+        }
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
@@ -101,15 +101,7 @@ public class ReadTransactionShould {
     }
 
     @Test
-    public void notAllowGetsOnThoroughTables() {
-        ImmutableSet<Cell> cellToGet = ImmutableSet.of(DUMMY_CELL);
-        checkThrowsAndNoInteraction(() -> readTransaction.get(DUMMY_THOROUGH_TABLE, cellToGet),
-                IllegalStateException.class,
-                "Cannot read");
-    }
-
-    @Test
-    public void notAllowSimpleGets() throws IllegalAccessException {
+    public void notAllowSimpleGetsOnThoroughTables() throws IllegalAccessException {
         Method[] declaredMethods = ReadTransaction.class.getDeclaredMethods();
 
         for (Method m : declaredMethods) {
@@ -130,7 +122,7 @@ public class ReadTransactionShould {
     }
 
     @Test
-    public void notAllowColumnRangeGets() {
+    public void notAllowBatchColumnRangeGets() {
         checkThrowsAndNoInteraction(() -> readTransaction.getRowsColumnRange(
                 DUMMY_THOROUGH_TABLE,
                 ImmutableList.of(EMPTY_BYTES),
@@ -140,7 +132,7 @@ public class ReadTransactionShould {
     }
 
     @Test
-    public void notAllowColumnRangeGets2() {
+    public void notAllowColumnRangeGets() {
         checkThrowsAndNoInteraction(() -> readTransaction.getRowsColumnRange(
                 DUMMY_THOROUGH_TABLE,
                 ImmutableList.of(EMPTY_BYTES),

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -40,6 +40,10 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Actions run by the `ReadOnlyTransactionManager` can no longer bypass necessary protections when using `getRowsColumnRange()`
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1521>`__)
+
     *    - |new|
          - Cassandra now attempts to truncate when performing a ``deleteRange(RangeRequest.All())`` in an effort to build up less garbage.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1617>`__)
@@ -228,6 +232,11 @@ v0.32.0
          - Removed an unused hamcrest import from the timestamp-impl project.
            This should reduce the size of our transitive dependencies, and therefore the size of product binaries.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1578>`__)
+
+    *    - |fixed|
+         - Fixed schema generation with Java 8 optionals.
+           To use Java8 optionals, supply ``OptionalType.JAVA8`` as an additional constructor argument when creating your ``Schema`` object.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1501>`__)
 
     *    - |devbreak|
          - Modified the type signature of ``BatchingVisitableView#of`` to no longer accept ``final BatchingVisitable<? extends T> underlyingVisitable`` and instead accept ``final BatchingVisitable<T> underlyingVisitable``.


### PR DESCRIPTION
…tion

The forwarding paradigm strikes again.

This stops column range scans from functioning against thorough tables when they should in fact fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1521)
<!-- Reviewable:end -->
