### PR TITLE
add atlasdb root level configs, de-duplicated other configs in the docs

### DIFF
--- a/docs/source/cluster_management/sweep.rst
+++ b/docs/source/cluster_management/sweep.rst
@@ -45,7 +45,7 @@ Tunable Configuration Options
 -----------------------------
 
 The following optional parameters can be tuned to optimize Sweep performance for a specific AtlasDB instance.
-You may set them as part of your :ref:`AtlasDB configuration <atlas_config>`, or as a CLI option if you are running sweep using the CLI.
+You may set them as part of your :ref:`AtlasDB configuration <atlas-config>`, or as a CLI option if you are running sweep using the CLI.
 
 .. csv-table::
    :header: "AtlasDB Config", "CLI Option", "Default", "Description"

--- a/docs/source/cluster_management/sweep/background-sweep.rst
+++ b/docs/source/cluster_management/sweep/background-sweep.rst
@@ -22,7 +22,7 @@ The Background Sweep Job determines which table to sweep by estimating which wou
 Configuration
 -------------
 
-The background sweeper can be enabled by setting the ``enableSweep`` property in the :ref:`AtlasDB configuration <atlas_config>` to true.
+The background sweeper can be enabled by setting the ``enableSweep`` property in the :ref:`AtlasDB configuration <atlas-config>` to true.
 For other configuration options, see :ref:`Tunable Sweep Configuration Options<sweep_tunable_parameters>`.
 
 Additional logging for Background Sweep

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -1,4 +1,4 @@
-.. _atlas_config:
+.. _atlas-config:
 
 =============
 Configuration
@@ -16,5 +16,63 @@ Configuration
    leader_config
    logging
 
-The AtlasDB configuration has two main parts - keyValueService and leader.
-Please look at the keyValueService config for the KVS you are using (either :ref:`Cassandra <cassandra-configuration>` or :ref:`Postgres <postgres-configuration>`) and the :ref:`Leader Configuration <leader-config>` page for configuring the leader block.
+AtlasDB Configuration
+=====================
+
+AtlasDB uses a YAML based configuration file with a default root configuration block denoted by ``atlasdb``.
+
+The primary config block for your AtlasDB client will be ``keyValueServiceConfig``. This is where all of the KVS specific
+parameters will go. Please see :ref:`key-value-service-configs` for details on specific KVS configurations.
+
+In addition to the ``keyValueServiceConfig``, you must specify a configuration for the timestamp and lock services.
+If you are using an embedded timestamp and lock service, see the :ref:`Leader Configuration <leader-config>` documentation.
+If you are using the :ref:`external Timelock service <external-timelock-service>`, then see the :ref:`Timelock client configuration <timelock-client-configuration>`.
+
+Other parameters related to :ref:`Sweep <sweep>` can also be specified here. For a full list of the configurations
+available at the ``atlasdb`` root level, see `AtlasDbConfig.java <https://github.com/palantir/atlasdb/blob/develop/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java>`__.
+
+Example Configuration
+=====================
+
+.. code-block:: yaml
+
+    atlasdb:
+      keyValueService:
+        type: cassandra
+        servers:
+          - cassandra-1:9160
+          - cassandra-2:9160
+          - cassandra-3:9160
+        poolSize: 30
+        keyspace: yourapp
+        credentials:
+          username: cassandra
+          password: cassandra
+        sslConfiguration:
+          trustStorePath: var/security/truststore.jks
+        replicationFactor: 3
+        mutationBatchCount: 10000
+        mutationBatchSizeBytes: 10000000
+        fetchBatchCount: 1000
+        safetyDisabled: false
+        autoRefreshNodes: false
+
+      leader:
+        # This should be at least half the number of nodes in your cluster
+        quorumSize: 2
+        learnerLogDir: var/data/paxosLogs
+        acceptorLogDir: var/data/paxosLogs
+        localServer: https://host1:3828
+        lockCreator: https://host1:3828
+        # This should be the same for every node
+        leaders:
+          - https://host1:3828 # If ssl is not enabled, then the hosts must be specified as http
+          - https://host2:3828
+          - https://host3:3828
+        sslConfiguration:
+          trustStorePath: var/security/truststore.jks
+
+      enableSweep: true
+      sweepBatchSize: 1000
+
+

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -72,7 +72,7 @@ Example Configuration
         sslConfiguration:
           trustStorePath: var/security/truststore.jks
 
-      enableSweep: true
+      enableSweep: false
       sweepBatchSize: 1000
 
 

--- a/docs/source/configuration/leader_config.rst
+++ b/docs/source/configuration/leader_config.rst
@@ -93,21 +93,7 @@ Failure to specify a leader configuration could lead to data corruption.
     atlasdb:
       keyValueService:
         type: cassandra
-        servers:
-          - cassandra:9160
-        poolSize: 20
-        keyspace: yourapp
-        credentials:
-          username: cassandra
-          password: cassandra
-        sslConfiguration:
-          trustStorePath: var/security/truststore.jks
-        replicationFactor: 1
-        mutationBatchCount: 10000
-        mutationBatchSizeBytes: 10000000
-        fetchBatchCount: 1000
-        safetyDisabled: false
-        autoRefreshNodes: false
+        # omitted for brevity
 
       leader:
         # This should be at least half the number of nodes in your cluster
@@ -115,7 +101,7 @@ Failure to specify a leader configuration could lead to data corruption.
         learnerLogDir: var/data/paxosLogs
         acceptorLogDir: var/data/paxosLogs
         # This should be different for every node. If ssl is not enabled, then the host must be specified as http
-        localServer: https://<yourhost>:3828
+        localServer: https://host1:3828
         # This should be the same for every node. If ssl is not enabled, then the host must be specified as http
         lockCreator: https://host1:3828
         # This should be the same for every node
@@ -139,7 +125,7 @@ To run an :ref:`offline CLI <offline-clis>`, you also need to specify a leader b
     atlasdb:
       keyValueService:
         type: cassandra
-        # continues as above - omitted for brevity
+        # omitted for brevity
 
       leader:
         # This should be at least half the number of nodes in your cluster
@@ -165,21 +151,7 @@ An example configuration is below.
     atlasdb:
       keyValueService:
         type: cassandra
-        servers:
-          - cassandra:9160
-        poolSize: 20
-        keyspace: yourapp
-        credentials:
-          username: cassandra
-          password: cassandra
-        sslConfiguration:
-          trustStorePath: var/security/truststore.jks
-        replicationFactor: 1
-        mutationBatchCount: 10000
-        mutationBatchSizeBytes: 10000000
-        fetchBatchCount: 1000
-        safetyDisabled: false
-        autoRefreshNodes: false
+        # omitted for brevity
 
       # no leader block
 
@@ -195,8 +167,10 @@ If you are running an :ref:`offline CLI <offline-clis>` then you must specify a 
     atlasdb:
       keyValueService:
         type: cassandra
-        # continues as above - omitted for brevity
+        # omitted for brevity
+
       # no leader block
+
       lock:
         servers:
           - "http://host1:3828/api"
@@ -204,6 +178,7 @@ If you are running an :ref:`offline CLI <offline-clis>` then you must specify a 
           - "http://host3:3828/api"
         sslConfiguration:
           trustStorePath: var/security/truststore.jks
+
       timestamp:
         servers:
           - "http://host1:3828/api"


### PR DESCRIPTION
I realized we didn't have example docs on how to enable the background sweep job, and then I realized we didn't have any docs on configurations for the root `atlasdb` block. Also removed some example configs from the leader configuration page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1543)
<!-- Reviewable:end -->
