### PR TITLE
Add missing PR link to FF PTS release notes

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,7 @@ develop
            supply the ``currentTimestamp`` query parameter, we would previously treat this as a fast-forward to zero
            and silently accept the request (returning 204) even though this is highly unlikely to be the user's
            intention, while we now fail loudly (returning a 400).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1538>`__)
 
     *    - |fixed|
          - Oracle query now uses the right hints when generating the query plan. This will improve performance for OracleKVS.


### PR DESCRIPTION
I accidentally left this out on PR #1538.

Although this change itself isn't worthy of a release note, changes to the release notes don't require [no release notes].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1555)
<!-- Reviewable:end -->
