### PR TITLE
Add scheme to timelock server pattern in docs

### DIFF
--- a/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
@@ -34,7 +34,7 @@ Required parameters:
            :ref:`timelock-server-configuration`.
 
     *    - serversList::servers
-         - A list of all hosts. The hosts must be specified as addresses, i.e. ``host:port``.
+         - A list of all hosts. The hosts must be specified as addresses, i.e. ``https://host:port``.
            At least one server must be specified. AtlasDB assumes that the Timelock Servers being pointed at
            are part of the same Timelock cluster.
 


### PR DESCRIPTION
This addresses a small source of confusion in the docs -- when I specified my servers as literally `host:port`, the atlasdb client threw an "unexpected url" error, so I made the servers into actual URLs like `https://host:port`, which worked. Not sure the best way to indicate this in the docs, but this PR is one suggestion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1539)
<!-- Reviewable:end -->
