### PR TITLE
bump database dependencies and collapse metrics versions

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -10,7 +10,13 @@ dependencies {
   testCompile project(":atlasdb-docker-test-utils")
   testCompile project(":atlasdb-ete-test-utils")
 
-  testCompile 'org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra
+  testCompile ('org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra) {
+    exclude module: 'junit'
+
+    // override ant to a newer one that is shared with the version in jmock-->cglib
+    exclude module: 'ant'
+    compile 'org.apache.ant:ant:' + libVersions.ant
+  }
   testCompile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
 
   testCompile group: 'org.mockito', name: 'mockito-core'

--- a/atlasdb-cassandra-integration-tests/versions.lock
+++ b/atlasdb-cassandra-integration-tests/versions.lock
@@ -2,11 +2,31 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "requested": "1.9.4"
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "requested": "1.9.4"
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
         }
     }
 }

--- a/atlasdb-cassandra-multinode-tests/build.gradle
+++ b/atlasdb-cassandra-multinode-tests/build.gradle
@@ -10,7 +10,13 @@ dependencies {
     testCompile project(":atlasdb-docker-test-utils")
     testCompile project(":atlasdb-ete-test-utils")
 
-    testCompile 'org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra
+    testCompile ('org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra) {
+       exclude module: 'junit'
+
+       // override ant to a newer one that is shared with the version in jmock-->cglib
+       exclude module: 'ant'
+       compile 'org.apache.ant:ant:' + libVersions.ant
+    }
     testCompile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
 
     testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'

--- a/atlasdb-cassandra-multinode-tests/versions.lock
+++ b/atlasdb-cassandra-multinode-tests/versions.lock
@@ -2,11 +2,31 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "requested": "1.9.4"
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "requested": "1.9.4"
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
         }
     }
 }

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -1,5 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply plugin: 'org.inferred.processors'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 apply from: "../gradle/shared.gradle"
 
@@ -11,6 +12,10 @@ dependencies {
 
   compile ('org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra) {
     exclude module: 'junit'
+
+    // override ant to a newer one that is shared with the version in jmock-->cglib
+    exclude module: 'ant'
+    compile 'org.apache.ant:ant:' + libVersions.ant
   }
   compile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
   compile group: 'com.google.guava', name: 'guava'
@@ -30,3 +35,18 @@ dependencies {
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'
 }
+
+shadowJar {
+  mergeServiceFiles()
+
+  relocate('com.carrotsearch.hppc',  atlasdb_shaded + 'hppc')
+  relocate('jflex', atlasdb_shaded + 'jflex')
+  relocate('org.apache.tools.ant', atlasdb_shaded + 'ant')
+  relocate('org.tarturus.snowball', atlasdb_shaded + 'snowball')
+  relocate('org.objectweb.asm', atlasdb_shaded + 'asm')
+  relocate('jnr', atlasdb_shaded + 'jnr')
+  relocate('io.netty', atlasdb_shaded + 'netty')
+}
+
+jar.dependsOn shadowJar
+jar.onlyIf { false }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -165,9 +165,15 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         return 62 * 1000;
     }
 
+    /*
+        Only allow this many extra enqueued requests above the configured poolsize onto a given node in the pool.
+        Attempts to enqueue more than this will immediately fail and instead fail over to another node as coordinator.
+        A person needing to modify this may have not enough backpressure in their application,
+        or have too much parallelism.
+     */
     @Value.Default
