### PR TITLE
accomodate OracleDB 12c+ responses in statement.executeBatch()

### DIFF
--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
@@ -869,8 +869,7 @@ public abstract class BasicSQL {
                     return false;
                 }
                 for (int numInsertedForRow : inserted) {
-                    if (numInsertedForRow != 1 &&
-                            numInsertedForRow != Statement.SUCCESS_NO_INFO) {
+                    if (numInsertedForRow == Statement.EXECUTE_FAILED) {
                         assert DBType.getTypeFromConnection(c) != DBType.ORACLE : "numInsertedForRow: " + numInsertedForRow; //$NON-NLS-1$
                         return false;
                     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,6 +49,10 @@ develop
            and silently accept the request (returning 204) even though this is highly unlikely to be the user's
            intention, while we now fail loudly (returning a 400).
 
+    *    - |fixed|
+         - Better support Oracle 12c batch responses
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1540>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
relevant documentation https://docs.oracle.com/database/121/JJDBC/oraperf.htm#JJDBC28770

Almost no code internally even checks the return boolean out of this; in the JDBC drivers we use, errors here will probably instead result in a SQLException being thrown, though the JDBC standard allows a driver if they want to do to make better attempts at pushing through parts of batches after major failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1540)
<!-- Reviewable:end -->
