### PR TITLE
Fix/pk  constraint and index

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -28,6 +28,8 @@ import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.nexus.db.sql.ExceptionCheck;
 
@@ -133,11 +135,25 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
 
         String prefixedTableName = prefixedTableNames.get(tableRef);
         conns.get().updateManyUnregisteredQuery(" /* DELETE_ONE (" + prefixedTableName + ") */ "
-                + " DELETE /*+ INDEX(m pk_" + prefixedTableName + ") */ "
+                + " DELETE /*+ INDEX(m " + getPrimaryKeyConstraintName(prefixedTableName) + ") */ "
                 + " FROM " + prefixedTableName + " m "
                 + " WHERE m.row_name = ? "
                 + "  AND m.col_name = ? "
                 + "  AND m.ts = ?",
                 args);
     }
+
+    private String getPrimaryKeyConstraintName(String tableName) {
+        String pkConstraintName = "pk_" + tableName;
+        if (config.type().equals(OracleDdlConfig.TYPE)) {
+            return truncateToMaxOracleLength(pkConstraintName);
+        }
+        return pkConstraintName;
+    }
+
+    private String truncateToMaxOracleLength(String constraintName) {
+        return constraintName
+                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+    }
+
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.OraclePrimaryKeyConstraintNames;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.nexus.db.sql.ExceptionCheck;
 
@@ -144,16 +144,9 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
     }
 
     private String getPrimaryKeyConstraintName(String tableName) {
-        String pkConstraintName = "pk_" + tableName;
         if (config.type().equals(OracleDdlConfig.TYPE)) {
-            return truncateToMaxOracleLength(pkConstraintName);
+            return OraclePrimaryKeyConstraintNames.get(tableName);
         }
-        return pkConstraintName;
+        return "pk_" + tableName;
     }
