### PR TITLE
Add typing information for rangeDeletion in generated code

### DIFF
--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -10,6 +10,7 @@ repositories {
 
 schemas = [
     'com.palantir.atlasdb.schema.SweepSchema',
+    'com.palantir.atlasdb.table.description.GenericTestSchema'
 ]
 
 libsDirName = file('build/artifacts')

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -1273,5 +1273,5 @@ public final class SweepPriorityTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "URN0DNH5wLcp9bwsNvieGQ==";
+    static String __CLASS_HASH = "uFAsbtFcwZvbKKbo+LobGg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -1016,7 +1016,7 @@ public final class SweepPriorityTable implements
     }
 
     @Override
-    public void delete(Iterable<SweepPriorityRow> rows) {
+    public void delete(Iterable<? extends SweepPriorityRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size() * 5);
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("d")));
@@ -1094,7 +1094,7 @@ public final class SweepPriorityTable implements
     }
 
     @Override
-    public Multimap<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> getRowsMultimap(Iterable<SweepPriorityRow> rows) {
+    public Multimap<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> getRowsMultimap(Iterable<? extends SweepPriorityRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -1120,7 +1120,7 @@ public final class SweepPriorityTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> getRowsMultimapInternal(Iterable<SweepPriorityRow> rows, ColumnSelection columns) {
+    private Multimap<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends SweepPriorityRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
@@ -1016,7 +1016,7 @@ public final class SweepProgressTable implements
     }
 
     @Override
-    public void delete(Iterable<SweepProgressRow> rows) {
+    public void delete(Iterable<? extends SweepProgressRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size() * 5);
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("d")));
@@ -1094,7 +1094,7 @@ public final class SweepProgressTable implements
     }
 
     @Override