-    public int cqlPoolTimeoutMillis() {
-        return 20 * 1000;
+    public int cqlPoolMaxQueueSize() {
+        return 256;
     }
 
     @Value.Default

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CQLKeyValueService.java
@@ -43,6 +43,7 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.JdkSSLOptions;
 import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.PreparedStatement;
@@ -51,7 +52,6 @@ import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
-import com.datastax.driver.core.SSLOptions;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
@@ -62,12 +62,10 @@ import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.datastax.driver.core.policies.WhiteListPolicy;
-import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
@@ -169,17 +167,17 @@ public class CQLKeyValueService extends AbstractKeyValueService {
         clusterBuilder.withCompression(Compression.LZ4);
 
         if (config.sslConfiguration().isPresent()) {
+            // We could switch to newer netty SSL configuration (perf++), but all of our other stuff
+            // uses the built-in java SSL configuration and doing something different could be a headache
             SSLContext sslContext = SslSocketFactories.createSslContext(config.sslConfiguration().get());
-            SSLOptions sslOptions = new SSLOptions(sslContext, SSLOptions.DEFAULT_SSL_CIPHER_SUITES);
+            JdkSSLOptions sslOptions = JdkSSLOptions.builder().withSSLContext(sslContext).build();
             clusterBuilder.withSSL(sslOptions);
-        } else if (config.ssl().isPresent() && config.ssl().get()) {
-            clusterBuilder.withSSL();
         }
 
         PoolingOptions poolingOptions = new PoolingOptions();
         poolingOptions.setMaxRequestsPerConnection(HostDistance.LOCAL, config.poolSize());
         poolingOptions.setMaxRequestsPerConnection(HostDistance.REMOTE, config.poolSize());
-        poolingOptions.setPoolTimeoutMillis(config.cqlPoolTimeoutMillis());
+        poolingOptions.setMaxQueueSize(config.cqlPoolMaxQueueSize());
         clusterBuilder.withPoolingOptions(poolingOptions);
 
         // defaults for queries; can override on per-query basis
@@ -212,17 +210,9 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             cluster = clusterBuilder.build();
             metadata = cluster.getMetadata(); // special; this is the first place we connect to
             // hosts, this is where people will see failures
-        } catch (NoHostAvailableException e) {
-            if (e.getMessage().contains("Unknown compression algorithm")) {
-                clusterBuilder.withCompression(Compression.NONE);
-                cluster = clusterBuilder.build();
-                metadata = cluster.getMetadata();
-            } else {
-                throw e;
-            }
-        } catch (IllegalStateException e) {
-            // god dammit datastax what did I do to _you_
-            if (e.getMessage().contains("requested compression is not available")) {
+        } catch (NoHostAvailableException | IllegalStateException e) {
+            if (e.getMessage().contains("Unknown compression algorithm")
+                    || e.getMessage().contains("requested compression is not available")) {
                 clusterBuilder.withCompression(Compression.NONE);
                 cluster = clusterBuilder.build();
                 metadata = cluster.getMetadata();
@@ -285,12 +275,8 @@ public class CQLKeyValueService extends AbstractKeyValueService {
 
         Set<Peer> peers = CQLKeyValueServices.getPeers(session);
 
-        boolean allNodesHaveSaneNumberOfVnodes = Iterables.all(peers, new Predicate<Peer>() {
-            @Override
-            public boolean apply(Peer peer) {
-                return peer.tokens.size() > CassandraConstants.ABSOLUTE_MINIMUM_NUMBER_OF_TOKENS_PER_NODE;
-            }
-        });
+        boolean allNodesHaveSaneNumberOfVnodes = Iterables.all(peers,
+                peer -> peer.tokens.size() > CassandraConstants.ABSOLUTE_MINIMUM_NUMBER_OF_TOKENS_PER_NODE);
 
         // node we're querying doesn't count itself as a peer
         if (peers.size() > 0 && !allNodesHaveSaneNumberOfVnodes) {
@@ -1159,12 +1145,7 @@ public class CQLKeyValueService extends AbstractKeyValueService {
             final Value value = Value.create(new byte[0], Value.INVALID_VALUE_TIMESTAMP);
             putInternal(
                     tableRef,
-                    Iterables.transform(cells, new Function<Cell, Map.Entry<Cell, Value>>() {
-                        @Override
-                        public Entry<Cell, Value> apply(Cell cell) {
-                            return Maps.immutableEntry(cell, value);
-                        }
-                    }), TransactionType.NONE);
+                    Iterables.transform(cells, cell -> Maps.immutableEntry(cell, value)), TransactionType.NONE);
         } catch (Throwable t) {
             throw Throwables.throwUncheckedException(t);
         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -349,9 +349,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         }
         List<Map<Cell, Value>> perHostResults = runAllTasksCancelOnFailure(tasks);
         Map<Cell, Value> result = Maps.newHashMapWithExpectedSize(Iterables.size(rows));
-        for (Map<Cell, Value> perHostResult : perHostResults) {
-            result.putAll(perHostResult);
-        }
+        perHostResults.forEach(result::putAll);
         return result;
     }
 
@@ -472,7 +470,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             }
 
             SetMultimap<Long, Cell> cellsByTs = Multimaps.invertFrom(
-                    Multimaps.forMap(timestampByCell), HashMultimap.<Long, Cell>create());
+                    Multimaps.forMap(timestampByCell), HashMultimap.create());
             Builder<Cell, Value> builder = ImmutableMap.builder();
             for (long ts : cellsByTs.keySet()) {
                 StartTsResultsCollector collector = new StartTsResultsCollector(ts);
@@ -1081,13 +1079,13 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
             Map<String, List<Mutation>> rowPuts = map.get(rowName);
             if (rowPuts == null) {
-                rowPuts = Maps.<String, List<Mutation>>newHashMap();
+                rowPuts = Maps.newHashMap();
                 map.put(rowName, rowPuts);
             }
 
             List<Mutation> tableMutations = rowPuts.get(internalTableName(tableCellAndValue.tableRef));
             if (tableMutations == null) {
-                tableMutations = Lists.<Mutation>newArrayList();
+                tableMutations = Lists.newArrayList();
                 rowPuts.put(internalTableName(tableCellAndValue.tableRef), tableMutations);
             }
 
@@ -1269,7 +1267,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         int mapIndex = 0;
                         for (long ts : Ordering.natural().immutableSortedCopy(cellVersions.getValue())) {
                             if (!maps.containsKey(mapIndex)) {
-                                maps.put(mapIndex, Maps.<ByteBuffer, Map<String, List<Mutation>>>newHashMap());
+                                maps.put(mapIndex, Maps.newHashMap());
                             }
                             Map<ByteBuffer, Map<String, List<Mutation>>> map = maps.get(mapIndex);
                             ByteBuffer colName = CassandraKeyValueServices.makeCompositeBuffer(
@@ -1284,11 +1282,11 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             mutation.setDeletion(del);
                             ByteBuffer rowName = ByteBuffer.wrap(cellVersions.getKey().getRowName());
                             if (!map.containsKey(rowName)) {
-                                map.put(rowName, Maps.<String, List<Mutation>>newHashMap());
+                                map.put(rowName, Maps.newHashMap());
                             }
                             Map<String, List<Mutation>> rowPuts = map.get(rowName);
                             if (!rowPuts.containsKey(internalTableName(tableRef))) {
-                                rowPuts.put(internalTableName(tableRef), Lists.<Mutation>newArrayList());
+                                rowPuts.put(internalTableName(tableRef), Lists.newArrayList());
                             }
                             rowPuts.get(internalTableName(tableRef)).add(mutation);
                             mapIndex++;
@@ -1567,9 +1565,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         boolean putMetadataWillNeedASchemaChange = !onlyMetadataChangesAreForNewTables;
 
         if (!tablesToActuallyCreate.isEmpty()) {
-            schemaMutationLock.runWithLock(() -> {
-                createTablesInternal(tablesToActuallyCreate);
-            });
+            schemaMutationLock.runWithLock(() -> createTablesInternal(tablesToActuallyCreate));
         }
         internalPutMetadataForTables(tablesToUpdateMetadataFor, putMetadataWillNeedASchemaChange);
     }
@@ -1947,12 +1943,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     public void addGarbageCollectionSentinelValues(TableReference tableRef, Set<Cell> cells) {
         try {
             final Value value = Value.create(PtBytes.EMPTY_BYTE_ARRAY, Value.INVALID_VALUE_TIMESTAMP);
-            putInternal(tableRef, Iterables.transform(cells, new Function<Cell, Map.Entry<Cell, Value>>() {
-                @Override
-                public Entry<Cell, Value> apply(Cell cell) {
-                    return Maps.immutableEntry(cell, value);
-                }
-            }));
+            putInternal(tableRef, Iterables.transform(cells, cell -> Maps.immutableEntry(cell, value)));
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         }
@@ -2212,12 +2203,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     private <V> Map<InetSocketAddress, Map<Cell, V>> partitionMapByHost(Iterable<Map.Entry<Cell, V>> cells) {
         Map<InetSocketAddress, List<Map.Entry<Cell, V>>> partitionedByHost =
-                partitionByHost(cells, new Function<Map.Entry<Cell, V>, byte[]>() {
-                    @Override
-                    public byte[] apply(Entry<Cell, V> entry) {
-                        return entry.getKey().getRowName();
-                    }
-                });
+                partitionByHost(cells, entry -> entry.getKey().getRowName());
         Map<InetSocketAddress, Map<Cell, V>> cellsByHost = Maps.newHashMap();
         for (Map.Entry<InetSocketAddress, List<Map.Entry<Cell, V>>> hostAndCells : partitionedByHost.entrySet()) {
             Map<Cell, V> cellsForHost = Maps.newHashMapWithExpectedSize(hostAndCells.getValue().size());

--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -1,14 +1,14 @@
 {
     "compileClasspath": {
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
+        "com.carrotsearch:hppc": {
+            "locked": "0.5.4",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "requested": "2.2.0-rc3"
+            "locked": "3.1.4",
+            "requested": "3.1.4"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
@@ -51,6 +51,43 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.palantir.remoting1:tracing"
+            ]
+        },
+        "com.github.jnr:jffi": {
+            "locked": "1.2.10",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.jnr:jnr-constants": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-ffi": {
+            "locked": "2.0.7",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-posix": {
+            "locked": "3.0.27",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.github.jnr:jnr-x86asm": {
+            "locked": "1.0.2",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.rholder:snowball-stemmer": {
+            "locked": "1.3.0.581.1",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -97,6 +134,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.concurrent-trees:concurrent-trees": {
+            "locked": "2.4.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -239,41 +282,48 @@
                 "com.palantir.atlasdb:atlasdb-client"
             ]
         },
+        "de.jflex:jflex": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -299,9 +349,19 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "requested": "1.9.4"
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
+        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "requested": "2.2.8"
+            "locked": "3.10",
+            "requested": "3.10"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
@@ -346,6 +406,40 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.4",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-tree"
+            ]
+        },
+        "org.ow2.asm:asm-analysis": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-tree": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-analysis",
+                "org.ow2.asm:asm-commons",
+                "org.ow2.asm:asm-util"
+            ]
+        },
+        "org.ow2.asm:asm-util": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
@@ -361,7 +455,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -383,15 +476,15 @@
         }
     },
     "runtime": {
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
+        "com.carrotsearch:hppc": {
+            "locked": "0.5.4",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "requested": "2.2.0-rc3"
+            "locked": "3.1.4",
+            "requested": "3.1.4"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
@@ -434,6 +527,43 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.palantir.remoting1:tracing"
+            ]
+        },
+        "com.github.jnr:jffi": {
+            "locked": "1.2.10",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.jnr:jnr-constants": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-ffi": {
+            "locked": "2.0.7",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-posix": {
+            "locked": "3.0.27",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.github.jnr:jnr-x86asm": {
+            "locked": "1.0.2",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.rholder:snowball-stemmer": {
+            "locked": "1.3.0.581.1",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -480,6 +610,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.concurrent-trees:concurrent-trees": {
+            "locked": "2.4.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -622,41 +758,48 @@
                 "com.palantir.atlasdb:atlasdb-client"
             ]
         },
+        "de.jflex:jflex": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -682,9 +825,19 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "requested": "1.9.4"
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
+        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "requested": "2.2.8"
+            "locked": "3.10",
+            "requested": "3.10"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
@@ -729,6 +882,40 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.4",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-tree"
+            ]
+        },
+        "org.ow2.asm:asm-analysis": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-tree": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-analysis",
+                "org.ow2.asm:asm-commons",
+                "org.ow2.asm:asm-util"
+            ]
+        },
+        "org.ow2.asm:asm-util": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
@@ -744,7 +931,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -17,15 +17,14 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
+        "com.carrotsearch:hppc": {
+            "locked": "0.5.4",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
+            "locked": "3.1.4",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -112,6 +111,43 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
+        "com.github.jnr:jffi": {
+            "locked": "1.2.10",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.jnr:jnr-constants": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-ffi": {
+            "locked": "2.0.7",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-posix": {
+            "locked": "3.0.27",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.github.jnr:jnr-x86asm": {
+            "locked": "1.0.2",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.rholder:snowball-stemmer": {
+            "locked": "1.3.0.581.1",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
@@ -184,6 +220,12 @@
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
                 "com.palantir.atlasdb:leader-election-impl"
+            ]
+        },
+        "com.googlecode.concurrent-trees:concurrent-trees": {
+            "locked": "2.4.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -544,6 +586,12 @@
                 "com.palantir.atlasdb:leader-election-impl"
             ]
         },