-
-    private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName
-                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
-    }
-
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -153,7 +153,7 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
 
     private String truncateToMaxOracleLength(String constraintName) {
         return constraintName
-                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleErrorConstants;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbDdlTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
@@ -259,7 +260,10 @@ public final class OracleDdlTable implements DbDdlTable {
     }
 
     private String getPrimaryKeyConstraintName(String tableName) {
-        String primaryKeyConstraintPrefix = "pk_";
-        return primaryKeyConstraintPrefix + tableName.substring(primaryKeyConstraintPrefix.length());
+        return truncateToMaxOracleLength("pk_" + tableName);
+    }
+
+    private String truncateToMaxOracleLength(String constraintName) {
+        return constraintName.substring(0, Math.max(OracleTableNameMapper.MAX_NAMESPACE_LENGTH, constraintName.length()));
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -26,7 +26,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleErrorConstants;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbDdlTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
@@ -260,11 +259,6 @@ public final class OracleDdlTable implements DbDdlTable {
     }
 
     private String getPrimaryKeyConstraintName(String tableName) {
-        return truncateToMaxOracleLength("pk_" + tableName);
-    }
-
-    private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName
-                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+        return OraclePrimaryKeyConstraintNames.get(tableName);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -264,6 +264,7 @@ public final class OracleDdlTable implements DbDdlTable {
     }
 
     private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName.substring(0, Math.max(OracleTableNameMapper.MAX_NAMESPACE_LENGTH, constraintName.length()));
+        return constraintName
+                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowQueryFactory.java
@@ -21,7 +21,6 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.FullQuery;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowValue;
@@ -72,7 +71,7 @@ public class OracleOverflowQueryFactory extends OracleQueryFactory {
         String query = " /* SELECT_OVERFLOW */ "
                 + " SELECT"
                 + "   /*+ USE_NL(t o) LEADING(t o) INDEX(o "
-                + getPrimaryKeyConstraintName(config.singleOverflowTable()) + ") */ "
+                + OraclePrimaryKeyConstraintNames.get(config.singleOverflowTable()) + ") */ "
                 + "   o.id, o.val "
                 + " FROM " + config.singleOverflowTable() + " o, "
                 + "   TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
@@ -83,21 +82,13 @@ public class OracleOverflowQueryFactory extends OracleQueryFactory {
     private FullQuery getNewOverflowQuery(ArrayHandler arg) {
         String query = " /* SELECT_OVERFLOW (" + overflowTableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t o) LEADING(t o) INDEX(o " + getPrimaryKeyConstraintName(overflowTableName) + ") */ "
+                + "   /*+ USE_NL(t o) LEADING(t o) INDEX(o "
+                + OraclePrimaryKeyConstraintNames.get(overflowTableName) + ") */ "
                 + "   o.id, o.val "
                 + " FROM " + overflowTableName + " o,"
                 + "   TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE t.max_ts = o.id ";
         return new FullQuery(query).withArg(arg);
-    }
-
-    private String getPrimaryKeyConstraintName(String name) {
-        return truncateToMaxOracleLength("pk_" + name);
-    }
-
-    private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName
-                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 
     private String structArrayPrefix() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowQueryFactory.java
@@ -97,7 +97,7 @@ public class OracleOverflowQueryFactory extends OracleQueryFactory {
 
     private String truncateToMaxOracleLength(String constraintName) {
         return constraintName.substring(0,
-                Math.max(OracleTableNameMapper.MAX_NAMESPACE_LENGTH, constraintName.length()));
+                Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 
     private String structArrayPrefix() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowQueryFactory.java
@@ -96,8 +96,8 @@ public class OracleOverflowQueryFactory extends OracleQueryFactory {
     }
 
     private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName.substring(0,
-                Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+        return constraintName
+                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 
     private String structArrayPrefix() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
@@ -35,7 +35,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbWriteTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
@@ -259,11 +258,6 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
     }
 
     private String getPrimaryKeyConstraintName(String tableName) {
-        return truncateToMaxOracleLength("pk_" + tableName);
-    }
-
-    private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName
-                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+        return OraclePrimaryKeyConstraintNames.get(tableName);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
@@ -264,6 +264,6 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
 
     private String truncateToMaxOracleLength(String constraintName) {
         return constraintName
-                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
@@ -263,6 +263,7 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
     }
 
     private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName.substring(0, Math.max(OracleTableNameMapper.MAX_NAMESPACE_LENGTH, constraintName.length()));
+        return constraintName
+                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowWriteTable.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbWriteTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
@@ -226,7 +227,7 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
             //
         }
         conn.updateManyUnregisteredQuery(" /* DELETE_ONE (" + shortTableName + ") */ "
-                + " DELETE /*+ INDEX(m pk_" + shortTableName + ") */ "
+                + " DELETE /*+ INDEX(m " + getPrimaryKeyConstraintName(shortTableName) + ") */ "
                 + " FROM " + shortTableName + " m "
                 + " WHERE m.row_name = ? "
                 + "  AND m.col_name = ? "
@@ -237,9 +238,9 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
     private void deleteOverflow(String overflowTable, List<Object[]> args) {
         String shortTableName = oraclePrefixedTableNames.get(tableRef);
         conns.get().updateManyUnregisteredQuery(" /* DELETE_ONE_OVERFLOW (" + overflowTable + ") */ "
-                + " DELETE /*+ INDEX(m pk_" + overflowTable + ") */ "
+                + " DELETE /*+ INDEX(m " + getPrimaryKeyConstraintName(overflowTable) + ") */ "
                 + "   FROM " + overflowTable + " m "
-                + "  WHERE m.id IN (SELECT /*+ INDEX(i pk_" + shortTableName + ") */ "
+                + "  WHERE m.id IN (SELECT /*+ INDEX(i " + getPrimaryKeyConstraintName(shortTableName) + ") */ "
                 + "                        i.overflow "
                 + "                   FROM " + shortTableName + " i "
                 + "                  WHERE i.row_name = ? "
@@ -255,5 +256,13 @@ public final class OracleOverflowWriteTable implements DbWriteTable {
         } catch (TableMappingNotFoundException e) {
             throw Throwables.propagate(e);
         }
+    }
+
+    private String getPrimaryKeyConstraintName(String tableName) {
+        return truncateToMaxOracleLength("pk_" + tableName);
+    }
+
+    private String truncateToMaxOracleLength(String constraintName) {
+        return constraintName.substring(0, Math.max(OracleTableNameMapper.MAX_NAMESPACE_LENGTH, constraintName.length()));
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OraclePrimaryKeyConstraintNames.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OraclePrimaryKeyConstraintNames.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
+
+public final class OraclePrimaryKeyConstraintNames {
+
+    private OraclePrimaryKeyConstraintNames() {
+        //Utility class
+    }
+
+    public static String get(String name) {
+        return truncateToMaxOracleLength("pk_" + name);
+    }
+
+    private static String truncateToMaxOracleLength(String constraintName) {
+        return StringUtils.left(constraintName, OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH);
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
@@ -458,7 +458,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
 
     private String truncateToMaxOracleLength(String constraintName) {
         return constraintName
-                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 
     private String structArrayPrefix() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.AbstractDbQueryFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.FullQuery;
 import com.palantir.db.oracle.JdbcHandler.ArrayHandler;
@@ -49,7 +50,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                        boolean includeValue) {
         String query = " /* GET_LATEST_ONE_ROW_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m "
                 + " WHERE m.row_name = ? "
@@ -76,7 +77,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                         boolean includeValue) {
         String query = " /* GET_LATEST_ROWS_SINGLE_BOUND_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -102,7 +103,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                         boolean includeValue) {
         String query = " /* GET_LATEST_ROWS_MANY_BOUNDS_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -129,7 +130,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                     boolean includeValue) {
         String query = " /* GET_ALL_ONE_ROW (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m "
                 + " WHERE m.row_name = ? "
@@ -154,7 +155,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                      boolean includeValue) {
         String query = " /* GET_ALL_ROWS_SINGLE_BOUND (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -178,7 +179,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                      boolean includeValue) {
         String query = " /* GET_ALL_ROWS_MANY_BOUNDS (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -200,7 +201,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getLatestCellQuery(Cell cell, long ts, boolean includeValue) {
         String query = " /* GET_LATEST_ONE_CELLS_INNER (" + tableName + ") */ "
                 + " SELECT "
-                + "   /*+ INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m "
                 + " WHERE m.row_name = ? "
@@ -215,7 +216,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getLatestCellsQuery(Iterable<Cell> cells, long ts, boolean includeValue) {
         String query = " /* GET_LATEST_CELLS_SINGLE_BOUND_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -230,7 +231,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getLatestCellsQuery(Collection<Map.Entry<Cell, Long>> cells, boolean includeValue) {
         String query = " /* GET_LATEST_CELLS_MANY_BOUNDS_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -245,7 +246,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getAllCellQuery(Cell cell, long ts, boolean includeValue) {
         String query = " /* GET_ALL_ONE_CELL (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m "
                 + " WHERE m.row_name = ? "
@@ -258,7 +259,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getAllCellsQuery(Iterable<Cell> cells, long ts, boolean includeValue) {
         String query = " /* GET_ALL_CELLS_SINGLE_BOUND (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -271,7 +272,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getAllCellsQuery(Collection<Map.Entry<Cell, Long>> cells, boolean includeValue) {
         String query = " /* GET_ALL_CELLS_MANY_BOUNDS (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m pk_" + tableName + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -296,7 +297,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
         }
         if (maxRows == 1) {
             String query = " /* GET_RANGE_ONE_ROW (" + tableName + ") */ "
-                    + " SELECT /*+ INDEX(m pk_" + tableName + ") */ "
+                    + " SELECT /*+ INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                     + (range.isReverse() ? "max" : "min") + "(m.row_name) as row_name "
                     + " FROM " + tableName + " m "
                     + (bounds.isEmpty() ? "" : " WHERE  " + Joiner.on(" AND ").join(bounds));
@@ -305,7 +306,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
 
         String query = " /* GET_RANGE_ROWS (" + tableName + ") */ "
                 + " SELECT inner.row_name FROM "
-                + "   ( SELECT /*+ INDEX(m pk_" + tableName + ") */ "
+                + "   ( SELECT /*+ INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
                 + "       DISTINCT m.row_name "
                 + "     FROM " + tableName + " m "
                 + (bounds.isEmpty() ? "" : " WHERE  " + Joiner.on(" AND ").join(bounds))
@@ -395,7 +396,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
         return " /* " + wrappedName + " (" + tableName + ") */ "
                 + " SELECT"
                 + "   /*+ USE_NL(i wrap) LEADING(i wrap) NO_MERGE(i) NO_PUSH_PRED(i)"
-                + "       INDEX(wrap pk_" + tableName + ") */ "
+                + "       INDEX(wrap " + getPrimaryKeyConstraintName() + ") */ "
                 + "   wrap.row_name, wrap.col_name, wrap.ts" + getValueSubselect("wrap", includeValue)
                 + " FROM " + tableName + " wrap, ( " + query + " ) i "
                 + " WHERE wrap.row_name = i.row_name "
@@ -440,6 +441,14 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
         }
         return config.jdbcHandler().createStructArray(
                 structArrayPrefix() + "CELL_TS", "" + structArrayPrefix() + "CELL_TS_TABLE", oraRows);
+    }
+
+    private String getPrimaryKeyConstraintName() {
+        return truncateToMaxOracleLength("pk_" + tableName);
+    }
+
+    private String truncateToMaxOracleLength(String constraintName) {
+        return constraintName.substring(0, Math.max(OracleTableNameMapper.MAX_NAMESPACE_LENGTH, constraintName.length()));
     }
 
     private String structArrayPrefix() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
@@ -29,7 +29,6 @@ import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.AbstractDbQueryFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.FullQuery;
 import com.palantir.db.oracle.JdbcHandler.ArrayHandler;
@@ -453,12 +452,7 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     }
 
     private String getPrimaryKeyConstraintName() {
-        return truncateToMaxOracleLength("pk_" + tableName);
-    }
-
-    private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName
-                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+        return OraclePrimaryKeyConstraintNames.get(tableName);
     }
 
     private String structArrayPrefix() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
@@ -50,7 +50,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                        boolean includeValue) {
         String query = " /* GET_LATEST_ONE_ROW_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m "
                 + " WHERE m.row_name = ? "
@@ -77,7 +78,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                         boolean includeValue) {
         String query = " /* GET_LATEST_ROWS_SINGLE_BOUND_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -103,7 +105,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                         boolean includeValue) {
         String query = " /* GET_LATEST_ROWS_MANY_BOUNDS_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -155,7 +158,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                      boolean includeValue) {
         String query = " /* GET_ALL_ROWS_SINGLE_BOUND (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -179,7 +183,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
                                      boolean includeValue) {
         String query = " /* GET_ALL_ROWS_MANY_BOUNDS (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -216,7 +221,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getLatestCellsQuery(Iterable<Cell> cells, long ts, boolean includeValue) {
         String query = " /* GET_LATEST_CELLS_SINGLE_BOUND_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -231,7 +237,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getLatestCellsQuery(Collection<Map.Entry<Cell, Long>> cells, boolean includeValue) {
         String query = " /* GET_LATEST_CELLS_MANY_BOUNDS_INNER (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, max(m.ts) as ts "
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -259,7 +266,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getAllCellsQuery(Iterable<Cell> cells, long ts, boolean includeValue) {
         String query = " /* GET_ALL_CELLS_SINGLE_BOUND (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -272,7 +280,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     public FullQuery getAllCellsQuery(Collection<Map.Entry<Cell, Long>> cells, boolean includeValue) {
         String query = " /* GET_ALL_CELLS_MANY_BOUNDS (" + tableName + ") */ "
                 + " SELECT"
-                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m " + getPrimaryKeyConstraintName() + ") */ "
+                + "   /*+ USE_NL(t m) CARDINALITY(t 1) CARDINALITY(m 10) INDEX(m "
+                + getPrimaryKeyConstraintName() + ") */ "
                 + "   m.row_name, m.col_name, m.ts" + getValueSubselect("m", includeValue)
                 + " FROM " + tableName + " m, TABLE(CAST(? AS " + structArrayPrefix() + "CELL_TS_TABLE)) t "
                 + " WHERE m.row_name = t.row_name "
@@ -448,7 +457,8 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
     }
 
     private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName.substring(0, Math.max(OracleTableNameMapper.MAX_NAMESPACE_LENGTH, constraintName.length()));
+        return constraintName
+                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 
     private String structArrayPrefix() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
@@ -338,7 +338,7 @@ public class DbKvsGetRanges {
 
     private String truncateToMaxOracleLength(String constraintName) {
         return constraintName
-                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 
     private String getPrefixedTableName(TableReference tableRef) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
@@ -44,9 +44,10 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameMapper;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.PrefixedTableNames;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.OraclePrimaryKeyConstraintNames;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
 import com.palantir.atlasdb.keyvalue.impl.RowResults;
 import com.palantir.common.collect.IterableView;
@@ -333,12 +334,10 @@ public class DbKvsGetRanges {
     }
 
     private String getPrimaryKeyConstraintName(TableReference tableRef) {
-        return truncateToMaxOracleLength("pk_" + getPrefixedTableName(tableRef));
-    }
-
-    private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName
-                .substring(0, Math.min(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
+        if (config.type().equals(OracleDdlConfig.TYPE)) {
+            return OraclePrimaryKeyConstraintNames.get(getPrefixedTableName(tableRef));
+        }
+        return "pk_" + getPrefixedTableName(tableRef);
     }
 
     private String getPrefixedTableName(TableReference tableRef) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
@@ -337,7 +337,8 @@ public class DbKvsGetRanges {
     }
 
     private String truncateToMaxOracleLength(String constraintName) {
-        return constraintName.substring(0, Math.max(OracleTableNameMapper.MAX_NAMESPACE_LENGTH, constraintName.length()));
+        return constraintName
+                .substring(0, Math.max(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH, constraintName.length()));
     }
 
     private String getPrefixedTableName(TableReference tableRef) {

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameMapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameMapperTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,6 +32,7 @@ import org.junit.rules.ExpectedException;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.OraclePrimaryKeyConstraintNames;
 import com.palantir.nexus.db.sql.AgnosticResultRow;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
 import com.palantir.nexus.db.sql.SqlConnection;
@@ -85,6 +87,20 @@ public class OracleTableNameMapperTest {
         expectedException.expectMessage(
                 "Cannot create any more tables with name starting with a_te__ThisIsAVeryLongTab");
         oracleTableNameMapper.getShortPrefixedTableName(connectionSupplier, TEST_PREFIX, tableRef);
+    }
+
+    @Test
+    public void shouldGetRightPrimaryKeyConstraintForLongTableNames() {
+        String pkConstraintName = OraclePrimaryKeyConstraintNames.get(LONG_TABLE_NAME);
+        assertThat(pkConstraintName, is(StringUtils.left("pk_" + LONG_TABLE_NAME, 30)));
+        assertThat(pkConstraintName.length(), is(OracleTableNameMapper.ORACLE_MAX_TABLE_NAME_LENGTH));
+    }
+
+    @Test
+    public void shouldGetRightPrimaryKeyConstraintForShortTableNames() {
+        String tableName = "table";
+        String pkConstraintName = OraclePrimaryKeyConstraintNames.get(tableName);
+        assertThat(pkConstraintName, is("pk_" + tableName));
     }
 
     private String getTableNameWithNumber(int tableNum) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
            intention, while we now fail loudly (returning a 400).
 
     *    - |fixed|
+         - Oracle query now uses the right hints when generating the query plan. This will improve performance for OracleKVS.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1540>`__)
+
+    *    - |fixed|
          - Better support Oracle 12c batch responses
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1540>`__)
 


### PR DESCRIPTION
This PR fixes the Oracle perf regression due to inconsistency between primary key constraint and the index hinting. All cases of hinting are fixed to be same as the pk_constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1549)
<!-- Reviewable:end -->
