### PR TITLE
Cassandra Timestamp Backup and Restore [Invalidate the Timestamp Tables Part 1 R3]

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -62,6 +62,7 @@ public class CassandraClientPoolIntegrationTest {
     private CassandraKeyValueService kv = CassandraKeyValueService.create(
             CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
             CassandraContainer.LEADER_CONFIG);
+    private CassandraClientPool clientPool = kv.getClientPool();
 
     @Before
     public void setUp() {
@@ -77,8 +78,7 @@ public class CassandraClientPoolIntegrationTest {
     // Pretty legit test if run manually or if we go back to multi-node tests
     @Test
     public void testTokenMapping() {
-        CassandraClientPool clientPool = kv.clientPool;
-        Map<Range<LightweightOppToken>, List<InetSocketAddress>> mapOfRanges = kv.clientPool.tokenMap.asMapOfRanges();
+        Map<Range<LightweightOppToken>, List<InetSocketAddress>> mapOfRanges = clientPool.tokenMap.asMapOfRanges();
 
         for (Entry<Range<LightweightOppToken>, List<InetSocketAddress>> entry : mapOfRanges.entrySet()) {
             Range<LightweightOppToken> tokenRange = entry.getKey();
@@ -97,15 +97,15 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testPoolGivenNoOptionTalksToBlacklistedHosts() {
-        kv.clientPool.blacklistedHosts.putAll(
-                Maps.transformValues(kv.clientPool.currentPools, clientPoolContainer -> Long.MAX_VALUE));
+        clientPool.blacklistedHosts.putAll(
+                Maps.transformValues(clientPool.currentPools, clientPoolContainer -> Long.MAX_VALUE));
         try {
-            kv.clientPool.run(describeRing);
+            clientPool.run(describeRing);
         } catch (Exception e) {
             fail("Should have been allowed to attempt forward progress after blacklisting all hosts in pool.");
         }
 
-        kv.clientPool.blacklistedHosts.clear();
+        clientPool.blacklistedHosts.clear();
     }
 
     private FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception> describeRing =

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -140,7 +140,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
         kvs.createTable(testTable, tableMetadata);
 
-        List<CfDef> knownCfs = kvs.clientPool.runWithRetry(client ->
+        List<CfDef> knownCfs = kvs.getClientPool().runWithRetry(client ->
                 client.describe_keyspace("atlasdb").getCf_defs());
         CfDef clusterSideCf = Iterables.getOnlyElement(knownCfs.stream()
                 .filter(cf -> cf.getName().equals("ns__never_seen"))
@@ -174,10 +174,10 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     public void testLockTablesStateCleanUp() throws Exception {
         CassandraKeyValueService ckvs = (CassandraKeyValueService) keyValueService;
         SchemaMutationLockTables lockTables = new SchemaMutationLockTables(
-                ckvs.clientPool,
+                ckvs.getClientPool(),
                 CassandraContainer.KVS_CONFIG);
         SchemaMutationLockTestTools lockTestTools = new SchemaMutationLockTestTools(
-                ckvs.clientPool,
+                ckvs.getClientPool(),
                 new UniqueSchemaMutationLockTable(lockTables, LockLeader.I_AM_THE_LOCK_LEADER));
 
         grabLock(lockTestTools);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -120,7 +120,7 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
 
     @Test
     public void describeVersionBehavesCorrectly() throws Exception {
-        kvs.clientPool.runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
+        kvs.getClientPool().runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
     }
 
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
@@ -127,12 +127,13 @@ public class CassandraTimestampBackupIntegrationTest {
     }
 
     @Test
-    public void throwsIfRestoringFromUnavailableBackup() {
-        assertThatThrownBy(backupRunner::restoreFromBackup).isInstanceOf(IllegalStateException.class);
+    public void restoreDoesNothingIfTimestampIsReadable() {
+        backupRunner.restoreFromBackup();
+        assertBoundEquals(INITIAL_VALUE);
     }
 
     @Test
-    public void throwsIfBothBoundsReadable() {
+    public void backupThrowsIfBothBoundsReadable() {
         setupTwoReadableBoundsInKv();
         assertThatThrownBy(backupRunner::backupExistingTimestamp).isInstanceOf(IllegalStateException.class);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
+import com.palantir.atlasdb.containers.CassandraContainer;
+import com.palantir.atlasdb.containers.Containers;
+import com.palantir.common.base.Throwables;
+import com.palantir.timestamp.TimestampBoundStore;
+
+public class CassandraTimestampBackupIntegrationTest {
+    private static final long INITIAL_VALUE = CassandraTimestampUtils.INITIAL_VALUE;
+    private static final long TIMESTAMP_1 = INITIAL_VALUE + 1000;
+    private static final long TIMESTAMP_2 = TIMESTAMP_1 + 1000;
+    private static final long TIMESTAMP_3 = TIMESTAMP_2 + 1000;
+
+    private static final long TIMEOUT_SECONDS = 5L;
+    private static final int POOL_SIZE = 16;
+
+    @ClassRule
+    public static final Containers CONTAINERS = new Containers(CassandraTimestampIntegrationTest.class)
+            .with(new CassandraContainer());
+
+    private final CassandraKeyValueService kv = CassandraKeyValueService.create(
+            CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
+            CassandraContainer.LEADER_CONFIG);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(POOL_SIZE);
+    private final TimestampBoundStore timestampBoundStore = CassandraTimestampBoundStore.create(kv);
+    private final CassandraTimestampBackupRunner backupRunner = new CassandraTimestampBackupRunner(kv);
+
+    @Before
+    public void setUp() {
+        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
+        backupRunner.createTimestampTable();
+    }
+
+    @After
+    public void close() {
+        kv.close();
+    }
+
+    @Test
+    public void canBackupWithDefaultValue() {
+        assertThat(backupRunner.backupExistingTimestamp(CassandraTimestampUtils.INITIAL_VALUE))
+                .isEqualTo(CassandraTimestampUtils.INITIAL_VALUE);
+    }
+
+    @Test
+    public void canBackupAlreadyStoredBound() {
+        timestampBoundStore.getUpperLimit();
+        timestampBoundStore.storeUpperLimit(TIMESTAMP_1);
+        assertThat(backupRunner.backupExistingTimestamp(TIMESTAMP_2)).isEqualTo(TIMESTAMP_1);
+    }
+
+    @Test
+    public void cannotReadAfterBackup() {
+        backupRunner.backupExistingTimestamp(TIMESTAMP_1);
+        assertTimestampNotReadable();
+    }
+
+    @Test
+    public void canBackupMultipleTimes() {
+        assertThat(backupRunner.backupExistingTimestamp(TIMESTAMP_1)).isEqualTo(TIMESTAMP_1);
+        assertThat(backupRunner.backupExistingTimestamp(TIMESTAMP_2)).isEqualTo(TIMESTAMP_1);
+        assertThat(backupRunner.backupExistingTimestamp(TIMESTAMP_3)).isEqualTo(TIMESTAMP_1);
+    }
+
+    @Test
+    public void resilientToMultipleConcurrentBackups() {
+        executeInParallelOnExecutorService(() -> backupRunner.backupExistingTimestamp(TIMESTAMP_1));
+        assertTimestampNotReadable();
+    }
+
+    private void assertTimestampNotReadable() {
+        assertThatThrownBy(timestampBoundStore::getUpperLimit).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void executeInParallelOnExecutorService(Runnable runnable) {
+        List<Future<?>> futures =
+                Stream.generate(() -> executorService.submit(runnable))
+                        .limit(POOL_SIZE)
+                        .collect(Collectors.toList());
+        futures.forEach(future -> {
+            try {
+                future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException exception) {
+                throw Throwables.rewrapAndThrowUncheckedException(exception);
+            }
+        });
+    }
+}

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
@@ -208,6 +208,18 @@ public class CassandraTimestampBackupIntegrationTest {
         assertThat(timestampBoundStore.getUpperLimit()).isEqualTo(TIMESTAMP_3);
     }
 
+    @Test
+    public void backupThrowsIfTimestampTableDoesNotExist() {
+        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
+        assertThatThrownBy(backupRunner::backupExistingTimestamp).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void restoreThrowsIfTimestampTableDoesNotExist() {
+        kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
+        assertThatThrownBy(backupRunner::restoreFromBackup).isInstanceOf(IllegalStateException.class);
+    }
+
     private void assertBoundEquals(long timestampBound) {
         assertThat(timestampBoundStore.getUpperLimit()).isEqualTo(timestampBound);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -60,6 +60,15 @@ public class CassandraTimestampIntegrationTest {
     }
 
     @Test
+    public void resilientToMultipleStoreUpperLimitBeforeGet() {
+        TimestampBoundStore ts = CassandraTimestampBoundStore.create(kv);
+        long limit = ts.getUpperLimit();
+        ts.storeUpperLimit(limit + 10);
+        ts.storeUpperLimit(limit + 20);
+        Assert.assertEquals(limit + 20, ts.getUpperLimit());
+    }
+
+    @Test
     public void testMultipleThrows() {
         TimestampBoundStore ts = CassandraTimestampBoundStore.create(kv);
         TimestampBoundStore ts2 = CassandraTimestampBoundStore.create(kv);

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile group: 'com.google.code.findbugs', name: 'annotations'
 
   testCompile group: 'org.mockito', name: 'mockito-core'
+  testCompile group: 'org.assertj', name: 'assertj-core'
 
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -2162,6 +2162,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         return queryRunner;
     }
 
+    public CassandraTables getCassandraTables() {
+        return cassandraTables;
+    }
+
     /**
      * Does not require all Cassandra nodes to be up and available, works as long as quorum is achieved.
      */

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -2158,6 +2158,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         }
     }
 
+    public TracingQueryRunner getTracingQueryRunner() {
+        return queryRunner;
+    }
+
     /**
      * Does not require all Cassandra nodes to be up and available, works as long as quorum is achieved.
      */

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -145,7 +145,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     protected final CassandraKeyValueServiceConfigManager configManager;
     private final Optional<CassandraJmxCompactionManager> compactionManager;
-    protected final CassandraClientPool clientPool;
+    private final CassandraClientPool clientPool;
     private SchemaMutationLock schemaMutationLock;
     private final Optional<LeaderConfig> leaderConfig;
     private final HiddenTables hiddenTables;
@@ -2156,6 +2156,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     tableRef,
                     e);
         }
+    }
+
+    public CassandraClientPool getClientPool() {
+        return clientPool;
     }
 
     public TracingQueryRunner getTracingQueryRunner() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -124,9 +124,10 @@ public class CassandraTimestampBackupRunner {
         BoundReadability boundReadability = getReadability(boundData);
 
         Preconditions.checkState(boundReadability != BoundReadability.BOTH,
-                "We had both backup and active bounds readable! This is unexpected. Please contact support.");
+                "We had both backup and active timestamp bounds readable! This is unexpected. Please contact support.");
         Preconditions.checkState(boundReadability != BoundReadability.NEITHER,
-                "We had an unreadable active bound with no backup! This is unexpected. Please contact support.");
+                "We had an unreadable active timestamp bound with no backup! This is unexpected. Please contact "
+                        + "support.");
         return boundReadability;
     }
 
@@ -158,7 +159,7 @@ public class CassandraTimestampBackupRunner {
         CassandraTables cassandraTables = cassandraKeyValueService.getCassandraTables();
         Preconditions.checkState(
                 cassandraTables.getExisting().contains(AtlasDbConstants.TIMESTAMP_TABLE.getQualifiedName()),
-                "[BACKUP/RESTORE] Tried to get bound data when the timestamp table didn't exist!");
+                "[BACKUP/RESTORE] Tried to get timestamp bound data when the timestamp table didn't exist!");
     }
 
     private void executeAndVerifyCas(Cassandra.Client client, Map<String, Pair<byte[], byte[]>> casMap) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -15,11 +15,21 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
+import java.nio.ByteBuffer;
+
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.common.annotation.Idempotent;
+import com.palantir.util.Pair;
 
 public class CassandraTimestampBackupRunner {
     private static final Logger log = LoggerFactory.getLogger(CassandraTimestampBackupRunner.class);
@@ -38,5 +48,58 @@ public class CassandraTimestampBackupRunner {
         cassandraKeyValueService.createTable(
                 AtlasDbConstants.TIMESTAMP_TABLE,
                 CassandraTimestampUtils.TIMESTAMP_TABLE_METADATA.persistToBytes());
+    }
+
+    /**
+     * Writes a backup of the existing timestamp to the database, if none exists. After this backup, this timestamp
+     * service can no longer be used until a restore. Note that the value returned is the value that was backed up;
+     * multiple calls to this method are safe, and will return the backed up value.
+     *
+     * @param defaultValue value to backup if the timestamp table is empty
+     * @return value of the timestamp that was backed up, if applicable
+     */
+    public synchronized long backupExistingTimestamp(long defaultValue) {
+        return clientPool().runWithRetry(client -> {
+            BoundData boundData = null; // TODO - getCurrentBoundData(client);
+            byte[] currentBound = boundData.bound();
+            byte[] currentBackupBound = boundData.backupBound();
+
+            if (CassandraTimestampUtils.isValidTimestampData(currentBackupBound)) {
+                // Backup bound has been updated!
+                Preconditions.checkState(!CassandraTimestampUtils.isValidTimestampData(currentBound),
+                        "We had both backup and active bounds readable! This is unexpected; please contact support.");
+                log.info("[BACKUP] Didn't backup, because there is already a backup bound.");
+                return PtBytes.toLong(currentBackupBound);
+            }
+
+            Preconditions.checkState(currentBound == null || CassandraTimestampUtils.isValidTimestampData(currentBound),
+                    "The timestamp is unreadable, though the backup is also unreadable! Please contact support.");
+            byte[] backupValue = MoreObjects.firstNonNull(currentBound, PtBytes.toBytes(defaultValue));
+            ByteBuffer casQueryBuffer = CassandraTimestampUtils.constructCheckAndSetMultipleQuery(
+                    ImmutableMap.of(
+                            CassandraTimestampUtils.ROW_AND_COLUMN_NAME,
+                            Pair.create(currentBound, CassandraTimestampUtils.INVALIDATED_VALUE.toByteArray()),
+                            CassandraTimestampUtils.BACKUP_COLUMN_NAME,
+                            Pair.create(currentBackupBound, backupValue)));
+//            executeQueryUnchecked(client, casQueryBuffer);
+            return PtBytes.toLong(backupValue);
+        });
+    }
+
+    private CassandraClientPool clientPool() {
+        return cassandraKeyValueService.clientPool;
+    }
+
+    private TracingQueryRunner queryRunner() {
+        return cassandraKeyValueService.getTracingQueryRunner();
+    }
+
+    @Value.Immutable
+    interface BoundData {
+        @Nullable
+        byte[] bound();
+
+        @Nullable
+        byte[] backupBound();
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -62,6 +62,8 @@ public class CassandraTimestampBackupRunner {
      * service can no longer be used until a restore. Note that the value returned is the value that was backed up;
      * multiple calls to this method are safe, and will return the backed up value.
      *
+     * This method assumes that the timestamp table exists.
+     *
      * @param defaultValue value to backup if the timestamp table is empty
      * @return value of the timestamp that was backed up, if applicable
      */
@@ -96,6 +98,8 @@ public class CassandraTimestampBackupRunner {
     /**
      * Restores a backup of an existing timestamp, if possible. Note that this method will throw if the timestamp
      * backup is unreadable, *and* the current bound is also unreadable.
+     *
+     * This method assumes that the timestamp table exists.
      */
     public synchronized void restoreFromBackup() {
         clientPool().runWithRetry(client -> {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -64,10 +64,9 @@ public class CassandraTimestampBackupRunner {
      *
      * This method assumes that the timestamp table exists.
      *
-     * @param defaultValue value to backup if the timestamp table is empty
      * @return value of the timestamp that was backed up, if applicable
      */
-    public synchronized long backupExistingTimestamp(long defaultValue) {
+    public synchronized long backupExistingTimestamp() {
         return clientPool().runWithRetry(client -> {
             BoundData boundData = getCurrentBoundData(client);
             byte[] currentBound = boundData.bound();
@@ -83,7 +82,8 @@ public class CassandraTimestampBackupRunner {
 
             Preconditions.checkState(currentBound == null || CassandraTimestampUtils.isValidTimestampData(currentBound),
                     "The timestamp is unreadable, though the backup is also unreadable! Please contact support.");
-            byte[] backupValue = MoreObjects.firstNonNull(currentBound, PtBytes.toBytes(defaultValue));
+            byte[] backupValue = MoreObjects.firstNonNull(currentBound,
+                    PtBytes.toBytes(CassandraTimestampUtils.INITIAL_VALUE));
             Map<String, Pair<byte[], byte[]>> casMap =
                     ImmutableMap.of(
                             CassandraTimestampUtils.ROW_AND_COLUMN_NAME,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -21,12 +21,12 @@ import org.slf4j.LoggerFactory;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.common.annotation.Idempotent;
 
-public class CassandraTimestampStore {
-    private static final Logger log = LoggerFactory.getLogger(CassandraTimestampStore.class);
+public class CassandraTimestampBackupRunner {
+    private static final Logger log = LoggerFactory.getLogger(CassandraTimestampBackupRunner.class);
 
     private final CassandraKeyValueService cassandraKeyValueService;
 
-    public CassandraTimestampStore(CassandraKeyValueService cassandraKeyValueService) {
+    public CassandraTimestampBackupRunner(CassandraKeyValueService cassandraKeyValueService) {
         this.cassandraKeyValueService = cassandraKeyValueService;
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -91,6 +91,7 @@ public class CassandraTimestampBackupRunner {
                             CassandraTimestampUtils.BACKUP_COLUMN_NAME,
                             Pair.create(currentBackupBound, backupValue)));
             executeQueryUnchecked(client, casQueryBuffer);
+            log.info("[BACKUP] Backed up the value {}", backupValue);
             return PtBytes.toLong(backupValue);
         });
     }
@@ -123,6 +124,7 @@ public class CassandraTimestampBackupRunner {
                             Pair.create(CassandraTimestampUtils.INVALIDATED_VALUE.toByteArray(), currentBackupBound),
                             CassandraTimestampUtils.BACKUP_COLUMN_NAME,
                             Pair.create(currentBackupBound, PtBytes.EMPTY_BYTE_ARRAY)));
+            log.info("[RESTORE] Restored the value {}", currentBackupBound);
             executeQueryUnchecked(client, casQueryBuffer);
             return null;
         });

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -179,7 +179,7 @@ public class CassandraTimestampBackupRunner {
     }
 
     private CassandraClientPool clientPool() {
-        return cassandraKeyValueService.clientPool;
+        return cassandraKeyValueService.getClientPool();
     }
 
     private TracingQueryRunner queryRunner() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -72,7 +72,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
 
     public static TimestampBoundStore create(CassandraKeyValueService kvs) {
         kvs.createTable(AtlasDbConstants.TIMESTAMP_TABLE, TIMESTAMP_TABLE_METADATA.persistToBytes());
-        return new CassandraTimestampBoundStore(kvs.clientPool);
+        return new CassandraTimestampBoundStore(kvs.getClientPool());
     }
 
     private CassandraTimestampBoundStore(CassandraClientPool clientPool) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -65,8 +65,6 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                         ColumnValueDescription.forType(ValueType.FIXED_LONG)))),
             ConflictHandler.IGNORE_ALL);
 
-    private static final long INITIAL_VALUE = 10000L;
-
     @GuardedBy("this")
     private long currentLimit = -1;
 
@@ -102,9 +100,10 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                     throw Throwables.throwUncheckedException(e);
                 }
                 if (result == null) {
-                    DebugLogger.logger.info("[GET] Null result, setting timestamp limit to {}", INITIAL_VALUE);
-                    cas(client, null, INITIAL_VALUE);
-                    return INITIAL_VALUE;
+                    DebugLogger.logger.info("[GET] Null result, setting timestamp limit to {}",
+                            CassandraTimestampUtils.INITIAL_VALUE);
+                    cas(client, null, CassandraTimestampUtils.INITIAL_VALUE);
+                    return CassandraTimestampUtils.INITIAL_VALUE;
                 }
                 Column column = result.getColumn();
                 currentLimit = PtBytes.toLong(column.getValue());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStore.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.common.annotation.Idempotent;
+
+public class CassandraTimestampStore {
+    private static final Logger log = LoggerFactory.getLogger(CassandraTimestampStore.class);
+
+    private final CassandraKeyValueService cassandraKeyValueService;
+
+    public CassandraTimestampStore(CassandraKeyValueService cassandraKeyValueService) {
+        this.cassandraKeyValueService = cassandraKeyValueService;
+    }
+
+    /**
+     * Creates the timestamp table, if it doesn't already exist.
+     */
+    @Idempotent
+    public void createTimestampTable() {
+        cassandraKeyValueService.createTable(
+                AtlasDbConstants.TIMESTAMP_TABLE,
+                CassandraTimestampUtils.TIMESTAMP_TABLE_METADATA.persistToBytes());
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -151,7 +151,8 @@ public final class CassandraTimestampUtils {
         return casResult.getRows().stream()
                     .filter(row -> {
                         String columnName = getColumnNameFromRow(row);
-                        return casMap.containsKey(columnName);})
+                        return casMap.containsKey(columnName);
+                    })
                     .collect(Collectors.toMap(
                             CassandraTimestampUtils::getColumnNameFromRow,
                             row -> getNamedColumnValue(row.getColumns(), VALUE_COLUMN)));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
@@ -159,7 +161,7 @@ public final class CassandraTimestampUtils {
         return PtBytes.toString(getNamedColumnValue(row.getColumns(), COLUMN_NAME_COLUMN));
     }
 
-    private static ImmutableIncongruency createIncongruency(
+    private static Incongruency createIncongruency(
             Map<String, byte[]> relevantCassandraState,
             String columnName,
             byte[] desiredValue) {
@@ -235,6 +237,7 @@ public final class CassandraTimestampUtils {
     interface Incongruency {
         String columnName();
         byte[] desiredState();
+        @Nullable
         byte[] actualState();
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -56,6 +56,7 @@ public final class CassandraTimestampUtils {
     public static final String ROW_AND_COLUMN_NAME = "ts";
     public static final String BACKUP_COLUMN_NAME = "oldTs";
     public static final ByteString INVALIDATED_VALUE = ByteString.copyFrom(new byte[] {0});
+    public static final long INITIAL_VALUE = 10000;
 
     private static final long CASSANDRA_TIMESTAMP = -1;
     private static final String ROW_AND_COLUMN_NAME_HEX_STRING = encodeCassandraHexString(ROW_AND_COLUMN_NAME);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -136,6 +136,11 @@ public final class CassandraTimestampUtils {
         }
     }
 
+    private static boolean isSuccessfullyApplied(CqlResult casResult) {
+        byte[] appliedValue = getNamedColumnValue(casResult.getRows().get(0).getColumns(), APPLIED_COLUMN);
+        return Arrays.equals(appliedValue, CQL_SUCCESS.toByteArray());
+    }
+
     private static Set<Incongruency> getIncongruencies(CqlResult casResult, Map<String, Pair<byte[], byte[]>> casMap) {
         Map<String, byte[]> relevantCassandraState = getRelevantCassandraState(casResult, casMap);
         return casMap.entrySet().stream()
@@ -171,11 +176,6 @@ public final class CassandraTimestampUtils {
                 .desiredState(desiredValue)
                 .actualState(relevantCassandraState.get(columnName))
                 .build();
-    }
-
-    private static boolean isSuccessfullyApplied(CqlResult casResult) {
-        Column appliedColumn = getNamedColumn(casResult.getRows().get(0).getColumns(), APPLIED_COLUMN);
-        return Arrays.equals(appliedColumn.getValue(), CQL_SUCCESS.toByteArray());
     }
 
     private static byte[] getNamedColumnValue(List<Column> columns, String columnName) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
+import com.palantir.atlasdb.table.description.ColumnValueDescription;
+import com.palantir.atlasdb.table.description.NameComponentDescription;
+import com.palantir.atlasdb.table.description.NameMetadataDescription;
+import com.palantir.atlasdb.table.description.NamedColumnDescription;
+import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+
+public final class CassandraTimestampUtils {
+    public static final TableMetadata TIMESTAMP_TABLE_METADATA = new TableMetadata(
+            NameMetadataDescription.create(ImmutableList.of(
+                    new NameComponentDescription("timestamp_name", ValueType.STRING))),
+            new ColumnMetadataDescription(ImmutableList.of(
+                    new NamedColumnDescription(
+                            CassandraTimestampUtils.ROW_AND_COLUMN_NAME,
+                            "current_max_ts",
+                            ColumnValueDescription.forType(ValueType.FIXED_LONG)))),
+            ConflictHandler.IGNORE_ALL);
+
+    public static final String ROW_AND_COLUMN_NAME = "ts";
+
+    private CassandraTimestampUtils() {
+        // utility class
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtils.java
@@ -28,6 +28,8 @@ import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -48,6 +50,8 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.util.Pair;
 
 public final class CassandraTimestampUtils {
+    private static final Logger log = LoggerFactory.getLogger(CassandraTimestampUtils.class);
+
     public static final TableMetadata TIMESTAMP_TABLE_METADATA = new TableMetadata(
             NameMetadataDescription.create(ImmutableList.of(
                     new NameComponentDescription("timestamp_name", ValueType.STRING))),
@@ -133,6 +137,12 @@ public final class CassandraTimestampUtils {
                 throw new IllegalStateException("[BACKUP/RESTORE] Observed incongruent state of the world; the"
                         + " following incongruencies were observed: " + incongruencies);
             }
+            /*
+             * If there are no incongruencies, then the state of the world is what we wanted it to be - possibly
+             * because we were upgrading and this call was made in parallel. Since the DB is in the desired state,
+             * we're continuing here.
+             */
+            log.debug("[BACKUP/RESTORE] CAS failed, but the DB state is as desired - continuing.");
         }
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -76,6 +76,34 @@ public class CassandraTimestampUtilsTest {
     }
 
     @Test
+    public void longConvertedToBytesIsValidTimestampData() {
+        assertThat(CassandraTimestampUtils.isValidTimestampData(PtBytes.toBytes(1234567L))).isTrue();
+        assertThat(CassandraTimestampUtils.isValidTimestampData(new byte[Long.BYTES])).isTrue();
+    }
+
+    @Test
+    public void invalidatedValueIsNotValidTimestampData() {
+        assertThat(CassandraTimestampUtils.isValidTimestampData(
+                CassandraTimestampUtils.INVALIDATED_VALUE.toByteArray()))
+                .isFalse();
+    }
+
+    @Test
+    public void emptyByteArrayIsNotValidTimestampData() {
+        assertThat(CassandraTimestampUtils.isValidTimestampData(EMPTY_BYTE_ARRAY)).isFalse();
+    }
+
+    @Test
+    public void nullIsNotValidTimestampData() {
+        assertThat(CassandraTimestampUtils.isValidTimestampData(null)).isFalse();
+    }
+
+    @Test
+    public void largeByteArrayIsNotValidTimestampData() {
+        assertThat(CassandraTimestampUtils.isValidTimestampData(new byte[100 * Long.BYTES])).isFalse();
+    }
+
+    @Test
     public void checkAndSetIsInsertIfNotExistsIfExpectedIsNull() {
         String query = queryBufferToString(CassandraTimestampUtils.constructCheckAndSetMultipleQuery(
                 ImmutableMap.of(COLUMN_NAME_1, Pair.create(null, VALUE_1))));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.apache.cassandra.thrift.Column;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.CqlRow;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.util.Pair;
+
+public class CassandraTimestampUtilsTest {
+    private static final long LONG_VALUE = 500L;
+
+    private static final byte[] KEY_1 = {120};
+    private static final String COLUMN_NAME_1 = "foo";
+    private static final byte[] COLUMN_BYTES_1 = PtBytes.toBytes(COLUMN_NAME_1);
+    private static final byte[] VALUE_1 = {4, 3, 2, 1};
+    private static final byte[] KEY_2 = {121};
+    private static final String COLUMN_NAME_2 = "bar";
+    private static final byte[] COLUMN_BYTES_2 = PtBytes.toBytes(COLUMN_NAME_2);
+    private static final byte[] VALUE_2 = {5, 9, 2, 6};
+
+    @Test
+    public void canGetValuesFromSelectionResult() {
+        List<Column> columnList1 = buildKeyValueColumnList(KEY_1, COLUMN_BYTES_1, VALUE_1);
+        List<Column> columnList2 = buildKeyValueColumnList(KEY_2, COLUMN_BYTES_2, VALUE_2);
+
+        CqlResult mockResult = createMockCqlResult(
+                ImmutableList.of(
+                        createMockCqlRow(columnList1),
+                        createMockCqlRow(columnList2)));
+        assertThat(CassandraTimestampUtils.getValuesFromSelectionResult(mockResult))
+                .isEqualTo(ImmutableMap.of(COLUMN_NAME_1, VALUE_1, COLUMN_NAME_2, VALUE_2));
+    }
+
+    @Test
+    public void canGetSelectQuery() {
+        String query = queryBufferToString(CassandraTimestampUtils.constructSelectFromTimestampTableQuery());
+        assertThat(query).isEqualTo("SELECT column1, value FROM \"_timestamp\" WHERE key=0x7473;");
+    }
+
+    @Test
+    public void checkAndSetIsInsertIfNotExistsIfExpectedIsNull() {
+        String query = queryBufferToString(CassandraTimestampUtils.constructCheckAndSetMultipleQuery(
+                ImmutableMap.of(COLUMN_NAME_1, Pair.create(null, VALUE_1))));
+        assertThat(query).contains("INSERT").contains("IF NOT EXISTS;");
+    }
+
+    @Test
+    public void checkAndSetIsUpdateIfEqualIfExpectedIsNotNull() {
+        String query = queryBufferToString(CassandraTimestampUtils.constructCheckAndSetMultipleQuery(
+                ImmutableMap.of(COLUMN_NAME_1, Pair.create(VALUE_1, VALUE_2))));
+        assertThat(query).contains("UPDATE").contains("IF " + CassandraTimestampUtils.VALUE_COLUMN + "=");
+    }
+
+    @Test
+    public void checkAndSetGeneratesBatchedStatements() {
+        String query = queryBufferToString(CassandraTimestampUtils.constructCheckAndSetMultipleQuery(
+                ImmutableMap.of(COLUMN_NAME_1, Pair.create(VALUE_1, VALUE_2),
+                        COLUMN_NAME_2, Pair.create(VALUE_2, VALUE_1))));
+        assertThat(query).contains("BEGIN UNLOGGED BATCH").contains("APPLY BATCH;");
+    }
+
+    private static List<Column> buildKeyValueColumnList(byte[] key, byte[] columnName, byte[] value) {
+        return ImmutableList.<Column>builder()
+                .add(createColumn("key", key))
+                .add(createColumn(CassandraTimestampUtils.COLUMN_NAME_COLUMN, columnName))
+                .add(createColumn(CassandraTimestampUtils.VALUE_COLUMN, value))
+                .build();
+    }
+
+    private static CqlRow createMockCqlRow(List<Column> columns) {
+        CqlRow row = mock(CqlRow.class);
+        when(row.getColumns()).thenReturn(columns);
+        return row;
+    }
+
+    private static CqlResult createMockCqlResult(List<CqlRow> rows) {
+        CqlResult result = mock(CqlResult.class);
+        when(result.getRows()).thenReturn(rows);
+        return result;
+    }
+
+    private static Column createColumn(String name, byte[] value) {
+        Column column = new Column();
+        column.setName(PtBytes.toBytes(name));
+        column.setValue(value);
+        return column;
+    }
+
+    private static String queryBufferToString(ByteBuffer query) {
+        return PtBytes.toString(query.array());
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -33,8 +33,6 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.util.Pair;
 
 public class CassandraTimestampUtilsTest {
-    private static final long LONG_VALUE = 500L;
-
     private static final byte[] KEY_1 = {120};
     private static final String COLUMN_NAME_1 = "foo";
     private static final byte[] COLUMN_BYTES_1 = PtBytes.toBytes(COLUMN_NAME_1);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -108,8 +108,8 @@ public class CassandraTimestampUtilsTest {
     public void unappliedResultIsCompatibleIfTheStateOfTheWorldMatchesTargets() {
         CqlResult mockResult = createMockCqlResult(
                 ImmutableList.of(
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_1, VALUE_1)),
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_2, VALUE_2))));
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_1, VALUE_1)),
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_2, VALUE_2))));
         CassandraTimestampUtils.verifyCompatible(mockResult, CAS_MAP_TWO_COLUMNS);
     }
 
@@ -117,9 +117,9 @@ public class CassandraTimestampUtilsTest {
     public void unappliedResultIsCompatibleIfWeHaveExtraRows() {
         CqlResult mockResult = createMockCqlResult(
                 ImmutableList.of(
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_1, VALUE_1)),
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_2, VALUE_2)),
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_3, VALUE_3))));
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_1, VALUE_1)),
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_2, VALUE_2)),
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_3, VALUE_3))));
         CassandraTimestampUtils.verifyCompatible(mockResult, CAS_MAP_TWO_COLUMNS);
     }
 
@@ -127,8 +127,8 @@ public class CassandraTimestampUtilsTest {
     public void unappliedResultIsIncompatibleIfTheStateOfTheWorldMatchesExpecteds() {
         CqlResult mockResult = createMockCqlResult(
                 ImmutableList.of(
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_1, EMPTY_BYTE_ARRAY)),
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_2, EMPTY_BYTE_ARRAY))));
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_1, EMPTY_BYTE_ARRAY)),
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_2, EMPTY_BYTE_ARRAY))));
         assertThatThrownBy(() -> CassandraTimestampUtils.verifyCompatible(mockResult, CAS_MAP_TWO_COLUMNS))
                 .isInstanceOf(IllegalStateException.class);
     }
