### PR TITLE
use immutables

### DIFF
--- a/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommandTest.java
+++ b/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommandTest.java
@@ -33,7 +33,7 @@ import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.dropwizard.AtlasDbConfigurationProvider;
-import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
+import com.palantir.atlasdb.memory.ImmutableInMemoryAtlasDbConfig;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
@@ -47,7 +47,7 @@ public class AtlasDbConsoleCommandTest {
                     .addLeaders(LOCAL_SERVER_NAME)
                     .localServer(LOCAL_SERVER_NAME)
                     .build())
-            .keyValueService(new InMemoryAtlasDbConfig())
+            .keyValueService(ImmutableInMemoryAtlasDbConfig.builder().build())
             .build();
 
     private static final Map<String, Object> ONLINE_PARAMS = Collections

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
@@ -26,7 +26,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 @JsonTypeName(InMemoryAtlasDbConfig.TYPE)
 @AutoService(KeyValueServiceConfig.class)
 @Value.Immutable
-public final class InMemoryAtlasDbConfig implements KeyValueServiceConfig {
+public abstract class InMemoryAtlasDbConfig implements KeyValueServiceConfig {
     public static final String TYPE = "memory";
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.memory;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.service.AutoService;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
@@ -15,12 +15,16 @@
  */
 package com.palantir.atlasdb.memory;
 
+import org.immutables.value.Value;
+
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.service.AutoService;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
+@JsonDeserialize(as = ImmutableInMemoryAtlasDbConfig.class)
 @JsonTypeName(InMemoryAtlasDbConfig.TYPE)
 @AutoService(KeyValueServiceConfig.class)
+@Value.Immutable
 public final class InMemoryAtlasDbConfig implements KeyValueServiceConfig {
     public static final String TYPE = "memory";
 


### PR DESCRIPTION
having config objects be .equals() to each other means we can do auto-reloading from the filesystem and compare to what it was previously (and only take action if something changed)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1587)
<!-- Reviewable:end -->
