### PR TITLE
[no release notes] Fix misplaced logging in PaxosSynchronizer

### DIFF
--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -49,9 +49,9 @@ public final class PaxosSynchronizer {
             if (paxosValue.equals(learnerToSynchronize.getGreatestLearnedValue())) {
                 log.info("Started up and found that our value {} is already the most recent.", paxosValue);
             } else {
+                learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
                 log.info("Started up and learned the most recent value: {}.", paxosValue);
             }
-            learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
         }
     }
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -47,11 +47,13 @@ public final class PaxosSynchronizer {
         if (mostRecentValue.isPresent()) {
             PaxosValue paxosValue = mostRecentValue.get();
             if (paxosValue.equals(learnerToSynchronize.getGreatestLearnedValue())) {
-                log.info("Started up and found that our value {} is already the most recent.", paxosValue);
+                log.warn("Started up and found that our value {} is already the most recent.", paxosValue);
             } else {
                 learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
-                log.info("Started up and learned the most recent value: {}.", paxosValue);
+                log.warn("Started up and learned the most recent value: {}.", paxosValue);
             }
+        } else {
+            log.warn("Did not learn any value from other learners.");
         }
     }
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -46,12 +46,12 @@ public final class PaxosSynchronizer {
         Optional<PaxosValue> mostRecentValue = getMostRecentLearnedValue(paxosLearners);
         if (mostRecentValue.isPresent()) {
             PaxosValue paxosValue = mostRecentValue.get();
-            learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
             if (paxosValue.equals(learnerToSynchronize.getGreatestLearnedValue())) {
                 log.info("Started up and found that our value {} is already the most recent.", paxosValue);
             } else {
                 log.info("Started up and learned the most recent value: {}.", paxosValue);
             }
+            learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
         }
     }
 


### PR DESCRIPTION
The logging was placed wrongly, meaning that we would always log "our value foo is already the most recent".

(Not the thrust of the failed build which I suspect is a rare flake, given it passed on rebuild (though a different Cassandra test flaked), 7x internally and quite a few times when run locally as well.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1528)
<!-- Reviewable:end -->
