### PR TITLE
Cassandra Timestamp Store (Invalidate the Timestamp Tables, Part I)

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -60,6 +60,15 @@ public class CassandraTimestampIntegrationTest {
     }
 
     @Test
+    public void resilientToMultipleStoresBeforeGet() {
+        TimestampBoundStore ts = CassandraTimestampBoundStore.create(kv);
+        long limit = ts.getUpperLimit();
+        ts.storeUpperLimit(limit + 10);
+        ts.storeUpperLimit(limit + 20);
+        Assert.assertEquals(limit + 20, ts.getUpperLimit());
+    }
+
+    @Test
     public void testMultipleThrows() {
         TimestampBoundStore ts = CassandraTimestampBoundStore.create(kv);
         TimestampBoundStore ts2 = CassandraTimestampBoundStore.create(kv);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -60,7 +60,7 @@ public class CassandraTimestampIntegrationTest {
     }
 
     @Test
-    public void resilientToMultipleStoresBeforeGet() {
+    public void resilientToMultipleStoreUpperLimitBeforeGet() {
         TimestampBoundStore ts = CassandraTimestampBoundStore.create(kv);
         long limit = ts.getUpperLimit();
         ts.storeUpperLimit(limit + 10);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreIntegrationTest.java
@@ -164,12 +164,11 @@ public class CassandraTimestampStoreIntegrationTest {
 
     @Test
     public void canRestoreWithoutBackupWithoutData() {
-        store.restoreFromBackup();
-        assertThat(store.getUpperLimit()).isEqualTo(Optional.empty());
+        assertThatThrownBy(store::restoreFromBackup).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void canRestoreWithoutBackupWithData() {
+    public void ignoresInvalidBackupIfDataAvailable() {
         store.storeTimestampBound(Optional.empty(), TIMESTAMP_1);
         store.restoreFromBackup();
         assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreIntegrationTest.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
+import com.palantir.atlasdb.containers.CassandraContainer;
+import com.palantir.atlasdb.containers.Containers;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.common.base.Throwables;
+
+public class CassandraTimestampStoreIntegrationTest {
+    private static final long TIMESTAMP_1 = 1L;
+    private static final long TIMESTAMP_2 = 2L;
+    private static final long TIMESTAMP_3 = 3L;
+
+    private static final long TIMEOUT_SECONDS = 5L;
+    private static final int POOL_SIZE = 16;
+
+    @ClassRule
+    public static final Containers CONTAINERS = new Containers(CassandraTimestampIntegrationTest.class)
+            .with(new CassandraContainer());
+
+    private final CassandraKeyValueService kv = CassandraKeyValueService.create(
+            CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
+            CassandraContainer.LEADER_CONFIG);
+    private final CassandraTimestampStore store = new CassandraTimestampStore(kv);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(POOL_SIZE);
+
+    @Before
+    public void setUp() {
+        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
+        store.createTimestampTable();
+    }
+
+    @After
+    public void close() {
+        kv.close();
+    }
+
+    @Test
+    public void canReadEmptyBoundWhenNothingIsStored() {
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void canReadStoredBounds() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_1);
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+    }
+
+    @Test
+    public void readsTheLatestStoredBoundGoingForwards() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_1);
+        store.storeTimestampBound(Optional.of(TIMESTAMP_1), TIMESTAMP_2);
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_2));
+    }
+
+    @Test
+    public void readsTheLatestStoredBoundGoingBackwards() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_2);
+        store.storeTimestampBound(Optional.of(TIMESTAMP_2), TIMESTAMP_1);
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+    }
+
+    @Test
+    public void throwsIfStoringBoundWithExpectationWhenThereIsNone() {
+        assertThatThrownBy(() -> store.storeTimestampBound(Optional.of(TIMESTAMP_1), TIMESTAMP_2))
+                .isInstanceOf(ConcurrentModificationException.class);
+    }
+
+    @Test
+    public void throwsIfStoringBoundWithIncorrectExpectation() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_1);
+        assertThatThrownBy(() -> store.storeTimestampBound(Optional.of(TIMESTAMP_2), TIMESTAMP_3))
+                .isInstanceOf(ConcurrentModificationException.class);
+    }
+
+    @Test
+    public void throwsIfReadingInvalidatedTimestampBound() {
+        store.backupExistingTimestamp(TIMESTAMP_1);
+        assertThatThrownBy(store::getUpperLimit).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void throwsIfStoringToABackedUpStore() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_1);
+        assertThat(store.backupExistingTimestamp(TIMESTAMP_3)).isEqualTo(TIMESTAMP_1);
+        assertThatThrownBy(() -> store.storeTimestampBound(Optional.of(TIMESTAMP_1), TIMESTAMP_2))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void throwsOnBackupOrRestoreWithTwoReadableBounds() {
+        store.backupExistingTimestamp(TIMESTAMP_1);
+        byte[] rowAndColumnNameBytes = PtBytes.toBytes(CassandraTimestampUtils.ROW_AND_COLUMN_NAME);
+        kv.put(AtlasDbConstants.TIMESTAMP_TABLE,
+                ImmutableMap.of(Cell.create(rowAndColumnNameBytes, rowAndColumnNameBytes),
+                        PtBytes.toBytes(TIMESTAMP_2)),
+                Long.MAX_VALUE - 1);
+        assertThatThrownBy(() -> store.backupExistingTimestamp(TIMESTAMP_2))
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(store::restoreFromBackup).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void backsUpStoredBound() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_1);
+        store.backupExistingTimestamp(TIMESTAMP_2);
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+    }
+
+    @Test
+    public void backsUpDefaultValueIfNoBoundExists() {
+        store.backupExistingTimestamp(TIMESTAMP_1);
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+    }
+
+    @Test
+    public void firstWriteWinsInPresenceOfMultipleBackups() {
+        assertThat(store.backupExistingTimestamp(TIMESTAMP_1)).isEqualTo(TIMESTAMP_1);
+        assertThat(store.backupExistingTimestamp(TIMESTAMP_2)).isEqualTo(TIMESTAMP_1);
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+    }
+
+    @Test
+    public void canRestoreWithoutBackupWithoutData() {
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void canRestoreWithoutBackupWithData() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_1);
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+    }
+
+    @Test
+    public void canRestoreTwice() {
+        store.backupExistingTimestamp(TIMESTAMP_1);
+        store.restoreFromBackup();
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+    }
+
+    @Test
+    public void multipleRestoresDoNotMakeUsGoBackInTime() {
+        store.backupExistingTimestamp(TIMESTAMP_1);
+        store.restoreFromBackup();
+        store.storeTimestampBound(Optional.of(TIMESTAMP_1), TIMESTAMP_2);
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_2)); // in particular, not TIMESTAMP_1
+    }
+
+    @Test
+    public void canBackupAndRestoreMultipleTimes() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_1);
+        assertThat(store.backupExistingTimestamp(TIMESTAMP_3)).isEqualTo(TIMESTAMP_1);
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+        store.storeTimestampBound(Optional.of(TIMESTAMP_1), TIMESTAMP_2);
+        assertThat(store.backupExistingTimestamp(TIMESTAMP_3)).isEqualTo(TIMESTAMP_2);
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_2));
+    }
+
+    @Test
+    public void resilientToMultipleConcurrentBackups() {
+        executeInParallelOnExecutorService(() -> store.backupExistingTimestamp(TIMESTAMP_1));
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_1));
+    }
+
+    @Test
+    public void resilientToMultipleConcurrentRestores() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_2);
+        executeInParallelOnExecutorService(store::restoreFromBackup);
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_2));
+    }
+
+    @Test
+    public void resilientToMultipleConcurrentBackupsAndRestores() {
+        store.storeTimestampBound(Optional.empty(), TIMESTAMP_3);
+        executeInParallelOnExecutorService(() -> {
+            if (ThreadLocalRandom.current().nextBoolean()) {
+                store.backupExistingTimestamp(TIMESTAMP_2);
+            } else {
+                store.restoreFromBackup();
+            }
+        });
+        store.restoreFromBackup();
+        assertThat(store.getUpperLimit()).isEqualTo(Optional.of(TIMESTAMP_3));
+    }
+
+    private void executeInParallelOnExecutorService(Runnable runnable) {
+        List<Future<?>> futures =
+                Stream.generate(() -> executorService.submit(runnable))
+                        .limit(POOL_SIZE)
+                        .collect(Collectors.toList());
+        futures.forEach(future -> {
+            try {
+                future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException exception) {
+                throw Throwables.rewrapAndThrowUncheckedException(exception);
+            }
+        });
+    }
+}

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile group: 'com.google.code.findbugs', name: 'annotations'
 
   testCompile group: 'org.mockito', name: 'mockito-core'
