### PR TITLE
Greatly reduce mallocs in SQLString.canonicalizeString()

### DIFF
--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -38,7 +38,8 @@ import com.palantir.exception.PalantirSqlException;
 import com.palantir.nexus.db.DBType;
 import com.palantir.nexus.db.SqlClause;
 
-
+// class extended by other projects
+@SuppressWarnings("WeakerAccess")
 public class SQLString extends BasicSQLString {
     private static final Pattern ALL_WORD_CHARS_REGEX = Pattern.compile("^[a-zA-Z_0-9\\.\\-]*$"); //$NON-NLS-1$
     private static final String UNREGISTERED_SQL_COMMENT = "/* UnregisteredSQLString */";
@@ -58,25 +59,28 @@ public class SQLString extends BasicSQLString {
      */
     @GuardedBy("cacheLock")
     private static volatile ImmutableMap<String, FinalSQLString> cachedUnregistered = ImmutableMap.of();
-    /** Rewritten registered queries */
+    /** Rewritten registered queries. */
     @GuardedBy("cacheLock")
     private static volatile ImmutableMap<String, FinalSQLString> cachedKeyed = ImmutableMap.of();
-    /** All registered queries */
+    /** All registered queries. */
     protected static final ConcurrentMap<String, FinalSQLString> registeredValues = new ConcurrentHashMap<String, FinalSQLString>();
-    /** DB-specific registered queries */
-    protected static final ConcurrentMap<String, ConcurrentMap<DBType, FinalSQLString>> registeredValuesOverride = new ConcurrentHashMap<String, ConcurrentMap<DBType, FinalSQLString>>();
+    /** DB-specific registered queries. */
+    protected static final ConcurrentMap<String, ConcurrentMap<DBType, FinalSQLString>> registeredValuesOverride =
+            new ConcurrentHashMap<>();
 
-    protected static interface OnUseCallback {
-        public void noteUse(SQLString used);
+    protected interface OnUseCallback {
+        void noteUse(SQLString used);
     }
+
     //by default, no callback. This is set in OverridableSQLString
-    protected static OnUseCallback callbackOnUse = new OnUseCallback(){
+    protected static OnUseCallback callbackOnUse = new OnUseCallback() {
         @Override
         public void noteUse(SQLString used) {
-           //do nothing
-        }};
+            //do nothing
+        }
+    };
 
-    protected static interface CallableCheckedException<T, E extends Exception> {
+    protected interface CallableCheckedException<T, E extends Exception> {
         T call() throws E;
     }
 
@@ -99,7 +103,8 @@ public class SQLString extends BasicSQLString {
         SQLString sqlString = new SQLString(key, sql, null);
         FinalSQLString newVal = new FinalSQLString(sqlString);
         FinalSQLString oldVal = registeredValues.put(key, newVal);
-        assert null == oldVal || oldVal.delegate.equals(newVal.delegate) : "newVal: " + newVal + " oldVal: " + oldVal; //$NON-NLS-1$ //$NON-NLS-2$
+        assert null == oldVal || oldVal.delegate.equals(newVal.delegate)
+                : "newVal: " + newVal + " oldVal: " + oldVal; //$NON-NLS-1$ //$NON-NLS-2$
         return new RegisteredSQLString(sqlString);
     }
 
@@ -121,7 +126,8 @@ public class SQLString extends BasicSQLString {
      * Same as the overloaded registerQuery, but overrides the query for a specific DBType.
      * @param key Unique identifier representing this query
      * @param sql The query that will be stored
-     * @param dbType Override the query for this DBType.  If this value is null, it is the same as <code>registerQuery(key, sql)</code>
+     * @param dbType Override the query for this DBType.
+     * If this value is null, it is the same as <code>registerQuery(key, sql)</code>
      */
     public static RegisteredSQLString registerQuery(String key, String sql, DBType dbType) {
         if (dbType == null) {
@@ -132,13 +138,14 @@ public class SQLString extends BasicSQLString {
         ConcurrentMap<DBType, FinalSQLString> newHash = new ConcurrentHashMap<DBType, FinalSQLString>();
 
         ConcurrentMap<DBType, FinalSQLString> dbTypeHash = registeredValuesOverride.putIfAbsent(key, newHash);
-        if(null == dbTypeHash) {
+        if (null == dbTypeHash) {
             dbTypeHash = newHash;
         }
         FinalSQLString newVal = new FinalSQLString(sqlString);
         FinalSQLString oldVal = dbTypeHash.put(dbType, newVal);
 
-        assert null == oldVal || newVal.delegate.equals(oldVal.delegate) : "newVal: " + newVal + " oldVal: " + oldVal; //$NON-NLS-1$ //$NON-NLS-2$
+        assert null == oldVal || newVal.delegate.equals(oldVal.delegate) :
+                "newVal: " + newVal + " oldVal: " + oldVal; //$NON-NLS-1$ //$NON-NLS-2$
         return new RegisteredSQLString(sqlString);
     }
 
@@ -147,45 +154,46 @@ public class SQLString extends BasicSQLString {
     }
 
     /**
-     * A query that has been registered with <code>registerQuery</code> can be looked up by its key.
-     * This factory returns a SQLString object representing the registered query.
-     * The stored query may have been overridden in the database and the object returned will reflect that.
-     * If the query is not overridden in the Database, we will check the dbType override first, then use the general registered query
-     * This factory is used by <code>SQL</code> to find a registered query.
+     * A query that has been registered with <code>registerQuery</code> can be looked up by its key. This factory
+     * returns a SQLString object representing the registered query. The stored query may have been overridden in the
+     * database and the object returned will reflect that. If the query is not overridden in the Database, we will check
+     * the dbType override first, then use the general registered query This factory is used by <code>SQL</code> to find
+     * a registered query.
      *
      * @param key The key that was passed to <code>registerQuery</code>
      * @param dbType Look for queries registered with this override first
      * @return a SQLString object representing the stored query
      */
-     static FinalSQLString getByKey(final String key, DBType dbType) {
+    static FinalSQLString getByKey(final String key, DBType dbType) {
         assert isValidKey(key) : "Keys only consist of word characters"; //$NON-NLS-1$
-        assert registeredValues.containsKey(key) || registeredValuesOverride.containsKey(key) : "Couldn't find SQLString key: " + key + ", dbtype " + dbType; //$NON-NLS-1$ //$NON-NLS-2$
+        assert registeredValues.containsKey(key) || registeredValuesOverride.containsKey(key) :
+                "Couldn't find SQLString key: " + key + ", dbtype " + dbType; //$NON-NLS-1$ //$NON-NLS-2$
 
         FinalSQLString cached = cachedKeyed.get(key);
-        if(null != cached) {
+        if (null != cached) {
             callbackOnUse.noteUse((SQLString) cached.delegate);
             return cached;
         }
 
         ConcurrentMap<DBType, FinalSQLString> dbTypeHash = registeredValuesOverride.get(key);
-        if(null != dbTypeHash) {
+        if (null != dbTypeHash) {
             FinalSQLString dbOverride = dbTypeHash.get(dbType);
-            if(null != dbOverride) {
+            if (null != dbOverride) {
                 return dbOverride;
             }
         }
 
         FinalSQLString valueForKey = registeredValues.get(key);
-        if(valueForKey == null) {
+        if (valueForKey == null) {
             return new FinalSQLString(new NullSQLString(key));
         }
         return valueForKey;
-     }
+    }
 
-     static FinalSQLString getByKey(String key, Connection connection) throws PalantirSqlException {
-         DBType type = DBType.getTypeFromConnection(connection);
-         return getByKey(key, type);
-     }
+    static FinalSQLString getByKey(String key, Connection connection) throws PalantirSqlException {
+        DBType type = DBType.getTypeFromConnection(connection);
+        return getByKey(key, type);
+    }
 
     public static boolean isValidKey(final String key) {
         return ALL_WORD_CHARS_REGEX.matcher(key).matches();
@@ -193,10 +201,11 @@ public class SQLString extends BasicSQLString {
 
     /**
      * A Factory used by the SQL class to turn a string sql query into an SQLString object.
-     * This may just contain the sql given, or the given SQL may be overriden in the database and the object returned will reflect that new SQL from the DB.
+     * This may just contain the sql given, or the given SQL may be overriden in the database and the object returned
+     * will reflect that new SQL from the DB.
      *
      * @param sql The string to be used in a query
-     * @return a SQLString object representing the given SQL.
+     * @return a SQLString object representing the given SQL
      */
     static FinalSQLString getUnregisteredQuery(String sql) {
         assert !isValidKey(sql) : "Unregistered Queries should not look like keys"; //$NON-NLS-1$
@@ -210,31 +219,31 @@ public class SQLString extends BasicSQLString {
     }
 
     /**
-     * Contructor for unregistered (dynamic) SQL
-     * @param sql
+     * Contructor for unregistered (dynamic) SQL.
+     * @param sql The string to be used in a query
      */
     private SQLString(String sql) {
         super(null, makeCommentString(null, null) + sql);
     }
 
     /**
-     * Contructor for registered SQL
-     * @param key
-     * @param sql
-     * @param dbType This is only used in making the SQL comment.
+     * Contructor for registered SQL.
+     * @param key The query key
+     * @param sql The string to be used in a query
+     * @param dbType This is only used in making the SQL comment
      */
     protected SQLString(String key, String sql, DBType dbType) {
         super(key, makeCommentString(key, dbType) + sql);
     }
 
     /**
-     * Creates an appropriate comment string for the beginning of a SQL statement
+     * Creates an appropriate comment string for the beginning of a SQL statement.
      * @param keyString Identifier for the SQL; will be null if the SQL is unregistered
-     * @param dbType
+     * @param dbType The database type
      */
     private static String makeCommentString(String keyString, DBType dbType) {
         String registrationState;
-        if(keyString != null) {
+        if (keyString != null) {
             registrationState = "SQLString Identifier: " + keyString; //$NON-NLS-1$
         } else {
             registrationState = "UnregisteredSQLString"; //$NON-NLS-1$
@@ -298,15 +307,16 @@ public class SQLString extends BasicSQLString {
 
     static class NullSQLString extends SQLString {
         final String key;
-        public NullSQLString(String key) {
+
+        NullSQLString(String key) {
             super(""); //$NON-NLS-1$
             this.key = key;
         }
 
         @Override
         public String getQuery() {
-            throw new PalantirRuntimeException("Could not find any registered query value for key: " + key +  //$NON-NLS-1$
-                    "\nThe key is potentially an unregistered query."); //$NON-NLS-1$
+            throw new PalantirRuntimeException("Could not find any registered query value for key: " + //$NON-NLS-1$
+                    key +  "\nThe key is potentially an unregistered query."); //$NON-NLS-1$
         }
     }
 
@@ -345,8 +355,8 @@ public class SQLString extends BasicSQLString {
             for (int i : variant) {
                 SqlClause clause = clauses.get(i);
                 keySet.add(clause.getKey());
-                key.append("_" + clause.getKey()); //$NON-NLS-1$
-                whereClause.append(" AND " + clause.getClause()); //$NON-NLS-1$
+                key.append("_").append(clause.getKey()); //$NON-NLS-1$
+                whereClause.append(" AND ").append(clause.getClause()); //$NON-NLS-1$
             }
             keySet.add(baseKey);
             String sql = String.format(sqlFormat, whereClause);
@@ -370,7 +380,6 @@ public class SQLString extends BasicSQLString {
         /**
          * Should only be called inside SQLString because this class essentially verifies that we've
          * checked for updates.
-         * @param sqlstring
          */
         private RegisteredSQLString(BasicSQLString sqlstring) {
             this.delegate = sqlstring;
@@ -389,11 +398,11 @@ public class SQLString extends BasicSQLString {
     }
 
     public static RegisteredSQLString getRegisteredQueryByKey(FinalSQLString key) {
-         return new RegisteredSQLString(key.delegate);
+        return new RegisteredSQLString(key.delegate);
     }
 
     protected static ImmutableMap<String, FinalSQLString> getCachedUnregistered() {
-            return cachedUnregistered;
+        return cachedUnregistered;
     }
 
     protected static void setCachedUnregistered(ImmutableMap<String, FinalSQLString> cachedUnregistered) {
@@ -403,7 +412,7 @@ public class SQLString extends BasicSQLString {
     }
 
     protected static ImmutableMap<String, FinalSQLString> getCachedKeyed() {
-            return cachedKeyed;
+        return cachedKeyed;
     }
 
     protected static void setCachedKeyed(ImmutableMap<String, FinalSQLString> cachedKeyed) {

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -42,6 +42,7 @@ import com.palantir.nexus.db.SqlClause;
 
 public class SQLString extends BasicSQLString {
     private static final Pattern ALL_WORD_CHARS_REGEX = Pattern.compile("^[a-zA-Z_0-9\\.\\-]*$"); //$NON-NLS-1$
+    private static final String UNREGISTERED_SQL_COMMENT = "/* UnregisteredSQLString */";
 
     /**
      * Callers changing the value of cachedUnregistered and
@@ -200,7 +201,7 @@ public class SQLString extends BasicSQLString {
      */
     static FinalSQLString getUnregisteredQuery(String sql) {
         assert !isValidKey(sql) : "Unregistered Queries should not look like keys"; //$NON-NLS-1$
-        FinalSQLString cached = cachedUnregistered.get(StringUtils.deleteWhitespace(canonicalizeString(sql)));
+        FinalSQLString cached = cachedUnregistered.get(canonicalizeString(sql));
         if(null != cached) {
             callbackOnUse.noteUse((SQLString) cached.delegate);
             return cached;
@@ -251,22 +252,49 @@ public class SQLString extends BasicSQLString {
     /**
      * Cleans up whitespace, any trailing semicolon, and prefixed comments that a string is
      * unregistered, in order to come up with a canonical representation of this sql string.
-     * @param s
-     * @return
      */
-    public static String canonicalizeString(String s) {
-        String trim = s.trim();
-        if(!trim.isEmpty() && trim.charAt(trim.length() - 1) == ';') {
-            trim = trim.substring(0, trim.length() - 1);
-        }
-        String prefix = "/* UnregisteredSQLString */"; //$NON-NLS-1$
-        if (trim.startsWith(prefix)) {
-            trim = trim.substring(prefix.length()).trim();
-        }
-        String [] sp = trim.split("\\s+"); //$NON-NLS-1$
-        return StringUtils.join(sp, " "); //$NON-NLS-1$
+    public static String canonicalizeString(String sql) {
+        return canonicalizeString(sql, false);
     }
 
+    static String canonicalizeStringAndRemoveWhitespaceEntirely(String sql) {
+        return canonicalizeString(sql, true);
+    }
+
+    private static String canonicalizeString(String original, boolean removeAllWhitespaceEntirely) {
+        StringBuilder cleanedString = new StringBuilder(original);
+        int originalIdx = 0;
+        int cleanedIdx = 0;
+        int firstUnregisteredIdx = cleanedString.indexOf(UNREGISTERED_SQL_COMMENT);
+
+        while (originalIdx < original.length()) {
+            char originalChar = original.charAt(originalIdx);
+            if (originalIdx == firstUnregisteredIdx) {
+                originalIdx += UNREGISTERED_SQL_COMMENT.length();
+                firstUnregisteredIdx = original.indexOf(UNREGISTERED_SQL_COMMENT, originalIdx);
+            } else if (originalChar == ' ' && (cleanedIdx == 0 || cleanedString.charAt(cleanedIdx - 1) == ' ')
+                    || (originalChar == ' ' && removeAllWhitespaceEntirely)) {
+                ++originalIdx;
+            } else {
+                cleanedString.setCharAt(cleanedIdx, originalChar);
+                ++cleanedIdx;
+                ++originalIdx;
+            }
+        }
+
+        if (cleanedString.charAt(cleanedIdx - 1) == ' ') {
+            --cleanedIdx;
+        }
+
+        if (cleanedString.charAt(cleanedIdx - 1) == ';') {
+            --cleanedIdx;
+            if (cleanedString.charAt(cleanedIdx - 1) == ' ') {
+                --cleanedIdx;
+            }
+        }
+
+        return cleanedString.substring(0, cleanedIdx);
+    }
 
     static class NullSQLString extends SQLString {
         final String key;

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.GuardedBy;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
 import com.google.common.collect.ImmutableMap;
@@ -201,8 +200,8 @@ public class SQLString extends BasicSQLString {
      */
     static FinalSQLString getUnregisteredQuery(String sql) {
         assert !isValidKey(sql) : "Unregistered Queries should not look like keys"; //$NON-NLS-1$
-        FinalSQLString cached = cachedUnregistered.get(canonicalizeString(sql));
-        if(null != cached) {
+        FinalSQLString cached = cachedUnregistered.get(canonicalizeStringAndRemoveWhitespaceEntirely(sql));
+        if (null != cached) {
             callbackOnUse.noteUse((SQLString) cached.delegate);
             return cached;
         }

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -291,7 +291,7 @@ public class SQLString extends BasicSQLString {
             }
         }
 
-        while (cleanedIdx > 0 && Character.isWhitespace(cleanedString.charAt(cleanedIdx - 1))) {
+        if (cleanedIdx > 0 && Character.isWhitespace(cleanedString.charAt(cleanedIdx - 1))) {
             --cleanedIdx;
         }
 

--- a/commons-db/src/test/java/com/palantir/nexus/db/sql/SQLStringTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/sql/SQLStringTest.java
@@ -32,6 +32,7 @@ public class SQLStringTest {
                 "insert  foo into bar;   ",
                 "insert  foo into bar; ;;  ",
                 "insert  foo into bar;\n;;  ",
+                "   insert \t\nfoo \n \tinto  \n\rbar\n\t;   ",
                 "/* UnregisteredSQLString */ insert foo into bar;",
                 "  /* UnregisteredSQLString */insert foo into bar",
                 "  /* UnregisteredSQLString */insert foo into bar ");

--- a/commons-db/src/test/java/com/palantir/nexus/db/sql/SQLStringTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/sql/SQLStringTest.java
@@ -30,6 +30,8 @@ public class SQLStringTest {
                 "insert foo into bar ; ",
                 "insert foo into bar;",
                 "insert  foo into bar;   ",
+                "insert  foo into bar; ;;  ",
+                "insert  foo into bar;\n;;  ",
                 "/* UnregisteredSQLString */ insert foo into bar;",
                 "  /* UnregisteredSQLString */insert foo into bar",
                 "  /* UnregisteredSQLString */insert foo into bar ");
@@ -43,18 +45,27 @@ public class SQLStringTest {
         List<String> testBatch = ImmutableList.of(
                 "/* UnregisteredSQLString */ insert foo into bar; /* UnregisteredSQLString */insert foo into bar;",
                 "insert foo into bar; /* UnregisteredSQLString */ insert foo into bar");
-        String canconicalBatch = "insert foo into bar; insert foo into bar";
+        String canonicalBatch = "insert foo into bar; insert foo into bar";
 
-        testBatch.forEach(sql -> assertEquals(canconicalBatch, SQLString.canonicalizeString(sql)));
+        testBatch.forEach(sql -> assertEquals(canonicalBatch, SQLString.canonicalizeString(sql)));
     }
 
     @Test
-    public void testCanonicalizeStringNoSpaces() {
+    public void testCanonicalizeStringAndRemoveWhitespaceEntirely() {
         List<String> testBatch = ImmutableList.of(
                 "/* UnregisteredSQLString */ insert foo into bar; /* UnregisteredSQLString */insert foo into bar;",
                 "insert foo into bar; /* UnregisteredSQLString */ insert foo into bar");
-        String canconicalBatch = "insertfoointobar;insertfoointobar";
+        String canonicalBatch = "insertfoointobar;insertfoointobar";
 
-        testBatch.forEach(sql -> assertEquals(canconicalBatch, SQLString.canonicalizeStringAndRemoveWhitespaceEntirely(sql)));
+        testBatch.forEach(sql -> assertEquals(canonicalBatch, SQLString.canonicalizeStringAndRemoveWhitespaceEntirely(sql)));
+    }
+
+    @Test
+    public void testCanonicalizeBlanks() throws Exception {
+        List<String> testBatch = ImmutableList.of("",
+                " ",
+                " ;; ; ");
+        testBatch.forEach(sql -> assertEquals("", SQLString.canonicalizeString(sql)));
+
     }
 }

--- a/commons-db/src/test/java/com/palantir/nexus/db/sql/SQLStringTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/sql/SQLStringTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.nexus.db.sql;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class SQLStringTest {
+    @Test
+    public void testCanonicalizeString() {
+        List<String> testQuery = ImmutableList.of(
+                "insert foo into bar ; ",
+                "insert foo into bar;",
+                "insert  foo into bar;   ",
+                "/* UnregisteredSQLString */ insert foo into bar;",
+                "  /* UnregisteredSQLString */insert foo into bar",
+                "  /* UnregisteredSQLString */insert foo into bar ");
+        String canonicalQuery = "insert foo into bar";
+
+        testQuery.forEach(sql -> assertEquals(canonicalQuery, SQLString.canonicalizeString(sql)));
+    }
+
+    @Test
+    public void testCanonicalizeBatch() {
+        List<String> testBatch = ImmutableList.of(
+                "/* UnregisteredSQLString */ insert foo into bar; /* UnregisteredSQLString */insert foo into bar;",
+                "insert foo into bar; /* UnregisteredSQLString */ insert foo into bar");
+        String canconicalBatch = "insert foo into bar; insert foo into bar";
+
+        testBatch.forEach(sql -> assertEquals(canconicalBatch, SQLString.canonicalizeString(sql)));
+    }
+
+    @Test
+    public void testCanonicalizeStringNoSpaces() {
+        List<String> testBatch = ImmutableList.of(
+                "/* UnregisteredSQLString */ insert foo into bar; /* UnregisteredSQLString */insert foo into bar;",
+                "insert foo into bar; /* UnregisteredSQLString */ insert foo into bar");
+        String canconicalBatch = "insertfoointobar;insertfoointobar";
+
+        testBatch.forEach(sql -> assertEquals(canconicalBatch, SQLString.canonicalizeStringAndRemoveWhitespaceEntirely(sql)));
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,8 +42,9 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |improved|
+         - Improved heap usage during heavy DBKVS querying
+           (Pull Request <https://github.com/palantir/atlasdb/pull/1560>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
partially addresses #735 , which identifies this as a hotspot for heap allocations

This new impl Is ~6.5x fewer allocs than the previous impl (and because it was memory-bound problem, is now ~6.5x faster), and rather than being bug-for-bug compat, adds some functionality. (cleans up multiple UNREGISTERED_SQL_COMMENT in large batches of statements now rather than just the first).

I'm not in love with removing the trailing semicolon; It really messes with the query's feng shui. So I'd be more than open to removing that piece of functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1560)
<!-- Reviewable:end -->
