### PR TITLE
Proof of concept: sockets for Paxos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,8 @@ allprojects {
         resolutionStrategy {
             failOnVersionConflict()
         }
+        
+        exclude group: "org.mortbay.jetty:servlet-api"
     }
 }
 

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     compile group: 'io.dropwizard.modules', name: 'dropwizard-java8'
 
     processor group: 'org.immutables', name: 'value'
+    processor 'com.google.auto.service:auto-service:1.0-rc2'
+
+    compile "org.java-websocket:Java-WebSocket:1.3.0"
 
     testCompile project(":atlasdb-config")
     testCompile project(path: ":leader-election-impl", configuration: "testArtifacts")

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
+import com.palantir.atlasdb.timelock.paxos.TimestampWebsocketServer;
 import com.palantir.remoting1.servers.jersey.HttpRemotingJerseyFeature;
 
 import io.dropwizard.Application;
@@ -60,6 +61,12 @@ public class TimeLockServerLauncher extends Application<TimeLockServerConfigurat
                 serverImpl,
                 configuration.clients());
 
+        String websocketTimestampClient = configuration.cluster().websocketTimestampClient();
+        TimestampWebsocketServer timestampServer = new TimestampWebsocketServer(
+                configuration.cluster().localWebsocketTimestampServer(),
+                clientToServices.get(websocketTimestampClient).getTimestampService());
+
+        environment.lifecycle().manage(timestampServer);
         environment.jersey().register(HttpRemotingJerseyFeature.DEFAULT);
         environment.jersey().register(new TimeLockResource(clientToServices));
     }
@@ -73,4 +80,5 @@ public class TimeLockServerLauncher extends Application<TimeLockServerConfigurat
         }
         return clientToServices.build();
     }
+
 }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/ClusterConfiguration.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/ClusterConfiguration.java