+        "de.jflex:jflex": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "io.airlift:airline": {
             "locked": "0.7",
             "transitive": [
@@ -553,7 +601,9 @@
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -571,32 +621,32 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -647,8 +697,20 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
+        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
+            "locked": "3.10",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -712,6 +774,40 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.4",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-tree"
+            ]
+        },
+        "org.ow2.asm:asm-analysis": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-tree": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-analysis",
+                "org.ow2.asm:asm-commons",
+                "org.ow2.asm:asm-util"
+            ]
+        },
+        "org.ow2.asm:asm-util": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
         "org.postgresql:postgresql": {
             "locked": "9.4.1209",
             "transitive": [
@@ -739,7 +835,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-cli/build.gradle
+++ b/atlasdb-cli/build.gradle
@@ -4,7 +4,7 @@ apply from: '../gradle/shared.gradle'
 apply plugin: 'org.inferred.processors'
 
 dependencies {
-    compile project(':atlasdb-cassandra')
+    compile project(path: ':atlasdb-cassandra', configuration: 'shadow')
     compile project(path: ':atlasdb-dagger', configuration: 'shadow')
     compile 'io.airlift:airline:0.7'
 

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -12,18 +12,6 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -109,7 +97,6 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
@@ -118,8 +105,6 @@
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-service",
-                "com.palantir.atlasdb:commons-annotations",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -127,7 +112,6 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.tritium:tritium-api",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -147,9 +131,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -215,7 +197,6 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-lock-api"
@@ -227,7 +208,6 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
@@ -243,12 +223,10 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:lock-impl",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-config": {
@@ -282,18 +260,6 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-dagger"
-            ]
-        },
-        "com.palantir.atlasdb:commons-annotations": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:commons-api"
-            ]
-        },
-        "com.palantir.atlasdb:commons-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-executors": {
@@ -340,14 +306,7 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:timestamp-impl"
-            ]
-        },
-        "com.palantir.atlasdb:timestamp-impl": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -372,19 +331,16 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
-                "com.palantir.atlasdb:lock-impl",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -435,12 +391,6 @@
                 "com.squareup.okhttp:okhttp"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
         "commons-io:commons-io": {
             "locked": "2.1",
             "transitive": [
@@ -477,38 +427,6 @@
             "locked": "0.9.3",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
             ]
         },
         "javax.inject:javax.inject": {
@@ -549,43 +467,11 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.config.crypto:encrypted-config-value-module",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.2.5",
-            "transitive": [
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.2.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.palantir.config.crypto:encrypted-config-value-module"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -607,22 +493,9 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.slf4j:log4j-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -630,11 +503,7 @@
                 "com.palantir.tritium:tritium-metrics",
                 "com.palantir.tritium:tritium-slf4j",
                 "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard:dropwizard-jackson",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.slf4j:jcl-over-slf4j",
-                "org.slf4j:log4j-over-slf4j"
+                "io.dropwizard:dropwizard-jackson"
             ]
         },
         "org.xerial.snappy:snappy-java": {
@@ -663,18 +532,6 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -760,7 +617,6 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
@@ -769,8 +625,6 @@
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-service",
-                "com.palantir.atlasdb:commons-annotations",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -778,7 +632,6 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.tritium:tritium-api",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -798,9 +651,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -866,7 +717,6 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-lock-api"
@@ -878,7 +728,6 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
@@ -894,12 +743,10 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:lock-impl",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-config": {
@@ -933,18 +780,6 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-dagger"
-            ]
-        },
-        "com.palantir.atlasdb:commons-annotations": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:commons-api"
-            ]
-        },
-        "com.palantir.atlasdb:commons-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-executors": {
@@ -991,14 +826,7 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:timestamp-impl"
-            ]
-        },
-        "com.palantir.atlasdb:timestamp-impl": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -1023,19 +851,16 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
-                "com.palantir.atlasdb:lock-impl",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1086,12 +911,6 @@
                 "com.squareup.okhttp:okhttp"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
         "commons-io:commons-io": {
             "locked": "2.1",
             "transitive": [
@@ -1128,38 +947,6 @@
             "locked": "0.9.3",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
             ]
         },
         "javax.inject:javax.inject": {
@@ -1200,43 +987,11 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.config.crypto:encrypted-config-value-module",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.2.5",
-            "transitive": [
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.2.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.palantir.config.crypto:encrypted-config-value-module"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1258,22 +1013,9 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.slf4j:log4j-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -1281,11 +1023,7 @@
                 "com.palantir.tritium:tritium-metrics",
                 "com.palantir.tritium:tritium-slf4j",
                 "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard:dropwizard-jackson",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.slf4j:jcl-over-slf4j",
-                "org.slf4j:log4j-over-slf4j"
+                "io.dropwizard:dropwizard-jackson"
             ]
         },
         "org.xerial.snappy:snappy-java": {

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -17,15 +17,14 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
+        "com.carrotsearch:hppc": {
+            "locked": "0.5.4",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
+            "locked": "3.1.4",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -112,6 +111,43 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
+        "com.github.jnr:jffi": {
+            "locked": "1.2.10",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.jnr:jnr-constants": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-ffi": {
+            "locked": "2.0.7",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-posix": {
+            "locked": "3.0.27",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.github.jnr:jnr-x86asm": {
+            "locked": "1.0.2",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.rholder:snowball-stemmer": {
+            "locked": "1.3.0.581.1",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
@@ -182,6 +218,12 @@
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
                 "com.palantir.atlasdb:leader-election-impl"
+            ]
+        },
+        "com.googlecode.concurrent-trees:concurrent-trees": {
+            "locked": "2.4.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -539,10 +581,18 @@
                 "com.palantir.atlasdb:leader-election-impl"
             ]
         },
+        "de.jflex:jflex": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -560,32 +610,32 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -641,8 +691,20 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
+        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
+            "locked": "3.10",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -718,6 +780,40 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.4",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-tree"
+            ]
+        },
+        "org.ow2.asm:asm-analysis": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-tree": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-analysis",
+                "org.ow2.asm:asm-commons",
+                "org.ow2.asm:asm-util"
+            ]
+        },
+        "org.ow2.asm:asm-util": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
         "org.postgresql:postgresql": {
             "locked": "9.4.1209",
             "transitive": [
@@ -745,7 +841,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-container-test-utils/build.gradle
+++ b/atlasdb-container-test-utils/build.gradle
@@ -5,7 +5,7 @@ apply from: "${rootProject.projectDir}/gradle/shared.gradle"
 
 dependencies {
     compile project(':atlasdb-api')
-    compile project(':atlasdb-cassandra')
+    compile project(path: ':atlasdb-cassandra', configuration: 'shadow')
     compile project(':atlasdb-docker-test-utils')
 
     compile group: 'com.google.guava', name: 'guava'

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -6,18 +6,6 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -30,35 +18,14 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.atlasdb:atlasdb-client"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.netflix.feign:feign-jackson",
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.github.almondtools:conmatch": {
@@ -77,63 +44,25 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-docker-test-utils",
-                "com.palantir.atlasdb:commons-annotations",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.atlasdb:timestamp-impl",
-                "com.palantir.tritium:tritium-api",
-                "com.palantir.tritium:tritium-core",
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics",
-                "com.palantir.tritium:tritium-slf4j"
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "1.3.9",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons",
-                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-docker-test-utils",
                 "com.palantir.docker.compose:docker-compose-rule-core",
-                "com.palantir.remoting1:tracing",
-                "com.palantir.remoting:ssl-config",
-                "com.palantir.tritium:tritium-core",
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "2.6.0",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-client-protobufs"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
-        "com.googlecode.protobuf-java-format:protobuf-java-format": {
-            "locked": "1.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
+                "com.palantir.remoting:ssl-config"
             ]
         },
         "com.jayway.awaitility:awaitility": {
@@ -142,70 +71,20 @@
                 "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
-        "com.netflix.feign:feign-core": {
-            "locked": "8.6.1",
-            "transitive": [
-                "com.netflix.feign:feign-jackson",
-                "com.netflix.feign:feign-jaxrs"
-            ]
-        },
-        "com.netflix.feign:feign-jackson": {
-            "locked": "8.6.1",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
-        "com.netflix.feign:feign-jaxrs": {
-            "locked": "8.6.1",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
         "com.palantir.atlasdb:atlasdb-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
+            "project": true
         },
         "com.palantir.atlasdb:atlasdb-cassandra": {
             "project": true
         },
-        "com.palantir.atlasdb:atlasdb-client": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "com.palantir.atlasdb:atlasdb-client-protobufs": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
         "com.palantir.atlasdb:atlasdb-commons": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:commons-api",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.atlasdb:atlasdb-docker-test-utils": {
             "project": true
-        },
-        "com.palantir.atlasdb:commons-annotations": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:commons-api"
-            ]
-        },
-        "com.palantir.atlasdb:commons-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
@@ -216,14 +95,7 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:timestamp-impl"
-            ]
-        },
-        "com.palantir.atlasdb:timestamp-impl": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.docker.compose:docker-compose-rule-core": {
@@ -238,60 +110,10 @@
                 "com.palantir.atlasdb:atlasdb-docker-test-utils"
             ]
         },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:timestamp-impl"
