### PR TITLE
Fix bug in Paxos Synchronizer leading to flaky test

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -54,20 +54,34 @@ public final class PaxosQuorumChecker {
      * @param executor runs the requests
      * @return a list responses
      */
-    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(ImmutableList<SERVICE> remotes,
-                                                                                                  final Function<SERVICE, RESPONSE> request,
-                                                                                                  int quorumSize,
-                                                                                                  Executor executor,
-                                                                                                  long remoteRequestTimeoutInSec) {
+    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(
+            ImmutableList<SERVICE> remotes,
+            final Function<SERVICE, RESPONSE> request,
+            int quorumSize,
+            Executor executor,
+            long remoteRequestTimeoutInSec) {
         return collectQuorumResponses(remotes, request, quorumSize, executor, remoteRequestTimeoutInSec, false);
     }
 
-    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(ImmutableList<SERVICE> remotes,
-                                                                                                  final Function<SERVICE, RESPONSE> request,
-                                                                                                  int quorumSize,
-                                                                                                  Executor executor,
-                                                                                                  long remoteRequestTimeoutInSec,
-                                                                                                  boolean onlyLogOnQuorumFailure) {
+    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(
+            ImmutableList<SERVICE> remotes,
+            final Function<SERVICE, RESPONSE> request,
+            int quorumSize,
+            Executor executor,
+            long remoteRequestTimeoutInSec,
+            boolean onlyLogOnQuorumFailure) {
+        return collectQuorumResponses(
+                remotes, request, quorumSize, executor, remoteRequestTimeoutInSec, onlyLogOnQuorumFailure, true);
+    }
+
+    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(
+            ImmutableList<SERVICE> remotes,
+            final Function<SERVICE, RESPONSE> request,
+            int quorumSize,
+            Executor executor,
+            long remoteRequestTimeoutInSec,
+            boolean onlyLogOnQuorumFailure,
+            boolean shortcircuitIfQuorumImpossible) {
         CompletionService<RESPONSE> responseCompletionService = new ExecutorCompletionService<RESPONSE>(executor);
 
         // kick off all the requests
@@ -93,7 +107,7 @@ public final class PaxosQuorumChecker {
             while (acksRecieved < quorumSize) {
                 try {
                     // check if quorum is impossible (nack quorum failure)
-                    if (nacksRecieved > remotes.size() - quorumSize) {
+                    if (shortcircuitIfQuorumImpossible && nacksRecieved > remotes.size() - quorumSize) {
                         break;
                     }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -104,7 +104,6 @@ public final class PaxosQuorumChecker {
      * @param executor runs the requests
      * @return a list of responses
      */
-
     private static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectResponses(
             ImmutableList<SERVICE> remotes,
             final Function<SERVICE, RESPONSE> request,

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -47,6 +47,8 @@ public final class PaxosQuorumChecker {
 
     /**
      * Collects a list of responses from a quorum of remote services.
+     * This method short-circuits if a quorum can no longer be obtained (if too many servers have sent nacks), and
+     * cancels pending requests once a quorum has been obtained.
      *
      * @param remotes a list endpoints to make the remote call on
      * @param request the request to make on each of the remote endpoints
@@ -70,11 +72,40 @@ public final class PaxosQuorumChecker {
             Executor executor,
             long remoteRequestTimeoutInSec,
             boolean onlyLogOnQuorumFailure) {
-        return collectQuorumResponses(
+        return collectResponses(
                 remotes, request, quorumSize, executor, remoteRequestTimeoutInSec, onlyLogOnQuorumFailure, true);
     }
 
-    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectQuorumResponses(
+    /**
+     * Collects as many responses as possible from remote services.
+     * This method will continue even in the presence of nacks.
+     *
+     * @param remotes a list of endpoints to make the remote call on
+     * @param request the request to make on each of the remote endpoints
+     * @param executor runs the requests
+     * @return a list of responses
+     */
+    public static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectAsManyResponsesAsPossible(
+            ImmutableList<SERVICE> remotes,
+            final Function<SERVICE, RESPONSE> request,
+            Executor executor,
+            long remoteRequestTimeoutInSec) {
+        return collectResponses(remotes, request, remotes.size(), executor, remoteRequestTimeoutInSec, false, false);
+    }
+
+    /**
+     * Collects a list of responses from remote services.
+     * This method may short-circuit if a quorum can no longer be obtained (depending on the
+     * shortcircuitIfQuorumImpossible parameter) and cancels pending requests once a quorum has been obtained.
+     *
+     * @param remotes a list of endpoints to make the remote call on
+     * @param request the request to make on each of the remote endpoints
+     * @param quorumSize number of acknowledge requests after termination
+     * @param executor runs the requests
+     * @return a list of responses
+     */
+
+    private static <SERVICE, RESPONSE extends PaxosResponse> List<RESPONSE> collectResponses(
             ImmutableList<SERVICE> remotes,
             final Function<SERVICE, RESPONSE> request,
             int quorumSize,

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -35,8 +35,6 @@ import com.palantir.paxos.PaxosValue;
 
 public final class PaxosSynchronizer {
     private static final Logger log = LoggerFactory.getLogger(PaxosSynchronizer.class);
-    private static final boolean ONLY_LOG_ON_QUORUM_FAILURE = true;
-    private static final boolean DO_NOT_SHORTCIRCUIT = false;
 
     private PaxosSynchronizer() {
         // utility
@@ -60,14 +58,11 @@ public final class PaxosSynchronizer {
 
     private static Optional<PaxosValue> getMostRecentLearnedValue(List<PaxosLearner> paxosLearners) {
         ExecutorService executor = Executors.newCachedThreadPool();
-        List<PaxosValueResponse> responses = PaxosQuorumChecker.collectQuorumResponses(
+        List<PaxosValueResponse> responses = PaxosQuorumChecker.collectAsManyResponsesAsPossible(
                 ImmutableList.copyOf(paxosLearners),
                 learner -> ImmutablePaxosValueResponse.of(learner.getGreatestLearnedValue()),
-                paxosLearners.size(),
                 executor,
-                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT_IN_SECONDS,
-                ONLY_LOG_ON_QUORUM_FAILURE,
-                DO_NOT_SHORTCIRCUIT);
+                PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT_IN_SECONDS);
         return responses.stream()
                 .filter(response -> response.paxosValue() != null)
                 .map(PaxosValueResponse::paxosValue)

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -36,6 +36,7 @@ import com.palantir.paxos.PaxosValue;
 public final class PaxosSynchronizer {
     private static final Logger log = LoggerFactory.getLogger(PaxosSynchronizer.class);
     private static final boolean ONLY_LOG_ON_QUORUM_FAILURE = true;
+    private static final boolean DO_NOT_SHORTCIRCUIT = false;
 
     private PaxosSynchronizer() {
         // utility
@@ -63,7 +64,8 @@ public final class PaxosSynchronizer {
                 paxosLearners.size(),
                 executor,
                 PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT_IN_SECONDS,
-                ONLY_LOG_ON_QUORUM_FAILURE);
+                ONLY_LOG_ON_QUORUM_FAILURE,
+                DO_NOT_SHORTCIRCUIT);
         return responses.stream()
                 .filter(response -> response.paxosValue() != null)
                 .map(PaxosValueResponse::paxosValue)

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -49,9 +49,9 @@ public final class PaxosSynchronizer {
             if (paxosValue.equals(learnerToSynchronize.getGreatestLearnedValue())) {
                 log.info("Started up and found that our value {} is already the most recent.", paxosValue);
             } else {
+                learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
                 log.info("Started up and learned the most recent value: {}.", paxosValue);
             }
-            learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
         }
     }
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -53,6 +53,8 @@ public final class PaxosSynchronizer {
                 learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
                 log.info("Started up and learned the most recent value: {}.", paxosValue);
             }
+        } else {
+            log.info("Started up, and no one I talked to knows anything yet.");
         }
     }
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -46,12 +46,12 @@ public final class PaxosSynchronizer {
         Optional<PaxosValue> mostRecentValue = getMostRecentLearnedValue(paxosLearners);
         if (mostRecentValue.isPresent()) {
             PaxosValue paxosValue = mostRecentValue.get();
-            learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
             if (paxosValue.equals(learnerToSynchronize.getGreatestLearnedValue())) {
                 log.info("Started up and found that our value {} is already the most recent.", paxosValue);
             } else {
                 log.info("Started up and learned the most recent value: {}.", paxosValue);
             }
+            learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
         }
     }
 


### PR DESCRIPTION
Fixes a bug in the PaxosSynchronizer which led to flaky behaviour in PaxosSynchronizerTest, specifically in the best-effort test. Although `PaxosQuorumChecker` would query node 1 before node 2, it was possible that node 1 had not finished learning the value, leading to us polling node 2. Then, we would have `PaxosQuorumChecker` terminate early because it couldn't achieve a quorum.

Also fixes a logging issue where we would always log "we already know the latest value", because the check was done after we learned the new value.

This change:
* allows `PaxosQuorumChecker` to be called in non-shortcircuiting mode.
* fixes the logging in `PaxosSynchronizer`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1529)
<!-- Reviewable:end -->
