### PR TITLE
Fix multiple deadlock scenarios in DbKvs

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapper.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
-import java.sql.SQLException;
 import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
@@ -49,29 +48,18 @@ class OracleTableNameUnmapper {
         String fullTableName = tablePrefix + DbKvs.internalTableName(tableRef);
         try {
             return unmappingCache.get(fullTableName, () -> {
-                SqlConnection conn = null;
-                try {
-                    conn = connectionSupplier.getNewUnsharedConnection();
-                    AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
-                            "SELECT short_table_name "
-                                    + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
-                                    + " WHERE table_name = ?", fullTableName);
-                    if (results.size() == 0) {
-                        throw new TableMappingNotFoundException(
-                                "The table " + fullTableName + " does not have a mapping."
-                                        + "This might be because the table does not exist.");
-                    }
-
-                    return Iterables.getOnlyElement(results.rows()).getString("short_table_name");
-                } finally {
-                    if (conn != null) {
-                        try {
-                            conn.getUnderlyingConnection().close();
-                        } catch (SQLException e) {
-                            log.error("Couldn't cleanup SQL connection while performing table name unmapping.", e);
-                        }
-                    }
+                SqlConnection conn = connectionSupplier.get();
+                AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
+                        "SELECT short_table_name "
+                                + "FROM " + AtlasDbConstants.ORACLE_NAME_MAPPING_TABLE
+                                + " WHERE table_name = ?", fullTableName);
+                if (results.size() == 0) {
+                    throw new TableMappingNotFoundException(
+                            "The table " + fullTableName + " does not have a mapping."
+                                    + "This might be because the table does not exist.");
                 }
+
+                return Iterables.getOnlyElement(results.rows()).getString("short_table_name");
             });
         } catch (ExecutionException e) {
             throw new TableMappingNotFoundException(e.getCause());

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionSupplier.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ConnectionSupplier.java
@@ -49,13 +49,6 @@ public class ConnectionSupplier implements SqlConnectionSupplier {
         return delegate.get();
     }
 
-    /**
-     * Responsibility of the consumer to close this connection when finished.
-     */
-    public SqlConnection getNewUnsharedConnection() {
-        return delegate.get();
-    }
-
     @Override
     public synchronized void close() {
         if (sharedConnection != null) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -303,22 +303,19 @@ public class DbKvs extends AbstractKeyValueService {
                 tableRef,
                 getByteSizingFunction());
 
-        runWrite(tableRef, new Function<DbWriteTable, Void>() {
-            @Override
-            public Void apply(DbWriteTable table) {
-                for (List<Entry<Cell, byte[]>> batch : batches) {
-                    try {
-                        table.put(batch, timestamp);
-                    } catch (KeyAlreadyExistsException e) {
-                        if (idempotent) {
-                            putIfNotUpdate(tableRef, table, batch, timestamp, e);
-                        } else {
-                            throw e;
-                        }
+        runReadWrite(tableRef, (readTable, writeTable) -> {
+            for (List<Entry<Cell, byte[]>> batch : batches) {
+                try {
+                    writeTable.put(batch, timestamp);
+                } catch (KeyAlreadyExistsException e) {
+                    if (idempotent) {
+                        putIfNotUpdate(readTable, writeTable, batch, timestamp, e);
+                    } else {
+                        throw e;
                     }
                 }
-                return null;
             }
+            return null;
         });
     }
 
@@ -329,15 +326,16 @@ public class DbKvs extends AbstractKeyValueService {
     }
 
     private void putIfNotUpdate(
-            TableReference tableRef,
-            DbWriteTable table,
+            DbReadTable readTable,
+            DbWriteTable writeTable,
             List<Entry<Cell, Value>> batch,
             KeyAlreadyExistsException ex) {
         Map<Cell, Long> timestampByCell = Maps.newHashMap();
         for (Entry<Cell, Value> entry : batch) {
             timestampByCell.put(entry.getKey(), entry.getValue().getTimestamp() + 1);
         }
-        Map<Cell, Value> results = get(tableRef, timestampByCell);
+
+        Map<Cell, Value> results = extractResults(readTable, readTable.getLatestCells(timestampByCell, true));
 
         ListIterator<Entry<Cell, Value>> iter = batch.listIterator();
         while (iter.hasNext()) {
@@ -354,19 +352,19 @@ public class DbKvs extends AbstractKeyValueService {
                 }
             }
         }
-        table.put(batch);
+        writeTable.put(batch);
     }
 
     private void putIfNotUpdate(
-            TableReference tableRef,
-            DbWriteTable table,
+            DbReadTable readTable,
+            DbWriteTable writeTable,
             List<Entry<Cell, byte[]>> batch,
             long timestamp,
             KeyAlreadyExistsException ex) {
         List<Entry<Cell, Value>> batchValues =
                 Lists.transform(batch,
                         input -> Maps.immutableEntry(input.getKey(), Value.create(input.getValue(), timestamp)));
-        putIfNotUpdate(tableRef, table, batchValues, ex);
+        putIfNotUpdate(readTable, writeTable, batchValues, ex);
     }
 
     @Override
@@ -379,18 +377,15 @@ public class DbKvs extends AbstractKeyValueService {
                 tableRef,
                 getValueSizingFunction());
 
-        runWrite(tableRef, new Function<DbWriteTable, Void>() {
-            @Override
-            public Void apply(DbWriteTable table) {
-                for (List<Entry<Cell, Value>> batch : batches) {
-                    try {
-                        table.put(batch);
-                    } catch (KeyAlreadyExistsException e) {
-                        putIfNotUpdate(tableRef, table, batch, e);
-                    }
+        runReadWrite(tableRef, (readTable, writeTable) -> {
+            for (List<Entry<Cell, Value>> batch : batches) {
+                try {
+                    writeTable.put(batch);
+                } catch (KeyAlreadyExistsException e) {
+                    putIfNotUpdate(readTable, writeTable, batch, e);
                 }
-                return null;
             }
+            return null;
         });
     }
 
@@ -1239,6 +1234,17 @@ public class DbKvs extends AbstractKeyValueService {
         }
     }
 
+    private <T> T runReadWrite(TableReference tableRef, ReadWriteTask<T> runner) {
+        ConnectionSupplier conns = new ConnectionSupplier(connections);
+        try {
+            return runner.run(
+                    dbTables.createRead(tableRef, conns),
+                    dbTables.createWrite(tableRef, conns));
+        } finally {
+            conns.close();
+        }
+    }
+
     private <T> T runWriteForceAutocommit(TableReference tableRef, Function<DbWriteTable, T> runner) {
         ConnectionSupplier conns = new ConnectionSupplier(connections);
         try {
@@ -1301,5 +1307,9 @@ public class DbKvs extends AbstractKeyValueService {
         return Optional.ofNullable(batchHint)
                 .map(x -> (int) (1.1 * x))
                 .orElse(100);
+    }
+
+    private interface ReadWriteTask<T> {
+        T run(DbReadTable readTable, DbWriteTable writeTable);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TableValueStyleCache.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TableValueStyleCache.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
-import java.sql.SQLException;
 import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
@@ -41,37 +40,22 @@ public final class TableValueStyleCache {
             TableReference metadataTable) {
         try {
             return valueStyleByTableRef.get(tableRef, () -> {
-                SqlConnection conn = null;
-                try {
-                    conn = connectionSupplier.getNewUnsharedConnection();
-                    AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
-                            String.format(
-                                    "SELECT table_size FROM %s WHERE table_name = ?",
-                                    metadataTable.getQualifiedName()),
-                            tableRef.getQualifiedName());
-                    Preconditions.checkArgument(
-                            !results.rows().isEmpty(),
-                            "table %s not found",
-                            tableRef.getQualifiedName());
+                SqlConnection conn = connectionSupplier.get();
+                AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
+                        String.format(
+                                "SELECT table_size FROM %s WHERE table_name = ?",
+                                metadataTable.getQualifiedName()),
+                        tableRef.getQualifiedName());
+                Preconditions.checkArgument(
+                        !results.rows().isEmpty(),
+                        "table %s not found",
+                        tableRef.getQualifiedName());
 
-                    return TableValueStyle.byId(Iterables.getOnlyElement(results.rows()).getInteger("table_size"));
-                } finally {
-                    closeUnderlyingConnection(conn);
-                }
+                return TableValueStyle.byId(Iterables.getOnlyElement(results.rows()).getInteger("table_size"));
             });
         } catch (ExecutionException e) {
             log.error("TableValueStyle for the table {} could not be retrieved.", tableRef.getQualifiedName());
             throw Throwables.propagate(e);
-        }
-    }
-
-    private static void closeUnderlyingConnection(SqlConnection connection) {
-        if (connection != null) {
-            try {
-                connection.getUnderlyingConnection().close();
-            } catch (SQLException e) {
-                log.error("Couldn't cleanup SQL connection while retrieving table size.", e);
-            }
         }
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
@@ -85,8 +85,8 @@ public class InDbTimestampBoundStore implements TimestampBoundStore {
     }
 
     private void init() {
-        try {
-            createTimestampTable(connManager.getConnection());
+        try (Connection conn = connManager.getConnection()) {
+            createTimestampTable(conn);
         } catch (SQLException error) {
             throw PalantirSqlException.create(error);
         }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleTableNameUnmapperTest.java
@@ -67,7 +67,7 @@ public class OracleTableNameUnmapperTest {
         SqlConnection sqlConnection = mock(SqlConnection.class);
         Connection connection = mock(Connection.class);
         when(sqlConnection.getUnderlyingConnection()).thenReturn(connection);
-        when(connectionSupplier.getNewUnsharedConnection()).thenReturn(sqlConnection);
+        when(connectionSupplier.get()).thenReturn(sqlConnection);
 
         resultSet = mock(AgnosticResultSet.class);
         when(sqlConnection

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TableValueStyleCacheTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/TableValueStyleCacheTest.java
@@ -48,7 +48,7 @@ public class TableValueStyleCacheTest {
     @Before
     public void setup() {
         SqlConnection mockConnection = mock(SqlConnection.class);
-        when(connectionSupplier.getNewUnsharedConnection()).thenReturn(mockConnection);
+        when(connectionSupplier.get()).thenReturn(mockConnection);
 
         AgnosticResultSet resultSet = mock(AgnosticResultSet.class);
         when(mockConnection.selectResultSetUnregisteredQuery(startsWith("SELECT table_size FROM"), anyObject()))
@@ -72,7 +72,7 @@ public class TableValueStyleCacheTest {
         assertThat(valueStyleCache.getTableType(
                 connectionSupplier, TEST_TABLE, AtlasDbConstants.DEFAULT_METADATA_TABLE),
                 is(TableValueStyle.OVERFLOW));
-        verify(connectionSupplier, times(1)).getNewUnsharedConnection();
+        verify(connectionSupplier, times(1)).get();
     }
 
 
@@ -85,7 +85,7 @@ public class TableValueStyleCacheTest {
                 connectionSupplier, TEST_TABLE, AtlasDbConstants.DEFAULT_METADATA_TABLE),
                 is(TableValueStyle.OVERFLOW));
 
-        verify(connectionSupplier, times(1)).getNewUnsharedConnection();
+        verify(connectionSupplier, times(1)).get();
     }
 
     @Test
@@ -98,7 +98,7 @@ public class TableValueStyleCacheTest {
                 connectionSupplier, TEST_TABLE, AtlasDbConstants.DEFAULT_METADATA_TABLE),
                 is(TableValueStyle.OVERFLOW));
 
-        verify(connectionSupplier, times(2)).getNewUnsharedConnection();
+        verify(connectionSupplier, times(2)).get();
     }
 
     @Test
@@ -111,7 +111,7 @@ public class TableValueStyleCacheTest {
                         connectionSupplier, TEST_TABLE_2, AtlasDbConstants.DEFAULT_METADATA_TABLE),
                 is(TableValueStyle.OVERFLOW));
 
-        verify(connectionSupplier, times(2)).getNewUnsharedConnection();
+        verify(connectionSupplier, times(2)).get();
     }
 
     @Test
@@ -129,13 +129,13 @@ public class TableValueStyleCacheTest {
                 valueStyleCache.getTableType(
                         connectionSupplier, TEST_TABLE, AtlasDbConstants.DEFAULT_METADATA_TABLE),
                 is(TableValueStyle.OVERFLOW));
-        verify(connectionSupplier, times(3)).getNewUnsharedConnection();
+        verify(connectionSupplier, times(3)).get();
 
         // No additional fetch required
         assertThat(
                 valueStyleCache.getTableType(
                         connectionSupplier, TEST_TABLE_2, AtlasDbConstants.DEFAULT_METADATA_TABLE),
                 is(TableValueStyle.OVERFLOW));
-        verify(connectionSupplier, times(3)).getNewUnsharedConnection();
+        verify(connectionSupplier, times(3)).get();
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -83,6 +83,9 @@ develop
          - Reduced logging noise from large Cassandra gets and puts by removing ERROR messages and only providing stacktraces at DEBUG.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1590>`__)
 
+    *    - |fixed|
+         - Fixed multiple connection pool deadlocks in DbKvs
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1566>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
- Reuse the existing connection in OracleTableNameUnmapper and TableValueStyleCache
- Eliminate a connection leak in InDbTimestampBoundStore
- Don't use more than one connection in DbKvs.put()
- Don't hold the connection longer than necessary in DbKvsGetRanges

<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
- Note what this change does and why it is needed
- Include details of who this change helps (without including internal product names)
- Include the Atlas release or date you need this by
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1566)
<!-- Reviewable:end -->