-            ]
-        },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "com.palantir.tritium:tritium-api": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.tritium:tritium-core",
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics",
-                "com.palantir.tritium:tritium-slf4j"
-            ]
-        },
-        "com.palantir.tritium:tritium-core": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics",
-                "com.palantir.tritium:tritium-slf4j"
-            ]
-        },
-        "com.palantir.tritium:tritium-lib": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
-        "com.palantir.tritium:tritium-metrics": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.tritium:tritium-lib"
-            ]
-        },
-        "com.palantir.tritium:tritium-slf4j": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.tritium:tritium-lib"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "commons-io:commons-io": {
@@ -300,50 +122,10 @@
                 "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.tritium:tritium-metrics",
-                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "javax.validation:validation-api": {
@@ -385,43 +167,11 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.docker.compose:docker-compose-rule-core",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.2.5",
-            "transitive": [
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.2.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
         "org.hamcrest:hamcrest-core": {
@@ -439,59 +189,18 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "com.palantir.tritium:tritium-metrics",
-                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
-            "locked": "1.1.2",
-            "transitive": [
-                "com.palantir.tritium:tritium-metrics"
-            ]
-        },
         "org.objenesis:objenesis": {
             "locked": "2.2",
             "transitive": [
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.slf4j:log4j-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.docker.compose:docker-compose-rule-core",
-                "com.palantir.remoting1:tracing",
-                "com.palantir.tritium:tritium-core",
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics",
-                "com.palantir.tritium:tritium-slf4j",
-                "io.dropwizard.metrics:metrics-core",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.slf4j:jcl-over-slf4j",
-                "org.slf4j:log4j-over-slf4j"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.1.7",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
+                "io.dropwizard.metrics:metrics-core"
             ]
         }
     },
@@ -502,18 +211,6 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -526,35 +223,14 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.atlasdb:atlasdb-client"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.netflix.feign:feign-jackson",
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.github.almondtools:conmatch": {
@@ -573,63 +249,25 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-docker-test-utils",
-                "com.palantir.atlasdb:commons-annotations",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.atlasdb:timestamp-impl",
-                "com.palantir.tritium:tritium-api",
-                "com.palantir.tritium:tritium-core",
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics",
-                "com.palantir.tritium:tritium-slf4j"
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "1.3.9",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons",
-                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-docker-test-utils",
                 "com.palantir.docker.compose:docker-compose-rule-core",
-                "com.palantir.remoting1:tracing",
-                "com.palantir.remoting:ssl-config",
-                "com.palantir.tritium:tritium-core",
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "2.6.0",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-client-protobufs"
-            ]
-        },
-        "com.googlecode.json-simple:json-simple": {
-            "locked": "1.1.1",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
-        "com.googlecode.protobuf-java-format:protobuf-java-format": {
-            "locked": "1.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
+                "com.palantir.remoting:ssl-config"
             ]
         },
         "com.jayway.awaitility:awaitility": {
@@ -638,70 +276,20 @@
                 "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
-        "com.netflix.feign:feign-core": {
-            "locked": "8.6.1",
-            "transitive": [
-                "com.netflix.feign:feign-jackson",
-                "com.netflix.feign:feign-jaxrs"
-            ]
-        },
-        "com.netflix.feign:feign-jackson": {
-            "locked": "8.6.1",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
-        "com.netflix.feign:feign-jaxrs": {
-            "locked": "8.6.1",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
         "com.palantir.atlasdb:atlasdb-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
+            "project": true
         },
         "com.palantir.atlasdb:atlasdb-cassandra": {
             "project": true
         },
-        "com.palantir.atlasdb:atlasdb-client": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "com.palantir.atlasdb:atlasdb-client-protobufs": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
         "com.palantir.atlasdb:atlasdb-commons": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:commons-api",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.atlasdb:atlasdb-docker-test-utils": {
             "project": true
-        },
-        "com.palantir.atlasdb:commons-annotations": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:commons-api"
-            ]
-        },
-        "com.palantir.atlasdb:commons-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
@@ -712,14 +300,7 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:timestamp-impl"
-            ]
-        },
-        "com.palantir.atlasdb:timestamp-impl": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.docker.compose:docker-compose-rule-core": {
@@ -734,60 +315,10 @@
                 "com.palantir.atlasdb:atlasdb-docker-test-utils"
             ]
         },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:timestamp-impl"
