### PR TITLE
Fix/intellij compiler errors

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitableView.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitableView.java
@@ -47,7 +47,7 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
     @Override
     protected abstract BatchingVisitable<T> delegate();
 
-    public static <T> BatchingVisitableView<T> of(final BatchingVisitable<? extends T> underlyingVisitable) {
+    public static <T> BatchingVisitableView<T> of(final BatchingVisitable<T> underlyingVisitable) {
         Preconditions.checkNotNull(underlyingVisitable, "Cannot wrap a null visitable");
         return new BatchingVisitableView<T>() {
             @Override

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
@@ -73,7 +73,7 @@ public class BatchingVisitables {
     private static <T> long countInternal(BatchingVisitable<T> visitable, int batchSize) {
         final long[] count = new long[1];
         visitable.batchAccept(batchSize,
-                AbortingVisitors.batching(
+                AbortingVisitors.<T, RuntimeException>batching(
                         new AbortingVisitor<T, RuntimeException>() {
                             @Override
                             public boolean visit(Object item) {
@@ -85,7 +85,7 @@ public class BatchingVisitables {
     }
 
     public static <T> boolean isEmpty(BatchingVisitable<T> v) {
-        return v.batchAccept(1, AbortingVisitors.batching(AbortingVisitors.<T>alwaysFalse()));
+        return v.batchAccept(1, AbortingVisitors.<T, RuntimeException>batching(AbortingVisitors.<T>alwaysFalse()));
     }
 
     /**
@@ -129,7 +129,7 @@ public class BatchingVisitables {
     @Nullable
     public static <T> T getFirst(BatchingVisitable<T> visitable, @Nullable T defaultElement) {
         final Mutable<T> ret = Mutables.newMutable(defaultElement);
-        visitable.batchAccept(1, AbortingVisitors.batching(new AbortingVisitor<T, RuntimeException>() {
+        visitable.batchAccept(1, AbortingVisitors.<T, RuntimeException>batching(new AbortingVisitor<T, RuntimeException>() {
             @Override
             public boolean visit(T item) {
                 ret.set(item);
@@ -183,7 +183,7 @@ public class BatchingVisitables {
         final Mutable<T> ret = Mutables.newMutable(defaultElement);
         v.batchAccept(
                 DEFAULT_BATCH_SIZE,
-                AbortingVisitors.batching(new AbortingVisitor<T, RuntimeException>() {
+                AbortingVisitors.<T, RuntimeException>batching(new AbortingVisitor<T, RuntimeException>() {
                     boolean hasSeenFirst = false;
                     @Override
                     public boolean visit(T item) throws RuntimeException {
@@ -226,7 +226,7 @@ public class BatchingVisitables {
         final Mutable<T> ret = Mutables.newMutable(defaultElement);
         v.batchAccept(
                 DEFAULT_BATCH_SIZE,
-                AbortingVisitors.batching(new AbortingVisitor<T, RuntimeException>() {
+                AbortingVisitors.<T, RuntimeException>batching(new AbortingVisitor<T, RuntimeException>() {
                     boolean hasSeenFirst = false;
                     @Override
                     public boolean visit(T item) throws RuntimeException {
@@ -253,7 +253,7 @@ public class BatchingVisitables {
     public static <T> T getLast(BatchingVisitable<T> visitable, @Nullable T defaultElement) {
         final Mutable<T> ret = Mutables.newMutable(defaultElement);
         visitable.batchAccept(DEFAULT_BATCH_SIZE,
-                AbortingVisitors.batching(new AbortingVisitor<T, RuntimeException>() {
+                AbortingVisitors.<T, RuntimeException>batching(new AbortingVisitor<T, RuntimeException>() {
             @Override
             public boolean visit(T item) {
                 ret.set(item);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,12 @@ develop
          - Removed an unused hamcrest import from timestamp-impl.  This should reduce the size of our transitive dependencies and therefore of product binaries.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1578>`__)
 
+    *    - |devbreak|
+         - Modified the type signature of `BatchingVisitableView#of` to no long accept `final BatchingVisitable<? extends T> underlyingVisitable` and instead accept
+           `final BatchingVisitable<T> underlyingVisitable`.  We do not believe this typing is in use.  If you discover that is not the case and you cannot work around it,
+           please file a ticket on the AtlasDB github page.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1582>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Currently includes #1581, but putting up for SA.  This only shrinks the type signature of BatchingVisitablesView#of instead of expanding that of AbortingVisitor which was resulting in a fairly large dev break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1582)
<!-- Reviewable:end -->
