### PR TITLE
BatchingVisitables: fix a type problem occurring on newer compilers

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -996,9 +996,9 @@ public class TableRenderer {
 
         private void renderDynamicDeleteRanges() {
             line("public void deleteRanges(Iterable<RangeRequest> ranges) {"); {
-                line("BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<", RowResult, ">, RuntimeException>() {"); {
+                line("BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends ", RowResult, ">, RuntimeException>() {"); {
                     line("@Override");
-                    line("public boolean visit(List<", RowResult, "> rowResults) {"); {
+                    line("public boolean visit(List<? extends ", RowResult, "> rowResults) {"); {
                         line("Multimap<", Row, ", ", Column, "> toRemove = HashMultimap.create();");
                         line("for (", RowResult, " rowResult : rowResults) {"); {
                             line("for (", ColumnValue, " columnValue : rowResult.getColumnValues()) {"); {
@@ -1016,9 +1016,9 @@ public class TableRenderer {
             line("public void deleteRanges(Iterable<RangeRequest> ranges) {"); {
                 line("BatchingVisitables.concat(getRanges(ranges))");
                 line("                  .transform(", RowResult, ".getRowNameFun())");
-                line("                  .batchAccept(1000, new AbortingVisitor<List<", Row, ">, RuntimeException>() {"); {
+                line("                  .batchAccept(1000, new AbortingVisitor<List<? extends ", Row, ">, RuntimeException>() {"); {
                     line("@Override");
-                    line("public boolean visit(List<", Row, "> rows) {"); {
+                    line("public boolean visit(List<? extends ", Row, "> rows) {"); {
                         line("delete(rows);");
                         line("return true;");
                     } line("}");

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/AbortingVisitors.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/AbortingVisitors.java
@@ -57,10 +57,10 @@ public class AbortingVisitors {
         };
     }
 
-    public static <T, K extends Exception> AbortingVisitor<Iterable<T>, K> batching(final AbortingVisitor<? super T, ? extends K> v) {
-        return new AbortingVisitor<Iterable<T>, K>() {
+    public static <T, K extends Exception> AbortingVisitor<Iterable<? extends T>, K> batching(final AbortingVisitor<? super T, ? extends K> v) {
+        return new AbortingVisitor<Iterable<? extends T>, K>() {
             @Override
-            public boolean visit(Iterable<T> item) throws K {
+            public boolean visit(Iterable<? extends T> item) throws K {
                 for (T t : item) {
                     if (!v.visit(t)) {
                         return false;

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/AbstractBatchingVisitable.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/AbstractBatchingVisitable.java
@@ -29,11 +29,11 @@ import com.google.common.collect.Lists;
  */
 public abstract class AbstractBatchingVisitable<T> implements BatchingVisitable<T> {
     @Override
-    final public <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<T>, K> v) throws K {
+    final public <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<? extends T>, K> v) throws K {
         Preconditions.checkArgument(batchSize > 0);
         if (v instanceof ConsistentVisitor) {
             @SuppressWarnings("unchecked")
-            AbortingVisitor<List<T>, K> v2 = (AbortingVisitor<List<T>, K>) v;
+            AbortingVisitor<List<? extends T>, K> v2 = (AbortingVisitor<List<? extends T>, K>) v;
             ConsistentVisitor<T, K> consistentVisitor = (ConsistentVisitor<T, K>) v2;
             Preconditions.checkState(consistentVisitor.visitorAlwaysReturnedTrue,
                     "passed a visitor that has already said stop");
@@ -59,20 +59,20 @@ public abstract class AbstractBatchingVisitable<T> implements BatchingVisitable<
     protected abstract <K extends Exception> void batchAcceptSizeHint(int batchSizeHint,
                                                                          ConsistentVisitor<T, K> v) throws K;
 
-    protected final static class ConsistentVisitor<T, K extends Exception> implements AbortingVisitor<List<T>, K> {
+    protected final static class ConsistentVisitor<T, K extends Exception> implements AbortingVisitor<List<? extends T>, K> {
         final int batchSize;
-        final AbortingVisitor<? super List<T>, K> v;
+        final AbortingVisitor<? super List<? extends T>, K> v;
         List<T> buffer = Lists.newArrayList();
         boolean visitorAlwaysReturnedTrue = true;
 
-        private ConsistentVisitor(int batchSize, AbortingVisitor<? super List<T>, K> av) {
+        private ConsistentVisitor(int batchSize, AbortingVisitor<? super List<? extends T>, K> av) {
             Preconditions.checkArgument(batchSize > 0);
             this.batchSize = batchSize;
             this.v = Preconditions.checkNotNull(av);
         }
 
         static <T, K extends Exception> ConsistentVisitor<T, K> create(int batchSize,
-                AbortingVisitor<? super List<T>, K> v) {
+                AbortingVisitor<? super List<? extends T>, K> v) {
             return new ConsistentVisitor<T, K>(batchSize, v);
         }
 
@@ -81,7 +81,7 @@ public abstract class AbstractBatchingVisitable<T> implements BatchingVisitable<
         }
 
         @Override
-        public boolean visit(List<T> list) throws K {
+        public boolean visit(List<? extends T> list) throws K {
             if (!visitorAlwaysReturnedTrue) {
                 throw new IllegalStateException("Cannot keep visiting if visitor returns false.");
             }

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitable.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitable.java
@@ -26,5 +26,5 @@ public interface BatchingVisitable<T> {
      *                  one which could be smaller, but will not be empty;
      * @return true if the visitor always returned true or was never called. false if the visitor ever returned false.
      */
-    <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<T>, K> v) throws K;
+    <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<? extends T>, K> v) throws K;
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitableView.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitableView.java
@@ -60,7 +60,7 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
     @Override
     public <K extends Exception> boolean batchAccept(
             int batchSize,
-            AbortingVisitor<? super List<T>, K> visitor) throws K {
+            AbortingVisitor<? super List<? extends T>, K> visitor) throws K {
         return delegate().batchAccept(batchSize, visitor);
     }
 
@@ -117,15 +117,15 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
      * requesting a batch of size 1.
      * A good example of this is in <code>BatchingVisitablesTest#testHintPageSize()</code>
      */
-    public <U> BatchingVisitableView<U> transformBatch(Function<? super List<T>, ? extends List<U>> fn) {
+    public <U> BatchingVisitableView<U> transformBatch(Function<? super List<? extends T>, ? extends List<U>> fn) {
         Preconditions.checkNotNull(fn, "Cannot transform using a null function");
         return BatchingVisitables.transformBatch(delegate(), fn);
     }
 
     public void forEach(int batchSize, final Visitor<T> visitor) {
-        delegate().batchAccept(batchSize, new AbortingVisitor<List<T>, RuntimeException>() {
+        delegate().batchAccept(batchSize, new AbortingVisitor<List<? extends T>, RuntimeException>() {
             @Override
-            public boolean visit(List<T> batch) throws RuntimeException {
+            public boolean visit(List<? extends T> batch) throws RuntimeException {
                 for (T item : batch) {
                     visitor.visit(item);
                 }
@@ -229,9 +229,9 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
         final ImmutableList.Builder<T> builder = ImmutableList.builder();
         delegate().batchAccept(
                 BatchingVisitables.KEEP_ALL_BATCH_SIZE,
-                new AbortingVisitor<List<T>, RuntimeException>() {
+                new AbortingVisitor<List<? extends T>, RuntimeException>() {
                     @Override
-                    public boolean visit(List<T> items) {
+                    public boolean visit(List<? extends T> items) {
                         builder.addAll(items);
                         return true;
                     }
@@ -248,9 +248,9 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
         final ImmutableSet.Builder<T> builder = ImmutableSet.builder();
         delegate().batchAccept(
                 BatchingVisitables.KEEP_ALL_BATCH_SIZE,
-                new AbortingVisitor<List<T>, RuntimeException>() {
+                new AbortingVisitor<List<? extends T>, RuntimeException>() {
                     @Override
-                    public boolean visit(List<T> items) {
+                    public boolean visit(List<? extends T> items) {
                         builder.addAll(items);
                         return true;
                     }
@@ -268,9 +268,9 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
         Preconditions.checkNotNull(collection, "Cannot copy the visitable into a null collection");
         delegate().batchAccept(
                 BatchingVisitables.KEEP_ALL_BATCH_SIZE,
-                new AbortingVisitor<List<T>, RuntimeException>() {
+                new AbortingVisitor<List<? extends T>, RuntimeException>() {
                     @Override
-                    public boolean visit(List<T> items) {
+                    public boolean visit(List<? extends T> items) {
                         collection.addAll(items);
                         return true;
                     }
@@ -285,9 +285,9 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
         Preconditions.checkNotNull(predicate, "Cannot check against a null predicate");
         return !delegate().batchAccept(
                 BatchingVisitables.DEFAULT_BATCH_SIZE,
-                new AbortingVisitor<List<T>, RuntimeException>() {
+                new AbortingVisitor<List<? extends T>, RuntimeException>() {
                     @Override
-                    public boolean visit(List<T> items) {
+                    public boolean visit(List<? extends T> items) {
                         for (T t : items) {
                             if (predicate.apply(t)) {
                                 return false;
@@ -306,9 +306,9 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
         Preconditions.checkNotNull(predicate, "Cannot check against a null predicate");
         return delegate().batchAccept(
                 BatchingVisitables.DEFAULT_BATCH_SIZE,
-                new AbortingVisitor<List<T>, RuntimeException>() {
+                new AbortingVisitor<List<? extends T>, RuntimeException>() {
                     @Override
-                    public boolean visit(List<T> items) {
+                    public boolean visit(List<? extends T> items) {
                         for (T t : items) {
                             if (!predicate.apply(t)) {
                                 return false;

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
@@ -45,7 +45,7 @@ public class BatchingVisitables {
     public static <T> BatchingVisitableView<T> emptyBatchingVisitable() {
         return BatchingVisitableView.of(new BatchingVisitable<T>() {
             @Override
-            public <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<T>, K> v)
+            public <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<? extends T>, K> v)
                     throws K {
                 return true;
             }
@@ -55,7 +55,7 @@ public class BatchingVisitables {
     public static <T> BatchingVisitableView<T> singleton(final T t) {
         return BatchingVisitableView.of(new BatchingVisitable<T>() {
             @Override
-            public <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<T>, K> v)
+            public <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<? extends T>, K> v)
                     throws K {
                 return v.visit(ImmutableList.of(t));
             }
@@ -99,9 +99,9 @@ public class BatchingVisitables {
             @Override
             protected <K extends Exception> void batchAcceptSizeHint(int batchSizeHint,
                     final ConsistentVisitor<T, K> v) throws K {
-                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<T>, K>() {
+                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<? extends T>, K>() {
                     @Override
-                    public boolean visit(List<T> batch) throws K {
+                    public boolean visit(List<? extends T> batch) throws K {
                         for (T t : batch) {
                             if (!condition.apply(t)) {
                                     return false;
@@ -144,9 +144,9 @@ public class BatchingVisitables {
     }
 
     public static <T> boolean isEqual(BatchingVisitable<T> v, final Iterator<T> it) {
-        boolean ret = v.batchAccept(DEFAULT_BATCH_SIZE, new AbortingVisitor<List<T>, RuntimeException>() {
+        boolean ret = v.batchAccept(DEFAULT_BATCH_SIZE, new AbortingVisitor<List<? extends T>, RuntimeException>() {
             @Override
-            public boolean visit(List<T> batch) {
+            public boolean visit(List<? extends T> batch) {
                 Iterator<T> toMatch = Iterators.limit(it, batch.size());
                 return Iterators.elementsEqual(toMatch, batch.iterator());
             }
@@ -265,34 +265,34 @@ public class BatchingVisitables {
 
     public static <T> BatchingVisitableView<T> filter(BatchingVisitable<T> visitable, final Predicate<? super T> pred) {
         Preconditions.checkNotNull(pred);
-        return transformBatch(visitable, new Function<List<T>, List<T>>() {
+        return transformBatch(visitable, new Function<List<? extends T>, List<T>>() {
             @Override
-            public List<T> apply(List<T> input) {
+            public List<T> apply(List<? extends T> input) {
                 return ImmutableList.copyOf(Iterables.filter(input, pred));
             }
         });
     }
 
     public static <F, T> BatchingVisitableView<T> transform(BatchingVisitable<F> visitable, final Function<? super F, ? extends T> f) {
-        return transformBatch(visitable, new Function<List<F>, List<T>>() {
+        return transformBatch(visitable, new Function<List<? extends F>, List<T>>() {
             @Override
-            public List<T> apply(List<F> from) {
+            public List<T> apply(List<? extends F> from) {
                 return Lists.transform(from, f);
             }
         });
     }
 
     public static <F, T> BatchingVisitableView<T> transformBatch(final BatchingVisitable<F> visitable,
-            final Function<? super List<F>, ? extends List<T>> f) {
+            final Function<? super List<? extends F>, ? extends List<T>> f) {
         Preconditions.checkNotNull(visitable);
         Preconditions.checkNotNull(f);
         return BatchingVisitableView.of(new AbstractBatchingVisitable<T>() {
             @Override
             protected <K extends Exception> void batchAcceptSizeHint(int batchSizeHint,
                                                                      final ConsistentVisitor<T, K> v) throws K {
-                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<F>, K>() {
+                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<? extends F>, K>() {
                     @Override
-                    public boolean visit(List<F> batch) throws K {
+                    public boolean visit(List<? extends F> batch) throws K {
                         return v.visit(f.apply(batch));
                     }
                 });
@@ -313,10 +313,10 @@ public class BatchingVisitables {
                 if (batchSizeHint > limit) {
                     batchSizeHint = (int)limit;
                 }
-                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<T>, K>() {
+                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<? extends T>, K>() {
                     long visited = 0;
                     @Override
-                    public boolean visit(List<T> batch) throws K {
+                    public boolean visit(List<? extends T> batch) throws K {
                         for (T item : batch) {
                             if (!v.visitOne(item)) {
                                 return false;
@@ -346,10 +346,10 @@ public class BatchingVisitables {
             @Override
             protected <K extends Exception> void batchAcceptSizeHint(int batchSizeHint,
                                                                         final ConsistentVisitor<T, K> v) throws K {
-                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<T>, K>() {
+                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<? extends T>, K>() {
                     long visited = 0;
                     @Override
-                    public boolean visit(List<T> batch) throws K {
+                    public boolean visit(List<? extends T> batch) throws K {
                         for (T item : batch) {
                             if (visited < toSkip) {
                                 visited++;
@@ -392,11 +392,11 @@ public class BatchingVisitables {
             protected <K extends Exception> void batchAcceptSizeHint(int batchSizeHint,
                                                                         final ConsistentVisitor<T, K> v)
                     throws K {
-                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<T>, K>() {
+                visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<? extends T>, K>() {
                     boolean hasVisitedFirst = false;
                     Object lastVisited = null;
                     @Override
-                    public boolean visit(List<T> batch) throws K {
+                    public boolean visit(List<? extends T> batch) throws K {
                         for (T item : batch) {
 
                             Object itemKey = function.apply(item);
@@ -484,16 +484,16 @@ public class BatchingVisitables {
      *
      * @see BatchingVisitableView for more helper methods
      */
-    public static <T, S extends T> BatchingVisitable<T> wrap(final BatchingVisitable<S> visitable) {
+    public static <T, S extends T> BatchingVisitable<T> wrap(final BatchingVisitable<? extends S> visitable) {
         if (visitable == null) {
             return null;
         }
         return new BatchingVisitable<T>() {
             @Override
-            public <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<T>, K> v) throws K {
+            public <K extends Exception> boolean batchAccept(int batchSize, AbortingVisitor<? super List<? extends T>, K> v) throws K {
                 // This cast is safe because an abortingVisitor can consume more specific values
                 @SuppressWarnings("unchecked")
-                AbortingVisitor<? super List<S>, K> specificVisitor = (AbortingVisitor<? super List<S>, K>) v;
+                AbortingVisitor<? super List<? extends S>, K> specificVisitor = (AbortingVisitor<? super List<? extends S>, K>) v;
                 return visitable.batchAccept(batchSize, specificVisitor);
             }
         };

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/PrefetchingBatchingVisitable.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/PrefetchingBatchingVisitable.java
@@ -55,9 +55,9 @@ public class PrefetchingBatchingVisitable<T> implements BatchingVisitable<T> {
 
     @Override
     public <K extends Exception> boolean batchAccept(final int batchSize,
-                                                     AbortingVisitor<? super List<T>, K> v)
+                                                     AbortingVisitor<? super List<? extends T>, K> v)
             throws K {
-        final Queue<List<T>> queue = Queues.newArrayDeque();
+        final Queue<List<? extends T>> queue = Queues.newArrayDeque();
         final Lock lock = new ReentrantLock();
         final Condition itemAvailable = lock.newCondition();
         final Condition spaceAvailable = lock.newCondition();
@@ -73,9 +73,9 @@ public class PrefetchingBatchingVisitable<T> implements BatchingVisitable<T> {
             public void run() {
                 try {
                     fetchTime.start();
-                    delegate.batchAccept(batchSize, new AbortingVisitor<List<T>, InterruptedException>() {
+                    delegate.batchAccept(batchSize, new AbortingVisitor<List<? extends T>, InterruptedException>() {
                         @Override
-                        public boolean visit(List<T> item) throws InterruptedException {
+                        public boolean visit(List<? extends T> item) throws InterruptedException {
                             fetchTime.stop();
                             fetchBlockedTime.start();
                             lock.lock();
@@ -118,7 +118,7 @@ public class PrefetchingBatchingVisitable<T> implements BatchingVisitable<T> {
 
         try {
             while (true) {
-                List<T> batch;
+                List<? extends T> batch;
                 visitBlockedTime.start();
                 lock.lock();
                 try {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
@@ -160,7 +160,7 @@ public final class KeyValueServiceScrubberStore implements ScrubberStore {
                 maxScrubTimestamp);
     }
 
-    private SortedMap<Long, Multimap<TableReference, Cell>> transformRows(List<RowResult<Value>> input) {
+    private SortedMap<Long, Multimap<TableReference, Cell>> transformRows(List<? extends RowResult<Value>> input) {
         SortedMap<Long, Multimap<TableReference, Cell>> scrubTimestampToTableNameToCell = Maps.newTreeMap();
         for (RowResult<Value> rowResult : input) {
             for (Map.Entry<Cell, Value> entry : rowResult.getCells()) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsAndTimestamps.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsAndTimestamps.java
@@ -36,7 +36,8 @@ public abstract class CellsAndTimestamps {
                 .build();
     }
 
-    public static CellsAndTimestamps fromCellAndTimestampsList(List<CellAndTimestamps> cellAndTimestampsList) {
+    public static CellsAndTimestamps fromCellAndTimestampsList(
+            List<? extends CellAndTimestamps> cellAndTimestampsList) {
         return ImmutableCellsAndTimestamps.builder()
                 .addAllCellAndTimestampsList(cellAndTimestampsList)
                 .build();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/RangeVisitor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/RangeVisitor.java
@@ -141,9 +141,9 @@ public class RangeVisitor {
     private long visitInternal(Transaction tx, Visitor visitor, RangeRequest request, MutableRange range) {
         final AtomicLong numVisited = new AtomicLong();
         boolean isEmpty = tx.getRange(tableRef, request).batchAccept(range.getBatchSize(),
-                new AbortingVisitor<List<RowResult<byte[]>>, RuntimeException>() {
+                new AbortingVisitor<List<? extends RowResult<byte[]>>, RuntimeException>() {
                     @Override
-                    public boolean visit(List<RowResult<byte[]>> batch) {
+                    public boolean visit(List<? extends RowResult<byte[]>> batch) {
                         visitor.visit(tx, batch);
                         if (batch.size() < range.getBatchSize()) {
                             range.setStartRow(null);
@@ -200,6 +200,6 @@ public class RangeVisitor {
     }
 
     public interface Visitor {
-        void visit(Transaction tx, List<RowResult<byte[]>> batch);
+        void visit(Transaction tx, List<? extends RowResult<byte[]>> batch);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
@@ -376,12 +376,12 @@ public final class TableTasks {
         };
     }
 
-    private static Iterable<Cell> asCells(final Iterable<RowResult<byte[]>> results) {
+    private static Iterable<Cell> asCells(final Iterable<? extends RowResult<byte[]>> results) {
         return new Iterable<Cell>() {
             @Override
             public Iterator<Cell> iterator() {
                 return new AbstractIterator<Cell>() {
-                    private final Iterator<RowResult<byte[]>> outerIter = results.iterator();
+                    private final Iterator<? extends RowResult<byte[]>> outerIter = results.iterator();
                     private byte[] row = null;
                     private Iterator<byte[]> innerIter = null;
                     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -760,7 +760,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             TableReference tableRef,
             RangeRequest range,
             int userRequestedSize,
-            AbortingVisitor<List<RowResult<byte[]>>, K> visitor,
+            AbortingVisitor<List<? extends RowResult<byte[]>>, K> visitor,
             int preFilterBatchSize) throws K {
         ClosableIterator<RowResult<byte[]>> postFilterIterator =
                 postFilterIterator(tableRef, range, preFilterBatchSize, Value.GET_VALUE);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -1517,9 +1517,9 @@ public final class DataTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<Index1IdxRowResult>, RuntimeException>() {
+            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends Index1IdxRowResult>, RuntimeException>() {
                 @Override
-                public boolean visit(List<Index1IdxRowResult> rowResults) {
+                public boolean visit(List<? extends Index1IdxRowResult> rowResults) {
                     Multimap<Index1IdxRow, Index1IdxColumn> toRemove = HashMultimap.create();
                     for (Index1IdxRowResult rowResult : rowResults) {
                         for (Index1IdxColumnValue columnValue : rowResult.getColumnValues()) {
@@ -2192,9 +2192,9 @@ public final class DataTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<Index2IdxRowResult>, RuntimeException>() {
+            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends Index2IdxRowResult>, RuntimeException>() {
                 @Override
-                public boolean visit(List<Index2IdxRowResult> rowResults) {
+                public boolean visit(List<? extends Index2IdxRowResult> rowResults) {
                     Multimap<Index2IdxRow, Index2IdxColumn> toRemove = HashMultimap.create();
                     for (Index2IdxRowResult rowResult : rowResults) {
                         for (Index2IdxColumnValue columnValue : rowResult.getColumnValues()) {
@@ -2845,9 +2845,9 @@ public final class DataTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<Index3IdxRowResult>, RuntimeException>() {
+            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends Index3IdxRowResult>, RuntimeException>() {
                 @Override
-                public boolean visit(List<Index3IdxRowResult> rowResults) {
+                public boolean visit(List<? extends Index3IdxRowResult> rowResults) {
                     Multimap<Index3IdxRow, Index3IdxColumn> toRemove = HashMultimap.create();
                     for (Index3IdxRowResult rowResult : rowResults) {
                         for (Index3IdxColumnValue columnValue : rowResult.getColumnValues()) {
@@ -3520,9 +3520,9 @@ public final class DataTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<Index4IdxRowResult>, RuntimeException>() {
+            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends Index4IdxRowResult>, RuntimeException>() {
                 @Override
-                public boolean visit(List<Index4IdxRowResult> rowResults) {
+                public boolean visit(List<? extends Index4IdxRowResult> rowResults) {
                     Multimap<Index4IdxRow, Index4IdxColumn> toRemove = HashMultimap.create();
                     for (Index4IdxRowResult rowResult : rowResults) {
                         for (Index4IdxColumnValue columnValue : rowResult.getColumnValues()) {
@@ -3636,5 +3636,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UfX2BLcIzo66QOV+PDQVSg==";
+    static String __CLASS_HASH = "HnfMRutCyVsBK7QAtC/+jA==";
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,6 +53,10 @@ develop
          - Better support Oracle 12c batch responses
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1540>`__)
 
+    *    - |devbreak| |fixed|
+         - Devs should regenerate their Schemas when upgrading to get rid of some type problems that are no longer
+           accepted in newer Java compilers.
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -1896,9 +1896,9 @@ public final class UserProfileTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<CookiesIdxRowResult>, RuntimeException>() {
+            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends CookiesIdxRowResult>, RuntimeException>() {
                 @Override
-                public boolean visit(List<CookiesIdxRowResult> rowResults) {
+                public boolean visit(List<? extends CookiesIdxRowResult> rowResults) {
                     Multimap<CookiesIdxRow, CookiesIdxColumn> toRemove = HashMultimap.create();
                     for (CookiesIdxRowResult rowResult : rowResults) {
                         for (CookiesIdxColumnValue columnValue : rowResult.getColumnValues()) {
@@ -2583,9 +2583,9 @@ public final class UserProfileTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<CreatedIdxRowResult>, RuntimeException>() {
+            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends CreatedIdxRowResult>, RuntimeException>() {
                 @Override
-                public boolean visit(List<CreatedIdxRowResult> rowResults) {
+                public boolean visit(List<? extends CreatedIdxRowResult> rowResults) {
                     Multimap<CreatedIdxRow, CreatedIdxColumn> toRemove = HashMultimap.create();
                     for (CreatedIdxRowResult rowResult : rowResults) {
                         for (CreatedIdxColumnValue columnValue : rowResult.getColumnValues()) {
@@ -3270,9 +3270,9 @@ public final class UserProfileTable implements
         }
 
         public void deleteRanges(Iterable<RangeRequest> ranges) {
-            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<UserBirthdaysIdxRowResult>, RuntimeException>() {
+            BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends UserBirthdaysIdxRowResult>, RuntimeException>() {
                 @Override
-                public boolean visit(List<UserBirthdaysIdxRowResult> rowResults) {
+                public boolean visit(List<? extends UserBirthdaysIdxRowResult> rowResults) {
                     Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> toRemove = HashMultimap.create();
                     for (UserBirthdaysIdxRowResult rowResult : rowResults) {
                         for (UserBirthdaysIdxColumnValue columnValue : rowResult.getColumnValues()) {
@@ -3386,5 +3386,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "twWonBYvnCo3eLx7bSPHnw==";
+    static String __CLASS_HASH = "gw55a2h5Qud/CxGW9RGGWA==";
 }


### PR DESCRIPTION
```<? super Iterable<? extends MyPersonalSanity>, K> v```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1545)
<!-- Reviewable:end -->