-            ]
-        },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "com.palantir.tritium:tritium-api": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.tritium:tritium-core",
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics",
-                "com.palantir.tritium:tritium-slf4j"
-            ]
-        },
-        "com.palantir.tritium:tritium-core": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics",
-                "com.palantir.tritium:tritium-slf4j"
-            ]
-        },
-        "com.palantir.tritium:tritium-lib": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
-        "com.palantir.tritium:tritium-metrics": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.tritium:tritium-lib"
-            ]
-        },
-        "com.palantir.tritium:tritium-slf4j": {
-            "locked": "0.6.0-beta",
-            "transitive": [
-                "com.palantir.tritium:tritium-lib"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "commons-io:commons-io": {
@@ -796,50 +327,10 @@
                 "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
-        "commons-lang:commons-lang": {
-            "locked": "2.6",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
-            ]
-        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.tritium:tritium-metrics",
-                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "javax.validation:validation-api": {
@@ -881,43 +372,11 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.docker.compose:docker-compose-rule-core",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.2.5",
-            "transitive": [
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.2.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
         "org.hamcrest:hamcrest-core": {
@@ -935,59 +394,18 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "org.hdrhistogram:HdrHistogram": {
-            "locked": "2.1.9",
-            "transitive": [
-                "com.palantir.tritium:tritium-metrics",
-                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
-            "locked": "1.1.2",
-            "transitive": [
-                "com.palantir.tritium:tritium-metrics"
-            ]
-        },
         "org.objenesis:objenesis": {
             "locked": "2.2",
             "transitive": [
                 "com.jayway.awaitility:awaitility"
             ]
         },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.slf4j:log4j-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.docker.compose:docker-compose-rule-core",
-                "com.palantir.remoting1:tracing",
-                "com.palantir.tritium:tritium-core",
-                "com.palantir.tritium:tritium-lib",
-                "com.palantir.tritium:tritium-metrics",
-                "com.palantir.tritium:tritium-slf4j",
-                "io.dropwizard.metrics:metrics-core",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.slf4j:jcl-over-slf4j",
-                "org.slf4j:log4j-over-slf4j"
-            ]
-        },
-        "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.1.7",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
+                "io.dropwizard.metrics:metrics-core"
             ]
         }
     }

--- a/atlasdb-dagger/build.gradle
+++ b/atlasdb-dagger/build.gradle
@@ -23,7 +23,7 @@ shadowJar {
   mergeServiceFiles()
   classifier ''
 
-  relocate('dagger', 'com.palantir.atlasdb.shaded.dagger')
+  relocate('dagger',   atlasdb_shaded + 'dagger')
 
   dependencies {
     include dependency(group: 'com.google.dagger', name: 'dagger')

--- a/atlasdb-dbkvs-hikari/build.gradle
+++ b/atlasdb-dbkvs-hikari/build.gradle
@@ -6,7 +6,7 @@ apply from: '../gradle/shared.gradle'
 dependencies {
   compile project(':commons-db')
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-  compile group: 'com.codahale.metrics', name: 'metrics-core'
+  compile group: 'io.dropwizard.metrics', name: 'metrics-core'
 
   processor group: 'org.immutables', name: 'value'
 }

--- a/atlasdb-dbkvs-hikari/versions.lock
+++ b/atlasdb-dbkvs-hikari/versions.lock
@@ -1,8 +1,5 @@
 {
     "compileClasspath": {
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2"
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -177,7 +174,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
@@ -187,9 +183,6 @@
         }
     },
     "runtime": {
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2"
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -364,7 +357,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -1,11 +1,5 @@
 {
     "compileClasspath": {
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -364,6 +358,7 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -458,7 +453,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
@@ -478,12 +472,6 @@
         }
     },
     "runtime": {
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -842,6 +830,7 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -936,7 +925,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -1,11 +1,5 @@
 {
     "compileClasspath": {
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -338,6 +332,7 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -406,7 +401,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
@@ -426,12 +420,6 @@
         }
     },
     "runtime": {
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -764,6 +752,7 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -832,7 +821,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -15,18 +15,6 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -137,7 +125,6 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-cli",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
@@ -148,8 +135,6 @@
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-service",
-                "com.palantir.atlasdb:commons-annotations",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -157,7 +142,6 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.tritium:tritium-api",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -177,9 +161,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -246,7 +228,6 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-lock-api"
@@ -264,7 +245,6 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
@@ -280,12 +260,10 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:lock-impl",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-config": {
@@ -326,18 +304,6 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-console",
                 "com.palantir.atlasdb:atlasdb-dagger"
-            ]
-        },
-        "com.palantir.atlasdb:commons-annotations": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:commons-api"
-            ]
-        },
-        "com.palantir.atlasdb:commons-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-executors": {
@@ -384,14 +350,7 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:timestamp-impl"
-            ]
-        },
-        "com.palantir.atlasdb:timestamp-impl": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -416,19 +375,16 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
-                "com.palantir.atlasdb:lock-impl",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -483,12 +439,6 @@
             "locked": "1.2",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-console"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
             ]
         },
         "commons-io:commons-io": {
@@ -658,38 +608,6 @@
                 "io.dropwizard:dropwizard-metrics"
             ]
         },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