@@ -137,8 +137,8 @@ public class CassandraTimestampUtilsTest {
     public void unappliedResultIsIncompatibleIfTheStateOfTheWorldIsIncorrect() {
         CqlResult mockResult = createMockCqlResult(
                 ImmutableList.of(
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_1, VALUE_2)),
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_2, VALUE_1))));
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_1, VALUE_2)),
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_2, VALUE_1))));
         assertThatThrownBy(() -> CassandraTimestampUtils.verifyCompatible(mockResult, CAS_MAP_TWO_COLUMNS))
                 .isInstanceOf(IllegalStateException.class);
     }
@@ -147,7 +147,7 @@ public class CassandraTimestampUtilsTest {
     public void unappliedResultIsIncompatibleIfWeHaveMissingRows() {
         CqlResult mockResult = createMockCqlResult(
                 ImmutableList.of(
-                        createMockCqlRow(buildApplicationColumnList(false, COLUMN_BYTES_1, VALUE_1))));
+                        createMockCqlRow(buildUnappliedColumnList(COLUMN_BYTES_1, VALUE_1))));
         assertThatThrownBy(() -> CassandraTimestampUtils.verifyCompatible(mockResult, CAS_MAP_TWO_COLUMNS))
                 .isInstanceOf(IllegalStateException.class);
     }
