### PR TITLE
Timelock: Fail loudly in the absence of a query param for fast-forward

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -46,7 +46,8 @@ develop
          - Fast forwarding a persistent timestamp service to ``Long.MIN_VALUE`` will now throw an exception; previously
            it would be a no-op. This is especially relevant for safety of remote requests; if a user does not
            supply the ``currentTimestamp`` query parameter, we would previously treat this as a fast-forward to zero
-           and silently accept the request (returning 204), while we now fail (returning a 400).
+           and silently accept the request (returning 204) even though this is highly unlikely to be the user's
+           intention, while we now fail loudly (returning a 400).
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,8 +42,11 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |devbreak| |improved|
+         - Fast forwarding a persistent timestamp service to ``Long.MIN_VALUE`` will now throw an exception; previously
+           it would be a no-op. This is especially relevant for safety of remote requests; if a user does not
+           supply the ``currentTimestamp`` query parameter, we would previously treat this as a fast-forward to zero
+           and silently accept the request (returning 204), while we now fail (returning a 400).
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/services/timelock_service/migration.rst
+++ b/docs/source/services/timelock_service/migration.rst
@@ -65,11 +65,11 @@ Step 3: Fast-Forwarding the Timelock Server
 
 The Timelock Server exposes an administrative interface, which features a ``fast-forward`` endpoint. Note that this is
 not typically exposed to AtlasDB clients. One can use it to advance the timestamp on the Timelock Server to ``TS``, as
-follows:
+follows (where ``test`` is the namespace you want your client to use).
 
    .. code:: bash
 
-      curl -XPOST localhost:8080/test/timestamp-admin/fast-forward?newMinimum=TS
+      curl -XPOST localhost:8080/test/timestamp-management/fast-forward?currentTimestamp=TS
 
 .. danger::
 
@@ -103,11 +103,12 @@ The steps for invalidating the old AtlasDB timestamp will vary, depending on you
         ALTER TABLE atlasdb_timestamp RENAME last_allocated TO LEGACY_last_allocated;
 
 - If using Cassandra, one method of invalidating the table is to overwrite the timestamp bound record with the
-  empty byte array (consider using ``cqlsh`` to do this).
+  empty byte array (consider using ``cqlsh`` to do this). This table is stored in the same keyspace that your
+  AtlasDB client uses for its key-value service.
 
      .. code:: bash
 
-        SELECT * FROM atlasdb."timestamp";
+        SELECT * FROM atlasdb."_timestamp";
         <note the value returned by this - call this K>
         INSERT INTO atlasdb."_timestamp" (key, column1, column2, value) VALUES (0x7472, 0x7472, -1, K);
         INSERT INTO atlasdb."_timestamp" (key, column1, column2, value) VALUES (0x7473, 0x7473, -1, 0x);

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementService.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.timestamp;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -23,16 +24,25 @@ import javax.ws.rs.core.MediaType;
 
 @Path("/timestamp-management")
 public interface TimestampManagementService {
+    long SENTINEL_TIMESTAMP = Long.MIN_VALUE;
+    String SENTINEL_TIMESTAMP_STRING =
+            SENTINEL_TIMESTAMP + ""; // can't use valueOf/toString because we need a compile time constant!
+
     /**
      * Updates the timestamp service to the currentTimestamp to ensure that all fresh timestamps issued after
      * this request are greater than the current timestamp.
      * The caller of this is responsible for not using any of the fresh timestamps previously served to it,
      * and must call getFreshTimestamps() to ensure it is using timestamps after the fastforward point.
      *
+     * If currentTimestamp is unspecified (e.g. in a remote request), we will fast forward to the SENTINEL_TIMESTAMP.
+     * This is intended to be Long.MIN_VALUE, so that regardless of the current state of the timestamp service
+     * it is effectively a no-op. To improve usability, this method is also allowed to throw an exception in this case.
+     *
      * @param currentTimestamp the largest timestamp issued until the fast-forward call
      */
     @POST
     @Path("fast-forward")
     @Produces(MediaType.APPLICATION_JSON)
-    void fastForwardTimestamp(@QueryParam("currentTimestamp") long currentTimestamp);
+    void fastForwardTimestamp(
+            @QueryParam("currentTimestamp") @DefaultValue(SENTINEL_TIMESTAMP_STRING) long currentTimestamp);
 }

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -67,6 +67,9 @@ public class PersistentTimestampService implements TimestampService, TimestampMa
 
     @Override
     public void fastForwardTimestamp(long currentTimestamp) {
+        Preconditions.checkArgument(currentTimestamp != TimestampManagementService.SENTINEL_TIMESTAMP,
+                "Cannot fast forward to the sentinel timestamp %s. If you accessed this timestamp service remotely"
+                        + " this is likely due to specifying an incorrect query parameter.", currentTimestamp);
         availableTimestamps.fastForwardTo(currentTimestamp);
     }
 

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
@@ -87,6 +87,11 @@ public class PersistentTimestampServiceMockingTest {
         assertThat(timestampService.getFreshTimestamp(), is(TIMESTAMP));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectFastForwardToTheSentinelValue() {
+        timestampService.fastForwardTimestamp(TimestampManagementService.SENTINEL_TIMESTAMP);
+    }
+
     private void waitForExecutorToFinish() throws InterruptedException {
         executor.shutdown();
         executor.awaitTermination(10, SECONDS);

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTests.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTests.java
@@ -86,6 +86,11 @@ public class PersistentTimestampServiceTests extends AbstractTimestampServiceTes
         assertThat(timestampBoundStore.numberOfAllocations(), is(lessThan(2)));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectFastForwardToTheSentinelValue() {
+        getTimestampManagementService().fastForwardTimestamp(TimestampManagementService.SENTINEL_TIMESTAMP);
+    }
+
     private void getTimestampAndIgnoreErrors() {
         try {
             getTimestampService().getFreshTimestamp();


### PR DESCRIPTION
This PR incorporates changes suggested by @tstearns when dogfooding the Timelock docs.

> 1. When running “fast-forward” against the timelock server. The docs say to hit “timestamp-admin/fast-forward?newMinimum=TS” but the endpoint appears to actually be “timestamp-management/fast-forward?currentTimestamp=TS”. Not only should the docs be changed, but another note is that if you use “newMinimum” instead of “currentTimestamp”, you get a 204 success response even though nothing happens. This was very confusing at first. Maybe it should return an error? Could be very dangerous if (a user) thinks the fast-forward was successful when it wasn’t.
> 2. In the part of the guide that describes how to invalidate the Cassandra timestamp table, the example keyspace used is “atlasdb”, but I just had to guess that it would actually be the name of the service (in this case “[REDACTED]”)...there is also a little typo in that one of the example CQLSH lines uses “timestamp” instead of “_timestamp” as the table name.

So this change:

* Changes PersistentTimestampService to throw on `Long.MIN_VALUE`. As a trade-off you can't fast-forward to `Long.MIN_VALUE` any more, but that's a no-op anyway.
* Sets default value of the `currentTimestamp` parameter to `Long.MIN_VALUE`. PersistentTimestampService will spit out an `IllegalArgumentException` with suitable message, meaning that Timelock will throw a 400 at the client in this case.

I've updated the docs with notes from the feedback too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1538)
<!-- Reviewable:end -->