-        },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.2",
             "transitive": [
@@ -765,45 +683,13 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "io.dropwizard:dropwizard-configuration",
-                "io.dropwizard:dropwizard-jersey",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.2.5",
-            "transitive": [
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.2.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "io.dropwizard:dropwizard-jersey"
             ]
         },
         "org.codehaus.groovy:groovy-all": {
@@ -1057,8 +943,7 @@
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging",
-                "org.apache.cassandra:cassandra-thrift"
+                "io.dropwizard:dropwizard-logging"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
@@ -1070,14 +955,12 @@
         "org.slf4j:log4j-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging",
-                "org.apache.cassandra:cassandra-thrift"
+                "io.dropwizard:dropwizard-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -1091,8 +974,6 @@
                 "io.dropwizard:dropwizard-logging",
                 "io.dropwizard:dropwizard-metrics",
                 "io.dropwizard:dropwizard-servlets",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
                 "org.slf4j:jcl-over-slf4j",
                 "org.slf4j:jul-to-slf4j",
                 "org.slf4j:log4j-over-slf4j"
@@ -1127,18 +1008,6 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -1249,7 +1118,6 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-cli",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
@@ -1260,8 +1128,6 @@
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-service",
-                "com.palantir.atlasdb:commons-annotations",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -1269,7 +1135,6 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.tritium:tritium-api",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -1289,9 +1154,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -1358,7 +1221,6 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-lock-api"
@@ -1376,7 +1238,6 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
@@ -1392,12 +1253,10 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:lock-impl",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-config": {
@@ -1438,18 +1297,6 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-console",
                 "com.palantir.atlasdb:atlasdb-dagger"
-            ]
-        },
-        "com.palantir.atlasdb:commons-annotations": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:commons-api"
-            ]
-        },
-        "com.palantir.atlasdb:commons-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-executors": {
@@ -1496,14 +1343,7 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:timestamp-impl"
-            ]
-        },
-        "com.palantir.atlasdb:timestamp-impl": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -1528,19 +1368,16 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
-                "com.palantir.atlasdb:lock-impl",
-                "com.palantir.atlasdb:timestamp-impl"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1595,12 +1432,6 @@
             "locked": "1.2",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-console"
-            ]
-        },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
             ]
         },
         "commons-io:commons-io": {
@@ -1770,38 +1601,6 @@
                 "io.dropwizard:dropwizard-metrics"
             ]
         },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
-        },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.2",
             "transitive": [
@@ -1877,45 +1676,13 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "io.dropwizard:dropwizard-configuration",
-                "io.dropwizard:dropwizard-jersey",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.2.5",
-            "transitive": [
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.2.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "io.dropwizard:dropwizard-jersey"
             ]
         },
         "org.codehaus.groovy:groovy-all": {
@@ -2169,8 +1936,7 @@
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging",
-                "org.apache.cassandra:cassandra-thrift"
+                "io.dropwizard:dropwizard-logging"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
@@ -2182,14 +1948,12 @@
         "org.slf4j:log4j-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging",
-                "org.apache.cassandra:cassandra-thrift"
+                "io.dropwizard:dropwizard-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -2203,8 +1967,6 @@
                 "io.dropwizard:dropwizard-logging",
                 "io.dropwizard:dropwizard-metrics",
                 "io.dropwizard:dropwizard-servlets",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
                 "org.slf4j:jcl-over-slf4j",
                 "org.slf4j:jul-to-slf4j",
                 "org.slf4j:log4j-over-slf4j"

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -15,18 +15,6 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -137,7 +125,6 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-cli",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
@@ -152,8 +139,6 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-rocksdb",
                 "com.palantir.atlasdb:atlasdb-service",
-                "com.palantir.atlasdb:commons-annotations",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -181,9 +166,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -250,7 +233,6 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-jdbc",
@@ -273,7 +255,6 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-rocksdb"
@@ -291,7 +272,6 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
@@ -358,18 +338,6 @@
                 "com.palantir.atlasdb:atlasdb-dagger"
             ]
         },
-        "com.palantir.atlasdb:commons-annotations": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:commons-api"
-            ]
-        },
-        "com.palantir.atlasdb:commons-api": {
-            "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
             "transitive": [
@@ -421,7 +389,6 @@
         "com.palantir.atlasdb:timestamp-impl": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-rocksdb"
             ]
@@ -448,7 +415,6 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
@@ -459,8 +425,7 @@
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -705,38 +670,6 @@
                 "io.dropwizard:dropwizard-metrics"
             ]
         },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
-            ]
-        },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.2",
             "transitive": [
@@ -812,26 +745,13 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "io.dropwizard:dropwizard-configuration",
-                "io.dropwizard:dropwizard-jersey",
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "io.dropwizard:dropwizard-jersey"
             ]
         },
         "org.apache.httpcomponents:httpclient": {
@@ -848,10 +768,7 @@
             ]
         },
         "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
+            "locked": "0.9.2"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.4.4",
@@ -1116,8 +1033,7 @@
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging",
-                "org.apache.cassandra:cassandra-thrift"
+                "io.dropwizard:dropwizard-logging"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
@@ -1129,14 +1045,12 @@
         "org.slf4j:log4j-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging",
-                "org.apache.cassandra:cassandra-thrift"
+                "io.dropwizard:dropwizard-logging"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -1151,7 +1065,6 @@
                 "io.dropwizard:dropwizard-logging",
                 "io.dropwizard:dropwizard-metrics",
                 "io.dropwizard:dropwizard-servlets",
-                "org.apache.cassandra:cassandra-thrift",
                 "org.apache.thrift:libthrift",
                 "org.slf4j:jcl-over-slf4j",
                 "org.slf4j:jul-to-slf4j",
@@ -1187,15 +1100,14 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
+        "com.carrotsearch:hppc": {
+            "locked": "0.5.4",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
+            "locked": "3.1.4",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -1307,6 +1219,43 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "com.github.jnr:jffi": {
+            "locked": "1.2.10",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.jnr:jnr-constants": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-ffi": {
+            "locked": "2.0.7",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-posix": {
+            "locked": "3.0.27",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.github.jnr:jnr-x86asm": {
+            "locked": "1.0.2",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.rholder:snowball-stemmer": {
+            "locked": "1.3.0.581.1",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
@@ -1383,6 +1332,12 @@
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
                 "com.palantir.atlasdb:leader-election-impl"
+            ]
+        },
+        "com.googlecode.concurrent-trees:concurrent-trees": {
+            "locked": "2.4.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -1776,6 +1731,12 @@
                 "org.apache.httpcomponents:httpclient"
             ]
         },