-    public Multimap<SweepProgressRow, SweepProgressNamedColumnValue<?>> getRowsMultimap(Iterable<SweepProgressRow> rows) {
+    public Multimap<SweepProgressRow, SweepProgressNamedColumnValue<?>> getRowsMultimap(Iterable<? extends SweepProgressRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -1120,7 +1120,7 @@ public final class SweepProgressTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<SweepProgressRow, SweepProgressNamedColumnValue<?>> getRowsMultimapInternal(Iterable<SweepProgressRow> rows, ColumnSelection columns) {
+    private Multimap<SweepProgressRow, SweepProgressNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends SweepProgressRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
@@ -1273,5 +1273,5 @@ public final class SweepProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "D+ku3UNbkHgU75aRsw008A==";
+    static String __CLASS_HASH = "V3qBerbzC3jrbSvCI/vomA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbImmutableTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbImmutableTable.java
@@ -34,7 +34,7 @@ public interface AtlasDbImmutableTable<ROW, COLUMN_VALUE, ROW_RESULT> extends Co
     List<COLUMN_VALUE> getRowColumns(ROW row);
     List<COLUMN_VALUE> getRowColumns(ROW row,
                                      ColumnSelection columnSelection);
-    Multimap<ROW, COLUMN_VALUE> getRowsMultimap(Iterable<ROW> rows);
+    Multimap<ROW, COLUMN_VALUE> getRowsMultimap(Iterable<? extends ROW> rows);
     Multimap<ROW, COLUMN_VALUE> getRowsMultimap(Iterable<ROW> rows,
                                                 ColumnSelection columnSelection);
     Multimap<ROW, COLUMN_VALUE> getAsyncRowsMultimap(Iterable<ROW> rows,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbNamedMutableTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbNamedMutableTable.java
@@ -22,5 +22,5 @@ package com.palantir.atlasdb.table.api;
 public interface AtlasDbNamedMutableTable<ROW, COLUMN_VALUE, ROW_RESULT> extends
         AtlasDbNamedImmutableTable<ROW, COLUMN_VALUE, ROW_RESULT> {
     void delete(ROW rows);
-    void delete(Iterable<ROW> rows);
+    void delete(Iterable<? extends ROW> rows);
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -936,7 +936,7 @@ public class TableRenderer {
             } line("}");
             line();
             line("@Override");
-            line("public void delete(Iterable<", Row, "> rows) {"); {
+            line("public void delete(Iterable<? extends ", Row, "> rows) {"); {
 
                 if (!cellReferencingIndices.isEmpty()) {
                     line("Multimap<", Row, ", ", ColumnValue, "> result = getRowsMultimap(rows);");
@@ -1132,7 +1132,7 @@ public class TableRenderer {
 
         private void renderGetRowsMultimap(boolean isDynamic) {
             line("@Override");
-            line("public Multimap<", Row, ", ", ColumnValue, "> getRowsMultimap(Iterable<", Row, "> rows) {"); {
+            line("public Multimap<", Row, ", ", ColumnValue, "> getRowsMultimap(Iterable<? extends ", Row, "> rows) {"); {
                 line("return getRowsMultimapInternal(rows, allColumns);");
             } line("}");
             line();
@@ -1158,7 +1158,7 @@ public class TableRenderer {
                 line("return AsyncProxy.create(exec.submit(c), Multimap.class);");
             } line("}");
             line();
-            line("private Multimap<", Row, ", ", ColumnValue, "> getRowsMultimapInternal(Iterable<", Row, "> rows, ColumnSelection columns) {"); {
+            line("private Multimap<", Row, ", ", ColumnValue, "> getRowsMultimapInternal(Iterable<? extends ", Row, "> rows, ColumnSelection columns) {"); {
                 line("SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);");
                 line("return getRowMapFromRowResults(results.values());");
             } line("}");

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/GenericTestSchema.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/GenericTestSchema.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.table.description;
+
+import java.io.File;
+
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.schema.AtlasSchema;
+
+public class GenericTestSchema implements AtlasSchema {
+    public static final AtlasSchema INSTANCE = new GenericTestSchema();
+
+    private static final Schema GENERIC_TEST_SCHEMA = generateSchema();
+
+    private static Schema generateSchema() {
+        Schema schema = new Schema("GenericTestSchema",
+                GenericTestSchema.class.getPackage().getName() + ".generated",
+                Namespace.DEFAULT_NAMESPACE);
+
+        // use for testing rangeScanAllowed code
+        schema.addTableDefinition("tableA", new TableDefinition() {{
+            javaTableName("TableA");
+
+            rowName();
+            rowComponent("component1", ValueType.STRING);
+
+            columns();
+            column("column1", "c", ValueType.VAR_LONG);
+
+            rangeScanAllowed();
+        }});
+
+        schema.addTableDefinition("tableB", new TableDefinition() {{
+            javaTableName("TableB");
+
+            rowName();
+            rowComponent("component1", ValueType.SHA256HASH);
+
+            columns();
+                dynamicColumns();
+                columnComponent("component2", ValueType.STRING);
+                value(ValueType.STRING);
+
+            rangeScanAllowed();
+        }});
+
+        return schema;
+    }
+
+    public static Schema getSchema() {
+        return GENERIC_TEST_SCHEMA;
+    }
+
+    public static void main(String[]  args) throws Exception {
+        GENERIC_TEST_SCHEMA.renderTables(new File("src/test/java"));
+    }
+
+    @Override
+    public Schema getLatestSchema() {
+        return GENERIC_TEST_SCHEMA;
+    }
+
+    @Override
+    public Namespace getNamespace() {
+        return Namespace.DEFAULT_NAMESPACE;
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/GenericTestSchema.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/GenericTestSchema.java
@@ -31,8 +31,8 @@ public class GenericTestSchema implements AtlasSchema {
                 Namespace.DEFAULT_NAMESPACE);
 
         // use for testing rangeScanAllowed code
-        schema.addTableDefinition("tableA", new TableDefinition() {{
-            javaTableName("TableA");
+        schema.addTableDefinition("rangeScanTest", new TableDefinition() {{
+            javaTableName("RangeScanTest");
 
             rowName();
             rowComponent("component1", ValueType.STRING);
@@ -43,8 +43,8 @@ public class GenericTestSchema implements AtlasSchema {
             rangeScanAllowed();
         }});
 
-        schema.addTableDefinition("tableB", new TableDefinition() {{
-            javaTableName("TableB");
+        schema.addTableDefinition("genericRangeScanTest", new TableDefinition() {{
+            javaTableName("GenericRangeScanTest");
 
             rowName();
             rowComponent("component1", ValueType.SHA256HASH);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -87,30 +87,30 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-public final class TableBTable implements
-        AtlasDbDynamicMutablePersistentTable<TableBTable.TableBRow,
-                                                TableBTable.TableBColumn,
-                                                TableBTable.TableBColumnValue,
-                                                TableBTable.TableBRowResult> {
+public final class GenericRangeScanTestTable implements
+        AtlasDbDynamicMutablePersistentTable<GenericRangeScanTestTable.GenericRangeScanTestRow,
+                                                GenericRangeScanTestTable.GenericRangeScanTestColumn,
+                                                GenericRangeScanTestTable.GenericRangeScanTestColumnValue,
+                                                GenericRangeScanTestTable.GenericRangeScanTestRowResult> {
     private final Transaction t;
-    private final List<TableBTrigger> triggers;
-    private final static String rawTableName = "tableB";
+    private final List<GenericRangeScanTestTrigger> triggers;
+    private final static String rawTableName = "genericRangeScanTest";
     private final TableReference tableRef;
     private final static ColumnSelection allColumns = ColumnSelection.all();
 
-    static TableBTable of(Transaction t, Namespace namespace) {
-        return new TableBTable(t, namespace, ImmutableList.<TableBTrigger>of());
+    static GenericRangeScanTestTable of(Transaction t, Namespace namespace) {
+        return new GenericRangeScanTestTable(t, namespace, ImmutableList.<GenericRangeScanTestTrigger>of());
     }
 
-    static TableBTable of(Transaction t, Namespace namespace, TableBTrigger trigger, TableBTrigger... triggers) {
-        return new TableBTable(t, namespace, ImmutableList.<TableBTrigger>builder().add(trigger).add(triggers).build());
+    static GenericRangeScanTestTable of(Transaction t, Namespace namespace, GenericRangeScanTestTrigger trigger, GenericRangeScanTestTrigger... triggers) {
+        return new GenericRangeScanTestTable(t, namespace, ImmutableList.<GenericRangeScanTestTrigger>builder().add(trigger).add(triggers).build());
     }
 
-    static TableBTable of(Transaction t, Namespace namespace, List<TableBTrigger> triggers) {
-        return new TableBTable(t, namespace, triggers);
+    static GenericRangeScanTestTable of(Transaction t, Namespace namespace, List<GenericRangeScanTestTrigger> triggers) {
+        return new GenericRangeScanTestTable(t, namespace, triggers);
     }
 
-    private TableBTable(Transaction t, Namespace namespace, List<TableBTrigger> triggers) {
+    private GenericRangeScanTestTable(Transaction t, Namespace namespace, List<GenericRangeScanTestTrigger> triggers) {
         this.t = t;
         this.tableRef = TableReference.create(namespace, rawTableName);
         this.triggers = triggers;
@@ -134,19 +134,19 @@ public final class TableBTable implements
 
     /**
      * <pre>
-     * TableBRow {
+     * GenericRangeScanTestRow {
      *   {@literal Sha256Hash component1};
      * }
      * </pre>
      */
-    public static final class TableBRow implements Persistable, Comparable<TableBRow> {
+    public static final class GenericRangeScanTestRow implements Persistable, Comparable<GenericRangeScanTestRow> {
         private final Sha256Hash component1;
 
-        public static TableBRow of(Sha256Hash component1) {
-            return new TableBRow(component1);
+        public static GenericRangeScanTestRow of(Sha256Hash component1) {
+            return new GenericRangeScanTestRow(component1);
         }
 
-        private TableBRow(Sha256Hash component1) {
+        private GenericRangeScanTestRow(Sha256Hash component1) {
             this.component1 = component1;
         }
 
@@ -154,20 +154,20 @@ public final class TableBTable implements
             return component1;
         }
 
-        public static Function<TableBRow, Sha256Hash> getComponent1Fun() {
-            return new Function<TableBRow, Sha256Hash>() {
+        public static Function<GenericRangeScanTestRow, Sha256Hash> getComponent1Fun() {
+            return new Function<GenericRangeScanTestRow, Sha256Hash>() {
                 @Override
-                public Sha256Hash apply(TableBRow row) {
+                public Sha256Hash apply(GenericRangeScanTestRow row) {
                     return row.component1;
                 }
             };
         }
 
-        public static Function<Sha256Hash, TableBRow> fromComponent1Fun() {
-            return new Function<Sha256Hash, TableBRow>() {
+        public static Function<Sha256Hash, GenericRangeScanTestRow> fromComponent1Fun() {
+            return new Function<Sha256Hash, GenericRangeScanTestRow>() {
                 @Override
-                public TableBRow apply(Sha256Hash row) {
-                    return TableBRow.of(row);
+                public GenericRangeScanTestRow apply(Sha256Hash row) {
+                    return GenericRangeScanTestRow.of(row);
                 }
             };
         }
@@ -178,13 +178,13 @@ public final class TableBTable implements
             return EncodingUtils.add(component1Bytes);
         }
 
-        public static final Hydrator<TableBRow> BYTES_HYDRATOR = new Hydrator<TableBRow>() {
+        public static final Hydrator<GenericRangeScanTestRow> BYTES_HYDRATOR = new Hydrator<GenericRangeScanTestRow>() {
             @Override
-            public TableBRow hydrateFromBytes(byte[] __input) {
+            public GenericRangeScanTestRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash component1 = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
                 __index += 32;
-                return new TableBRow(component1);
+                return new GenericRangeScanTestRow(component1);
             }
         };
 
@@ -206,7 +206,7 @@ public final class TableBTable implements
             if (getClass() != obj.getClass()) {
                 return false;
             }
-            TableBRow other = (TableBRow) obj;
+            GenericRangeScanTestRow other = (GenericRangeScanTestRow) obj;
             return Objects.equal(component1, other.component1);
         }
 
@@ -216,7 +216,7 @@ public final class TableBTable implements
         }
 
         @Override
-        public int compareTo(TableBRow o) {
+        public int compareTo(GenericRangeScanTestRow o) {
             return ComparisonChain.start()
                 .compare(this.component1, o.component1)
                 .result();
@@ -225,19 +225,19 @@ public final class TableBTable implements
 
     /**
      * <pre>
-     * TableBColumn {
+     * GenericRangeScanTestColumn {
      *   {@literal String component2};
      * }
      * </pre>
      */
-    public static final class TableBColumn implements Persistable, Comparable<TableBColumn> {
+    public static final class GenericRangeScanTestColumn implements Persistable, Comparable<GenericRangeScanTestColumn> {
         private final String component2;
 
-        public static TableBColumn of(String component2) {
-            return new TableBColumn(component2);
+        public static GenericRangeScanTestColumn of(String component2) {
+            return new GenericRangeScanTestColumn(component2);
         }
 
-        private TableBColumn(String component2) {
+        private GenericRangeScanTestColumn(String component2) {
             this.component2 = component2;
         }
 
@@ -245,20 +245,20 @@ public final class TableBTable implements
             return component2;
         }
 
-        public static Function<TableBColumn, String> getComponent2Fun() {
-            return new Function<TableBColumn, String>() {
+        public static Function<GenericRangeScanTestColumn, String> getComponent2Fun() {
+            return new Function<GenericRangeScanTestColumn, String>() {
                 @Override
-                public String apply(TableBColumn row) {
+                public String apply(GenericRangeScanTestColumn row) {
                     return row.component2;
                 }
             };
         }
 
-        public static Function<String, TableBColumn> fromComponent2Fun() {
-            return new Function<String, TableBColumn>() {
+        public static Function<String, GenericRangeScanTestColumn> fromComponent2Fun() {
+            return new Function<String, GenericRangeScanTestColumn>() {
                 @Override
-                public TableBColumn apply(String row) {
-                    return TableBColumn.of(row);
+                public GenericRangeScanTestColumn apply(String row) {
+                    return GenericRangeScanTestColumn.of(row);
                 }
             };
         }
@@ -269,13 +269,13 @@ public final class TableBTable implements
             return EncodingUtils.add(component2Bytes);
         }
 
-        public static final Hydrator<TableBColumn> BYTES_HYDRATOR = new Hydrator<TableBColumn>() {
+        public static final Hydrator<GenericRangeScanTestColumn> BYTES_HYDRATOR = new Hydrator<GenericRangeScanTestColumn>() {
             @Override
-            public TableBColumn hydrateFromBytes(byte[] __input) {
+            public GenericRangeScanTestColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String component2 = PtBytes.toString(__input, __index, __input.length-__index);
                 __index += 0;
-                return new TableBColumn(component2);
+                return new GenericRangeScanTestColumn(component2);
             }
         };
 
@@ -297,7 +297,7 @@ public final class TableBTable implements
             if (getClass() != obj.getClass()) {
                 return false;
             }
-            TableBColumn other = (TableBColumn) obj;
+            GenericRangeScanTestColumn other = (GenericRangeScanTestColumn) obj;
             return Objects.equal(component2, other.component2);
         }
 
@@ -307,15 +307,15 @@ public final class TableBTable implements
         }
 
         @Override
-        public int compareTo(TableBColumn o) {
+        public int compareTo(GenericRangeScanTestColumn o) {
             return ComparisonChain.start()
                 .compare(this.component2, o.component2)
                 .result();
         }
     }
 
-    public interface TableBTrigger {
-        public void putTableB(Multimap<TableBRow, ? extends TableBColumnValue> newRows);
+    public interface GenericRangeScanTestTrigger {
+        public void putGenericRangeScanTest(Multimap<GenericRangeScanTestRow, ? extends GenericRangeScanTestColumnValue> newRows);
     }
 
     /**
@@ -328,20 +328,20 @@ public final class TableBTable implements
      * }
      * </pre>
      */
-    public static final class TableBColumnValue implements ColumnValue<String> {
-        private final TableBColumn columnName;
+    public static final class GenericRangeScanTestColumnValue implements ColumnValue<String> {
+        private final GenericRangeScanTestColumn columnName;
         private final String value;
 
-        public static TableBColumnValue of(TableBColumn columnName, String value) {
-            return new TableBColumnValue(columnName, value);
+        public static GenericRangeScanTestColumnValue of(GenericRangeScanTestColumn columnName, String value) {
+            return new GenericRangeScanTestColumnValue(columnName, value);
         }
 
-        private TableBColumnValue(TableBColumn columnName, String value) {
+        private GenericRangeScanTestColumnValue(GenericRangeScanTestColumn columnName, String value) {
             this.columnName = columnName;
             this.value = value;
         }
 
-        public TableBColumn getColumnName() {
+        public GenericRangeScanTestColumn getColumnName() {
             return columnName;
         }
 
@@ -366,19 +366,19 @@ public final class TableBTable implements
             return PtBytes.toString(bytes, 0, bytes.length-0);
         }
 
-        public static Function<TableBColumnValue, TableBColumn> getColumnNameFun() {
-            return new Function<TableBColumnValue, TableBColumn>() {
+        public static Function<GenericRangeScanTestColumnValue, GenericRangeScanTestColumn> getColumnNameFun() {
+            return new Function<GenericRangeScanTestColumnValue, GenericRangeScanTestColumn>() {
                 @Override
-                public TableBColumn apply(TableBColumnValue columnValue) {
+                public GenericRangeScanTestColumn apply(GenericRangeScanTestColumnValue columnValue) {
                     return columnValue.getColumnName();
                 }
             };
         }
 
-        public static Function<TableBColumnValue, String> getValueFun() {
-            return new Function<TableBColumnValue, String>() {
+        public static Function<GenericRangeScanTestColumnValue, String> getValueFun() {
+            return new Function<GenericRangeScanTestColumnValue, String>() {
                 @Override
-                public String apply(TableBColumnValue columnValue) {
+                public String apply(GenericRangeScanTestColumnValue columnValue) {
                     return columnValue.getValue();
                 }
             };
@@ -393,48 +393,48 @@ public final class TableBTable implements
         }
     }
 
-    public static final class TableBRowResult implements TypedRowResult {
-        private final TableBRow rowName;
-        private final ImmutableSet<TableBColumnValue> columnValues;
+    public static final class GenericRangeScanTestRowResult implements TypedRowResult {
+        private final GenericRangeScanTestRow rowName;
+        private final ImmutableSet<GenericRangeScanTestColumnValue> columnValues;
 
-        public static TableBRowResult of(RowResult<byte[]> rowResult) {
-            TableBRow rowName = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
-            Set<TableBColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+        public static GenericRangeScanTestRowResult of(RowResult<byte[]> rowResult) {
+            GenericRangeScanTestRow rowName = GenericRangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<GenericRangeScanTestColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
-                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-                String value = TableBColumnValue.hydrateValue(e.getValue());
-                columnValues.add(TableBColumnValue.of(col, value));
+                GenericRangeScanTestColumn col = GenericRangeScanTestColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                String value = GenericRangeScanTestColumnValue.hydrateValue(e.getValue());
+                columnValues.add(GenericRangeScanTestColumnValue.of(col, value));
             }
-            return new TableBRowResult(rowName, ImmutableSet.copyOf(columnValues));
+            return new GenericRangeScanTestRowResult(rowName, ImmutableSet.copyOf(columnValues));
         }
 
-        private TableBRowResult(TableBRow rowName, ImmutableSet<TableBColumnValue> columnValues) {
+        private GenericRangeScanTestRowResult(GenericRangeScanTestRow rowName, ImmutableSet<GenericRangeScanTestColumnValue> columnValues) {
             this.rowName = rowName;
             this.columnValues = columnValues;
         }
 
         @Override
-        public TableBRow getRowName() {
+        public GenericRangeScanTestRow getRowName() {
             return rowName;
         }
 
-        public Set<TableBColumnValue> getColumnValues() {
+        public Set<GenericRangeScanTestColumnValue> getColumnValues() {
             return columnValues;
         }
 
-        public static Function<TableBRowResult, TableBRow> getRowNameFun() {
-            return new Function<TableBRowResult, TableBRow>() {
+        public static Function<GenericRangeScanTestRowResult, GenericRangeScanTestRow> getRowNameFun() {
+            return new Function<GenericRangeScanTestRowResult, GenericRangeScanTestRow>() {
                 @Override
-                public TableBRow apply(TableBRowResult rowResult) {
+                public GenericRangeScanTestRow apply(GenericRangeScanTestRowResult rowResult) {
                     return rowResult.rowName;
                 }
             };
         }
 
-        public static Function<TableBRowResult, ImmutableSet<TableBColumnValue>> getColumnValuesFun() {
-            return new Function<TableBRowResult, ImmutableSet<TableBColumnValue>>() {
+        public static Function<GenericRangeScanTestRowResult, ImmutableSet<GenericRangeScanTestColumnValue>> getColumnValuesFun() {
+            return new Function<GenericRangeScanTestRowResult, ImmutableSet<GenericRangeScanTestColumnValue>>() {
                 @Override
-                public ImmutableSet<TableBColumnValue> apply(TableBRowResult rowResult) {
+                public ImmutableSet<GenericRangeScanTestColumnValue> apply(GenericRangeScanTestRowResult rowResult) {
                     return rowResult.columnValues;
                 }
             };
@@ -450,60 +450,60 @@ public final class TableBTable implements
     }
 
     @Override
-    public void delete(TableBRow row, TableBColumn column) {
+    public void delete(GenericRangeScanTestRow row, GenericRangeScanTestColumn column) {
         delete(ImmutableMultimap.of(row, column));
     }
 
     @Override
-    public void delete(Iterable<TableBRow> rows) {
-        Multimap<TableBRow, TableBColumn> toRemove = HashMultimap.create();
-        Multimap<TableBRow, TableBColumnValue> result = getRowsMultimap(rows);
-        for (Entry<TableBRow, TableBColumnValue> e : result.entries()) {
+    public void delete(Iterable<GenericRangeScanTestRow> rows) {
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> toRemove = HashMultimap.create();
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> result = getRowsMultimap(rows);
+        for (Entry<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> e : result.entries()) {
             toRemove.put(e.getKey(), e.getValue().getColumnName());
         }
         delete(toRemove);
     }
 
     @Override
-    public void delete(Multimap<TableBRow, TableBColumn> values) {
+    public void delete(Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> values) {
         t.delete(tableRef, ColumnValues.toCells(values));
     }
 
     @Override
-    public void put(TableBRow rowName, Iterable<TableBColumnValue> values) {
-        put(ImmutableMultimap.<TableBRow, TableBColumnValue>builder().putAll(rowName, values).build());
+    public void put(GenericRangeScanTestRow rowName, Iterable<GenericRangeScanTestColumnValue> values) {
+        put(ImmutableMultimap.<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>builder().putAll(rowName, values).build());
     }
 
     @Override
-    public void put(TableBRow rowName, TableBColumnValue... values) {
-        put(ImmutableMultimap.<TableBRow, TableBColumnValue>builder().putAll(rowName, values).build());
+    public void put(GenericRangeScanTestRow rowName, GenericRangeScanTestColumnValue... values) {
+        put(ImmutableMultimap.<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>builder().putAll(rowName, values).build());
     }
 
     @Override
-    public void put(Multimap<TableBRow, ? extends TableBColumnValue> values) {
+    public void put(Multimap<GenericRangeScanTestRow, ? extends GenericRangeScanTestColumnValue> values) {
         t.useTable(tableRef, this);
         t.put(tableRef, ColumnValues.toCellValues(values));
-        for (TableBTrigger trigger : triggers) {
-            trigger.putTableB(values);
+        for (GenericRangeScanTestTrigger trigger : triggers) {
+            trigger.putGenericRangeScanTest(values);
         }
     }
 
     @Override
-    public void putUnlessExists(TableBRow rowName, Iterable<TableBColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<TableBRow, TableBColumnValue>builder().putAll(rowName, values).build());
+    public void putUnlessExists(GenericRangeScanTestRow rowName, Iterable<GenericRangeScanTestColumnValue> values) {
+        putUnlessExists(ImmutableMultimap.<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>builder().putAll(rowName, values).build());
     }
 
     @Override
-    public void putUnlessExists(TableBRow rowName, TableBColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<TableBRow, TableBColumnValue>builder().putAll(rowName, values).build());
+    public void putUnlessExists(GenericRangeScanTestRow rowName, GenericRangeScanTestColumnValue... values) {
+        putUnlessExists(ImmutableMultimap.<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>builder().putAll(rowName, values).build());
     }
 
     @Override
-    public void putUnlessExists(Multimap<TableBRow, ? extends TableBColumnValue> rows) {
-        Multimap<TableBRow, TableBColumn> toGet = Multimaps.transformValues(rows, TableBColumnValue.getColumnNameFun());
-        Multimap<TableBRow, TableBColumnValue> existing = get(toGet);
-        Multimap<TableBRow, TableBColumnValue> toPut = HashMultimap.create();
-        for (Entry<TableBRow, ? extends TableBColumnValue> entry : rows.entries()) {
+    public void putUnlessExists(Multimap<GenericRangeScanTestRow, ? extends GenericRangeScanTestColumnValue> rows) {
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> toGet = Multimaps.transformValues(rows, GenericRangeScanTestColumnValue.getColumnNameFun());
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> existing = get(toGet);
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> toPut = HashMultimap.create();
+        for (Entry<GenericRangeScanTestRow, ? extends GenericRangeScanTestColumnValue> entry : rows.entries()) {
             if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
                 toPut.put(entry.getKey(), entry.getValue());
             }
@@ -512,46 +512,46 @@ public final class TableBTable implements
     }
 
     @Override
-    public void touch(Multimap<TableBRow, TableBColumn> values) {
-        Multimap<TableBRow, TableBColumnValue> currentValues = get(values);
+    public void touch(Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> values) {
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> currentValues = get(values);
         put(currentValues);
-        Multimap<TableBRow, TableBColumn> toDelete = HashMultimap.create(values);
-        for (Map.Entry<TableBRow, TableBColumnValue> e : currentValues.entries()) {
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> e : currentValues.entries()) {
             toDelete.remove(e.getKey(), e.getValue().getColumnName());
         }
         delete(toDelete);
     }
 
-    public static ColumnSelection getColumnSelection(Collection<TableBColumn> cols) {
+    public static ColumnSelection getColumnSelection(Collection<GenericRangeScanTestColumn> cols) {
         return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
     }
 
-    public static ColumnSelection getColumnSelection(TableBColumn... cols) {
+    public static ColumnSelection getColumnSelection(GenericRangeScanTestColumn... cols) {
         return getColumnSelection(Arrays.asList(cols));
     }
 
     @Override
-    public Multimap<TableBRow, TableBColumnValue> get(Multimap<TableBRow, TableBColumn> cells) {
+    public Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> get(Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> cells) {
         Set<Cell> rawCells = ColumnValues.toCells(cells);
         Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
-        Multimap<TableBRow, TableBColumnValue> rowMap = HashMultimap.create();
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> rowMap = HashMultimap.create();
         for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
             if (e.getValue().length > 0) {
-                TableBRow row = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
-                String val = TableBColumnValue.hydrateValue(e.getValue());
-                rowMap.put(row, TableBColumnValue.of(col, val));
+                GenericRangeScanTestRow row = GenericRangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                GenericRangeScanTestColumn col = GenericRangeScanTestColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                String val = GenericRangeScanTestColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, GenericRangeScanTestColumnValue.of(col, val));
             }
         }
         return rowMap;
     }
 
     @Override
-    public Multimap<TableBRow, TableBColumnValue> getAsync(final Multimap<TableBRow, TableBColumn> cells, ExecutorService exec) {
-        Callable<Multimap<TableBRow, TableBColumnValue>> c =
-                new Callable<Multimap<TableBRow, TableBColumnValue>>() {
+    public Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> getAsync(final Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> cells, ExecutorService exec) {
+        Callable<Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>> c =
+                new Callable<Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>>() {
             @Override
-            public Multimap<TableBRow, TableBColumnValue> call() {
+            public Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> call() {
                 return get(cells);
             }
         };
@@ -559,82 +559,82 @@ public final class TableBTable implements
     }
 
     @Override
-    public List<TableBColumnValue> getRowColumns(TableBRow row) {
+    public List<GenericRangeScanTestColumnValue> getRowColumns(GenericRangeScanTestRow row) {
         return getRowColumns(row, allColumns);
     }
 
     @Override
-    public List<TableBColumnValue> getRowColumns(TableBRow row, ColumnSelection columns) {
+    public List<GenericRangeScanTestColumnValue> getRowColumns(GenericRangeScanTestRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return ImmutableList.of();
         } else {
-            List<TableBColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            List<GenericRangeScanTestColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
-                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-                String val = TableBColumnValue.hydrateValue(e.getValue());
-                ret.add(TableBColumnValue.of(col, val));
+                GenericRangeScanTestColumn col = GenericRangeScanTestColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                String val = GenericRangeScanTestColumnValue.hydrateValue(e.getValue());
+                ret.add(GenericRangeScanTestColumnValue.of(col, val));
             }
             return ret;
         }
     }
 
     @Override
-    public Multimap<TableBRow, TableBColumnValue> getRowsMultimap(Iterable<? extends TableBRow> rows) {
+    public Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> getRowsMultimap(Iterable<? extends GenericRangeScanTestRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
     @Override
-    public Multimap<TableBRow, TableBColumnValue> getRowsMultimap(Iterable<TableBRow> rows, ColumnSelection columns) {
+    public Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> getRowsMultimap(Iterable<GenericRangeScanTestRow> rows, ColumnSelection columns) {
         return getRowsMultimapInternal(rows, columns);
     }
 
     @Override
-    public Multimap<TableBRow, TableBColumnValue> getAsyncRowsMultimap(Iterable<TableBRow> rows, ExecutorService exec) {
+    public Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> getAsyncRowsMultimap(Iterable<GenericRangeScanTestRow> rows, ExecutorService exec) {
         return getAsyncRowsMultimap(rows, allColumns, exec);
     }
 
     @Override
-    public Multimap<TableBRow, TableBColumnValue> getAsyncRowsMultimap(final Iterable<TableBRow> rows, final ColumnSelection columns, ExecutorService exec) {
-        Callable<Multimap<TableBRow, TableBColumnValue>> c =
-                new Callable<Multimap<TableBRow, TableBColumnValue>>() {
+    public Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> getAsyncRowsMultimap(final Iterable<GenericRangeScanTestRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>> c =
+                new Callable<Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>>() {
             @Override
-            public Multimap<TableBRow, TableBColumnValue> call() {
+            public Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> call() {
                 return getRowsMultimapInternal(rows, columns);
             }
         };
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<TableBRow, TableBColumnValue> getRowsMultimapInternal(Iterable<? extends TableBRow> rows, ColumnSelection columns) {
+    private Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> getRowsMultimapInternal(Iterable<? extends GenericRangeScanTestRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
 
-    private static Multimap<TableBRow, TableBColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
-        Multimap<TableBRow, TableBColumnValue> rowMap = HashMultimap.create();
+    private static Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> rowMap = HashMultimap.create();
         for (RowResult<byte[]> result : rowResults) {
-            TableBRow row = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            GenericRangeScanTestRow row = GenericRangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
             for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
-                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-                String val = TableBColumnValue.hydrateValue(e.getValue());
-                rowMap.put(row, TableBColumnValue.of(col, val));
+                GenericRangeScanTestColumn col = GenericRangeScanTestColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                String val = GenericRangeScanTestColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, GenericRangeScanTestColumnValue.of(col, val));
             }
         }
         return rowMap;
     }
 
     @Override
-    public Map<TableBRow, BatchingVisitable<TableBColumnValue>> getRowsColumnRange(Iterable<TableBRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+    public Map<GenericRangeScanTestRow, BatchingVisitable<GenericRangeScanTestColumnValue>> getRowsColumnRange(Iterable<GenericRangeScanTestRow> rows, BatchColumnRangeSelection columnRangeSelection) {
         Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<TableBRow, BatchingVisitable<TableBColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        Map<GenericRangeScanTestRow, BatchingVisitable<GenericRangeScanTestColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
-            TableBRow row = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-            BatchingVisitable<TableBColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
-                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
-                String val = TableBColumnValue.hydrateValue(result.getValue());
-                return TableBColumnValue.of(col, val);
+            GenericRangeScanTestRow row = GenericRangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<GenericRangeScanTestColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                GenericRangeScanTestColumn col = GenericRangeScanTestColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                String val = GenericRangeScanTestColumnValue.hydrateValue(result.getValue());
+                return GenericRangeScanTestColumnValue.of(col, val);
             });
             transformed.put(row, bv);
         }
@@ -642,39 +642,39 @@ public final class TableBTable implements
     }
 
     @Override
-    public Iterator<Map.Entry<TableBRow, TableBColumnValue>> getRowsColumnRange(Iterable<TableBRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+    public Iterator<Map.Entry<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>> getRowsColumnRange(Iterable<GenericRangeScanTestRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
         Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
         return Iterators.transform(results, e -> {
-            TableBRow row = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-            TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
-            String val = TableBColumnValue.hydrateValue(e.getValue());
-            TableBColumnValue colValue = TableBColumnValue.of(col, val);
+            GenericRangeScanTestRow row = GenericRangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            GenericRangeScanTestColumn col = GenericRangeScanTestColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            String val = GenericRangeScanTestColumnValue.hydrateValue(e.getValue());
+            GenericRangeScanTestColumnValue colValue = GenericRangeScanTestColumnValue.of(col, val);
             return Maps.immutableEntry(row, colValue);
         });
     }
 
-    public BatchingVisitableView<TableBRowResult> getRange(RangeRequest range) {
+    public BatchingVisitableView<GenericRangeScanTestRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
         }
-        return BatchingVisitables.transform(t.getRange(tableRef, range), new Function<RowResult<byte[]>, TableBRowResult>() {
+        return BatchingVisitables.transform(t.getRange(tableRef, range), new Function<RowResult<byte[]>, GenericRangeScanTestRowResult>() {
             @Override
-            public TableBRowResult apply(RowResult<byte[]> input) {
-                return TableBRowResult.of(input);
+            public GenericRangeScanTestRowResult apply(RowResult<byte[]> input) {
+                return GenericRangeScanTestRowResult.of(input);
             }
         });
     }
 
-    public IterableView<BatchingVisitable<TableBRowResult>> getRanges(Iterable<RangeRequest> ranges) {
+    public IterableView<BatchingVisitable<GenericRangeScanTestRowResult>> getRanges(Iterable<RangeRequest> ranges) {
         Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRanges(tableRef, ranges);
         return IterableView.of(rangeResults).transform(
-                new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<TableBRowResult>>() {
+                new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<GenericRangeScanTestRowResult>>() {
             @Override
-            public BatchingVisitable<TableBRowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
-                return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, TableBRowResult>() {
+            public BatchingVisitable<GenericRangeScanTestRowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
+                return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, GenericRangeScanTestRowResult>() {
                     @Override
-                    public TableBRowResult apply(RowResult<byte[]> row) {
-                        return TableBRowResult.of(row);
+                    public GenericRangeScanTestRowResult apply(RowResult<byte[]> row) {
+                        return GenericRangeScanTestRowResult.of(row);
                     }
                 });
             }
@@ -686,12 +686,12 @@ public final class TableBTable implements
     }
 
     public void deleteRanges(Iterable<RangeRequest> ranges) {
-        BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends TableBRowResult>, RuntimeException>() {
+        BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends GenericRangeScanTestRowResult>, RuntimeException>() {
             @Override
-            public boolean visit(List<? extends TableBRowResult> rowResults) {
-                Multimap<TableBRow, TableBColumn> toRemove = HashMultimap.create();
-                for (TableBRowResult rowResult : rowResults) {
-                    for (TableBColumnValue columnValue : rowResult.getColumnValues()) {
+            public boolean visit(List<? extends GenericRangeScanTestRowResult> rowResults) {
+                Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> toRemove = HashMultimap.create();
+                for (GenericRangeScanTestRowResult rowResult : rowResults) {
+                    for (GenericRangeScanTestColumnValue columnValue : rowResult.getColumnValues()) {
                         toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
                     }
                 }
@@ -800,5 +800,5 @@ public final class TableBTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "P8cLbFPi7+BySFRzNALyhQ==";
+    static String __CLASS_HASH = "HC8jpHEu9OYxOfY9Q8v3Rw==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
@@ -38,28 +38,28 @@ public final class GenericTestSchemaTableFactory {
         return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
     }
 
-    public TableATable getTableATable(Transaction t, TableATable.TableATrigger... triggers) {
-        return TableATable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    public GenericRangeScanTestTable getGenericRangeScanTestTable(Transaction t, GenericRangeScanTestTable.GenericRangeScanTestTrigger... triggers) {
+        return GenericRangeScanTestTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public TableBTable getTableBTable(Transaction t, TableBTable.TableBTrigger... triggers) {
-        return TableBTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    public RangeScanTestTable getRangeScanTestTable(Transaction t, RangeScanTestTable.RangeScanTestTrigger... triggers) {
+        return RangeScanTestTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
     public interface SharedTriggers extends
-            TableATable.TableATrigger,
-            TableBTable.TableBTrigger {
+            GenericRangeScanTestTable.GenericRangeScanTestTrigger,
+            RangeScanTestTable.RangeScanTestTrigger {
         /* empty */
     }
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
-        public void putTableA(Multimap<TableATable.TableARow, ? extends TableATable.TableANamedColumnValue<?>> newRows) {
+        public void putGenericRangeScanTest(Multimap<GenericRangeScanTestTable.GenericRangeScanTestRow, ? extends GenericRangeScanTestTable.GenericRangeScanTestColumnValue> newRows) {
             // do nothing
         }
 
         @Override
-        public void putTableB(Multimap<TableBTable.TableBRow, ? extends TableBTable.TableBColumnValue> newRows) {
+        public void putRangeScanTest(Multimap<RangeScanTestTable.RangeScanTestRow, ? extends RangeScanTestTable.RangeScanTestNamedColumnValue<?>> newRows) {
             // do nothing
         }
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
@@ -1,0 +1,66 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.util.List;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.table.generation.Triggers;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
+public final class GenericTestSchemaTableFactory {
+    private final static Namespace defaultNamespace = Namespace.create("default", Namespace.UNCHECKED_NAME);
+    private final List<Function<? super Transaction, SharedTriggers>> sharedTriggers;
+    private final Namespace namespace;
+
+    public static GenericTestSchemaTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
+        return new GenericTestSchemaTableFactory(sharedTriggers, namespace);
+    }
+
+    public static GenericTestSchemaTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+        return new GenericTestSchemaTableFactory(sharedTriggers, defaultNamespace);
+    }
+
+    private GenericTestSchemaTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
+        this.sharedTriggers = sharedTriggers;
+        this.namespace = namespace;
+    }
+
+    public static GenericTestSchemaTableFactory of(Namespace namespace) {
+        return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), namespace);
+    }
+
+    public static GenericTestSchemaTableFactory of() {
+        return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
+    }
+
+    public TableATable getTableATable(Transaction t, TableATable.TableATrigger... triggers) {
+        return TableATable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public TableBTable getTableBTable(Transaction t, TableBTable.TableBTrigger... triggers) {
+        return TableBTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public interface SharedTriggers extends
+            TableATable.TableATrigger,
+            TableBTable.TableBTrigger {
+        /* empty */
+    }
+
+    public abstract static class NullSharedTriggers implements SharedTriggers {
+        @Override
+        public void putTableA(Multimap<TableATable.TableARow, ? extends TableATable.TableANamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putTableB(Multimap<TableBTable.TableBRow, ? extends TableBTable.TableBColumnValue> newRows) {
+            // do nothing
+        }
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -87,32 +87,32 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-public final class TableATable implements
-        AtlasDbMutablePersistentTable<TableATable.TableARow,
-                                         TableATable.TableANamedColumnValue<?>,
-                                         TableATable.TableARowResult>,
-        AtlasDbNamedMutableTable<TableATable.TableARow,
-                                    TableATable.TableANamedColumnValue<?>,
-                                    TableATable.TableARowResult> {
+public final class RangeScanTestTable implements
+        AtlasDbMutablePersistentTable<RangeScanTestTable.RangeScanTestRow,
+                                         RangeScanTestTable.RangeScanTestNamedColumnValue<?>,
+                                         RangeScanTestTable.RangeScanTestRowResult>,
+        AtlasDbNamedMutableTable<RangeScanTestTable.RangeScanTestRow,
+                                    RangeScanTestTable.RangeScanTestNamedColumnValue<?>,
+                                    RangeScanTestTable.RangeScanTestRowResult> {
     private final Transaction t;
-    private final List<TableATrigger> triggers;
-    private final static String rawTableName = "tableA";
+    private final List<RangeScanTestTrigger> triggers;
+    private final static String rawTableName = "rangeScanTest";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(TableANamedColumn.values());
+    private final static ColumnSelection allColumns = getColumnSelection(RangeScanTestNamedColumn.values());
 
-    static TableATable of(Transaction t, Namespace namespace) {
-        return new TableATable(t, namespace, ImmutableList.<TableATrigger>of());
+    static RangeScanTestTable of(Transaction t, Namespace namespace) {
+        return new RangeScanTestTable(t, namespace, ImmutableList.<RangeScanTestTrigger>of());
     }
 
-    static TableATable of(Transaction t, Namespace namespace, TableATrigger trigger, TableATrigger... triggers) {
-        return new TableATable(t, namespace, ImmutableList.<TableATrigger>builder().add(trigger).add(triggers).build());
+    static RangeScanTestTable of(Transaction t, Namespace namespace, RangeScanTestTrigger trigger, RangeScanTestTrigger... triggers) {
+        return new RangeScanTestTable(t, namespace, ImmutableList.<RangeScanTestTrigger>builder().add(trigger).add(triggers).build());
     }
 
-    static TableATable of(Transaction t, Namespace namespace, List<TableATrigger> triggers) {
-        return new TableATable(t, namespace, triggers);
+    static RangeScanTestTable of(Transaction t, Namespace namespace, List<RangeScanTestTrigger> triggers) {
+        return new RangeScanTestTable(t, namespace, triggers);
     }
 
-    private TableATable(Transaction t, Namespace namespace, List<TableATrigger> triggers) {
+    private RangeScanTestTable(Transaction t, Namespace namespace, List<RangeScanTestTrigger> triggers) {
         this.t = t;
         this.tableRef = TableReference.create(namespace, rawTableName);
         this.triggers = triggers;
@@ -136,19 +136,19 @@ public final class TableATable implements
 
     /**
      * <pre>
-     * TableARow {
+     * RangeScanTestRow {
      *   {@literal String component1};
      * }
      * </pre>
      */
-    public static final class TableARow implements Persistable, Comparable<TableARow> {
+    public static final class RangeScanTestRow implements Persistable, Comparable<RangeScanTestRow> {
         private final String component1;
 
-        public static TableARow of(String component1) {
-            return new TableARow(component1);
+        public static RangeScanTestRow of(String component1) {
+            return new RangeScanTestRow(component1);
         }
 
-        private TableARow(String component1) {
+        private RangeScanTestRow(String component1) {
             this.component1 = component1;
         }
 
@@ -156,20 +156,20 @@ public final class TableATable implements
             return component1;
         }
 
-        public static Function<TableARow, String> getComponent1Fun() {
-            return new Function<TableARow, String>() {
+        public static Function<RangeScanTestRow, String> getComponent1Fun() {
+            return new Function<RangeScanTestRow, String>() {
                 @Override
-                public String apply(TableARow row) {
+                public String apply(RangeScanTestRow row) {
                     return row.component1;
                 }
             };
         }
 
-        public static Function<String, TableARow> fromComponent1Fun() {
-            return new Function<String, TableARow>() {
+        public static Function<String, RangeScanTestRow> fromComponent1Fun() {
+            return new Function<String, RangeScanTestRow>() {
                 @Override
-                public TableARow apply(String row) {
-                    return TableARow.of(row);
+                public RangeScanTestRow apply(String row) {
+                    return RangeScanTestRow.of(row);
                 }
             };
         }
@@ -180,13 +180,13 @@ public final class TableATable implements
             return EncodingUtils.add(component1Bytes);
         }
 
-        public static final Hydrator<TableARow> BYTES_HYDRATOR = new Hydrator<TableARow>() {
+        public static final Hydrator<RangeScanTestRow> BYTES_HYDRATOR = new Hydrator<RangeScanTestRow>() {
             @Override
-            public TableARow hydrateFromBytes(byte[] __input) {
+            public RangeScanTestRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String component1 = PtBytes.toString(__input, __index, __input.length-__index);
                 __index += 0;
-                return new TableARow(component1);
+                return new RangeScanTestRow(component1);
             }
         };
 
@@ -208,7 +208,7 @@ public final class TableATable implements
             if (getClass() != obj.getClass()) {
                 return false;
             }
-            TableARow other = (TableARow) obj;
+            RangeScanTestRow other = (RangeScanTestRow) obj;
             return Objects.equal(component1, other.component1);
         }
 
@@ -218,14 +218,14 @@ public final class TableATable implements
         }
 
         @Override
-        public int compareTo(TableARow o) {
+        public int compareTo(RangeScanTestRow o) {
             return ComparisonChain.start()
                 .compare(this.component1, o.component1)
                 .result();
         }
     }
 
-    public interface TableANamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+    public interface RangeScanTestNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
 
     /**
      * <pre>
@@ -234,7 +234,7 @@ public final class TableATable implements
      * }
      * </pre>
      */
-    public static final class Column1 implements TableANamedColumnValue<Long> {
+    public static final class Column1 implements RangeScanTestNamedColumnValue<Long> {
         private final Long value;
 
         public static Column1 of(Long value) {
@@ -287,40 +287,40 @@ public final class TableATable implements
         }
     }
 
-    public interface TableATrigger {
-        public void putTableA(Multimap<TableARow, ? extends TableANamedColumnValue<?>> newRows);
+    public interface RangeScanTestTrigger {
+        public void putRangeScanTest(Multimap<RangeScanTestRow, ? extends RangeScanTestNamedColumnValue<?>> newRows);
     }
 
-    public static final class TableARowResult implements TypedRowResult {
+    public static final class RangeScanTestRowResult implements TypedRowResult {
         private final RowResult<byte[]> row;
 
-        public static TableARowResult of(RowResult<byte[]> row) {
-            return new TableARowResult(row);
+        public static RangeScanTestRowResult of(RowResult<byte[]> row) {
+            return new RangeScanTestRowResult(row);
         }
 
-        private TableARowResult(RowResult<byte[]> row) {
+        private RangeScanTestRowResult(RowResult<byte[]> row) {
             this.row = row;
         }
 
         @Override
-        public TableARow getRowName() {
-            return TableARow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        public RangeScanTestRow getRowName() {
+            return RangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
         }
 
-        public static Function<TableARowResult, TableARow> getRowNameFun() {
-            return new Function<TableARowResult, TableARow>() {
+        public static Function<RangeScanTestRowResult, RangeScanTestRow> getRowNameFun() {
+            return new Function<RangeScanTestRowResult, RangeScanTestRow>() {
                 @Override
-                public TableARow apply(TableARowResult rowResult) {
+                public RangeScanTestRow apply(RangeScanTestRowResult rowResult) {
                     return rowResult.getRowName();
                 }
             };
         }
 
-        public static Function<RowResult<byte[]>, TableARowResult> fromRawRowResultFun() {
-            return new Function<RowResult<byte[]>, TableARowResult>() {
+        public static Function<RowResult<byte[]>, RangeScanTestRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, RangeScanTestRowResult>() {
                 @Override
-                public TableARowResult apply(RowResult<byte[]> rowResult) {
-                    return new TableARowResult(rowResult);
+                public RangeScanTestRowResult apply(RowResult<byte[]> rowResult) {
+                    return new RangeScanTestRowResult(rowResult);
                 }
             };
         }
@@ -338,10 +338,10 @@ public final class TableATable implements
             return value.getValue();
         }
 
-        public static Function<TableARowResult, Long> getColumn1Fun() {
-            return new Function<TableARowResult, Long>() {
+        public static Function<RangeScanTestRowResult, Long> getColumn1Fun() {
+            return new Function<RangeScanTestRowResult, Long>() {
                 @Override
-                public Long apply(TableARowResult rowResult) {
+                public Long apply(RangeScanTestRowResult rowResult) {
                     return rowResult.getColumn1();
                 }
             };
@@ -356,7 +356,7 @@ public final class TableATable implements
         }
     }
 
-    public enum TableANamedColumn {
+    public enum RangeScanTestNamedColumn {
         COLUMN1 {
             @Override
             public byte[] getShortName() {
@@ -366,36 +366,36 @@ public final class TableATable implements
 
         public abstract byte[] getShortName();
 
-        public static Function<TableANamedColumn, byte[]> toShortName() {
-            return new Function<TableANamedColumn, byte[]>() {
+        public static Function<RangeScanTestNamedColumn, byte[]> toShortName() {
+            return new Function<RangeScanTestNamedColumn, byte[]>() {
                 @Override
-                public byte[] apply(TableANamedColumn namedColumn) {
+                public byte[] apply(RangeScanTestNamedColumn namedColumn) {
                     return namedColumn.getShortName();
                 }
             };
         }
     }
 
-    public static ColumnSelection getColumnSelection(Collection<TableANamedColumn> cols) {
-        return ColumnSelection.create(Collections2.transform(cols, TableANamedColumn.toShortName()));
+    public static ColumnSelection getColumnSelection(Collection<RangeScanTestNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, RangeScanTestNamedColumn.toShortName()));
     }
 
-    public static ColumnSelection getColumnSelection(TableANamedColumn... cols) {
+    public static ColumnSelection getColumnSelection(RangeScanTestNamedColumn... cols) {
         return getColumnSelection(Arrays.asList(cols));
     }
 
-    private static final Map<String, Hydrator<? extends TableANamedColumnValue<?>>> shortNameToHydrator =
-            ImmutableMap.<String, Hydrator<? extends TableANamedColumnValue<?>>>builder()
+    private static final Map<String, Hydrator<? extends RangeScanTestNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends RangeScanTestNamedColumnValue<?>>>builder()
                 .put("c", Column1.BYTES_HYDRATOR)
                 .build();
 
-    public Map<TableARow, Long> getColumn1s(Collection<TableARow> rows) {
-        Map<Cell, TableARow> cells = Maps.newHashMapWithExpectedSize(rows.size());
-        for (TableARow row : rows) {
+    public Map<RangeScanTestRow, Long> getColumn1s(Collection<RangeScanTestRow> rows) {
+        Map<Cell, RangeScanTestRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (RangeScanTestRow row : rows) {
             cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("c")), row);
         }
         Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<TableARow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
+        Map<RangeScanTestRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> e : results.entrySet()) {
             Long val = Column1.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
             ret.put(cells.get(e.getKey()), val);
@@ -403,44 +403,44 @@ public final class TableATable implements
         return ret;
     }
 
-    public void putColumn1(TableARow row, Long value) {
+    public void putColumn1(RangeScanTestRow row, Long value) {
         put(ImmutableMultimap.of(row, Column1.of(value)));
     }
 
-    public void putColumn1(Map<TableARow, Long> map) {
-        Map<TableARow, TableANamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<TableARow, Long> e : map.entrySet()) {
+    public void putColumn1(Map<RangeScanTestRow, Long> map) {
+        Map<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<RangeScanTestRow, Long> e : map.entrySet()) {
             toPut.put(e.getKey(), Column1.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn1UnlessExists(TableARow row, Long value) {
+    public void putColumn1UnlessExists(RangeScanTestRow row, Long value) {
         putUnlessExists(ImmutableMultimap.of(row, Column1.of(value)));
     }
 
-    public void putColumn1UnlessExists(Map<TableARow, Long> map) {
-        Map<TableARow, TableANamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<TableARow, Long> e : map.entrySet()) {
+    public void putColumn1UnlessExists(Map<RangeScanTestRow, Long> map) {
+        Map<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<RangeScanTestRow, Long> e : map.entrySet()) {
             toPut.put(e.getKey(), Column1.of(e.getValue()));
         }
         putUnlessExists(Multimaps.forMap(toPut));
     }
 
     @Override
-    public void put(Multimap<TableARow, ? extends TableANamedColumnValue<?>> rows) {
+    public void put(Multimap<RangeScanTestRow, ? extends RangeScanTestNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
         t.put(tableRef, ColumnValues.toCellValues(rows));
-        for (TableATrigger trigger : triggers) {
-            trigger.putTableA(rows);
+        for (RangeScanTestTrigger trigger : triggers) {
+            trigger.putRangeScanTest(rows);
         }
     }
 
     @Override
-    public void putUnlessExists(Multimap<TableARow, ? extends TableANamedColumnValue<?>> rows) {
-        Multimap<TableARow, TableANamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<TableARow, TableANamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<TableARow, ? extends TableANamedColumnValue<?>> entry : rows.entries()) {
+    public void putUnlessExists(Multimap<RangeScanTestRow, ? extends RangeScanTestNamedColumnValue<?>> rows) {
+        Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<RangeScanTestRow, ? extends RangeScanTestNamedColumnValue<?>> entry : rows.entries()) {
             if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
                 toPut.put(entry.getKey(), entry.getValue());
             }
@@ -448,69 +448,69 @@ public final class TableATable implements
         put(toPut);
     }
 
-    public void deleteColumn1(TableARow row) {
+    public void deleteColumn1(RangeScanTestRow row) {
         deleteColumn1(ImmutableSet.of(row));
     }
 
-    public void deleteColumn1(Iterable<TableARow> rows) {
+    public void deleteColumn1(Iterable<RangeScanTestRow> rows) {
         byte[] col = PtBytes.toCachedBytes("c");
         Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
         t.delete(tableRef, cells);
     }
 
     @Override
-    public void delete(TableARow row) {
+    public void delete(RangeScanTestRow row) {
         delete(ImmutableSet.of(row));
     }
 
     @Override
-    public void delete(Iterable<? extends TableARow> rows) {
+    public void delete(Iterable<? extends RangeScanTestRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("c")));
         t.delete(tableRef, cells);
     }
 
-    public Optional<TableARowResult> getRow(TableARow row) {
+    public Optional<RangeScanTestRowResult> getRow(RangeScanTestRow row) {
         return getRow(row, allColumns);
     }
 
-    public Optional<TableARowResult> getRow(TableARow row, ColumnSelection columns) {
+    public Optional<RangeScanTestRowResult> getRow(RangeScanTestRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return Optional.absent();
         } else {
-            return Optional.of(TableARowResult.of(rowResult));
+            return Optional.of(RangeScanTestRowResult.of(rowResult));
         }
     }
 
     @Override
-    public List<TableARowResult> getRows(Iterable<TableARow> rows) {
+    public List<RangeScanTestRowResult> getRows(Iterable<RangeScanTestRow> rows) {
         return getRows(rows, allColumns);
     }
 
     @Override
-    public List<TableARowResult> getRows(Iterable<TableARow> rows, ColumnSelection columns) {
+    public List<RangeScanTestRowResult> getRows(Iterable<RangeScanTestRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
-        List<TableARowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        List<RangeScanTestRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
         for (RowResult<byte[]> row : results.values()) {
-            rowResults.add(TableARowResult.of(row));
+            rowResults.add(RangeScanTestRowResult.of(row));
         }
         return rowResults;
     }
 
     @Override
-    public List<TableARowResult> getAsyncRows(Iterable<TableARow> rows, ExecutorService exec) {
+    public List<RangeScanTestRowResult> getAsyncRows(Iterable<RangeScanTestRow> rows, ExecutorService exec) {
         return getAsyncRows(rows, allColumns, exec);
     }
 
     @Override
-    public List<TableARowResult> getAsyncRows(final Iterable<TableARow> rows, final ColumnSelection columns, ExecutorService exec) {
-        Callable<List<TableARowResult>> c =
-                new Callable<List<TableARowResult>>() {
+    public List<RangeScanTestRowResult> getAsyncRows(final Iterable<RangeScanTestRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<List<RangeScanTestRowResult>> c =
+                new Callable<List<RangeScanTestRowResult>>() {
             @Override
-            public List<TableARowResult> call() {
+            public List<RangeScanTestRowResult> call() {
                 return getRows(rows, columns);
             }
         };
@@ -518,18 +518,18 @@ public final class TableATable implements
     }
 
     @Override
-    public List<TableANamedColumnValue<?>> getRowColumns(TableARow row) {
+    public List<RangeScanTestNamedColumnValue<?>> getRowColumns(RangeScanTestRow row) {
         return getRowColumns(row, allColumns);
     }
 
     @Override
-    public List<TableANamedColumnValue<?>> getRowColumns(TableARow row, ColumnSelection columns) {
+    public List<RangeScanTestNamedColumnValue<?>> getRowColumns(RangeScanTestRow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return ImmutableList.of();
         } else {
-            List<TableANamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            List<RangeScanTestNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                 ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
@@ -538,41 +538,41 @@ public final class TableATable implements
     }
 
     @Override
-    public Multimap<TableARow, TableANamedColumnValue<?>> getRowsMultimap(Iterable<? extends TableARow> rows) {
+    public Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> getRowsMultimap(Iterable<? extends RangeScanTestRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
     @Override
-    public Multimap<TableARow, TableANamedColumnValue<?>> getRowsMultimap(Iterable<TableARow> rows, ColumnSelection columns) {
+    public Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> getRowsMultimap(Iterable<RangeScanTestRow> rows, ColumnSelection columns) {
         return getRowsMultimapInternal(rows, columns);
     }
 
     @Override
-    public Multimap<TableARow, TableANamedColumnValue<?>> getAsyncRowsMultimap(Iterable<TableARow> rows, ExecutorService exec) {
+    public Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> getAsyncRowsMultimap(Iterable<RangeScanTestRow> rows, ExecutorService exec) {
         return getAsyncRowsMultimap(rows, allColumns, exec);
     }
 
     @Override
-    public Multimap<TableARow, TableANamedColumnValue<?>> getAsyncRowsMultimap(final Iterable<TableARow> rows, final ColumnSelection columns, ExecutorService exec) {
-        Callable<Multimap<TableARow, TableANamedColumnValue<?>>> c =
-                new Callable<Multimap<TableARow, TableANamedColumnValue<?>>>() {
+    public Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> getAsyncRowsMultimap(final Iterable<RangeScanTestRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>>> c =
+                new Callable<Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>>>() {
             @Override
-            public Multimap<TableARow, TableANamedColumnValue<?>> call() {
+            public Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> call() {
                 return getRowsMultimapInternal(rows, columns);
             }
         };
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<TableARow, TableANamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends TableARow> rows, ColumnSelection columns) {
+    private Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends RangeScanTestRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
 
-    private static Multimap<TableARow, TableANamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
-        Multimap<TableARow, TableANamedColumnValue<?>> rowMap = HashMultimap.create();
+    private static Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> rowMap = HashMultimap.create();
         for (RowResult<byte[]> result : rowResults) {
-            TableARow row = TableARow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            RangeScanTestRow row = RangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
             for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
                 rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
@@ -581,12 +581,12 @@ public final class TableATable implements
     }
 
     @Override
-    public Map<TableARow, BatchingVisitable<TableANamedColumnValue<?>>> getRowsColumnRange(Iterable<TableARow> rows, BatchColumnRangeSelection columnRangeSelection) {
+    public Map<RangeScanTestRow, BatchingVisitable<RangeScanTestNamedColumnValue<?>>> getRowsColumnRange(Iterable<RangeScanTestRow> rows, BatchColumnRangeSelection columnRangeSelection) {
         Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<TableARow, BatchingVisitable<TableANamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        Map<RangeScanTestRow, BatchingVisitable<RangeScanTestNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
-            TableARow row = TableARow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-            BatchingVisitable<TableANamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+            RangeScanTestRow row = RangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<RangeScanTestNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
                 return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
             });
             transformed.put(row, bv);
@@ -595,37 +595,37 @@ public final class TableATable implements
     }
 
     @Override
-    public Iterator<Map.Entry<TableARow, TableANamedColumnValue<?>>> getRowsColumnRange(Iterable<TableARow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+    public Iterator<Map.Entry<RangeScanTestRow, RangeScanTestNamedColumnValue<?>>> getRowsColumnRange(Iterable<RangeScanTestRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
         Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
         return Iterators.transform(results, e -> {
-            TableARow row = TableARow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-            TableANamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            RangeScanTestRow row = RangeScanTestRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            RangeScanTestNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
             return Maps.immutableEntry(row, colValue);
         });
     }
 
-    public BatchingVisitableView<TableARowResult> getRange(RangeRequest range) {
+    public BatchingVisitableView<RangeScanTestRowResult> getRange(RangeRequest range) {
         if (range.getColumnNames().isEmpty()) {
             range = range.getBuilder().retainColumns(allColumns).build();
         }
-        return BatchingVisitables.transform(t.getRange(tableRef, range), new Function<RowResult<byte[]>, TableARowResult>() {
+        return BatchingVisitables.transform(t.getRange(tableRef, range), new Function<RowResult<byte[]>, RangeScanTestRowResult>() {
             @Override
-            public TableARowResult apply(RowResult<byte[]> input) {
-                return TableARowResult.of(input);
+            public RangeScanTestRowResult apply(RowResult<byte[]> input) {
+                return RangeScanTestRowResult.of(input);
             }
         });
     }
 
-    public IterableView<BatchingVisitable<TableARowResult>> getRanges(Iterable<RangeRequest> ranges) {
+    public IterableView<BatchingVisitable<RangeScanTestRowResult>> getRanges(Iterable<RangeRequest> ranges) {
         Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRanges(tableRef, ranges);
         return IterableView.of(rangeResults).transform(
-                new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<TableARowResult>>() {
+                new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<RangeScanTestRowResult>>() {
             @Override
-            public BatchingVisitable<TableARowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
-                return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, TableARowResult>() {
+            public BatchingVisitable<RangeScanTestRowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
+                return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, RangeScanTestRowResult>() {
                     @Override
-                    public TableARowResult apply(RowResult<byte[]> row) {
-                        return TableARowResult.of(row);
+                    public RangeScanTestRowResult apply(RowResult<byte[]> row) {
+                        return RangeScanTestRowResult.of(row);
                     }
                 });
             }
@@ -638,10 +638,10 @@ public final class TableATable implements
 
     public void deleteRanges(Iterable<RangeRequest> ranges) {
         BatchingVisitables.concat(getRanges(ranges))
-                          .transform(TableARowResult.getRowNameFun())
-                          .batchAccept(1000, new AbortingVisitor<List<? extends TableARow>, RuntimeException>() {
+                          .transform(RangeScanTestRowResult.getRowNameFun())
+                          .batchAccept(1000, new AbortingVisitor<List<? extends RangeScanTestRow>, RuntimeException>() {
             @Override
-            public boolean visit(List<? extends TableARow> rows) {
+            public boolean visit(List<? extends RangeScanTestRow> rows) {
                 delete(rows);
                 return true;
             }
@@ -747,5 +747,5 @@ public final class TableATable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "wG86qhmr/JfjLsM4x9piyg==";
+    static String __CLASS_HASH = "BTMX0u5VM+o9jfSqcqyWnA==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/TableATable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/TableATable.java
@@ -1,4 +1,4 @@
-package com.palantir.atlasdb.cas.generated;
+package com.palantir.atlasdb.table.description.generated;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -87,32 +87,32 @@ import com.palantir.util.AssertUtils;
 import com.palantir.util.crypto.Sha256Hash;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
-public final class CheckAndSetTable implements
-        AtlasDbMutablePersistentTable<CheckAndSetTable.CheckAndSetRow,
-                                         CheckAndSetTable.CheckAndSetNamedColumnValue<?>,
-                                         CheckAndSetTable.CheckAndSetRowResult>,
-        AtlasDbNamedMutableTable<CheckAndSetTable.CheckAndSetRow,
-                                    CheckAndSetTable.CheckAndSetNamedColumnValue<?>,
-                                    CheckAndSetTable.CheckAndSetRowResult> {
+public final class TableATable implements
+        AtlasDbMutablePersistentTable<TableATable.TableARow,
+                                         TableATable.TableANamedColumnValue<?>,
+                                         TableATable.TableARowResult>,
+        AtlasDbNamedMutableTable<TableATable.TableARow,
+                                    TableATable.TableANamedColumnValue<?>,
+                                    TableATable.TableARowResult> {
     private final Transaction t;
-    private final List<CheckAndSetTrigger> triggers;
-    private final static String rawTableName = "check_and_set";
+    private final List<TableATrigger> triggers;
+    private final static String rawTableName = "tableA";
     private final TableReference tableRef;
-    private final static ColumnSelection allColumns = getColumnSelection(CheckAndSetNamedColumn.values());
+    private final static ColumnSelection allColumns = getColumnSelection(TableANamedColumn.values());
 
-    static CheckAndSetTable of(Transaction t, Namespace namespace) {
-        return new CheckAndSetTable(t, namespace, ImmutableList.<CheckAndSetTrigger>of());
+    static TableATable of(Transaction t, Namespace namespace) {
+        return new TableATable(t, namespace, ImmutableList.<TableATrigger>of());
     }
 
-    static CheckAndSetTable of(Transaction t, Namespace namespace, CheckAndSetTrigger trigger, CheckAndSetTrigger... triggers) {
-        return new CheckAndSetTable(t, namespace, ImmutableList.<CheckAndSetTrigger>builder().add(trigger).add(triggers).build());
+    static TableATable of(Transaction t, Namespace namespace, TableATrigger trigger, TableATrigger... triggers) {
+        return new TableATable(t, namespace, ImmutableList.<TableATrigger>builder().add(trigger).add(triggers).build());
     }
 
-    static CheckAndSetTable of(Transaction t, Namespace namespace, List<CheckAndSetTrigger> triggers) {
-        return new CheckAndSetTable(t, namespace, triggers);
+    static TableATable of(Transaction t, Namespace namespace, List<TableATrigger> triggers) {
+        return new TableATable(t, namespace, triggers);
     }
 
-    private CheckAndSetTable(Transaction t, Namespace namespace, List<CheckAndSetTrigger> triggers) {
+    private TableATable(Transaction t, Namespace namespace, List<TableATrigger> triggers) {
         this.t = t;
         this.tableRef = TableReference.create(namespace, rawTableName);
         this.triggers = triggers;
@@ -136,64 +136,64 @@ public final class CheckAndSetTable implements
 
     /**
      * <pre>
-     * CheckAndSetRow {
-     *   {@literal Long id};
+     * TableARow {
+     *   {@literal String component1};
      * }
      * </pre>
      */
-    public static final class CheckAndSetRow implements Persistable, Comparable<CheckAndSetRow> {
-        private final long id;
+    public static final class TableARow implements Persistable, Comparable<TableARow> {
+        private final String component1;
 
-        public static CheckAndSetRow of(long id) {
-            return new CheckAndSetRow(id);
+        public static TableARow of(String component1) {
+            return new TableARow(component1);
         }
 
-        private CheckAndSetRow(long id) {
-            this.id = id;
+        private TableARow(String component1) {
+            this.component1 = component1;
         }
 
-        public long getId() {
-            return id;
+        public String getComponent1() {
+            return component1;
         }
 
-        public static Function<CheckAndSetRow, Long> getIdFun() {
-            return new Function<CheckAndSetRow, Long>() {
+        public static Function<TableARow, String> getComponent1Fun() {
+            return new Function<TableARow, String>() {
                 @Override
-                public Long apply(CheckAndSetRow row) {
-                    return row.id;
+                public String apply(TableARow row) {
+                    return row.component1;
                 }
             };
         }
 
-        public static Function<Long, CheckAndSetRow> fromIdFun() {
-            return new Function<Long, CheckAndSetRow>() {
+        public static Function<String, TableARow> fromComponent1Fun() {
+            return new Function<String, TableARow>() {
                 @Override
-                public CheckAndSetRow apply(Long row) {
-                    return CheckAndSetRow.of(row);
+                public TableARow apply(String row) {
+                    return TableARow.of(row);
                 }
             };
         }
 
         @Override
         public byte[] persistToBytes() {
-            byte[] idBytes = PtBytes.toBytes(Long.MIN_VALUE ^ id);
-            return EncodingUtils.add(idBytes);
+            byte[] component1Bytes = PtBytes.toBytes(component1);
+            return EncodingUtils.add(component1Bytes);
         }
 
-        public static final Hydrator<CheckAndSetRow> BYTES_HYDRATOR = new Hydrator<CheckAndSetRow>() {
+        public static final Hydrator<TableARow> BYTES_HYDRATOR = new Hydrator<TableARow>() {
             @Override
-            public CheckAndSetRow hydrateFromBytes(byte[] __input) {
+            public TableARow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
-                return new CheckAndSetRow(id);
+                String component1 = PtBytes.toString(__input, __index, __input.length-__index);
+                __index += 0;
+                return new TableARow(component1);
             }
         };
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("id", id)
+                .add("component1", component1)
                 .toString();
         }
 
@@ -208,24 +208,24 @@ public final class CheckAndSetTable implements
             if (getClass() != obj.getClass()) {
                 return false;
             }
-            CheckAndSetRow other = (CheckAndSetRow) obj;
-            return Objects.equal(id, other.id);
+            TableARow other = (TableARow) obj;
+            return Objects.equal(component1, other.component1);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(id);
+            return Objects.hashCode(component1);
         }
 
         @Override
-        public int compareTo(CheckAndSetRow o) {
+        public int compareTo(TableARow o) {
             return ComparisonChain.start()
-                .compare(this.id, o.id)
+                .compare(this.component1, o.component1)
                 .result();
         }
     }
 
-    public interface CheckAndSetNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+    public interface TableANamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
 
     /**
      * <pre>
@@ -234,25 +234,25 @@ public final class CheckAndSetTable implements
      * }
      * </pre>
      */
-    public static final class Value implements CheckAndSetNamedColumnValue<Long> {
+    public static final class Column1 implements TableANamedColumnValue<Long> {
         private final Long value;
 
-        public static Value of(Long value) {
-            return new Value(value);
+        public static Column1 of(Long value) {
+            return new Column1(value);
         }
 
-        private Value(Long value) {
+        private Column1(Long value) {
             this.value = value;
         }
 
         @Override
         public String getColumnName() {
-            return "value";
+            return "column1";
         }
 
         @Override
         public String getShortColumnName() {
-            return "v";
+            return "c";
         }
 
         @Override
@@ -262,20 +262,20 @@ public final class CheckAndSetTable implements
 
         @Override
         public byte[] persistValue() {
-            byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
             return CompressionUtils.compress(bytes, Compression.NONE);
         }
 
         @Override
         public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("v");
+            return PtBytes.toCachedBytes("c");
         }
 
-        public static final Hydrator<Value> BYTES_HYDRATOR = new Hydrator<Value>() {
+        public static final Hydrator<Column1> BYTES_HYDRATOR = new Hydrator<Column1>() {
             @Override
-            public Value hydrateFromBytes(byte[] bytes) {
+            public Column1 hydrateFromBytes(byte[] bytes) {
                 bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));
+                return of(EncodingUtils.decodeUnsignedVarLong(bytes, 0));
             }
         };
 
@@ -287,62 +287,62 @@ public final class CheckAndSetTable implements
         }
     }
 
-    public interface CheckAndSetTrigger {
-        public void putCheckAndSet(Multimap<CheckAndSetRow, ? extends CheckAndSetNamedColumnValue<?>> newRows);
+    public interface TableATrigger {
+        public void putTableA(Multimap<TableARow, ? extends TableANamedColumnValue<?>> newRows);
     }
 
-    public static final class CheckAndSetRowResult implements TypedRowResult {
+    public static final class TableARowResult implements TypedRowResult {
         private final RowResult<byte[]> row;
 
-        public static CheckAndSetRowResult of(RowResult<byte[]> row) {
-            return new CheckAndSetRowResult(row);
+        public static TableARowResult of(RowResult<byte[]> row) {
+            return new TableARowResult(row);
         }
 
-        private CheckAndSetRowResult(RowResult<byte[]> row) {
+        private TableARowResult(RowResult<byte[]> row) {
             this.row = row;
         }
 
         @Override
-        public CheckAndSetRow getRowName() {
-            return CheckAndSetRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        public TableARow getRowName() {
+            return TableARow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
         }
 
-        public static Function<CheckAndSetRowResult, CheckAndSetRow> getRowNameFun() {
-            return new Function<CheckAndSetRowResult, CheckAndSetRow>() {
+        public static Function<TableARowResult, TableARow> getRowNameFun() {
+            return new Function<TableARowResult, TableARow>() {
                 @Override
-                public CheckAndSetRow apply(CheckAndSetRowResult rowResult) {
+                public TableARow apply(TableARowResult rowResult) {
                     return rowResult.getRowName();
                 }
             };
         }
 
-        public static Function<RowResult<byte[]>, CheckAndSetRowResult> fromRawRowResultFun() {
-            return new Function<RowResult<byte[]>, CheckAndSetRowResult>() {
+        public static Function<RowResult<byte[]>, TableARowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, TableARowResult>() {
                 @Override
-                public CheckAndSetRowResult apply(RowResult<byte[]> rowResult) {
-                    return new CheckAndSetRowResult(rowResult);
+                public TableARowResult apply(RowResult<byte[]> rowResult) {
+                    return new TableARowResult(rowResult);
                 }
             };
         }
 
-        public boolean hasValue() {
-            return row.getColumns().containsKey(PtBytes.toCachedBytes("v"));
+        public boolean hasColumn1() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("c"));
         }
 
-        public Long getValue() {
-            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("v"));
+        public Long getColumn1() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("c"));
             if (bytes == null) {
                 return null;
             }
-            Value value = Value.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            Column1 value = Column1.BYTES_HYDRATOR.hydrateFromBytes(bytes);
             return value.getValue();
         }
 
-        public static Function<CheckAndSetRowResult, Long> getValueFun() {
-            return new Function<CheckAndSetRowResult, Long>() {
+        public static Function<TableARowResult, Long> getColumn1Fun() {
+            return new Function<TableARowResult, Long>() {
                 @Override
-                public Long apply(CheckAndSetRowResult rowResult) {
-                    return rowResult.getValue();
+                public Long apply(TableARowResult rowResult) {
+                    return rowResult.getColumn1();
                 }
             };
         }
@@ -351,96 +351,96 @@ public final class CheckAndSetTable implements
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
                 .add("RowName", getRowName())
-                .add("Value", getValue())
+                .add("Column1", getColumn1())
                 .toString();
         }
     }
 
-    public enum CheckAndSetNamedColumn {
-        VALUE {
+    public enum TableANamedColumn {
+        COLUMN1 {
             @Override
             public byte[] getShortName() {
-                return PtBytes.toCachedBytes("v");
+                return PtBytes.toCachedBytes("c");
             }
         };
 
         public abstract byte[] getShortName();
 
-        public static Function<CheckAndSetNamedColumn, byte[]> toShortName() {
-            return new Function<CheckAndSetNamedColumn, byte[]>() {
+        public static Function<TableANamedColumn, byte[]> toShortName() {
+            return new Function<TableANamedColumn, byte[]>() {
                 @Override
-                public byte[] apply(CheckAndSetNamedColumn namedColumn) {
+                public byte[] apply(TableANamedColumn namedColumn) {
                     return namedColumn.getShortName();
                 }
             };
         }
     }
 
-    public static ColumnSelection getColumnSelection(Collection<CheckAndSetNamedColumn> cols) {
-        return ColumnSelection.create(Collections2.transform(cols, CheckAndSetNamedColumn.toShortName()));
+    public static ColumnSelection getColumnSelection(Collection<TableANamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, TableANamedColumn.toShortName()));
     }
 
-    public static ColumnSelection getColumnSelection(CheckAndSetNamedColumn... cols) {
+    public static ColumnSelection getColumnSelection(TableANamedColumn... cols) {
         return getColumnSelection(Arrays.asList(cols));
     }
 
-    private static final Map<String, Hydrator<? extends CheckAndSetNamedColumnValue<?>>> shortNameToHydrator =
-            ImmutableMap.<String, Hydrator<? extends CheckAndSetNamedColumnValue<?>>>builder()
-                .put("v", Value.BYTES_HYDRATOR)
+    private static final Map<String, Hydrator<? extends TableANamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends TableANamedColumnValue<?>>>builder()
+                .put("c", Column1.BYTES_HYDRATOR)
                 .build();
 
-    public Map<CheckAndSetRow, Long> getValues(Collection<CheckAndSetRow> rows) {
-        Map<Cell, CheckAndSetRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
-        for (CheckAndSetRow row : rows) {
-            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("v")), row);
+    public Map<TableARow, Long> getColumn1s(Collection<TableARow> rows) {
+        Map<Cell, TableARow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (TableARow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("c")), row);
         }
         Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<CheckAndSetRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
+        Map<TableARow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> e : results.entrySet()) {
-            Long val = Value.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            Long val = Column1.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
             ret.put(cells.get(e.getKey()), val);
         }
         return ret;
     }
 
-    public void putValue(CheckAndSetRow row, Long value) {
-        put(ImmutableMultimap.of(row, Value.of(value)));
+    public void putColumn1(TableARow row, Long value) {
+        put(ImmutableMultimap.of(row, Column1.of(value)));
     }
 
-    public void putValue(Map<CheckAndSetRow, Long> map) {
-        Map<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<CheckAndSetRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
+    public void putColumn1(Map<TableARow, Long> map) {
+        Map<TableARow, TableANamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<TableARow, Long> e : map.entrySet()) {
+            toPut.put(e.getKey(), Column1.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(CheckAndSetRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
+    public void putColumn1UnlessExists(TableARow row, Long value) {
+        putUnlessExists(ImmutableMultimap.of(row, Column1.of(value)));
     }
 
-    public void putValueUnlessExists(Map<CheckAndSetRow, Long> map) {
-        Map<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<CheckAndSetRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
+    public void putColumn1UnlessExists(Map<TableARow, Long> map) {
+        Map<TableARow, TableANamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<TableARow, Long> e : map.entrySet()) {
+            toPut.put(e.getKey(), Column1.of(e.getValue()));
         }
         putUnlessExists(Multimaps.forMap(toPut));
     }
 
     @Override
-    public void put(Multimap<CheckAndSetRow, ? extends CheckAndSetNamedColumnValue<?>> rows) {
+    public void put(Multimap<TableARow, ? extends TableANamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
         t.put(tableRef, ColumnValues.toCellValues(rows));
-        for (CheckAndSetTrigger trigger : triggers) {
-            trigger.putCheckAndSet(rows);
+        for (TableATrigger trigger : triggers) {
+            trigger.putTableA(rows);
         }
     }
 
     @Override
-    public void putUnlessExists(Multimap<CheckAndSetRow, ? extends CheckAndSetNamedColumnValue<?>> rows) {
-        Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<CheckAndSetRow, ? extends CheckAndSetNamedColumnValue<?>> entry : rows.entries()) {
+    public void putUnlessExists(Multimap<TableARow, ? extends TableANamedColumnValue<?>> rows) {
+        Multimap<TableARow, TableANamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<TableARow, TableANamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<TableARow, ? extends TableANamedColumnValue<?>> entry : rows.entries()) {
             if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
                 toPut.put(entry.getKey(), entry.getValue());
             }
@@ -448,69 +448,69 @@ public final class CheckAndSetTable implements
         put(toPut);
     }
 
-    public void deleteValue(CheckAndSetRow row) {
-        deleteValue(ImmutableSet.of(row));
+    public void deleteColumn1(TableARow row) {
+        deleteColumn1(ImmutableSet.of(row));
     }
 
-    public void deleteValue(Iterable<CheckAndSetRow> rows) {
-        byte[] col = PtBytes.toCachedBytes("v");
+    public void deleteColumn1(Iterable<TableARow> rows) {
+        byte[] col = PtBytes.toCachedBytes("c");
         Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
         t.delete(tableRef, cells);
     }
 
     @Override
-    public void delete(CheckAndSetRow row) {
+    public void delete(TableARow row) {
         delete(ImmutableSet.of(row));
     }
 
     @Override
-    public void delete(Iterable<? extends CheckAndSetRow> rows) {
+    public void delete(Iterable<? extends TableARow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("c")));
         t.delete(tableRef, cells);
     }
 
-    public Optional<CheckAndSetRowResult> getRow(CheckAndSetRow row) {
+    public Optional<TableARowResult> getRow(TableARow row) {
         return getRow(row, allColumns);
     }
 
-    public Optional<CheckAndSetRowResult> getRow(CheckAndSetRow row, ColumnSelection columns) {
+    public Optional<TableARowResult> getRow(TableARow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return Optional.absent();
         } else {
-            return Optional.of(CheckAndSetRowResult.of(rowResult));
+            return Optional.of(TableARowResult.of(rowResult));
         }
     }
 
     @Override
-    public List<CheckAndSetRowResult> getRows(Iterable<CheckAndSetRow> rows) {
+    public List<TableARowResult> getRows(Iterable<TableARow> rows) {
         return getRows(rows, allColumns);
     }
 
     @Override
-    public List<CheckAndSetRowResult> getRows(Iterable<CheckAndSetRow> rows, ColumnSelection columns) {
+    public List<TableARowResult> getRows(Iterable<TableARow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
-        List<CheckAndSetRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        List<TableARowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
         for (RowResult<byte[]> row : results.values()) {
-            rowResults.add(CheckAndSetRowResult.of(row));
+            rowResults.add(TableARowResult.of(row));
         }
         return rowResults;
     }
 
     @Override
-    public List<CheckAndSetRowResult> getAsyncRows(Iterable<CheckAndSetRow> rows, ExecutorService exec) {
+    public List<TableARowResult> getAsyncRows(Iterable<TableARow> rows, ExecutorService exec) {
         return getAsyncRows(rows, allColumns, exec);
     }
 
     @Override
-    public List<CheckAndSetRowResult> getAsyncRows(final Iterable<CheckAndSetRow> rows, final ColumnSelection columns, ExecutorService exec) {
-        Callable<List<CheckAndSetRowResult>> c =
-                new Callable<List<CheckAndSetRowResult>>() {
+    public List<TableARowResult> getAsyncRows(final Iterable<TableARow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<List<TableARowResult>> c =
+                new Callable<List<TableARowResult>>() {
             @Override
-            public List<CheckAndSetRowResult> call() {
+            public List<TableARowResult> call() {
                 return getRows(rows, columns);
             }
         };
@@ -518,18 +518,18 @@ public final class CheckAndSetTable implements
     }
 
     @Override
-    public List<CheckAndSetNamedColumnValue<?>> getRowColumns(CheckAndSetRow row) {
+    public List<TableANamedColumnValue<?>> getRowColumns(TableARow row) {
         return getRowColumns(row, allColumns);
     }
 
     @Override
-    public List<CheckAndSetNamedColumnValue<?>> getRowColumns(CheckAndSetRow row, ColumnSelection columns) {
+    public List<TableANamedColumnValue<?>> getRowColumns(TableARow row, ColumnSelection columns) {
         byte[] bytes = row.persistToBytes();
         RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
         if (rowResult == null) {
             return ImmutableList.of();
         } else {
-            List<CheckAndSetNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            List<TableANamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
             for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
                 ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
@@ -538,41 +538,41 @@ public final class CheckAndSetTable implements
     }
 
     @Override
-    public Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> getRowsMultimap(Iterable<? extends CheckAndSetRow> rows) {
+    public Multimap<TableARow, TableANamedColumnValue<?>> getRowsMultimap(Iterable<? extends TableARow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
     @Override
-    public Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> getRowsMultimap(Iterable<CheckAndSetRow> rows, ColumnSelection columns) {
+    public Multimap<TableARow, TableANamedColumnValue<?>> getRowsMultimap(Iterable<TableARow> rows, ColumnSelection columns) {
         return getRowsMultimapInternal(rows, columns);
     }
 
     @Override
-    public Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> getAsyncRowsMultimap(Iterable<CheckAndSetRow> rows, ExecutorService exec) {
+    public Multimap<TableARow, TableANamedColumnValue<?>> getAsyncRowsMultimap(Iterable<TableARow> rows, ExecutorService exec) {
         return getAsyncRowsMultimap(rows, allColumns, exec);
     }
 
     @Override
-    public Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> getAsyncRowsMultimap(final Iterable<CheckAndSetRow> rows, final ColumnSelection columns, ExecutorService exec) {
-        Callable<Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>>> c =
-                new Callable<Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>>>() {
+    public Multimap<TableARow, TableANamedColumnValue<?>> getAsyncRowsMultimap(final Iterable<TableARow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<Multimap<TableARow, TableANamedColumnValue<?>>> c =
+                new Callable<Multimap<TableARow, TableANamedColumnValue<?>>>() {
             @Override
-            public Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> call() {
+            public Multimap<TableARow, TableANamedColumnValue<?>> call() {
                 return getRowsMultimapInternal(rows, columns);
             }
         };
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends CheckAndSetRow> rows, ColumnSelection columns) {
+    private Multimap<TableARow, TableANamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends TableARow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
 
-    private static Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
-        Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> rowMap = HashMultimap.create();
+    private static Multimap<TableARow, TableANamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<TableARow, TableANamedColumnValue<?>> rowMap = HashMultimap.create();
         for (RowResult<byte[]> result : rowResults) {
-            CheckAndSetRow row = CheckAndSetRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            TableARow row = TableARow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
             for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
                 rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
             }
@@ -581,12 +581,12 @@ public final class CheckAndSetTable implements
     }
 
     @Override
-    public Map<CheckAndSetRow, BatchingVisitable<CheckAndSetNamedColumnValue<?>>> getRowsColumnRange(Iterable<CheckAndSetRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+    public Map<TableARow, BatchingVisitable<TableANamedColumnValue<?>>> getRowsColumnRange(Iterable<TableARow> rows, BatchColumnRangeSelection columnRangeSelection) {
         Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
-        Map<CheckAndSetRow, BatchingVisitable<CheckAndSetNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        Map<TableARow, BatchingVisitable<TableANamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
-            CheckAndSetRow row = CheckAndSetRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
-            BatchingVisitable<CheckAndSetNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+            TableARow row = TableARow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<TableANamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
                 return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
             });
             transformed.put(row, bv);
@@ -595,25 +595,55 @@ public final class CheckAndSetTable implements
     }
 
     @Override
-    public Iterator<Map.Entry<CheckAndSetRow, CheckAndSetNamedColumnValue<?>>> getRowsColumnRange(Iterable<CheckAndSetRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+    public Iterator<Map.Entry<TableARow, TableANamedColumnValue<?>>> getRowsColumnRange(Iterable<TableARow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
         Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
         return Iterators.transform(results, e -> {
-            CheckAndSetRow row = CheckAndSetRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
-            CheckAndSetNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            TableARow row = TableARow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            TableANamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
             return Maps.immutableEntry(row, colValue);
         });
     }
 
-    public BatchingVisitableView<CheckAndSetRowResult> getAllRowsUnordered() {
-        return getAllRowsUnordered(allColumns);
+    public BatchingVisitableView<TableARowResult> getRange(RangeRequest range) {
+        if (range.getColumnNames().isEmpty()) {
+            range = range.getBuilder().retainColumns(allColumns).build();
+        }
+        return BatchingVisitables.transform(t.getRange(tableRef, range), new Function<RowResult<byte[]>, TableARowResult>() {
+            @Override
+            public TableARowResult apply(RowResult<byte[]> input) {
+                return TableARowResult.of(input);
+            }
+        });
     }
 
-    public BatchingVisitableView<CheckAndSetRowResult> getAllRowsUnordered(ColumnSelection columns) {
-        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
-                new Function<RowResult<byte[]>, CheckAndSetRowResult>() {
+    public IterableView<BatchingVisitable<TableARowResult>> getRanges(Iterable<RangeRequest> ranges) {
+        Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRanges(tableRef, ranges);
+        return IterableView.of(rangeResults).transform(
+                new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<TableARowResult>>() {
             @Override
-            public CheckAndSetRowResult apply(RowResult<byte[]> input) {
-                return CheckAndSetRowResult.of(input);
+            public BatchingVisitable<TableARowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
+                return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, TableARowResult>() {
+                    @Override
+                    public TableARowResult apply(RowResult<byte[]> row) {
+                        return TableARowResult.of(row);
+                    }
+                });
+            }
+        });
+    }
+
+    public void deleteRange(RangeRequest range) {
+        deleteRanges(ImmutableSet.of(range));
+    }
+
+    public void deleteRanges(Iterable<RangeRequest> ranges) {
+        BatchingVisitables.concat(getRanges(ranges))
+                          .transform(TableARowResult.getRowNameFun())
+                          .batchAccept(1000, new AbortingVisitor<List<? extends TableARow>, RuntimeException>() {
+            @Override
+            public boolean visit(List<? extends TableARow> rows) {
+                delete(rows);
+                return true;
             }
         });
     }
@@ -717,5 +747,5 @@ public final class CheckAndSetTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "vRzK/r2VXST+puDjpkcKPA==";
+    static String __CLASS_HASH = "wG86qhmr/JfjLsM4x9piyg==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/TableBTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/TableBTable.java
@@ -1,0 +1,804 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedExpiringSet;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.common.proxy.AsyncProxy;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+public final class TableBTable implements
+        AtlasDbDynamicMutablePersistentTable<TableBTable.TableBRow,
+                                                TableBTable.TableBColumn,
+                                                TableBTable.TableBColumnValue,
+                                                TableBTable.TableBRowResult> {
+    private final Transaction t;
+    private final List<TableBTrigger> triggers;
+    private final static String rawTableName = "tableB";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = ColumnSelection.all();
+
+    static TableBTable of(Transaction t, Namespace namespace) {
+        return new TableBTable(t, namespace, ImmutableList.<TableBTrigger>of());
+    }
+
+    static TableBTable of(Transaction t, Namespace namespace, TableBTrigger trigger, TableBTrigger... triggers) {
+        return new TableBTable(t, namespace, ImmutableList.<TableBTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static TableBTable of(Transaction t, Namespace namespace, List<TableBTrigger> triggers) {
+        return new TableBTable(t, namespace, triggers);
+    }
+
+    private TableBTable(Transaction t, Namespace namespace, List<TableBTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * TableBRow {
+     *   {@literal Sha256Hash component1};
+     * }
+     * </pre>
+     */
+    public static final class TableBRow implements Persistable, Comparable<TableBRow> {
+        private final Sha256Hash component1;
+
+        public static TableBRow of(Sha256Hash component1) {
+            return new TableBRow(component1);
+        }
+
+        private TableBRow(Sha256Hash component1) {
+            this.component1 = component1;
+        }
+
+        public Sha256Hash getComponent1() {
+            return component1;
+        }
+
+        public static Function<TableBRow, Sha256Hash> getComponent1Fun() {
+            return new Function<TableBRow, Sha256Hash>() {
+                @Override
+                public Sha256Hash apply(TableBRow row) {
+                    return row.component1;
+                }
+            };
+        }
+
+        public static Function<Sha256Hash, TableBRow> fromComponent1Fun() {
+            return new Function<Sha256Hash, TableBRow>() {
+                @Override
+                public TableBRow apply(Sha256Hash row) {
+                    return TableBRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] component1Bytes = component1.getBytes();
+            return EncodingUtils.add(component1Bytes);
+        }
+
+        public static final Hydrator<TableBRow> BYTES_HYDRATOR = new Hydrator<TableBRow>() {
+            @Override
+            public TableBRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Sha256Hash component1 = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
+                __index += 32;
+                return new TableBRow(component1);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("component1", component1)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TableBRow other = (TableBRow) obj;
+            return Objects.equal(component1, other.component1);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(component1);
+        }
+
+        @Override
+        public int compareTo(TableBRow o) {
+            return ComparisonChain.start()
+                .compare(this.component1, o.component1)
+                .result();
+        }
+    }
+
+    /**
+     * <pre>
+     * TableBColumn {
+     *   {@literal String component2};
+     * }
+     * </pre>
+     */
+    public static final class TableBColumn implements Persistable, Comparable<TableBColumn> {
+        private final String component2;
+
+        public static TableBColumn of(String component2) {
+            return new TableBColumn(component2);
+        }
+
+        private TableBColumn(String component2) {
+            this.component2 = component2;
+        }
+
+        public String getComponent2() {
+            return component2;
+        }
+
+        public static Function<TableBColumn, String> getComponent2Fun() {
+            return new Function<TableBColumn, String>() {
+                @Override
+                public String apply(TableBColumn row) {
+                    return row.component2;
+                }
+            };
+        }
+
+        public static Function<String, TableBColumn> fromComponent2Fun() {
+            return new Function<String, TableBColumn>() {
+                @Override
+                public TableBColumn apply(String row) {
+                    return TableBColumn.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] component2Bytes = PtBytes.toBytes(component2);
+            return EncodingUtils.add(component2Bytes);
+        }
+
+        public static final Hydrator<TableBColumn> BYTES_HYDRATOR = new Hydrator<TableBColumn>() {
+            @Override
+            public TableBColumn hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                String component2 = PtBytes.toString(__input, __index, __input.length-__index);
+                __index += 0;
+                return new TableBColumn(component2);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("component2", component2)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TableBColumn other = (TableBColumn) obj;
+            return Objects.equal(component2, other.component2);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(component2);
+        }
+
+        @Override
+        public int compareTo(TableBColumn o) {
+            return ComparisonChain.start()
+                .compare(this.component2, o.component2)
+                .result();
+        }
+    }
+
+    public interface TableBTrigger {
+        public void putTableB(Multimap<TableBRow, ? extends TableBColumnValue> newRows);
+    }
+
+    /**
+     * <pre>
+     * Column name description {
+     *   {@literal String component2};
+     * }
+     * Column value description {
+     *   type: String;
+     * }
+     * </pre>
+     */
+    public static final class TableBColumnValue implements ColumnValue<String> {
+        private final TableBColumn columnName;
+        private final String value;
+
+        public static TableBColumnValue of(TableBColumn columnName, String value) {
+            return new TableBColumnValue(columnName, value);
+        }
+
+        private TableBColumnValue(TableBColumn columnName, String value) {
+            this.columnName = columnName;
+            this.value = value;
+        }
+
+        public TableBColumn getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return columnName.persistToBytes();
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = PtBytes.toBytes(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        public static String hydrateValue(byte[] bytes) {
+            bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+            return PtBytes.toString(bytes, 0, bytes.length-0);
+        }
+
+        public static Function<TableBColumnValue, TableBColumn> getColumnNameFun() {
+            return new Function<TableBColumnValue, TableBColumn>() {
+                @Override
+                public TableBColumn apply(TableBColumnValue columnValue) {
+                    return columnValue.getColumnName();
+                }
+            };
+        }
+
+        public static Function<TableBColumnValue, String> getValueFun() {
+            return new Function<TableBColumnValue, String>() {
+                @Override
+                public String apply(TableBColumnValue columnValue) {
+                    return columnValue.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("ColumnName", this.columnName)
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public static final class TableBRowResult implements TypedRowResult {
+        private final TableBRow rowName;
+        private final ImmutableSet<TableBColumnValue> columnValues;
+
+        public static TableBRowResult of(RowResult<byte[]> rowResult) {
+            TableBRow rowName = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<TableBColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                String value = TableBColumnValue.hydrateValue(e.getValue());
+                columnValues.add(TableBColumnValue.of(col, value));
+            }
+            return new TableBRowResult(rowName, ImmutableSet.copyOf(columnValues));
+        }
+
+        private TableBRowResult(TableBRow rowName, ImmutableSet<TableBColumnValue> columnValues) {
+            this.rowName = rowName;
+            this.columnValues = columnValues;
+        }
+
+        @Override
+        public TableBRow getRowName() {
+            return rowName;
+        }
+
+        public Set<TableBColumnValue> getColumnValues() {
+            return columnValues;
+        }
+
+        public static Function<TableBRowResult, TableBRow> getRowNameFun() {
+            return new Function<TableBRowResult, TableBRow>() {
+                @Override
+                public TableBRow apply(TableBRowResult rowResult) {
+                    return rowResult.rowName;
+                }
+            };
+        }
+
+        public static Function<TableBRowResult, ImmutableSet<TableBColumnValue>> getColumnValuesFun() {
+            return new Function<TableBRowResult, ImmutableSet<TableBColumnValue>>() {
+                @Override
+                public ImmutableSet<TableBColumnValue> apply(TableBRowResult rowResult) {
+                    return rowResult.columnValues;
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("ColumnValues", getColumnValues())
+                .toString();
+        }
+    }
+
+    @Override
+    public void delete(TableBRow row, TableBColumn column) {
+        delete(ImmutableMultimap.of(row, column));
+    }
+
+    @Override
+    public void delete(Iterable<TableBRow> rows) {
+        Multimap<TableBRow, TableBColumn> toRemove = HashMultimap.create();
+        Multimap<TableBRow, TableBColumnValue> result = getRowsMultimap(rows);
+        for (Entry<TableBRow, TableBColumnValue> e : result.entries()) {
+            toRemove.put(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toRemove);
+    }
+
+    @Override
+    public void delete(Multimap<TableBRow, TableBColumn> values) {
+        t.delete(tableRef, ColumnValues.toCells(values));
+    }
+
+    @Override
+    public void put(TableBRow rowName, Iterable<TableBColumnValue> values) {
+        put(ImmutableMultimap.<TableBRow, TableBColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(TableBRow rowName, TableBColumnValue... values) {
+        put(ImmutableMultimap.<TableBRow, TableBColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(Multimap<TableBRow, ? extends TableBColumnValue> values) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(values));
+        for (TableBTrigger trigger : triggers) {
+            trigger.putTableB(values);
+        }
+    }
+
+    @Override
+    public void putUnlessExists(TableBRow rowName, Iterable<TableBColumnValue> values) {
+        putUnlessExists(ImmutableMultimap.<TableBRow, TableBColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void putUnlessExists(TableBRow rowName, TableBColumnValue... values) {
+        putUnlessExists(ImmutableMultimap.<TableBRow, TableBColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void putUnlessExists(Multimap<TableBRow, ? extends TableBColumnValue> rows) {
+        Multimap<TableBRow, TableBColumn> toGet = Multimaps.transformValues(rows, TableBColumnValue.getColumnNameFun());
+        Multimap<TableBRow, TableBColumnValue> existing = get(toGet);
+        Multimap<TableBRow, TableBColumnValue> toPut = HashMultimap.create();
+        for (Entry<TableBRow, ? extends TableBColumnValue> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    @Override
+    public void touch(Multimap<TableBRow, TableBColumn> values) {
+        Multimap<TableBRow, TableBColumnValue> currentValues = get(values);
+        put(currentValues);
+        Multimap<TableBRow, TableBColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<TableBRow, TableBColumnValue> e : currentValues.entries()) {
+            toDelete.remove(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toDelete);
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<TableBColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
+    }
+
+    public static ColumnSelection getColumnSelection(TableBColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    @Override
+    public Multimap<TableBRow, TableBColumnValue> get(Multimap<TableBRow, TableBColumn> cells) {
+        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
+        Multimap<TableBRow, TableBColumnValue> rowMap = HashMultimap.create();
+        for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
+            if (e.getValue().length > 0) {
+                TableBRow row = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                String val = TableBColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, TableBColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Multimap<TableBRow, TableBColumnValue> getAsync(final Multimap<TableBRow, TableBColumn> cells, ExecutorService exec) {
+        Callable<Multimap<TableBRow, TableBColumnValue>> c =
+                new Callable<Multimap<TableBRow, TableBColumnValue>>() {
+            @Override
+            public Multimap<TableBRow, TableBColumnValue> call() {
+                return get(cells);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), Multimap.class);
+    }
+
+    @Override
+    public List<TableBColumnValue> getRowColumns(TableBRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<TableBColumnValue> getRowColumns(TableBRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<TableBColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                String val = TableBColumnValue.hydrateValue(e.getValue());
+                ret.add(TableBColumnValue.of(col, val));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<TableBRow, TableBColumnValue> getRowsMultimap(Iterable<? extends TableBRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<TableBRow, TableBColumnValue> getRowsMultimap(Iterable<TableBRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    @Override
+    public Multimap<TableBRow, TableBColumnValue> getAsyncRowsMultimap(Iterable<TableBRow> rows, ExecutorService exec) {
+        return getAsyncRowsMultimap(rows, allColumns, exec);
+    }
+
+    @Override
+    public Multimap<TableBRow, TableBColumnValue> getAsyncRowsMultimap(final Iterable<TableBRow> rows, final ColumnSelection columns, ExecutorService exec) {
+        Callable<Multimap<TableBRow, TableBColumnValue>> c =
+                new Callable<Multimap<TableBRow, TableBColumnValue>>() {
+            @Override
+            public Multimap<TableBRow, TableBColumnValue> call() {
+                return getRowsMultimapInternal(rows, columns);
+            }
+        };
+        return AsyncProxy.create(exec.submit(c), Multimap.class);
+    }
+
+    private Multimap<TableBRow, TableBColumnValue> getRowsMultimapInternal(Iterable<? extends TableBRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<TableBRow, TableBColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<TableBRow, TableBColumnValue> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            TableBRow row = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                String val = TableBColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, TableBColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<TableBRow, BatchingVisitable<TableBColumnValue>> getRowsColumnRange(Iterable<TableBRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TableBRow, BatchingVisitable<TableBColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TableBRow row = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<TableBColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                String val = TableBColumnValue.hydrateValue(result.getValue());
+                return TableBColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<TableBRow, TableBColumnValue>> getRowsColumnRange(Iterable<TableBRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            TableBRow row = TableBRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            TableBColumn col = TableBColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            String val = TableBColumnValue.hydrateValue(e.getValue());
+            TableBColumnValue colValue = TableBColumnValue.of(col, val);
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<TableBRowResult> getRange(RangeRequest range) {
+        if (range.getColumnNames().isEmpty()) {
+            range = range.getBuilder().retainColumns(allColumns).build();
+        }
+        return BatchingVisitables.transform(t.getRange(tableRef, range), new Function<RowResult<byte[]>, TableBRowResult>() {
+            @Override
+            public TableBRowResult apply(RowResult<byte[]> input) {
+                return TableBRowResult.of(input);
+            }
+        });
+    }
+
+    public IterableView<BatchingVisitable<TableBRowResult>> getRanges(Iterable<RangeRequest> ranges) {
+        Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRanges(tableRef, ranges);
+        return IterableView.of(rangeResults).transform(
+                new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<TableBRowResult>>() {
+            @Override
+            public BatchingVisitable<TableBRowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
+                return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, TableBRowResult>() {
+                    @Override
+                    public TableBRowResult apply(RowResult<byte[]> row) {
+                        return TableBRowResult.of(row);
+                    }
+                });
+            }
+        });
+    }
+
+    public void deleteRange(RangeRequest range) {
+        deleteRanges(ImmutableSet.of(range));
+    }
+
+    public void deleteRanges(Iterable<RangeRequest> ranges) {
+        BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<? extends TableBRowResult>, RuntimeException>() {
+            @Override
+            public boolean visit(List<? extends TableBRowResult> rowResults) {
+                Multimap<TableBRow, TableBColumn> toRemove = HashMultimap.create();
+                for (TableBRowResult rowResult : rowResults) {
+                    for (TableBColumnValue columnValue : rowResult.getColumnValues()) {
+                        toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
+                    }
+                }
+                delete(toRemove);
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AsyncProxy}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutableExpiringTable}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutableExpiringTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedExpiringSet}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link ExecutorService}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "P8cLbFPi7+BySFRzNALyhQ==";
+}

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
@@ -717,5 +717,5 @@ public final class CheckAndSetTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "vRzK/r2VXST+puDjpkcKPA==";
+    static String __CLASS_HASH = "/9n4pYFQN4hnqMn44C51mw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/IndexTestSchema.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/IndexTestSchema.java
@@ -33,7 +33,7 @@ public class IndexTestSchema implements AtlasSchema {
 
     private static Schema generateSchema() {
         Schema schema = new Schema("IndexTest",
-                IndexTest.class.getPackage().getName() + ".generated",
+                IndexTestSchema.class.getPackage().getName() + ".generated",
                 Namespace.DEFAULT_NAMESPACE);
 
         schema.addTableDefinition("data", new TableDefinition() {{

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -598,7 +598,7 @@ public final class DataTable implements
     }
 
     @Override
-    public void delete(Iterable<DataRow> rows) {
+    public void delete(Iterable<? extends DataRow> rows) {
         Multimap<DataRow, DataNamedColumnValue<?>> result = getRowsMultimap(rows);
         deleteIndex1Idx(result);
         deleteIndex2Idx(result);
@@ -677,7 +677,7 @@ public final class DataTable implements
     }
 
     @Override
-    public Multimap<DataRow, DataNamedColumnValue<?>> getRowsMultimap(Iterable<DataRow> rows) {
+    public Multimap<DataRow, DataNamedColumnValue<?>> getRowsMultimap(Iterable<? extends DataRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -703,7 +703,7 @@ public final class DataTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<DataRow, DataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<DataRow> rows, ColumnSelection columns) {
+    private Multimap<DataRow, DataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends DataRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -1412,7 +1412,7 @@ public final class DataTable implements
         }
 
         @Override
-        public Multimap<Index1IdxRow, Index1IdxColumnValue> getRowsMultimap(Iterable<Index1IdxRow> rows) {
+        public Multimap<Index1IdxRow, Index1IdxColumnValue> getRowsMultimap(Iterable<? extends Index1IdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -1438,7 +1438,7 @@ public final class DataTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<Index1IdxRow, Index1IdxColumnValue> getRowsMultimapInternal(Iterable<Index1IdxRow> rows, ColumnSelection columns) {
+        private Multimap<Index1IdxRow, Index1IdxColumnValue> getRowsMultimapInternal(Iterable<? extends Index1IdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
@@ -2087,7 +2087,7 @@ public final class DataTable implements
         }
 
         @Override
-        public Multimap<Index2IdxRow, Index2IdxColumnValue> getRowsMultimap(Iterable<Index2IdxRow> rows) {
+        public Multimap<Index2IdxRow, Index2IdxColumnValue> getRowsMultimap(Iterable<? extends Index2IdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -2113,7 +2113,7 @@ public final class DataTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<Index2IdxRow, Index2IdxColumnValue> getRowsMultimapInternal(Iterable<Index2IdxRow> rows, ColumnSelection columns) {
+        private Multimap<Index2IdxRow, Index2IdxColumnValue> getRowsMultimapInternal(Iterable<? extends Index2IdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
@@ -2740,7 +2740,7 @@ public final class DataTable implements
         }
 
         @Override
-        public Multimap<Index3IdxRow, Index3IdxColumnValue> getRowsMultimap(Iterable<Index3IdxRow> rows) {
+        public Multimap<Index3IdxRow, Index3IdxColumnValue> getRowsMultimap(Iterable<? extends Index3IdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -2766,7 +2766,7 @@ public final class DataTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<Index3IdxRow, Index3IdxColumnValue> getRowsMultimapInternal(Iterable<Index3IdxRow> rows, ColumnSelection columns) {
+        private Multimap<Index3IdxRow, Index3IdxColumnValue> getRowsMultimapInternal(Iterable<? extends Index3IdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
@@ -3415,7 +3415,7 @@ public final class DataTable implements
         }
 
         @Override
-        public Multimap<Index4IdxRow, Index4IdxColumnValue> getRowsMultimap(Iterable<Index4IdxRow> rows) {
+        public Multimap<Index4IdxRow, Index4IdxColumnValue> getRowsMultimap(Iterable<? extends Index4IdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -3441,7 +3441,7 @@ public final class DataTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<Index4IdxRow, Index4IdxColumnValue> getRowsMultimapInternal(Iterable<Index4IdxRow> rows, ColumnSelection columns) {
+        private Multimap<Index4IdxRow, Index4IdxColumnValue> getRowsMultimapInternal(Iterable<? extends Index4IdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
@@ -3636,5 +3636,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "HnfMRutCyVsBK7QAtC/+jA==";
+    static String __CLASS_HASH = "jBfeZXhBQBT0h0JTHK+04Q==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -667,7 +667,7 @@ public final class TwoColumnsTable implements
     }
 
     @Override
-    public void delete(Iterable<TwoColumnsRow> rows) {
+    public void delete(Iterable<? extends TwoColumnsRow> rows) {
         Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> result = getRowsMultimap(rows);
         deleteFooToIdCondIdx(result);
         deleteFooToIdIdx(result);
@@ -745,7 +745,7 @@ public final class TwoColumnsTable implements
     }
 
     @Override
-    public Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> getRowsMultimap(Iterable<TwoColumnsRow> rows) {
+    public Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> getRowsMultimap(Iterable<? extends TwoColumnsRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -771,7 +771,7 @@ public final class TwoColumnsTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> getRowsMultimapInternal(Iterable<TwoColumnsRow> rows, ColumnSelection columns) {
+    private Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends TwoColumnsRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -1442,7 +1442,7 @@ public final class TwoColumnsTable implements
         }
 
         @Override
-        public Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumnValue> getRowsMultimap(Iterable<FooToIdCondIdxRow> rows) {
+        public Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumnValue> getRowsMultimap(Iterable<? extends FooToIdCondIdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -1468,7 +1468,7 @@ public final class TwoColumnsTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumnValue> getRowsMultimapInternal(Iterable<FooToIdCondIdxRow> rows, ColumnSelection columns) {
+        private Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumnValue> getRowsMultimapInternal(Iterable<? extends FooToIdCondIdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
@@ -2104,7 +2104,7 @@ public final class TwoColumnsTable implements
         }
 
         @Override
-        public Multimap<FooToIdIdxRow, FooToIdIdxColumnValue> getRowsMultimap(Iterable<FooToIdIdxRow> rows) {
+        public Multimap<FooToIdIdxRow, FooToIdIdxColumnValue> getRowsMultimap(Iterable<? extends FooToIdIdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -2130,7 +2130,7 @@ public final class TwoColumnsTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<FooToIdIdxRow, FooToIdIdxColumnValue> getRowsMultimapInternal(Iterable<FooToIdIdxRow> rows, ColumnSelection columns) {
+        private Multimap<FooToIdIdxRow, FooToIdIdxColumnValue> getRowsMultimapInternal(Iterable<? extends FooToIdIdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
@@ -2291,5 +2291,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UpDk9nRzPSLNVC6dlfbS7g==";
+    static String __CLASS_HASH = "lEHDqlc+AZAiVBpItKn3Sw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTestSchema.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/StreamTestSchema.java
@@ -30,7 +30,7 @@ public class StreamTestSchema implements AtlasSchema {
 
     private static Schema generateSchema() {
         Schema schema = new Schema("StreamTest",
-                StreamTest.class.getPackage().getName() + ".generated",
+                StreamTestSchema.class.getPackage().getName() + ".generated",
                 Namespace.DEFAULT_NAMESPACE);
 
         // stores a mapping from key to streamId

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
@@ -464,7 +464,7 @@ public final class KeyValueTable implements
     }
 
     @Override
-    public void delete(Iterable<KeyValueRow> rows) {
+    public void delete(Iterable<? extends KeyValueRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("s")));
@@ -538,7 +538,7 @@ public final class KeyValueTable implements
     }
 
     @Override
-    public Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> getRowsMultimap(Iterable<KeyValueRow> rows) {
+    public Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> getRowsMultimap(Iterable<? extends KeyValueRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -564,7 +564,7 @@ public final class KeyValueTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<KeyValueRow> rows, ColumnSelection columns) {
+    private Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends KeyValueRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -717,5 +717,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "26REEPuBZ5/GeJc3UVRfug==";
+    static String __CLASS_HASH = "aXUGXbyY3eB7JKmTH2kNfg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -581,7 +581,7 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
     }
 
     @Override
-    public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestMaxMemStreamHashAidxRow> rows) {
+    public Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowsMultimap(Iterable<? extends StreamTestMaxMemStreamHashAidxRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -607,7 +607,7 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<StreamTestMaxMemStreamHashAidxRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<? extends StreamTestMaxMemStreamHashAidxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -766,5 +766,5 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "6KjHR4/i7R8TPVeWh0VB6Q==";
+    static String __CLASS_HASH = "4oOKtcl+yNpeqCk6gZwZwA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -581,7 +581,7 @@ public final class StreamTestMaxMemStreamIdxTable implements
     }
 
     @Override
-    public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowsMultimap(Iterable<StreamTestMaxMemStreamIdxRow> rows) {
+    public Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowsMultimap(Iterable<? extends StreamTestMaxMemStreamIdxRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -607,7 +607,7 @@ public final class StreamTestMaxMemStreamIdxTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowsMultimapInternal(Iterable<StreamTestMaxMemStreamIdxRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> getRowsMultimapInternal(Iterable<? extends StreamTestMaxMemStreamIdxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -766,5 +766,5 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "HTDDCKZJoVbnP2nQipqeHA==";
+    static String __CLASS_HASH = "DRFE7mdvS/JcLQ1lv8uO1A==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -488,7 +488,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
     }
 
     @Override
-    public void delete(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
+    public void delete(Iterable<? extends StreamTestMaxMemStreamMetadataRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
@@ -562,7 +562,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
     }
 
     @Override
-    public Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestMaxMemStreamMetadataRow> rows) {
+    public Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<? extends StreamTestMaxMemStreamMetadataRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -588,7 +588,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestMaxMemStreamMetadataRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends StreamTestMaxMemStreamMetadataRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -741,5 +741,5 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ovKBuFSKXhb5ELOhaS04Gw==";
+    static String __CLASS_HASH = "OqoGSmXn45N6rHp1IGBFpQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -476,7 +476,7 @@ public final class StreamTestMaxMemStreamValueTable implements
     }
 
     @Override
-    public void delete(Iterable<StreamTestMaxMemStreamValueRow> rows) {
+    public void delete(Iterable<? extends StreamTestMaxMemStreamValueRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
@@ -550,7 +550,7 @@ public final class StreamTestMaxMemStreamValueTable implements
     }
 
     @Override
-    public Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestMaxMemStreamValueRow> rows) {
+    public Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<? extends StreamTestMaxMemStreamValueRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -576,7 +576,7 @@ public final class StreamTestMaxMemStreamValueTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestMaxMemStreamValueRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends StreamTestMaxMemStreamValueRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -729,5 +729,5 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "YN3vYMkZLfm4msMBJmEanw==";
+    static String __CLASS_HASH = "y8N3BFHR13illAZO+0P1Tw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
@@ -581,7 +581,7 @@ public final class StreamTestStreamHashAidxTable implements
     }
 
     @Override
-    public Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestStreamHashAidxRow> rows) {
+    public Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowsMultimap(Iterable<? extends StreamTestStreamHashAidxRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -607,7 +607,7 @@ public final class StreamTestStreamHashAidxTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<StreamTestStreamHashAidxRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<? extends StreamTestStreamHashAidxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -766,5 +766,5 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "VbDm0a59P2vKIlgwBro4YQ==";
+    static String __CLASS_HASH = "J8xGxb0ve3zm3HIfEyw0uQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
@@ -581,7 +581,7 @@ public final class StreamTestStreamIdxTable implements
     }
 
     @Override
-    public Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> getRowsMultimap(Iterable<StreamTestStreamIdxRow> rows) {
+    public Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> getRowsMultimap(Iterable<? extends StreamTestStreamIdxRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -607,7 +607,7 @@ public final class StreamTestStreamIdxTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> getRowsMultimapInternal(Iterable<StreamTestStreamIdxRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> getRowsMultimapInternal(Iterable<? extends StreamTestStreamIdxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -766,5 +766,5 @@ public final class StreamTestStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "jSX282CSmW6BAjJUY5s3Jw==";
+    static String __CLASS_HASH = "VCDYJiik5t/cGCPR9sHMkw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -488,7 +488,7 @@ public final class StreamTestStreamMetadataTable implements
     }
 
     @Override
-    public void delete(Iterable<StreamTestStreamMetadataRow> rows) {
+    public void delete(Iterable<? extends StreamTestStreamMetadataRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
@@ -562,7 +562,7 @@ public final class StreamTestStreamMetadataTable implements
     }
 
     @Override
-    public Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestStreamMetadataRow> rows) {
+    public Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<? extends StreamTestStreamMetadataRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -588,7 +588,7 @@ public final class StreamTestStreamMetadataTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestStreamMetadataRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends StreamTestStreamMetadataRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -741,5 +741,5 @@ public final class StreamTestStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "3ojwsIhrTIviW11wySPLxA==";
+    static String __CLASS_HASH = "xj5jbxU9xwb6ECyXymcWTQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -476,7 +476,7 @@ public final class StreamTestStreamValueTable implements
     }
 
     @Override
-    public void delete(Iterable<StreamTestStreamValueRow> rows) {
+    public void delete(Iterable<? extends StreamTestStreamValueRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
@@ -550,7 +550,7 @@ public final class StreamTestStreamValueTable implements
     }
 
     @Override
-    public Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestStreamValueRow> rows) {
+    public Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<? extends StreamTestStreamValueRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -576,7 +576,7 @@ public final class StreamTestStreamValueTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestStreamValueRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends StreamTestStreamValueRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -729,5 +729,5 @@ public final class StreamTestStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "bGruW2fk4ePTtlzh25i7mA==";
+    static String __CLASS_HASH = "HrEJOO9+OhGlsm0Phi30Iw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
@@ -581,7 +581,7 @@ public final class StreamTestWithHashStreamHashAidxTable implements
     }
 
     @Override
-    public Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestWithHashStreamHashAidxRow> rows) {
+    public Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> getRowsMultimap(Iterable<? extends StreamTestWithHashStreamHashAidxRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -607,7 +607,7 @@ public final class StreamTestWithHashStreamHashAidxTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<StreamTestWithHashStreamHashAidxRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<? extends StreamTestWithHashStreamHashAidxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -766,5 +766,5 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "wGi6hcD4OPK2Fnz76AFEvA==";
+    static String __CLASS_HASH = "gOEbCjFojJgKpfUZkTsqpA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
@@ -590,7 +590,7 @@ public final class StreamTestWithHashStreamIdxTable implements
     }
 
     @Override
-    public Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue> getRowsMultimap(Iterable<StreamTestWithHashStreamIdxRow> rows) {
+    public Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue> getRowsMultimap(Iterable<? extends StreamTestWithHashStreamIdxRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -616,7 +616,7 @@ public final class StreamTestWithHashStreamIdxTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue> getRowsMultimapInternal(Iterable<StreamTestWithHashStreamIdxRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue> getRowsMultimapInternal(Iterable<? extends StreamTestWithHashStreamIdxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -775,5 +775,5 @@ public final class StreamTestWithHashStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "TTJpdgTnyp3pKJMSGWzMEw==";
+    static String __CLASS_HASH = "vUIFkfaq/RO904vjcWl98A==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -497,7 +497,7 @@ public final class StreamTestWithHashStreamMetadataTable implements
     }
 
     @Override
-    public void delete(Iterable<StreamTestWithHashStreamMetadataRow> rows) {
+    public void delete(Iterable<? extends StreamTestWithHashStreamMetadataRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
@@ -571,7 +571,7 @@ public final class StreamTestWithHashStreamMetadataTable implements
     }
 
     @Override
-    public Multimap<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestWithHashStreamMetadataRow> rows) {
+    public Multimap<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<? extends StreamTestWithHashStreamMetadataRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -597,7 +597,7 @@ public final class StreamTestWithHashStreamMetadataTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestWithHashStreamMetadataRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends StreamTestWithHashStreamMetadataRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -750,5 +750,5 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "oplV0XBNSDiuh+BC+uOnmg==";
+    static String __CLASS_HASH = "ZW+JuxlGLHq+K4dOwHX+Mg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
@@ -485,7 +485,7 @@ public final class StreamTestWithHashStreamValueTable implements
     }
 
     @Override
-    public void delete(Iterable<StreamTestWithHashStreamValueRow> rows) {
+    public void delete(Iterable<? extends StreamTestWithHashStreamValueRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
@@ -559,7 +559,7 @@ public final class StreamTestWithHashStreamValueTable implements
     }
 
     @Override
-    public Multimap<StreamTestWithHashStreamValueRow, StreamTestWithHashStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestWithHashStreamValueRow> rows) {
+    public Multimap<StreamTestWithHashStreamValueRow, StreamTestWithHashStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<? extends StreamTestWithHashStreamValueRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -585,7 +585,7 @@ public final class StreamTestWithHashStreamValueTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<StreamTestWithHashStreamValueRow, StreamTestWithHashStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestWithHashStreamValueRow> rows, ColumnSelection columns) {
+    private Multimap<StreamTestWithHashStreamValueRow, StreamTestWithHashStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends StreamTestWithHashStreamValueRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -738,5 +738,5 @@ public final class StreamTestWithHashStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "f9j87h9bCmX57DOhXfUplw==";
+    static String __CLASS_HASH = "tmVPql4CwNB0pk5vnhG2hg==";
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,7 @@ develop
     *    - |devbreak| |fixed|
          - Devs should regenerate their Schemas when upgrading to get rid of some type problems that are no longer
            accepted in newer Java compilers.
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/1545>`__) and (`Pull Request 2 <https://github.com/palantir/atlasdb/pull/1571>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -581,7 +581,7 @@ public final class UserPhotosStreamHashAidxTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimap(Iterable<UserPhotosStreamHashAidxRow> rows) {
+    public Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimap(Iterable<? extends UserPhotosStreamHashAidxRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -607,7 +607,7 @@ public final class UserPhotosStreamHashAidxTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<UserPhotosStreamHashAidxRow> rows, ColumnSelection columns) {
+    private Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<? extends UserPhotosStreamHashAidxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -766,5 +766,5 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "dQJo6NvMXsoKhKg3Vq7GNg==";
+    static String __CLASS_HASH = "3G/WHTh4hLHpmqMKsxV+NQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -766,5 +766,5 @@ public final class UserPhotosStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "0BCwlfLHYV5Htu8FCwnBXA==";
+    static String __CLASS_HASH = "MsppknNWxXR0JaPCpat7GA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -581,7 +581,7 @@ public final class UserPhotosStreamIdxTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimap(Iterable<UserPhotosStreamIdxRow> rows) {
+    public Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimap(Iterable<? extends UserPhotosStreamIdxRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -607,7 +607,7 @@ public final class UserPhotosStreamIdxTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimapInternal(Iterable<UserPhotosStreamIdxRow> rows, ColumnSelection columns) {
+    private Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> getRowsMultimapInternal(Iterable<? extends UserPhotosStreamIdxRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -741,5 +741,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "pF65FiYhkVyYcSGzmQXwbQ==";
+    static String __CLASS_HASH = "hOiyQljQ1kFcWbt6a/FX+Q==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -488,7 +488,7 @@ public final class UserPhotosStreamMetadataTable implements
     }
 
     @Override
-    public void delete(Iterable<UserPhotosStreamMetadataRow> rows) {
+    public void delete(Iterable<? extends UserPhotosStreamMetadataRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
@@ -562,7 +562,7 @@ public final class UserPhotosStreamMetadataTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<UserPhotosStreamMetadataRow> rows) {
+    public Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<? extends UserPhotosStreamMetadataRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -588,7 +588,7 @@ public final class UserPhotosStreamMetadataTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<UserPhotosStreamMetadataRow> rows, ColumnSelection columns) {
+    private Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends UserPhotosStreamMetadataRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -729,5 +729,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lp86MkgeeTISottbieOOIA==";
+    static String __CLASS_HASH = "oSZ1LSj2T/7UdMo6PTUscw==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -476,7 +476,7 @@ public final class UserPhotosStreamValueTable implements
     }
 
     @Override
-    public void delete(Iterable<UserPhotosStreamValueRow> rows) {
+    public void delete(Iterable<? extends UserPhotosStreamValueRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
         Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
@@ -550,7 +550,7 @@ public final class UserPhotosStreamValueTable implements
     }
 
     @Override
-    public Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<UserPhotosStreamValueRow> rows) {
+    public Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<? extends UserPhotosStreamValueRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -576,7 +576,7 @@ public final class UserPhotosStreamValueTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<UserPhotosStreamValueRow> rows, ColumnSelection columns) {
+    private Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends UserPhotosStreamValueRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -995,7 +995,7 @@ public final class UserProfileTable implements
     }
 
     @Override
-    public void delete(Iterable<UserProfileRow> rows) {
+    public void delete(Iterable<? extends UserProfileRow> rows) {
         Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> result = getRowsMultimap(rows);
         deleteCookiesIdx(result);
         deleteCreatedIdx(result);
@@ -1076,7 +1076,7 @@ public final class UserProfileTable implements
     }
 
     @Override
-    public Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimap(Iterable<UserProfileRow> rows) {
+    public Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimap(Iterable<? extends UserProfileRow> rows) {
         return getRowsMultimapInternal(rows, allColumns);
     }
 
@@ -1102,7 +1102,7 @@ public final class UserProfileTable implements
         return AsyncProxy.create(exec.submit(c), Multimap.class);
     }
 
-    private Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimapInternal(Iterable<UserProfileRow> rows, ColumnSelection columns) {
+    private Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> getRowsMultimapInternal(Iterable<? extends UserProfileRow> rows, ColumnSelection columns) {
         SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
         return getRowMapFromRowResults(results.values());
     }
@@ -1791,7 +1791,7 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimap(Iterable<CookiesIdxRow> rows) {
+        public Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimap(Iterable<? extends CookiesIdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -1817,7 +1817,7 @@ public final class UserProfileTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimapInternal(Iterable<CookiesIdxRow> rows, ColumnSelection columns) {
+        private Multimap<CookiesIdxRow, CookiesIdxColumnValue> getRowsMultimapInternal(Iterable<? extends CookiesIdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
@@ -2478,7 +2478,7 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimap(Iterable<CreatedIdxRow> rows) {
+        public Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimap(Iterable<? extends CreatedIdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -2504,7 +2504,7 @@ public final class UserProfileTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimapInternal(Iterable<CreatedIdxRow> rows, ColumnSelection columns) {
+        private Multimap<CreatedIdxRow, CreatedIdxColumnValue> getRowsMultimapInternal(Iterable<? extends CreatedIdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }
@@ -3165,7 +3165,7 @@ public final class UserProfileTable implements
         }
 
         @Override
-        public Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimap(Iterable<UserBirthdaysIdxRow> rows) {
+        public Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimap(Iterable<? extends UserBirthdaysIdxRow> rows) {
             return getRowsMultimapInternal(rows, allColumns);
         }
 
@@ -3191,7 +3191,7 @@ public final class UserProfileTable implements
             return AsyncProxy.create(exec.submit(c), Multimap.class);
         }
 
-        private Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimapInternal(Iterable<UserBirthdaysIdxRow> rows, ColumnSelection columns) {
+        private Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> getRowsMultimapInternal(Iterable<? extends UserBirthdaysIdxRow> rows, ColumnSelection columns) {
             SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
             return getRowMapFromRowResults(results.values());
         }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -3386,5 +3386,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "gw55a2h5Qud/CxGW9RGGWA==";
+    static String __CLASS_HASH = "XAWQ7jzaJOs0v1rHKKvroQ==";
 }


### PR DESCRIPTION
The original change missed rangeDeletions as they were not tested in the code base.

Our product nightly integration tests caught this failure and we were able to fix it before releasing

@clockfort for the original change

I have added a test schema that would catch these problems if they were to occur in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1571)
<!-- Reviewable:end -->