+  testCompile group: 'org.assertj', name: 'assertj-core'
 
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -157,7 +157,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     private final ConsistencyLevel writeConsistency = ConsistencyLevel.EACH_QUORUM;
     private final ConsistencyLevel deleteConsistency = ConsistencyLevel.ALL;
 
-    protected final TracingQueryRunner queryRunner;
+    private final TracingQueryRunner queryRunner;
     private final CassandraTables cassandraTables;
 
     public static CassandraKeyValueService create(
@@ -2156,6 +2156,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     tableRef,
                     e);
         }
+    }
+
+    public TracingQueryRunner getTracingQueryRunner() {
+        return queryRunner;
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -157,7 +157,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     private final ConsistencyLevel writeConsistency = ConsistencyLevel.EACH_QUORUM;
     private final ConsistencyLevel deleteConsistency = ConsistencyLevel.ALL;
 
-    private final TracingQueryRunner queryRunner;
+    protected final TracingQueryRunner queryRunner;
     private final CassandraTables cassandraTables;
 
     public static CassandraKeyValueService create(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -71,6 +71,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
         DebugLogger.logger.debug("[PUT] Storing upper limit of {}.", limit);
         try {
             cassandraTimestampStore.storeTimestampBound(currentLimit, limit);
+            currentLimit = limit;
         } catch (ConcurrentModificationException e) {
             throw new MultipleRunningTimestampServiceError(
                     "CAS unsuccessful; this may indicate that another timestamp service is running against this"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -60,6 +60,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
     public synchronized void storeUpperLimit(final long limit) {
         DebugLogger.logger.debug("[PUT] Storing upper limit of {}.", limit);
         attemptToStoreTimestampBound(Optional.of(currentLimit), limit);
+        currentLimit = limit;
     }
 
     private long getBoundFromStore() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -82,11 +82,11 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
         }
     }
 
-    private MultipleRunningTimestampServiceError constructMultipleServiceError(ConcurrentModificationException e) {
+    private MultipleRunningTimestampServiceError constructMultipleServiceError(ConcurrentModificationException ex) {
         throw new MultipleRunningTimestampServiceError(
                 "CAS unsuccessful; this may indicate that another timestamp service is running against this"
                         + " cassandra keyspace, possibly caused by multiple copies of a service running without"
                         + " a configured set of leaders, or a CLI being run with an embedded timestamp service"
-                        + " against an already running service.", e);
+                        + " against an already running service.", ex);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -15,25 +15,16 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import java.nio.ByteBuffer;
-import java.util.stream.Collectors;
+import java.util.ConcurrentModificationException;
+import java.util.Optional;
 
 import javax.annotation.concurrent.GuardedBy;
 
-import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Cassandra.Client;
-import org.apache.cassandra.thrift.Column;
-import org.apache.cassandra.thrift.ColumnOrSuperColumn;
-import org.apache.cassandra.thrift.ColumnPath;
-import org.apache.cassandra.thrift.ConsistencyLevel;
-import org.apache.cassandra.thrift.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
 import com.palantir.atlasdb.table.description.ColumnValueDescription;
 import com.palantir.atlasdb.table.description.NameComponentDescription;
@@ -42,12 +33,9 @@ import com.palantir.atlasdb.table.description.NamedColumnDescription;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
-import com.palantir.common.base.FunctionCheckedException;
-import com.palantir.common.base.Throwables;
 import com.palantir.timestamp.DebugLogger;
 import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 import com.palantir.timestamp.TimestampBoundStore;
-import com.palantir.util.debug.ThreadDumps;
 
 public final class CassandraTimestampBoundStore implements TimestampBoundStore {
     private static final Logger log = LoggerFactory.getLogger(CassandraTimestampBoundStore.class);
@@ -70,128 +58,48 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
     @GuardedBy("this")
     private long currentLimit = -1;
 
-    private final CassandraClientPool clientPool;
+    private final CassandraTimestampStore cassandraTimestampStore;
 
     public static TimestampBoundStore create(CassandraKeyValueService kvs) {
         kvs.createTable(AtlasDbConstants.TIMESTAMP_TABLE, TIMESTAMP_TABLE_METADATA.persistToBytes());
-        return new CassandraTimestampBoundStore(kvs.clientPool);
+        return new CassandraTimestampBoundStore(kvs);
     }
 
-    private CassandraTimestampBoundStore(CassandraClientPool clientPool) {
+    private CassandraTimestampBoundStore(CassandraKeyValueService kvs) {
         DebugLogger.logger.info(
                 "Creating CassandraTimestampBoundStore object on thread {}. This should only happen once.",
                 Thread.currentThread().getName());
-        this.clientPool = Preconditions.checkNotNull(clientPool, "clientPool cannot be null");
+        this.cassandraTimestampStore = new CassandraTimestampStore(kvs);
     }
 
     @Override
     public synchronized long getUpperLimit() {
         DebugLogger.logger.debug("[GET] Getting upper limit");
-        return clientPool.runWithRetry(new FunctionCheckedException<Client, Long, RuntimeException>() {
-            @Override
-            public Long apply(Client client) {
-                ByteBuffer rowName = getRowName();
-                ColumnPath columnPath = new ColumnPath(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName());
-                columnPath.setColumn(getColumnName());
-                ColumnOrSuperColumn result;
-                try {
-                    result = client.get(rowName, columnPath, ConsistencyLevel.LOCAL_QUORUM);
-                } catch (NotFoundException e) {
-                    result = null;
-                } catch (Exception e) {
-                    throw Throwables.throwUncheckedException(e);
-                }
-                if (result == null) {
-                    DebugLogger.logger.info("[GET] Null result, setting timestamp limit to {}", INITIAL_VALUE);
-                    cas(client, null, INITIAL_VALUE);
-                    return INITIAL_VALUE;
-                }
-                Column column = result.getColumn();
-                currentLimit = PtBytes.toLong(column.getValue());
-                DebugLogger.logger.info("[GET] Setting cached timestamp limit to {}.", currentLimit);
-                return currentLimit;
-            }
-        });
+        Optional<Long> currentBound = cassandraTimestampStore.getUpperLimit();
+        long boundToStore;
+        if (!currentBound.isPresent()) {
+            DebugLogger.logger.info("[GET] Null result, setting timestamp limit to {}", INITIAL_VALUE);
+            cassandraTimestampStore.storeTimestampBound(null, INITIAL_VALUE);
+            boundToStore = INITIAL_VALUE;
+        } else {
+            boundToStore = currentBound.get();
+        }
+        currentLimit = boundToStore;
+        DebugLogger.logger.info("[GET] Setting cached timestamp limit to {}.", currentLimit);
+        return currentLimit;
     }
 
     @Override
     public synchronized void storeUpperLimit(final long limit) {
         DebugLogger.logger.debug("[PUT] Storing upper limit of {}.", limit);
-        clientPool.runWithRetry(new FunctionCheckedException<Client, Void, RuntimeException>() {
-            @Override
-            public Void apply(Client client) {
-                cas(client, currentLimit, limit);
-                return null;
-            }
-        });
-    }
-
-    private void cas(Client client, Long oldVal, long newVal) {
-        final CASResult result;
         try {
-            DebugLogger.logger.info("[CAS] Trying to set upper limit from {} to {}.", oldVal, newVal);
-            result = client.cas(
-                    getRowName(),
-                    AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName(),
-                    oldVal == null ? ImmutableList.of() : ImmutableList.of(makeColumn(oldVal)),
-                    ImmutableList.of(makeColumn(newVal)),
-                    ConsistencyLevel.SERIAL,
-                    ConsistencyLevel.EACH_QUORUM);
-        } catch (Exception e) {
-            log.error("[CAS] Error trying to set from {} to {}", oldVal, newVal, e);
-            DebugLogger.logger.error("[CAS] Error trying to set from {} to {}", oldVal, newVal, e);
-            throw Throwables.throwUncheckedException(e);
+            cassandraTimestampStore.storeTimestampBound(currentLimit, limit);
+        } catch (ConcurrentModificationException e) {
+            throw new MultipleRunningTimestampServiceError(
+                    "CAS unsuccessful; this may indicate that another timestamp service is running against this"
+                            + " cassandra keyspace, possibly caused by multiple copies of a service running without"
+                            + " a configured set of leaders, or a CLI being run with an embedded timestamp service"
+                            + " against an already running service.", e);
         }
-        if (!result.isSuccess()) {
-            String msg = "Unable to CAS from {} to {}."
-                    + " Timestamp limit changed underneath us (limit in memory: {}, stored in DB: {})."
-                    + " This may indicate that another timestamp service is running against this cassandra keyspace."
-                    + " This is likely caused by multiple copies of a service running without a configured set of"
-                    + " leaders or a CLI being run with an embedded timestamp service against an already running"
-                    + " service.";
-            MultipleRunningTimestampServiceError err = new MultipleRunningTimestampServiceError(
-                    String.format(replaceBracesWithStringFormatSpecifier(msg),
-                            oldVal,
-                            newVal,
-                            currentLimit,
-                            getCurrentTimestampValues(result)));
-            log.error(msg, oldVal, newVal, currentLimit, getCurrentTimestampValues(result), err);
-            DebugLogger.logger.error(msg, oldVal, newVal, currentLimit, getCurrentTimestampValues(result), err);
-            DebugLogger.logger.error("Thread dump: {}", ThreadDumps.programmaticThreadDump());
-            throw err;
-        } else {
-            DebugLogger.logger.info("[CAS] Setting cached limit to {}.", newVal);
-            currentLimit = newVal;
-        }
-    }
-
-    private String replaceBracesWithStringFormatSpecifier(String msg) {
-        return msg.replaceAll("\\{\\}", "%s");
-    }
-
-    private String getCurrentTimestampValues(CASResult result) {
-        return result.current_values.stream()
-                .map(Column::getValue)
-                .map(PtBytes::toLong)
-                .map(String::valueOf)
-                .collect(Collectors.joining(", "));
-    }
-
-    private Column makeColumn(long ts) {
-        Column col = new Column();
-        col.setName(getColumnName());
-        col.setValue(PtBytes.toBytes(ts));
-        col.setTimestamp(CASSANDRA_TIMESTAMP);
-        return col;
-    }
-
-    private static byte[] getColumnName() {
-        return CassandraKeyValueServices
-                .makeCompositeBuffer(PtBytes.toBytes(ROW_AND_COLUMN_NAME), CASSANDRA_TIMESTAMP)
-                .array();
-    }
-
-    private static ByteBuffer getRowName() {
-        return ByteBuffer.wrap(PtBytes.toBytes(ROW_AND_COLUMN_NAME));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -92,7 +92,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                 + " Timestamp limit changed underneath us (limit in memory: {}, stored in DB: {})."
                 + " This may indicate that another timestamp service is running against this cassandra keyspace,"
                 + " possibly caused by multiple copies of a service running without a configured set of leaders,"
-                + " or a CLI being run with an embedded timestamp service against an already runnign service.";
+                + " or a CLI being run with an embedded timestamp service against an already running service.";
         log.error(msg, expected, target, expected, actual);
         DebugLogger.logger.error("Thread dump: {}", ThreadDumps.programmaticThreadDump());
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Optional;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.cassandra.thrift.Column;
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.CqlRow;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
+import com.palantir.atlasdb.table.description.ColumnValueDescription;
+import com.palantir.atlasdb.table.description.NameComponentDescription;
+import com.palantir.atlasdb.table.description.NameMetadataDescription;
+import com.palantir.atlasdb.table.description.NamedColumnDescription;
+import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.common.base.Throwables;
+import com.palantir.timestamp.DebugLogger;
+import com.palantir.util.debug.ThreadDumps;
+
+public class CassandraTimestampStore {
+    private static final Logger log = LoggerFactory.getLogger(CassandraTimestampBoundStore.class);
+
+    private static final long CASSANDRA_TIMESTAMP = 0L;
+    private static final String ROW_AND_COLUMN_NAME = "ts";
+    private static final String BACKUP_COLUMN_NAME = "oldTs";
+    private static final byte[] INVALIDATED_VALUE = new byte[1];
+
+    private static final byte[] SUCCESSFUL_OPERATION = {1};
+
+    public static final TableMetadata TIMESTAMP_TABLE_METADATA = new TableMetadata(
+            NameMetadataDescription.create(ImmutableList.of(
+                    new NameComponentDescription("timestamp_name", ValueType.STRING))),
+            new ColumnMetadataDescription(ImmutableList.of(
+                    new NamedColumnDescription(
+                            ROW_AND_COLUMN_NAME,
+                            "current_max_ts",
+                            ColumnValueDescription.forType(ValueType.FIXED_LONG)))),
+            ConflictHandler.IGNORE_ALL);
+
+    private final CassandraKeyValueService cassandraKeyValueService;
+
+    public CassandraTimestampStore(CassandraKeyValueService cassandraKeyValueService) {
+        this.cassandraKeyValueService = cassandraKeyValueService;
+    }
+
+    /**
+     * Creates the timestamp table. Note that this operation is idempotent.
+     */
+    public void createTimestampTable() {
+        cassandraKeyValueService.createTable(
+                AtlasDbConstants.TIMESTAMP_TABLE,
+                TIMESTAMP_TABLE_METADATA.persistToBytes());
+    }
+
+    /**
+     * Gets the upper timestamp limit from the database if it exists.
+     * @return Timestamp limit stored in the KVS
+     */
+    public synchronized Optional<Long> getUpperLimit() {
+        return cassandraKeyValueService.clientPool.runWithRetry(client -> {
+            String selectQuery = String.format(
+                    "SELECT value FROM %s WHERE key=%s AND column1=%s;",
+                    wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
+                    encodeCassandraHexString(ROW_AND_COLUMN_NAME),
+                    encodeCassandraHexString(ROW_AND_COLUMN_NAME));
+            ByteBuffer queryBuffer = ByteBuffer.wrap(PtBytes.toBytes(selectQuery));
+            try {
+                CqlResult result = client.execute_cql3_query(queryBuffer, Compression.NONE, ConsistencyLevel.QUORUM);
+                List<CqlRow> cqlRows = result.getRows();
+                if (cqlRows.isEmpty()) {
+                    return Optional.empty();
+                }
+                return Optional.of(PtBytes.toLong(Iterables.getOnlyElement(getColumnsFromOnlyRow(cqlRows)).getValue()));
+            } catch (TException e) {
+                throw Throwables.rewrapAndThrowUncheckedException(e);
+            }
+        });
+    }
+
+    public synchronized void storeTimestampBound(Long expected, long target) {
+        cassandraKeyValueService.clientPool.runWithRetry(client -> {
+            String updateQuery;
+            if (expected == null) {
+                updateQuery = String.format(
+                        "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, -1, %s) IF NOT EXISTS;",
+                        wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
+                        encodeCassandraHexString(ROW_AND_COLUMN_NAME),
+                        encodeCassandraHexString(ROW_AND_COLUMN_NAME),
+                        encodeCassandraHexBytes(PtBytes.toBytes(target)));
+            } else {
+                updateQuery = String.format(
+                        "UPDATE %s SET value=%s WHERE key=%s AND column1=%s AND column2=-1 IF value=%s;",
+                        wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
+                        encodeCassandraHexBytes(PtBytes.toBytes(target)),
+                        encodeCassandraHexString(ROW_AND_COLUMN_NAME),
+                        encodeCassandraHexString(ROW_AND_COLUMN_NAME),
+                        encodeCassandraHexBytes(PtBytes.toBytes(expected)));
+            }
+            ByteBuffer queryBuffer = ByteBuffer.wrap(PtBytes.toBytes(updateQuery));
+            try {
+                CqlResult result = client.execute_cql3_query(queryBuffer, Compression.NONE, ConsistencyLevel.QUORUM);
+                Column appliedColumn = getColumnsFromOnlyRow(result.getRows()).get(0);
+                if (!Arrays.equals(appliedColumn.getValue(), SUCCESSFUL_OPERATION)) {
+                    throw constructConcurrentTimestampStoreException(expected, target, result);
+                }
+                return null;
+            } catch (TException e) {
+                throw Throwables.rewrapAndThrowUncheckedException(e);
+            }
+        });
+    }
+
+    private ConcurrentModificationException constructConcurrentTimestampStoreException(
+            Long expected,
+            long target,
+            CqlResult result) {
+        Column valueColumn;
+        if (expected == null) {
+            valueColumn = getColumnsFromOnlyRow(result.getRows()).get(4);
+        } else {
+            valueColumn = getColumnsFromOnlyRow(result.getRows()).get(1);
+        }
+        long actual = PtBytes.toLong(valueColumn.getValue());
+
+        String msg = "Unable to CAS from {} to {}."
+                + " Timestamp limit changed underneath us (limit in memory: {}, stored in DB: {}).";
+        ConcurrentModificationException except = new ConcurrentModificationException(
+                String.format(replaceBracesWithStringFormatSpecifier(msg),
+                        expected,
+                        target,
+                        expected,
+                        actual));
+        log.error(msg, expected, target, expected, actual);
+        DebugLogger.logger.error("Thread dump: {}", ThreadDumps.programmaticThreadDump());
+        throw except;
+    }
+
+    /**
+     * Stores a backup of the existing timestamp.
+     */
+    public synchronized void backupExistingTimestamp() {
+        throw new UnsupportedOperationException("TODO implement me");
+    }
+
+    public synchronized void restoreFromBackup() {
+        throw new UnsupportedOperationException("TODO implement me");
+    }
+
+    private static String wrapInQuotes(String tableName) {
+        return "\"" + tableName + "\"";
+    }
+
+    private static String encodeCassandraHexString(String string) {
+        return encodeCassandraHexBytes(PtBytes.toBytes(string));
+    }
+
+    private static String encodeCassandraHexBytes(byte[] bytes) {
+        return "0x" + DatatypeConverter.printHexBinary(bytes);
+    }
+
+    private static List<Column> getColumnsFromOnlyRow(List<CqlRow> cqlRows) {
+        return Iterables.getOnlyElement(cqlRows).getColumns();
+    }
+
+    private static String replaceBracesWithStringFormatSpecifier(String msg) {
+        return msg.replaceAll("\\{\\}", "%s");
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
@@ -94,7 +94,13 @@ public class CassandraTimestampStore {
     /**
      * Writes a backup of the existing timestamp to the database. After this backup, this timestamp service can
      * no longer be used until a restore.
-     * @throws IllegalStateException if the timestamp has already been backed up
+     *
+     * This may be implemented as follows:
+     *  - Read the value of the backup timestamp. If this is readable, skip (already backed up).
+     *  - Read the value of the timestamp (TS). If this is unreadable, fail.
+     *  - Do a conditional logged batch:
+     *    - CAS the main timestamp, expecting TS, to the INVALIDATED_VALUE
+     *    - Put unless exists the value of TS to the backup timestamp.
      */
     public synchronized void backupExistingTimestamp() {
         throw new UnsupportedOperationException("TODO implement me");
@@ -102,7 +108,13 @@ public class CassandraTimestampStore {
 
     /**
      * Restores a backup of an existing timestamp.
-     * @throws IllegalStateException if there was no backup
+     *
+     * This may be implemented following the inverse of the backup process:
+     *  - Read the value of the timestamp. If this is readable, skip.
+     *  - Read the value of the backup (BT). If this is unreadable, fail.
+     *  - Do a conditional logged batch:
+     *    - Conditionally delete the backup if it matches BT
+     *    - CAS the main timestamp, expecting INVALIDATED_VALUE, to BT.
      */
     public synchronized void restoreFromBackup() {
         throw new UnsupportedOperationException("TODO implement me");

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.nio.ByteBuffer;
-import java.util.ConcurrentModificationException;
 import java.util.Map;
 import java.util.Optional;
 
@@ -80,7 +79,7 @@ public class CassandraTimestampStore {
      * Stores an upper timestamp limit in the database in an atomic way.
      * @param expected Expected current value of the timestamp bound (or null if there is no bound)
      * @param target Upper timestamp limit we want to store in the database
-     * @throws ConcurrentModificationException if the expected value does not match the bound in the database
+     * @return StoreTimestampResult indicating if the operation was successful, and the actual and expected bounds
      */
     public synchronized StoreTimestampResult storeTimestampBound(Optional<Long> expected, long target) {
         return clientPool().runWithRetry(client -> {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
@@ -70,7 +70,7 @@ public class CassandraTimestampStore {
         return clientPool().runWithRetry(client -> {
             BoundData boundData = getCurrentBoundData(client);
             if (boundData.bound() == null) {
-                return Optional.empty();
+                return Optional.<Long>empty();
             }
             Preconditions.checkState(CassandraTimestampUtils.isValidTimestampData(boundData.bound()),
                     "The timestamp bound cannot be read.");

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
@@ -154,8 +154,8 @@ public class CassandraTimestampStore {
             byte[] currentBackupBound = boundData.backupBound();
 
             if (CassandraTimestampUtils.isValidTimestampData(currentBound)) {
-                Preconditions.checkState(currentBackupBound == null ||
-                                !CassandraTimestampUtils.isValidTimestampData(currentBackupBound),
+                Preconditions.checkState(currentBackupBound == null
+                                || !CassandraTimestampUtils.isValidTimestampData(currentBackupBound),
                         "We had both backup and active bounds readable! This is unexpected; please contact support.");
                 log.info("[RESTORE] Didn't restore from backup, because the current timestamp is already readable.");
                 return null;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
@@ -176,7 +176,7 @@ public class CassandraTimestampStore {
     }
 
     private TracingQueryRunner queryRunner() {
-        return cassandraKeyValueService.queryRunner;
+        return cassandraKeyValueService.getTracingQueryRunner();
     }
 
     private CqlResult executeQueryUnchecked(Cassandra.Client client, ByteBuffer query) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
@@ -16,15 +16,10 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-import javax.xml.bind.DatatypeConverter;
-
-import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.CqlResult;
@@ -33,43 +28,13 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.encoding.PtBytes;
-import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
-import com.palantir.atlasdb.table.description.ColumnValueDescription;
-import com.palantir.atlasdb.table.description.NameComponentDescription;
-import com.palantir.atlasdb.table.description.NameMetadataDescription;
-import com.palantir.atlasdb.table.description.NamedColumnDescription;
-import com.palantir.atlasdb.table.description.TableMetadata;
-import com.palantir.atlasdb.table.description.ValueType;
-import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.common.base.Throwables;
 import com.palantir.timestamp.DebugLogger;
 import com.palantir.util.debug.ThreadDumps;
 
 public class CassandraTimestampStore {
     private static final Logger log = LoggerFactory.getLogger(CassandraTimestampStore.class);
-
-    private static final long CASSANDRA_TIMESTAMP = -1;
-
-    private static final String ROW_AND_COLUMN_NAME = "ts";
-    public static final String ROW_AND_COLUMN_NAME_HEX_STRING = encodeCassandraHexString(ROW_AND_COLUMN_NAME);
-    private static final String BACKUP_COLUMN_NAME = "oldTs";
-    private static final byte[] INVALIDATED_VALUE = new byte[1];
-
-    private static final byte[] SUCCESSFUL_OPERATION = {1};
-
-    public static final TableMetadata TIMESTAMP_TABLE_METADATA = new TableMetadata(
-            NameMetadataDescription.create(ImmutableList.of(
-                    new NameComponentDescription("timestamp_name", ValueType.STRING))),
-            new ColumnMetadataDescription(ImmutableList.of(
-                    new NamedColumnDescription(
-                            ROW_AND_COLUMN_NAME,
-                            "current_max_ts",
-                            ColumnValueDescription.forType(ValueType.FIXED_LONG)))),
-            ConflictHandler.IGNORE_ALL);
 
     private final CassandraKeyValueService cassandraKeyValueService;
 
@@ -83,7 +48,7 @@ public class CassandraTimestampStore {
     public void createTimestampTable() {
         cassandraKeyValueService.createTable(
                 AtlasDbConstants.TIMESTAMP_TABLE,
-                TIMESTAMP_TABLE_METADATA.persistToBytes());
+                CassandraTimestampUtils.TIMESTAMP_TABLE_METADATA.persistToBytes());
     }
 
     /**
@@ -92,15 +57,14 @@ public class CassandraTimestampStore {
      */
     public synchronized Optional<Long> getUpperLimit() {
         return cassandraKeyValueService.clientPool.runWithRetry(client -> {
-            ByteBuffer queryBuffer = constructSelectTimestampBoundQuery();
+            ByteBuffer queryBuffer = CassandraTimestampUtils.constructSelectTimestampBoundQuery();
             try {
                 CqlResult result = client.execute_cql3_query(queryBuffer, Compression.NONE, ConsistencyLevel.QUORUM);
                 List<CqlRow> cqlRows = result.getRows();
                 if (cqlRows.isEmpty()) {
-                    return Optional.empty();
+                    return Optional.<Long>empty();
                 }
-                Column valueColumn = getNamedColumn(result, "value");
-                return Optional.of(PtBytes.toLong(valueColumn.getValue()));
+                return Optional.of(CassandraTimestampUtils.getLongValue(result));
             } catch (TException e) {
                 throw Throwables.rewrapAndThrowUncheckedException(e);
             }
@@ -109,7 +73,7 @@ public class CassandraTimestampStore {
 
     public synchronized void storeTimestampBound(Long expected, long target) {
         cassandraKeyValueService.clientPool.runWithRetry(client -> {
-            ByteBuffer queryBuffer = constructCheckAndSetCqlQuery(expected, target);
+            ByteBuffer queryBuffer = CassandraTimestampUtils.constructCheckAndSetCqlQuery(expected, target);
             try {
                 CqlResult result = client.execute_cql3_query(queryBuffer, Compression.NONE, ConsistencyLevel.QUORUM);
                 checkOperationWasApplied(expected, target, result);
@@ -132,18 +96,16 @@ public class CassandraTimestampStore {
     }
 
     private void checkOperationWasApplied(Long expected, long target, CqlResult result) {
-        Column appliedColumn = getNamedColumn(result, "[applied]");
-        if (!Arrays.equals(appliedColumn.getValue(), SUCCESSFUL_OPERATION)) {
+        if (!CassandraTimestampUtils.wasOperationApplied(result)) {
             throw constructConcurrentTimestampStoreException(expected, target, result);
         }
     }
 
-    private ConcurrentModificationException constructConcurrentTimestampStoreException(
+    private static ConcurrentModificationException constructConcurrentTimestampStoreException(
             Long expected,
             long target,
             CqlResult result) {
-        Column valueColumn = getNamedColumn(result, "value");
-        long actual = PtBytes.toLong(valueColumn.getValue());
+        long actual = CassandraTimestampUtils.getLongValue(result);
 
         String msg = "Unable to CAS from {} to {}."
                 + " Timestamp limit changed underneath us (limit in memory: {}, stored in DB: {}).";
@@ -156,68 +118,6 @@ public class CassandraTimestampStore {
         log.error(msg, expected, target, expected, actual);
         DebugLogger.logger.error("Thread dump: {}", ThreadDumps.programmaticThreadDump());
         throw except;
-    }
-
-    private static Column getNamedColumn(CqlResult cqlResult, String columnName) {
-        List<Column> columns = getColumnsFromOnlyRow(cqlResult.getRows());
-        return Iterables.getOnlyElement(
-                columns.stream()
-                .filter(column -> columnName.equals(PtBytes.toString(column.getName())))
-                .collect(Collectors.toList()));
-    }
-
-    private ByteBuffer constructSelectTimestampBoundQuery() {
-        String selectQuery = String.format(
-                "SELECT value FROM %s WHERE key=%s AND column1=%s;",
-                wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
-                ROW_AND_COLUMN_NAME_HEX_STRING,
-                ROW_AND_COLUMN_NAME_HEX_STRING);
-        return ByteBuffer.wrap(PtBytes.toBytes(selectQuery));
-    }
-
-    private ByteBuffer constructCheckAndSetCqlQuery(Long expected, long target) {
-        String updateQuery = (expected == null)
-                ? constructInsertIfNotExistsQuery(target)
-                : constructUpdateIfEqualQuery(expected, target);
-
-        return ByteBuffer.wrap(PtBytes.toBytes(updateQuery));
-    }
-
-    private String constructUpdateIfEqualQuery(Long expected, long target) {
-        return String.format(
-                "UPDATE %s SET value=%s WHERE key=%s AND column1=%s AND column2=%s IF value=%s;",
-                wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
-                encodeCassandraHexBytes(PtBytes.toBytes(target)),
-                ROW_AND_COLUMN_NAME_HEX_STRING,
-                ROW_AND_COLUMN_NAME_HEX_STRING,
-                CASSANDRA_TIMESTAMP,
-                encodeCassandraHexBytes(PtBytes.toBytes(expected)));
-    }
-
-    private String constructInsertIfNotExistsQuery(long target) {
-        return String.format(
-                "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, %s, %s) IF NOT EXISTS;",
-                wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
-                ROW_AND_COLUMN_NAME_HEX_STRING,
-                ROW_AND_COLUMN_NAME_HEX_STRING,
-                CASSANDRA_TIMESTAMP,
-                encodeCassandraHexBytes(PtBytes.toBytes(target)));
-    }
-
-    private static String wrapInQuotes(String tableName) {
-        return "\"" + tableName + "\"";
-    }
-
-    private static String encodeCassandraHexString(String string) {
-        return encodeCassandraHexBytes(PtBytes.toBytes(string));
-    }
-
-    private static String encodeCassandraHexBytes(byte[] bytes) {
-        return "0x" + DatatypeConverter.printHexBinary(bytes);
-    }
-
-    private static List<Column> getColumnsFromOnlyRow(List<CqlRow> cqlRows) {
-        return Iterables.getOnlyElement(cqlRows).getColumns();
     }
 
     private static String replaceBracesWithStringFormatSpecifier(String msg) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -68,10 +68,12 @@ public final class CassandraTimestampUtils {
 
     public static ByteBuffer constructSelectTimestampBoundQuery() {
         String selectQuery = String.format(
-                "SELECT value FROM %s WHERE key=%s AND column1=%s;",
+                "SELECT %s FROM %s WHERE key=%s AND column1=%s AND column2=%s;",
+                VALUE_COLUMN,
                 wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
                 ROW_AND_COLUMN_NAME_HEX_STRING,
-                ROW_AND_COLUMN_NAME_HEX_STRING);
+                ROW_AND_COLUMN_NAME_HEX_STRING,
+                CASSANDRA_TIMESTAMP);
         return ByteBuffer.wrap(PtBytes.toBytes(selectQuery));
     }
 
@@ -90,6 +92,9 @@ public final class CassandraTimestampUtils {
 
     public static long getLongValue(CqlResult cqlResult) {
         Column valueColumn = getNamedColumn(cqlResult, VALUE_COLUMN);
+        if (Arrays.equals(INVALIDATED_VALUE, valueColumn.getValue())) {
+            throw new IllegalStateException("Couldn't extract a long from the invalidated value!");
+        }
         return PtBytes.toLong(valueColumn.getValue());
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -27,6 +27,7 @@ import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -63,11 +64,13 @@ public final class CassandraTimestampUtils {
 
     private static final String ROW_AND_COLUMN_NAME_HEX_STRING = encodeCassandraHexString(ROW_AND_COLUMN_NAME);
 
-    private static final String APPLIED_COLUMN = "[applied]";
+    @VisibleForTesting
+    static final String APPLIED_COLUMN = "[applied]";
     private static final String COLUMN_NAME_COLUMN = "column1";
     private static final String VALUE_COLUMN = "value";
 
-    private static final byte[] SUCCESSFUL_OPERATION = {1};
+    @VisibleForTesting
+    static final byte[] SUCCESSFUL_OPERATION = {1};
 
     private CassandraTimestampUtils() {
         // utility class

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -65,7 +65,7 @@ public final class CassandraTimestampUtils {
     private static final byte[] SUCCESSFUL_OPERATION = {1};
 
     public static final String BACKUP_COLUMN_NAME = "oldTs";
-    private static final byte[] INVALIDATED_VALUE = new byte[1];
+    public static final byte[] INVALIDATED_VALUE = new byte[1];
 
     private CassandraTimestampUtils() {
         // utility class
@@ -101,8 +101,8 @@ public final class CassandraTimestampUtils {
             return constructInsertIfNotExistsQuery(columnName, target);
         }
         if (target == null) {
-            // delete
-            throw new UnsupportedOperationException("TODO implement delete");
+            // We treat this as a no op for now, which satisfies our purposes.
+            return "";
         }
         return constructUpdateIfEqualQuery(columnName, expected, target);
     }
@@ -116,12 +116,12 @@ public final class CassandraTimestampUtils {
         return PtBytes.toLong(getNamedColumn(getColumnsFromOnlyRow(result), VALUE_COLUMN).getValue());
     }
 
-    public static Map<String, Long> getLongValuesFromSelectionResult(CqlResult result) {
+    public static Map<String, byte[]> getValuesFromSelectionResult(CqlResult result) {
         return result.getRows().stream()
                 .map(CqlRow::getColumns)
                 .collect(Collectors.toMap(
                         cols -> PtBytes.toString(getNamedColumn(cols, COLUMN_NAME_COLUMN).getValue()),
-                        cols -> PtBytes.toLong(getNamedColumn(cols, VALUE_COLUMN).getValue())));
+                        cols -> getNamedColumn(cols, VALUE_COLUMN).getValue()));
     }
 
     private static String constructUpdateIfEqualQuery(String columnName, byte[] expected, byte[] target) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -23,8 +23,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
@@ -32,6 +30,8 @@ import org.apache.cassandra.thrift.CqlRow;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.io.BaseEncoding;
+import com.google.protobuf.ByteString;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
@@ -67,8 +67,7 @@ public final class CassandraTimestampUtils {
     private static final byte[] SUCCESSFUL_OPERATION = {1};
 
     public static final String BACKUP_COLUMN_NAME = "oldTs";
-
-    static final byte[] INVALIDATED_VALUE = new byte[1];
+    public static final ByteString INVALIDATED_VALUE = ByteString.copyFrom(new byte[1]);
 
     private CassandraTimestampUtils() {
         // utility class
@@ -174,7 +173,7 @@ public final class CassandraTimestampUtils {
     }
 
     private static String encodeCassandraHexBytes(byte[] bytes) {
-        return "0x" + DatatypeConverter.printHexBinary(bytes);
+        return "0x" + BaseEncoding.base16().upperCase().encode(bytes);
     }
 
     private static List<Column> getColumnsFromOnlyRow(CqlResult cqlResult) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -65,7 +65,8 @@ public final class CassandraTimestampUtils {
     private static final byte[] SUCCESSFUL_OPERATION = {1};
 
     public static final String BACKUP_COLUMN_NAME = "oldTs";
-    public static final byte[] INVALIDATED_VALUE = new byte[1];
+
+    static final byte[] INVALIDATED_VALUE = new byte[1];
 
     private CassandraTimestampUtils() {
         // utility class

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -58,7 +58,7 @@ public final class CassandraTimestampUtils {
 
     public static final String ROW_AND_COLUMN_NAME = "ts";
     public static final String BACKUP_COLUMN_NAME = "oldTs";
-    public static final ByteString INVALIDATED_VALUE = ByteString.copyFrom(new byte[1]);
+    public static final ByteString INVALIDATED_VALUE = ByteString.copyFrom(new byte[] {0});
 
     private static final long CASSANDRA_TIMESTAMP = -1;
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -66,8 +66,8 @@ public final class CassandraTimestampUtils {
 
     @VisibleForTesting
     static final String APPLIED_COLUMN = "[applied]";
-    private static final String COLUMN_NAME_COLUMN = "column1";
-    private static final String VALUE_COLUMN = "value";
+    static final String COLUMN_NAME_COLUMN = "column1";
+    static final String VALUE_COLUMN = "value";
 
     @VisibleForTesting
     static final byte[] SUCCESSFUL_OPERATION = {1};

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -146,9 +146,7 @@ public final class CassandraTimestampUtils {
     }
 
     private static String constructCheckAndSetQuery(String columnName, byte[] expected, byte[] target) {
-        if (target == null) {
-            return "";
-        }
+        Preconditions.checkState(target != null, "Should not CAS to a null target!");
         if (expected == null) {
             return constructInsertIfNotExistsQuery(columnName, target);
         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.cassandra.thrift.Column;
+import org.apache.cassandra.thrift.CqlResult;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
+import com.palantir.atlasdb.table.description.ColumnValueDescription;
+import com.palantir.atlasdb.table.description.NameComponentDescription;
+import com.palantir.atlasdb.table.description.NameMetadataDescription;
+import com.palantir.atlasdb.table.description.NamedColumnDescription;
+import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+
+public final class CassandraTimestampUtils {
+    public static final TableMetadata TIMESTAMP_TABLE_METADATA = new TableMetadata(
+            NameMetadataDescription.create(ImmutableList.of(
+                    new NameComponentDescription("timestamp_name", ValueType.STRING))),
+            new ColumnMetadataDescription(ImmutableList.of(
+                    new NamedColumnDescription(
+                            CassandraTimestampUtils.ROW_AND_COLUMN_NAME,
+                            "current_max_ts",
+                            ColumnValueDescription.forType(ValueType.FIXED_LONG)))),
+            ConflictHandler.IGNORE_ALL);
+
+    private static final long CASSANDRA_TIMESTAMP = -1;
+
+    private static final String ROW_AND_COLUMN_NAME = "ts";
+    private static final String ROW_AND_COLUMN_NAME_HEX_STRING = encodeCassandraHexString(ROW_AND_COLUMN_NAME);
+
+    private static final String APPLIED_COLUMN = "[applied]";
+    private static final String VALUE_COLUMN = "value";
+
+    private static final byte[] SUCCESSFUL_OPERATION = {1};
+
+    private static final String BACKUP_COLUMN_NAME = "oldTs";
+    private static final byte[] INVALIDATED_VALUE = new byte[1];
+
+    private CassandraTimestampUtils() {
+        // utility class
+    }
+
+    public static ByteBuffer constructSelectTimestampBoundQuery() {
+        String selectQuery = String.format(
+                "SELECT value FROM %s WHERE key=%s AND column1=%s;",
+                wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
+                ROW_AND_COLUMN_NAME_HEX_STRING,
+                ROW_AND_COLUMN_NAME_HEX_STRING);
+        return ByteBuffer.wrap(PtBytes.toBytes(selectQuery));
+    }
+
+    public static ByteBuffer constructCheckAndSetCqlQuery(Long expected, long target) {
+        String updateQuery = (expected == null)
+                ? constructInsertIfNotExistsQuery(target)
+                : constructUpdateIfEqualQuery(expected, target);
+
+        return ByteBuffer.wrap(PtBytes.toBytes(updateQuery));
+    }
+
+    public static boolean wasOperationApplied(CqlResult cqlResult) {
+        Column appliedColumn = getNamedColumn(cqlResult, APPLIED_COLUMN);
+        return Arrays.equals(appliedColumn.getValue(), SUCCESSFUL_OPERATION);
+    }
+
+    public static long getLongValue(CqlResult cqlResult) {
+        Column valueColumn = getNamedColumn(cqlResult, VALUE_COLUMN);
+        return PtBytes.toLong(valueColumn.getValue());
+    }
+
+    private static Column getNamedColumn(CqlResult cqlResult, String columnName) {
+        List<Column> columns = getColumnsFromOnlyRow(cqlResult);
+        return Iterables.getOnlyElement(
+                columns.stream()
+                        .filter(column -> columnName.equals(PtBytes.toString(column.getName())))
+                        .collect(Collectors.toList()));
+    }
+
+    private static String constructUpdateIfEqualQuery(Long expected, long target) {
+        return String.format(
+                "UPDATE %s SET value=%s WHERE key=%s AND column1=%s AND column2=%s IF value=%s;",
+                wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
+                encodeCassandraHexBytes(PtBytes.toBytes(target)),
+                ROW_AND_COLUMN_NAME_HEX_STRING,
+                ROW_AND_COLUMN_NAME_HEX_STRING,
+                CASSANDRA_TIMESTAMP,
+                encodeCassandraHexBytes(PtBytes.toBytes(expected)));
+    }
+
+    private static String constructInsertIfNotExistsQuery(long target) {
+        return String.format(
+                "INSERT INTO %s (key, column1, column2, value) VALUES (%s, %s, %s, %s) IF NOT EXISTS;",
+                wrapInQuotes(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
+                ROW_AND_COLUMN_NAME_HEX_STRING,
+                ROW_AND_COLUMN_NAME_HEX_STRING,
+                CASSANDRA_TIMESTAMP,
+                encodeCassandraHexBytes(PtBytes.toBytes(target)));
+    }
+
+    private static String wrapInQuotes(String tableName) {
+        return "\"" + tableName + "\"";
+    }
+
+    private static String encodeCassandraHexString(String string) {
+        return encodeCassandraHexBytes(PtBytes.toBytes(string));
+    }
+
+    private static String encodeCassandraHexBytes(byte[] bytes) {
+        return "0x" + DatatypeConverter.printHexBinary(bytes);
+    }
+
+    private static List<Column> getColumnsFromOnlyRow(CqlResult cqlResult) {
+        return Iterables.getOnlyElement(cqlResult.getRows()).getColumns();
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
@@ -29,12 +30,24 @@ import org.apache.cassandra.thrift.CqlRow;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.encoding.PtBytes;
 
 public class CassandraTimestampUtilsTest {
+    private static final long LONG_VALUE = 500L;
+
+    private static final byte[] KEY_1 = {120};
+    private static final String COLUMN_NAME_1 = "foo";
+    private static final byte[] COLUMN_BYTES_1 = PtBytes.toBytes(COLUMN_NAME_1);
+    private static final byte[] VALUE_1 = {4, 3, 2, 1};
+    private static final byte[] KEY_2 = {121};
+    private static final String COLUMN_NAME_2 = "bar";
+    private static final byte[] COLUMN_BYTES_2 = PtBytes.toBytes(COLUMN_NAME_2);
+    private static final byte[] VALUE_2 = {5, 9, 2, 6};
+
     @Test
     public void canIdentifyDataManipulationAsSuccessful() {
-        CqlResult result = createMockSingleColumnCqlResult(
+        CqlResult result = createMockSingleRowSingleColumnCqlResult(
                 CassandraTimestampUtils.APPLIED_COLUMN,
                 CassandraTimestampUtils.SUCCESSFUL_OPERATION);
         assertThat(CassandraTimestampUtils.wasOperationApplied(result)).isTrue();
@@ -43,7 +56,7 @@ public class CassandraTimestampUtilsTest {
     @Test
     public void canIdentifyDataManipulationAsUnsuccessful() {
         byte[] failedOperation = {0};
-        CqlResult result = createMockSingleColumnCqlResult(
+        CqlResult result = createMockSingleRowSingleColumnCqlResult(
                 CassandraTimestampUtils.APPLIED_COLUMN,
                 failedOperation);
         assertThat(CassandraTimestampUtils.wasOperationApplied(result)).isFalse();
@@ -51,22 +64,75 @@ public class CassandraTimestampUtilsTest {
 
     @Test
     public void throwsOnDataManipulationIfResultIsMissingAppliedColumn() {
-        CqlResult result = createMockSingleColumnCqlResult(
+        CqlResult result = createMockSingleRowSingleColumnCqlResult(
                 "foo",
                 CassandraTimestampUtils.SUCCESSFUL_OPERATION);
         assertThatThrownBy(() -> CassandraTimestampUtils.wasOperationApplied(result))
                 .isInstanceOf(NoSuchElementException.class);
     }
 
-    private static CqlResult createMockSingleColumnCqlResult(String name, byte[] value) {
-        return createMockCqlResult(ImmutableList.of(createColumn(name, value)));
+    @Test
+    public void canGetPresentLongValueFromApplicationResult() {
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(createColumn(CassandraTimestampUtils.APPLIED_COLUMN, CassandraTimestampUtils.SUCCESSFUL_OPERATION))
+                .add(createColumn(CassandraTimestampUtils.VALUE_COLUMN, PtBytes.toBytes(LONG_VALUE)))
+                .build();
+        CqlResult result = createMockSingleRowCqlResult(columns);
+        assertThat(CassandraTimestampUtils.getLongValueFromApplicationResult(result))
+                .isEqualTo(Optional.of(LONG_VALUE));
     }
 
-    private static CqlResult createMockCqlResult(List<Column> columns) {
+    @Test
+    public void canGetEmptyLongValueFromApplicationResult() {
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(createColumn(CassandraTimestampUtils.APPLIED_COLUMN, CassandraTimestampUtils.SUCCESSFUL_OPERATION))
+                .build();
+        CqlResult result = createMockSingleRowCqlResult(columns);
+        assertThat(CassandraTimestampUtils.getLongValueFromApplicationResult(result))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void canGetValuesFromSelectionResult() {
+        List<Column> columnList1 = buildKeyValueColumnList(KEY_1, COLUMN_BYTES_1, VALUE_1);
+        List<Column> columnList2 = buildKeyValueColumnList(KEY_2, COLUMN_BYTES_2, VALUE_2);
+
+        CqlResult mockResult = createMockCqlResult(
+                ImmutableList.of(
+                        createMockCqlRow(columnList1),
+                        createMockCqlRow(columnList2)));
+        assertThat(CassandraTimestampUtils.getValuesFromSelectionResult(mockResult))
+                .isEqualTo(ImmutableMap.of(COLUMN_NAME_1, VALUE_1, COLUMN_NAME_2, VALUE_2));
+    }
+
+    private List<Column> buildKeyValueColumnList(byte[] key, byte[] columnName, byte[] value) {
+        return ImmutableList.<Column>builder()
+                .add(createColumn("key", key))
+                .add(createColumn(CassandraTimestampUtils.COLUMN_NAME_COLUMN, columnName))
+                .add(createColumn(CassandraTimestampUtils.VALUE_COLUMN, value))
+                .build();
+    }
+
+    private static CqlResult createMockSingleRowSingleColumnCqlResult(String name, byte[] value) {
+        return createMockSingleRowCqlResult(ImmutableList.of(createColumn(name, value)));
+    }
+
+    private static CqlResult createMockSingleRowCqlResult(List<Column> columns) {
+        CqlResult result = mock(CqlResult.class);
+        CqlRow mockRow = createMockCqlRow(columns);
+        when(result.getRows()).thenReturn(ImmutableList.of(mockRow));
+        return result;
+    }
+
+    private static CqlRow createMockCqlRow(List<Column> columns) {
         CqlRow row = mock(CqlRow.class);
         when(row.getColumns()).thenReturn(columns);
+        return row;
+    }
+
+    private static CqlResult createMockCqlResult(List<CqlRow> rows) {
         CqlResult result = mock(CqlResult.class);
-        when(result.getRows()).thenReturn(ImmutableList.of(row));
+        when(result.getRows()).thenReturn(rows);
         return result;
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.apache.cassandra.thrift.Column;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.CqlRow;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.encoding.PtBytes;
+
+public class CassandraTimestampUtilsTest {
+    @Test
+    public void canIdentifyDataManipulationAsSuccessful() {
+        CqlResult result = createMockSingleColumnCqlResult(
+                CassandraTimestampUtils.APPLIED_COLUMN,
+                CassandraTimestampUtils.SUCCESSFUL_OPERATION);
+        assertThat(CassandraTimestampUtils.wasOperationApplied(result)).isTrue();
+    }
+
+    @Test
+    public void canIdentifyDataManipulationAsUnsuccessful() {
+        byte[] failedOperation = {0};
+        CqlResult result = createMockSingleColumnCqlResult(
+                CassandraTimestampUtils.APPLIED_COLUMN,
+                failedOperation);
+        assertThat(CassandraTimestampUtils.wasOperationApplied(result)).isFalse();
+    }
+
+    @Test
+    public void throwsOnDataManipulationIfResultIsMissingAppliedColumn() {
+        CqlResult result = createMockSingleColumnCqlResult(
+                "foo",
+                CassandraTimestampUtils.SUCCESSFUL_OPERATION);
+        assertThatThrownBy(() -> CassandraTimestampUtils.wasOperationApplied(result))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    private static CqlResult createMockSingleColumnCqlResult(String name, byte[] value) {
+        return createMockCqlResult(ImmutableList.of(createColumn(name, value)));
+    }
+
+    private static CqlResult createMockCqlResult(List<Column> columns) {
+        CqlRow row = mock(CqlRow.class);
+        when(row.getColumns()).thenReturn(columns);
+        CqlResult result = mock(CqlResult.class);
+        when(result.getRows()).thenReturn(ImmutableList.of(row));
+        return result;
+    }
+
+    private static Column createColumn(String name, byte[] value) {
+        Column column = new Column();
+        column.setName(PtBytes.toBytes(name));
+        column.setValue(value);
+        return column;
+    }
+}


### PR DESCRIPTION
This change:

- Refactors most of the Cassandra interaction that `CassandraTimestampBoundStore` had to its own class, `CassandraTimestampStore` (and to a utility `CassandraTimestampUtils` class too).
- Also, uses CQL instead of the Thrift API which I found rather difficult to use.

To do:

- [x] Improve the integration tests, which are a bit weak and failed to catch a bug (see commit no. 4)
- [x] Implement the actual backup/restore methods in `CassandraTimestampStore`
- [x] Unit tests for the utils class (it is covered by the integration test, but we should improve this)

The backup/restore utils are not going to be used anywhere yet, as at the end of this change.

Not fully ready yet, but future work for this stage only concerns tests and the two unimplemented methods in `CassandraTimestampStore`, so I'd prefer to start this review early.

@gmaretic @gsheasby I think you have the most context on where I plan to take this, following the other PR #1514.

@jboreiko for SA; also, semantics might not be exactly equivalent (in particular, we check-then-act in getUpperLimit() at the CTBS level as opposed to inside the client pool, but since getUpperLimit is synchronized I think this is safe anyway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1558)
<!-- Reviewable:end -->