+        "de.jflex:jflex": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "io.airlift:airline": {
             "locked": "0.7",
             "transitive": [
@@ -1792,7 +1753,9 @@
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "io.dropwizard.metrics:metrics-jersey2",
                 "io.dropwizard.metrics:metrics-jetty9",
@@ -1933,32 +1896,32 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -2046,8 +2009,20 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
+        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
+            "locked": "3.10",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -2342,6 +2317,40 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.4",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-tree"
+            ]
+        },
+        "org.ow2.asm:asm-analysis": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-tree": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-analysis",
+                "org.ow2.asm:asm-commons",
+                "org.ow2.asm:asm-util"
+            ]
+        },
+        "org.ow2.asm:asm-util": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
         "org.postgresql:postgresql": {
             "locked": "9.4.1209",
             "transitive": [
@@ -2377,7 +2386,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-perf/build.gradle
+++ b/atlasdb-perf/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   compile project(':atlasdb-api')
   compile project(':atlasdb-dagger')
   compile project(':atlasdb-dbkvs')
-  compile project(':atlasdb-cassandra')
+  compile project(path: ':atlasdb-cassandra', configuration: 'shadow')
 
   compile group: 'io.airlift', name: 'airline', version: '0.7'
   compile group: 'org.reflections', name: 'reflections', version: '0.9.10'

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -24,8 +24,11 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.performance.benchmarks.table.ConsecutiveNarrowTable;
 import com.palantir.atlasdb.performance.benchmarks.table.RegeneratingTable;
 
 @State(Scope.Benchmark)
@@ -34,6 +37,18 @@ public class KvsDeleteBenchmarks {
     private Object doDelete(RegeneratingTable<Multimap<Cell, Long>> table) {
         table.getKvs().delete(table.getTableRef(), table.getTableCells());
         return table.getTableCells();
+    }
+
+    private Object doDeleteRange(ConsecutiveNarrowTable table, int numBatches) {
+        Iterable<RangeRequest> rangeRequests;
+        if (numBatches == 1) {
+            rangeRequests = ImmutableList.of(RangeRequest.all());
+        } else {
+            rangeRequests = table.getRangeRequests(1, table.getNumRows() / numBatches);
+        }
+        rangeRequests.forEach(rangeRequest -> table.getKvs().deleteRange(table.getTableRef(), rangeRequest));
+
+        return rangeRequests;
     }
 
     @Benchmark
@@ -48,6 +63,20 @@ public class KvsDeleteBenchmarks {
     @Measurement(time = 22, timeUnit = TimeUnit.SECONDS)
     public Object batchDelete(RegeneratingTable.KvsBatchRegeneratingTable table) {
         return doDelete(table);
+    }
+
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
+    public Object batchRangeDelete(ConsecutiveNarrowTable.CleanNarrowTable table) {
+        return doDeleteRange(table, 4);
+    }
+
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
+    public Object allRangeDelete(ConsecutiveNarrowTable.CleanNarrowTable table) {
+        return doDeleteRange(table, 1);
     }
 
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -40,12 +40,11 @@ public class KvsDeleteBenchmarks {
     }
 
     private Object doDeleteRange(ConsecutiveNarrowTable table, int numBatches) {
-        Iterable<RangeRequest> rangeRequests;
-        if (numBatches == 1) {
-            rangeRequests = ImmutableList.of(RangeRequest.all());
-        } else {
-            rangeRequests = table.getRangeRequests(1, table.getNumRows() / numBatches);
-        }
+        Iterable<RangeRequest> rangeRequests =
+                numBatches == 1
+                        ? ImmutableList.of(RangeRequest.all())
+                        : table.getRangeRequests(1, table.getNumRows() / numBatches);
+
         rangeRequests.forEach(rangeRequest -> table.getKvs().deleteRange(table.getTableRef(), rangeRequest));
 
         return rangeRequests;

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -18,19 +18,6 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -123,7 +110,6 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
@@ -173,9 +159,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -261,7 +245,6 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
@@ -274,7 +257,6 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
@@ -351,7 +333,6 @@
         "com.palantir.atlasdb:commons-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -420,7 +401,6 @@
         "com.palantir.atlasdb:timestamp-impl": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs"
             ]
         },
@@ -455,7 +435,6 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:commons-db",
@@ -467,8 +446,7 @@
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -525,12 +503,6 @@
                 "com.palantir.atlasdb:commons-db"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
         "commons-dbutils:commons-dbutils": {
             "locked": "1.3",
             "transitive": [
@@ -561,6 +533,7 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -575,38 +548,6 @@
             "locked": "0.9.3",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
             ]
         },
         "javax.inject:javax.inject": {
@@ -668,51 +609,19 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:commons-db",
                 "com.palantir.config.crypto:encrypted-config-value-module",
-                "com.palantir.docker.compose:docker-compose-rule-core",
-                "org.apache.cassandra:cassandra-thrift"
+                "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
         "org.apache.commons:commons-math3": {
             "locked": "3.2",
             "transitive": [
                 "org.openjdk.jmh:jmh-core"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.2.5",
-            "transitive": [
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.2.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.hamcrest:hamcrest-core": {
@@ -774,23 +683,10 @@
             "locked": "0.9.10",
             "requested": "0.9.10"
         },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.slf4j:log4j-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.docker.compose:docker-compose-rule-core",
@@ -801,11 +697,7 @@
                 "com.palantir.tritium:tritium-slf4j",
                 "com.zaxxer:HikariCP",
                 "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard:dropwizard-jackson",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.slf4j:jcl-over-slf4j",
-                "org.slf4j:log4j-over-slf4j"
+                "io.dropwizard:dropwizard-jackson"
             ]
         },
         "org.xerial.snappy:snappy-java": {
@@ -840,19 +732,6 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
-            ]
-        },
-        "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -945,7 +824,6 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
@@ -995,9 +873,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -1083,7 +959,6 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
@@ -1096,7 +971,6 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
@@ -1173,7 +1047,6 @@
         "com.palantir.atlasdb:commons-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -1242,7 +1115,6 @@
         "com.palantir.atlasdb:timestamp-impl": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs"
             ]
         },
@@ -1277,7 +1149,6 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:commons-db",
@@ -1289,8 +1160,7 @@
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1347,12 +1217,6 @@
                 "com.palantir.atlasdb:commons-db"
             ]
         },