@@ -158,10 +158,9 @@ public class CassandraTimestampUtilsTest {
                 .build();
     }
 
-    private static List<Column> buildApplicationColumnList(boolean applied, byte[] columnName, byte[] value) {
+    private static List<Column> buildUnappliedColumnList(byte[] columnName, byte[] value) {
         return ImmutableList.<Column>builder()
-                .add(createColumn(CassandraTimestampUtils.APPLIED_COLUMN,
-                        applied ? CQL_SUCCESS : CQL_FAILURE))
+                .add(createColumn(CassandraTimestampUtils.APPLIED_COLUMN, CQL_FAILURE))
                 .add(createColumn(CassandraTimestampUtils.COLUMN_NAME_COLUMN, columnName))
                 .add(createColumn(CassandraTimestampUtils.VALUE_COLUMN, value))
                 .build();

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -126,6 +126,13 @@ public class CassandraTimestampUtilsTest {
     }
 
     @Test
+    public void checkAndSetThrowsIfTryingToSetToNull() {
+        assertThatThrownBy(() -> CassandraTimestampUtils.constructCheckAndSetMultipleQuery(
+                ImmutableMap.of(COLUMN_NAME_1, Pair.create(VALUE_1, null))))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
     public void appliedResultIsCompatible() {
         CqlResult mockResult = createMockCqlResult(
                 ImmutableList.of(createMockCqlRow(buildAppliedColumnList())));


### PR DESCRIPTION
This change:
* Introduces `CassandraTimestampBackupRunner` (CTBR) which runs timestamp bound invalidation/revalidation operations.
* Introduces an explicit validation of the state after the CAS operations in CTBR (i.e. your operation was applied, _or_ it was not but the state of the world matches what you wanted to make it).
* Unit and integration tests for all of the above

Basically it was decided that the migration to CQL in #1558 is higher risk than the team would like to take at this time, so this change leaves the CassandraTimestampBoundStore codepaths largely untouched.

Effectively this is #1558 minus the changes to CTBS and CTS codepaths and tests exclusive to the removed functionality, plus more aggressive validation logic to explicitly ensure that it's safe to proceed after a backup or restore.

Of course this is not-great from a code quality point of view, but the cost of a misfire in CTBS would be extremely high.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1569)
<!-- Reviewable:end -->