@@ -32,9 +32,16 @@ import com.google.common.net.HostAndPort;
 @Value.Immutable
 public abstract class ClusterConfiguration {
     public abstract String localServer();
+    public abstract String localWebsocketTimestampServer();
+    public abstract String localWebsocketPaxosServer();
+    public abstract String websocketTimestampClient();
+    public abstract PaxosTransport paxosTransport();
 
     @Size(min = 1)
     public abstract Set<String> servers();
+
+    @Size(min = 1)
+    public abstract Set<String> websocketPaxosServers();
 
     @Value.Check
     protected void check() {

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/PaxosTransport.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/PaxosTransport.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock.config;
+
+public enum PaxosTransport {
+    HTTP,
+    WEBSOCKET
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosMethod.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosMethod.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+/**
+ *
+ */
+public enum PaxosMethod {
+    PREPARE,
+    ACCEPT,
+    GET_LATEST_PREPARED_OR_ACCEPTED,
+    LEARN,
+    GET_LEARNED_VALUE,
+    GET_GREATEST_LEARNED_VALUE,
+    GET_LEADED_VALUES_SINCE;
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosWebsocketClient.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosWebsocketClient.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static com.palantir.atlasdb.timelock.paxos.WebsocketMessage.mapUnchecked;
+
+import java.net.URI;
+import java.util.Collection;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.palantir.paxos.BooleanPaxosResponse;
+import com.palantir.paxos.PaxosAcceptor;
+import com.palantir.paxos.PaxosLearner;
+import com.palantir.paxos.PaxosPromise;
+import com.palantir.paxos.PaxosProposal;
+import com.palantir.paxos.PaxosProposalId;
+import com.palantir.paxos.PaxosValue;
+
+import io.dropwizard.lifecycle.Managed;
+
+public class PaxosWebsocketClient extends WebsocketClientBase implements PaxosLearner, PaxosAcceptor, Managed  {
+
+    public PaxosWebsocketClient(String serverURI) {
+        super(URI.create(serverURI));
+    }
+
+    @Override
+    public PaxosPromise prepare(long seq, PaxosProposalId pid) {
+        WebsocketMessage response = sendRequest(PaxosMethod.PREPARE, Long.toString(seq), mapUnchecked(pid));
+        return response.objAt(0, PaxosPromise.class);
+    }
+
+    @Override
+    public BooleanPaxosResponse accept(long seq, PaxosProposal proposal) {
+        WebsocketMessage response = sendRequest(PaxosMethod.ACCEPT, Long.toString(seq), mapUnchecked(proposal));
+        return response.objAt(0, BooleanPaxosResponse.class);
+    }
+
+    @Override
+    public long getLatestSequencePreparedOrAccepted() {
+        WebsocketMessage response = sendRequest(PaxosMethod.GET_LATEST_PREPARED_OR_ACCEPTED);
+        return response.longAt(0);
+    }
+
+    @Override
+    public void learn(long seq, PaxosValue val) {
+        WebsocketMessage response = sendRequest(PaxosMethod.LEARN, Long.toString(seq), mapUnchecked(val));
+        assert response != null;
+    }
+
+    @Override
+    public PaxosValue getLearnedValue(long seq) {
+        WebsocketMessage response = sendRequest(PaxosMethod.GET_LEARNED_VALUE, Long.toString(seq));
+        return response.objAt(0, PaxosValue.class);
+    }
+
+    @Override
+    public PaxosValue getGreatestLearnedValue() {
+        WebsocketMessage response = sendRequest(PaxosMethod.GET_GREATEST_LEARNED_VALUE);
+        return response.objAt(0, PaxosValue.class);
+    }
+
+    @Override
+    public Collection<PaxosValue> getLearnedValuesSince(long seq) {
+        WebsocketMessage response = sendRequest(PaxosMethod.GET_LEADED_VALUES_SINCE, Long.toString(seq));
+        return response.objAt(0, new TypeReference<Collection<PaxosValue>>() {});
+    }
+
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosWebsocketServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosWebsocketServer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import static com.palantir.atlasdb.timelock.paxos.WebsocketMessage.mapUnchecked;
+
+import java.util.Collection;
+
+import org.java_websocket.WebSocket;
+
+import com.palantir.paxos.BooleanPaxosResponse;
+import com.palantir.paxos.PaxosAcceptor;
+import com.palantir.paxos.PaxosLearner;
+import com.palantir.paxos.PaxosPromise;
+import com.palantir.paxos.PaxosProposal;
+import com.palantir.paxos.PaxosProposalId;
+import com.palantir.paxos.PaxosValue;
+
+public class PaxosWebsocketServer extends WebsocketServerBase {
+
+    private final PaxosLearner learner;
+    private final PaxosAcceptor acceptor;
+
+    public PaxosWebsocketServer(String uri, PaxosLearner learner, PaxosAcceptor acceptor) {
+        super(uri);
+        this.learner = learner;
+        this.acceptor = acceptor;
+    }
+
+    @Override
+    public WebsocketMessage processRequest(WebSocket conn, WebsocketMessage message) {
+        switch (PaxosMethod.valueOf(message.methodName())) {
+            case PREPARE: {
+                long seq = message.longAt(0);
+                PaxosProposalId pid = message.objAt(1, PaxosProposalId.class);
+                PaxosPromise promise = acceptor.prepare(seq, pid);
+                return message.response(mapUnchecked(promise));
+            }
+            case ACCEPT: {
+                long seq = message.longAt(0);
+                PaxosProposal proposal = message.objAt(1, PaxosProposal.class);
+                BooleanPaxosResponse response = acceptor.accept(seq, proposal);
+                return message.response(mapUnchecked(response));
+            }
+            case GET_LATEST_PREPARED_OR_ACCEPTED: {
+                Long latest = acceptor.getLatestSequencePreparedOrAccepted();
+                return message.response(latest.toString());
+            }
+            case LEARN: {
+                long seq = message.longAt(0);
+                PaxosValue value = message.objAt(1, PaxosValue.class);
+                learner.learn(seq, value);
+                return null;
+            }
+            case GET_LEARNED_VALUE: {
+                long seq = message.longAt(0);
+                PaxosValue value = learner.getLearnedValue(seq);
+                return message.response(mapUnchecked(value));
+            }
+            case GET_GREATEST_LEARNED_VALUE: {
+                PaxosValue value = learner.getGreatestLearnedValue();
+                return message.response(mapUnchecked(value));
+            }
+            case GET_LEADED_VALUES_SINCE: {
+                long seq = message.longAt(0);
+                Collection<PaxosValue> values = learner.getLearnedValuesSince(seq);
+                return message.response(mapUnchecked(values));
+            }
+        }
+
+        throw new IllegalArgumentException("unknown method: " + message.methodName());
+    }
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/TimestampWebsocketServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/TimestampWebsocketServer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import org.java_websocket.WebSocket;
+
+import com.palantir.timestamp.TimestampService;
+
+import io.dropwizard.lifecycle.Managed;
+
+public class TimestampWebsocketServer extends WebsocketServerBase implements Managed {
+
+    private final TimestampService timestampService;
+
+    public TimestampWebsocketServer(String uri, TimestampService timestampService) {
+        super(uri);
+        this.timestampService = timestampService;
+    }
+
+
+    @Override
+    public WebsocketMessage processRequest(WebSocket conn, WebsocketMessage message) {
+        if (message.methodName().equals("timestamp")) {
+            Long timestamp = timestampService.getFreshTimestamp();
+            return message.response(timestamp.toString());
+        }
+
+        throw new IllegalArgumentException("unknown method: " + message.methodName());
+    }
+
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/WebsocketClientBase.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/WebsocketClientBase.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.java_websocket.WebSocket.READYSTATE;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Maps;
+
+import io.dropwizard.lifecycle.Managed;
+
+/**
+ *
+ */
+public abstract class WebsocketClientBase extends WebSocketClient implements Managed {
+
+    private static final Logger log = LoggerFactory.getLogger(PaxosWebsocketClient.class);
+
+    private final AtomicLong messageIdProvider = new AtomicLong(1);
+    private final ConcurrentMap<String, CompletableFuture<WebsocketMessage>> sentMessages = Maps.newConcurrentMap();
+
+    public WebsocketClientBase(URI serverURI) {
+        super(serverURI);
+    }
+
+    @Override
+    public void onOpen(ServerHandshake handshakedata) {
+        log.info("websocket opened", this);
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean remote) {
+        log.info("websocket closed", this);
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        log.error("websocket encountered error", this, ex);
+    }
+
+    @Override
+    public void onMessage(String data) {
+        //log.info("recieved message {}", message);
+        try {
+            handleResponse(data);
+        } catch (Throwable t) {
+            log.error("error handling message {}", data, t);
+        }
+    }
+
+    private void handleResponse(String data) {
+        WebsocketMessage message = WebsocketMessage.parse(data);
+
+        CompletableFuture<WebsocketMessage> future = sentMessages.get(message.messageId());
+        if (future == null) {
+            log.warn("recieved response for nonexistent messageId {}", message.messageId());
+            return;
+        }
+
+        future.complete(message);
+    }
+
+    protected WebsocketMessage sendRequest(Object method, String...args) {
+        waitUntilOpen();
+
+        String messageId = Long.toString(messageIdProvider.getAndIncrement());
+        String message = WebsocketMessage.request(messageId, method.toString(), args);
+
+        CompletableFuture<WebsocketMessage> future = new CompletableFuture<>();
+        sentMessages.put(messageId, future);
+        send(message);
+
+        try {
+            return future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private synchronized void waitUntilOpen() {
+        if (getReadyState() != READYSTATE.OPEN) {
+            try {
+                connectBlocking();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public void start() throws Exception {
+        log.info("starting");
+        connect();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        close();
+    }
+
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/WebsocketMessage.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/WebsocketMessage.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+
+public class WebsocketMessage {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new GuavaModule());
+
+    private final String messageId;
+    private final String methodName;
+    private final String[] args;
+
+    public WebsocketMessage(String messageId, String methodName, String[] args) {
+        this.messageId = messageId;
+        this.methodName = methodName;
+        this.args = args;
+    }
+
+    public String messageId() {
+        return messageId;
+    }
+
+    public String methodName() {
+        return methodName;
+    }
+
+    public String[] args() {
+        return args;
+    }
+
+    public static String request(String messageId, String methodName, String...args) {
+        return new WebsocketMessage(messageId, methodName, args).toString();
+    }
+
+    public static WebsocketMessage parse(String message) {
+        String[] parts = StringUtils.split(message, ' ');
+
+        String messageId = parts[0];
+        String methodName = parts[1];
+
+        if (parts.length == 2) {
+            return new WebsocketMessage(messageId, methodName, new String[0]);
+        }
+
+        String[] args = Arrays.copyOfRange(parts, 2, parts.length);
+        return new WebsocketMessage(messageId, methodName, args);
+    }
+
+    public String argAt(int index) {
+        return args[index];
+    }
+
+    public long longAt(int index) {
+        return Long.valueOf(args[index]);
+    }
+
+    public <T> T objAt(int index, Class<T> clazz) {
+        return mapUnchecked(args[index], clazz);
+    }
+
+    public <T> T objAt(int index, TypeReference<T> clazz) {
+        return mapUnchecked(args[index], clazz);
+    }
+
+    public WebsocketMessage response(String...args) {
+        return new WebsocketMessage(messageId, methodName, args);
+    }
+
+    @Override
+    public String toString() {
+        String result = String.format("%s %s", messageId, methodName);
+
+        if (args.length == 0) {
+            return result;
+        }
+
+        return result + " " + String.join(" ", args);
+    }
+
+    public static <T> T mapUnchecked(String json, TypeReference<T> clazz) {
+        try {
+            return MAPPER.readValue(json, clazz);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T mapUnchecked(String json, Class<T> clazz) {
+        try {
+            return MAPPER.readValue(json, clazz);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String mapUnchecked(Object obj) {
+        try {
+            return MAPPER.writeValueAsString(obj);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/WebsocketServerBase.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/WebsocketServerBase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.dropwizard.lifecycle.Managed;
+
+
+public abstract class WebsocketServerBase extends WebSocketServer implements Managed {
+
+    private static final Logger log = LoggerFactory.getLogger(WebsocketServerBase.class);
+
+
+    public WebsocketServerBase(String uriString) {
+        this(URI.create(uriString));
+    }
+
+    public WebsocketServerBase(URI uri) {
+        super(new InetSocketAddress(uri.getHost(), uri.getPort()));
+        log.info("creating server at {}", uri);
+    }
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+        log.info("websocket opened: {}", conn);
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+        log.info("websocket closed: {}", conn);
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+        log.error("websocket error: {}", conn, ex);
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String data) {
+        //log.info("recieved message {}", message);
+        try {
+            handleRequest(conn, data);
+        } catch (Throwable e) {
+            log.error("error handling message {}", data, e);
+        }
+    }
+
+    private void handleRequest(WebSocket conn, String data) {
+        WebsocketMessage message = WebsocketMessage.parse(data);
+
+        WebsocketMessage reply = processRequest(conn, message);
+        if (reply != null) {
+            conn.send(reply.toString());
+        }
+    }
+
+    public abstract WebsocketMessage processRequest(WebSocket conn, WebsocketMessage message);
+
+}

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/TimelockPerfTests.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/TimelockPerfTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
+import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.timestamp.TimestampService;
+
+public class TimelockPerfTests {
+
+    static final Logger log = LoggerFactory.getLogger(TimelockPerfTests.class);
+
+    private static final String[] SERVER_URIS = new String[] {
+            "http://localhost:8080/test",
+            "http://localhost:8081/test",
+            "http://localhost:8082/test"};
+
+    private static final String[] WEBSOCKET_SERVER_URIS = new String[] {
+            "http://localhost:8060",
+            "http://localhost:8061",
+            "http://localhost:8062"};
+
+    private static final int NUM_REQUESTS = 10000;
+
+    TimestampService httpTmestampService;
+    TimestampService websocketTimestampService;
+
+    @Before
+    public void find_the_leader() {
+        for (int i = 0; i < SERVER_URIS.length; i++) {
+            if (isLeader(SERVER_URIS[i])) {
+                httpTmestampService = createHttpProxy(SERVER_URIS[i]);
+                websocketTimestampService = createWebsocketProxy(WEBSOCKET_SERVER_URIS[i]);
+            }
+        }
+
+        if (httpTmestampService == null) {
+            throw new IllegalStateException("could not successfully contact any server");
+        }
+
+        // sanity check
+        httpTmestampService.getFreshTimestamp();
+        websocketTimestampService.getFreshTimestamp();
+    }
+
+    @Test
+    public void get_timestamp() {
+        measureRequestTimes(() -> httpTmestampService.getFreshTimestamp(), "http");
+        measureRequestTimes(() -> websocketTimestampService.getFreshTimestamp(), "websocket");
+    }
+
+    private void measureRequestTimes(Supplier<Long> timestampFunc, String name) {
+        log.warn("starting test for {}", name);
+
+        // warm up
+        for (int i = 0; i < 1000; i++) {
+            timestampFunc.get();
+        }
+
+        // time requests
+        Stopwatch timer = Stopwatch.createStarted();
+
+        long lastTs = -1;
+        for (int i = 0; i < NUM_REQUESTS; i++) {
+            long ts = timestampFunc.get();
+            assertTrue(ts > lastTs);
+            lastTs = ts;
+        }
+
+        long totalTime = timer.elapsed(TimeUnit.MILLISECONDS);
+        log.warn("{}: {} requests", name, NUM_REQUESTS);
+        log.warn("average request time: {} ms", totalTime / (double)NUM_REQUESTS);
+        log.warn("total time: {} ms", totalTime);
+    }
+
+    private boolean isLeader(String serverUri) {
+        try {
+            createHttpProxy(serverUri).getFreshTimestamp();
+            return true;
+        } catch(Throwable e) {
+            log.warn("error, trying another server: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private TimestampService createHttpProxy(String serverUri) {
+        TimestampService timestampService = AtlasDbHttpClients.createProxy(
+                Optional.absent(),
+                serverUri,
+                TimestampService.class);
+        return timestampService;
+    }
+
+    private TimestampService createWebsocketProxy(String serverUri) {
+        return new TimestampWebsocketClient(URI.create(serverUri));
+    }
+
+
+}

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/TimestampWebsocketClient.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/TimestampWebsocketClient.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import java.net.URI;
+
+import javax.ws.rs.NotSupportedException;
+
+import com.palantir.atlasdb.timelock.paxos.WebsocketClientBase;
+import com.palantir.atlasdb.timelock.paxos.WebsocketMessage;
+import com.palantir.timestamp.TimestampRange;
+import com.palantir.timestamp.TimestampService;
+
+public class TimestampWebsocketClient extends WebsocketClientBase implements TimestampService {
+
+    public TimestampWebsocketClient(URI serverURI) {
+        super(serverURI);
+    }
+
+    @Override
+    public long getFreshTimestamp() {
+        WebsocketMessage response = sendRequest("timestamp");
+        return response.longAt(0);
+    }
+
+    @Override
+    public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
+        throw new NotSupportedException();
+    }
+
+}

--- a/timelock-server/var/conf/timelock0.yml
+++ b/timelock-server/var/conf/timelock0.yml
@@ -1,0 +1,30 @@
+clients:
+  - test
+  - test2
+
+cluster:
+  localServer: localhost:8080
+  localWebsocketPaxosServer: http://localhost:8070
+  localWebsocketTimestampServer: http://localhost:8060
+  websocketTimestampClient: test
+  paxosTransport: WEBSOCKET
+  servers:
+    - localhost:8080
+    - localhost:8081
+    - localhost:8082
+  websocketPaxosServers:
+    - http://localhost:8070
+    - http://localhost:8071
+    - http://localhost:8072
+
+
+algorithm:
+  type: paxos
+
+server:
+  applicationConnectors:
+  - type: http 
+    port: 8080
+  adminConnectors:
+  - type: http 
+    port: 9080

--- a/timelock-server/var/conf/timelock1.yml
+++ b/timelock-server/var/conf/timelock1.yml
@@ -1,0 +1,29 @@
+clients:
+  - test
+  - test2
+
+cluster:
+  localServer: localhost:8081
+  localWebsocketPaxosServer: http://localhost:8071
+  localWebsocketTimestampServer: http://localhost:8061
+  websocketTimestampClient: test
+  paxosTransport: WEBSOCKET
+  servers:
+    - localhost:8080
+    - localhost:8081
+    - localhost:8082
+  websocketPaxosServers:
+    - http://localhost:8070
+    - http://localhost:8071
+    - http://localhost:8072
+
+algorithm:
+  type: paxos
+
+server:
+  applicationConnectors:
+  - type: http 
+    port: 8081
+  adminConnectors:
+  - type: http 
+    port: 9081

--- a/timelock-server/var/conf/timelock2.yml
+++ b/timelock-server/var/conf/timelock2.yml
@@ -1,0 +1,29 @@
+clients:
+  - test
+  - test2
+
+cluster:
+  localServer: localhost:8082
+  localWebsocketPaxosServer: http://localhost:8072
+  localWebsocketTimestampServer: http://localhost:8062
+  websocketTimestampClient: test
+  paxosTransport: WEBSOCKET
+  servers:
+    - localhost:8080
+    - localhost:8081
+    - localhost:8082
+  websocketPaxosServers:
+    - http://localhost:8070
+    - http://localhost:8071
+    - http://localhost:8072
+
+algorithm:
+  type: paxos
+
+server:
+  applicationConnectors:
+  - type: http 
+    port: 8082
+  adminConnectors:
+  - type: http 
+    port: 9082


### PR DESCRIPTION
DO NOT MERGE
This code is hacky/untested and just a proof of concept.

Fixes #1548.

I did some experimentation with replacing all the HTTP calls with Websockets, with some pretty interesting results. Here are baseline local test results (3 node setup) of `PaxosTimelockServer#getFreshTimestamp`:
```
17:40:03.627 [main] WARN  c.p.a.timelock.TimelockPerfTests - http: 10000 requests
17:40:03.627 [main] WARN  c.p.a.timelock.TimelockPerfTests - average request time: 3.6459
17:40:03.627 [main] WARN  c.p.a.timelock.TimelockPerfTests - total time: 36459
```

If we use a Websocket for the client -> server connection, we get:
```
17:39:27.166 [main] WARN  c.p.a.timelock.TimelockPerfTests - websocket: 10000 requests
17:39:27.168 [main] WARN  c.p.a.timelock.TimelockPerfTests - average request time: 1.9781
17:39:27.169 [main] WARN  c.p.a.timelock.TimelockPerfTests - total time: 19781

```
(approximately 50% time reduction)

Taking this a step further, if we use Websockets for the Paxos Learner / Acceptor communications, we get:
```
17:41:46.482 [main] WARN  c.p.a.timelock.TimelockPerfTests - websocket: 10000 requests
17:41:46.484 [main] WARN  c.p.a.timelock.TimelockPerfTests - average request time: 0.1946
17:41:46.485 [main] WARN  c.p.a.timelock.TimelockPerfTests - total time: 1946
```
(another reduction of ~50% of the original time)

Overall this gives an order-of-magnitude improvement. The theory is that since the baseline test needs two roundtrip http requests per call (one from client -> server, and another from server -> other server to obtain a paxos quorum), eliminating each one of these shaves off about 50% of the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1561)
<!-- Reviewable:end -->