-        "commons-codec:commons-codec": {
-            "locked": "1.10",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient"
-            ]
-        },
         "commons-dbutils:commons-dbutils": {
             "locked": "1.3",
             "transitive": [
@@ -1383,6 +1247,7 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -1397,38 +1262,6 @@
             "locked": "0.9.3",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
-            ]
-        },
-        "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler",
-                "io.netty:netty-transport"
-            ]
-        },
-        "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-handler"
-            ]
-        },
-        "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-buffer"
-            ]
-        },
-        "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
-            "transitive": [
-                "io.netty:netty-codec",
-                "io.netty:netty-handler"
             ]
         },
         "javax.inject:javax.inject": {
@@ -1490,51 +1323,19 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:commons-db",
                 "com.palantir.config.crypto:encrypted-config-value-module",
-                "com.palantir.docker.compose:docker-compose-rule-core",
-                "org.apache.cassandra:cassandra-thrift"
+                "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
         "org.apache.commons:commons-math3": {
             "locked": "3.2",
             "transitive": [
                 "org.openjdk.jmh:jmh-core"
-            ]
-        },
-        "org.apache.commons:commons-pool2": {
-            "locked": "2.4.2",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.httpcomponents:httpclient": {
-            "locked": "4.2.5",
-            "transitive": [
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.httpcomponents:httpcore": {
-            "locked": "4.2.4",
-            "transitive": [
-                "org.apache.httpcomponents:httpclient",
-                "org.apache.thrift:libthrift"
-            ]
-        },
-        "org.apache.thrift:libthrift": {
-            "locked": "0.9.2",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.hamcrest:hamcrest-core": {
@@ -1596,23 +1397,10 @@
             "locked": "0.9.10",
             "requested": "0.9.10"
         },
-        "org.slf4j:jcl-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
-        "org.slf4j:log4j-over-slf4j": {
-            "locked": "1.7.5",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
                 "ch.qos.logback:logback-classic",
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.docker.compose:docker-compose-rule-core",
@@ -1623,11 +1411,7 @@
                 "com.palantir.tritium:tritium-slf4j",
                 "com.zaxxer:HikariCP",
                 "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard:dropwizard-jackson",
-                "org.apache.cassandra:cassandra-thrift",
-                "org.apache.thrift:libthrift",
-                "org.slf4j:jcl-over-slf4j",
-                "org.slf4j:log4j-over-slf4j"
+                "io.dropwizard:dropwizard-jackson"
             ]
         },
         "org.xerial.snappy:snappy-java": {

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -951,14 +951,14 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
-        "com.codahale.metrics:metrics-core": {
-            "locked": "3.0.2",
+        "com.carrotsearch:hppc": {
+            "locked": "0.5.4",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "2.2.0-rc3",
+            "locked": "3.1.4",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -1069,6 +1069,43 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "com.github.jnr:jffi": {
+            "locked": "1.2.10",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.jnr:jnr-constants": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-ffi": {
+            "locked": "2.0.7",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.github.jnr:jnr-posix"
+            ]
+        },
+        "com.github.jnr:jnr-posix": {
+            "locked": "3.0.27",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.github.jnr:jnr-x86asm": {
+            "locked": "1.0.2",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "com.github.rholder:snowball-stemmer": {
+            "locked": "1.3.0.581.1",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
@@ -1134,6 +1171,12 @@
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
                 "com.palantir.atlasdb:leader-election-impl"
+            ]
+        },
+        "com.googlecode.concurrent-trees:concurrent-trees": {
+            "locked": "2.4.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -1419,6 +1462,12 @@
                 "com.palantir.atlasdb:leader-election-impl"
             ]
         },
+        "de.jflex:jflex": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "io.dropwizard.metrics:metrics-annotation": {
             "locked": "3.1.1",
             "transitive": [
@@ -1429,6 +1478,7 @@
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.tritium:tritium-metrics",
                 "io.dropwizard.metrics:metrics-jersey2",
@@ -1567,32 +1617,32 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.27.Final",
+            "locked": "4.0.37.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -1666,8 +1716,20 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
+        "org.apache.ant:ant": {
+            "locked": "1.9.4",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.ant:ant-launcher": {
+            "locked": "1.9.4",
+            "transitive": [
+                "org.apache.ant:ant"
+            ]
+        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "2.2.8",
+            "locked": "3.10",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -1943,6 +2005,40 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.4",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-tree"
+            ]
+        },
+        "org.ow2.asm:asm-analysis": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
+        "org.ow2.asm:asm-tree": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi",
+                "org.ow2.asm:asm-analysis",
+                "org.ow2.asm:asm-commons",
+                "org.ow2.asm:asm-util"
+            ]
+        },
+        "org.ow2.asm:asm-util": {
+            "locked": "5.0.3",
+            "transitive": [
+                "com.github.jnr:jnr-ffi"
+            ]
+        },
         "org.rocksdb:rocksdbjni": {
             "locked": "4.1.0",
             "transitive": [
@@ -1972,7 +2068,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'com.github.johnrengelman.shadow' version '1.2.4'
     id 'com.palantir.configuration-resolver' version '0.1.0'
     id 'com.palantir.git-version' version '0.5.2'
     id 'org.inferred.processors' version '1.2.4-rc2'

--- a/cassandra-partitioner/versions.lock
+++ b/cassandra-partitioner/versions.lock
@@ -8,8 +8,8 @@
             "requested": "18.0"
         },
         "org.apache.cassandra:cassandra-all": {
-            "locked": "2.2.8",
-            "requested": "2.2.8"
+            "locked": "3.10",
+            "requested": "3.10"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
@@ -25,8 +25,8 @@
             "requested": "18.0"
         },
         "org.apache.cassandra:cassandra-all": {
-            "locked": "2.2.8",
-            "requested": "2.2.8"
+            "locked": "3.10",
+            "requested": "3.10"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,10 @@ develop
            removal please file a ticket with the dev team for immediate support (as we did not take the time to properly deprecate the methods).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1689>`__)
 
+    *    - |fixed| |improved|
+         - Cassandra depedencies have been bumped to newer versions; should fix a bug (#1654) that caused Atlas probing downed Cassandra nodes every few minutes to see if they were up and working yet to eventually take out the entire cluster by steadily building up leaked connections, due to a bug in the underlying driver.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1524>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -124,3 +124,5 @@ task verifyDependencyLocksAreCurrent << {
 }
 
 check.dependsOn generateLock, verifyDependencyLocksAreCurrent
+
+ext.atlasdb_shaded = 'com.palantir.atlasdb.shaded'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -27,8 +27,8 @@ ext.libVersions =
     jackson_annotation: '2.5.0',
     jacoco: '0.7.7.201606060606',
     snakeyaml: '1.12',
-    cassandra: '2.2.8',
-    cassandra_driver_core: '2.2.0-rc3',
+    cassandra: '3.10',
+    cassandra_driver_core: '3.1.4',
     groovy: '2.4.4',
     hamcrest: '1.3',
     libthrift: '0.9.2',
@@ -37,6 +37,7 @@ ext.libVersions =
     hikariCP: '2.4.7',
     checkstyle: '6.18',
     findbugsAnnotations: '2.0.3',
+    ant: '1.9.4',
 
     // Danger, Will Robinson!
     //

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,4 @@
 ch.qos.logback:* = 1.1.3
-com.codahale.metrics:metrics-core = 3.0.2
 com.fasterxml.jackson.*:* = 2.6.7
 com.github.rholder:guava-retrying = 2.0.0
 com.github.tomakehurst:wiremock = 1.57


### PR DESCRIPTION
Change overview:
- SSL changed a bunch in the interim versions of the datastax C* drivers. I don't think we can fully move onto the true new-hotness they provide of netty-ssl instead of JSSE-SSL without major headaches in how we currently do truststore configuration across all our services, so I elected not to make that particular change.
- datastax driver changed its behavior from "have a timeout when waiting to grab a connection from the full pool" to "have a length-limited queue of requestors waiting to grab a connection from the full pool"
- I did a drive-by Java8-itizing of a bunch of the code as I walked through looking for deprecated calls against the new APIs.
- there was an existing problem where Atlas was exporting com.codahale.metrics: old version and io.dropwizard.metrics : new version; this caused problems for foundry consumers. This is now fixed by bumping our direct dependency in dbkvs-hikari package and by bumping up the datastax driver (such that they now both use the same, new version of the package both under the new dropwizard name)

Random asides:
- You're going to see another bump in a month which will let us get rid of the reflection we're doing in the thrift-backed KVS. Really I'm just bumping now to get most of the work out of the way incrementally.
- I'm going to watch our internal perf testing micro benchmarks and see if there are any perf changes from this.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1524)
<!-- Reviewable:end -->
