### PR TITLE
Add endpoint to log filtered locks on LockServer

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/ExpiringToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/ExpiringToken.java
@@ -47,6 +47,12 @@ public interface ExpiringToken {
     @Nullable LockClient getClient();
 
     /**
+     * Returns the set of locks which were successfully acquired as a map
+     * from descriptor to lock mode.
+     */
+    SortedLockCollection<LockDescriptor> getLockDescriptors();
+
+    /**
      * Returns the amount of time that it takes for these locks to
      * expire.
      */

--- a/lock-api/src/main/java/com/palantir/lock/ForwardingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/ForwardingLockService.java
@@ -148,4 +148,9 @@ public abstract class ForwardingLockService extends ForwardingObject implements 
     public void logCurrentState() {
         delegate().logCurrentState();
     }
+
+    @Override
+    public void logCurrentHeldLocks(String descriptorRegex, boolean versionIdNecessary) {
+        delegate().logCurrentHeldLocks(descriptorRegex, versionIdNecessary);
+    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/ForwardingRemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/ForwardingRemoteLockService.java
@@ -60,4 +60,9 @@ public abstract class ForwardingRemoteLockService extends ForwardingObject imple
     public void logCurrentState() {
         delegate().logCurrentState();
     }
+
+    @Override
+    public void logCurrentHeldLocks(String descriptorRegex, boolean versionIdNecessary) {
+        delegate().logCurrentHeldLocks(descriptorRegex, versionIdNecessary);
+    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/HeldLocksGrant.java
+++ b/lock-api/src/main/java/com/palantir/lock/HeldLocksGrant.java
@@ -83,6 +83,11 @@ import com.google.common.base.Preconditions;
         return null;
     }
 
+    @Override
+    public SortedLockCollection<LockDescriptor> getLockDescriptors() {
+        return getLocks();
+    }
+
     /**
      * Returns the time (in milliseconds since the epoch) since this token was
      * created.
@@ -106,6 +111,7 @@ import com.google.common.base.Preconditions;
      * Returns the set of locks which were successfully acquired, as a mapping
      * from descriptor to lock mode.
      */
+    @Deprecated
     public SortedLockCollection<LockDescriptor> getLocks() {
         Preconditions.checkState(!lockMap.isEmpty());
         return lockMap;

--- a/lock-api/src/main/java/com/palantir/lock/HeldLocksToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/HeldLocksToken.java
@@ -112,6 +112,7 @@ import com.google.common.collect.Iterables;
      * Returns the set of locks which were successfully acquired as a map
      * from descriptor to lock mode.
      */
+    @Override
     @JsonIgnore
     public SortedLockCollection<LockDescriptor> getLockDescriptors() {
         return lockMap;

--- a/lock-api/src/main/java/com/palantir/lock/LockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockService.java
@@ -183,4 +183,7 @@ import com.palantir.common.annotation.NonIdempotent;
     @Override
     @Idempotent void logCurrentState();
 
+    @Override
+    @Idempotent void logCurrentHeldLocks(String descriptorRegex, boolean versionIdNecessary);
+
 }

--- a/lock-api/src/main/java/com/palantir/lock/RemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/RemoteLockService.java
@@ -23,6 +23,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.palantir.common.annotation.Idempotent;
@@ -99,4 +100,11 @@ public interface RemoteLockService {
     @POST
     @Path("log-current-state")
     void logCurrentState();
+
+    @POST
+    @Path("log-filtered-current-state")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void logCurrentHeldLocks(
+            @QueryParam("descriptor") String descriptorRegex,
+            @QueryParam("version_id_necessary") boolean versionIdNecessary);
 }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -37,6 +37,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -795,7 +797,7 @@ import com.palantir.util.Pair;
         }
         HeldLocksGrant realGrant = heldLocks.realToken;
         changeOwner(heldLocks.locks, INTERNAL_LOCK_GRANT_CLIENT, client);
-        HeldLocksToken token = createHeldLocksToken(client, realGrant.getLocks(),
+        HeldLocksToken token = createHeldLocksToken(client, realGrant.getLockDescriptors(),
                 heldLocks.locks, realGrant.getLockTimeout(), realGrant.getVersionId());
         if (log.isTraceEnabled()) {
             log.trace(".useGrant(" + client + ", " + grant + ") returns " + token);
@@ -819,7 +821,7 @@ import com.palantir.util.Pair;
         }
         HeldLocksGrant realGrant = heldLocks.realToken;
         changeOwner(heldLocks.locks, INTERNAL_LOCK_GRANT_CLIENT, client);
-        HeldLocksToken token = createHeldLocksToken(client, realGrant.getLocks(),
+        HeldLocksToken token = createHeldLocksToken(client, realGrant.getLockDescriptors(),
                 heldLocks.locks, realGrant.getLockTimeout(), realGrant.getVersionId());
         if (log.isTraceEnabled()) {
             log.trace(".useGrant(" + client + ", " + grantId.toString(Character.MAX_RADIX)
@@ -978,13 +980,7 @@ import com.palantir.util.Pair;
      */
     @Override
     public void logCurrentState() {
-        StringBuilder logString = new StringBuilder();
-        logString.append("Logging current state. Time = ").append(currentTimeMillis()).append("\n");
-        logString.append("isStandaloneServer = ").append(isStandaloneServer).append("\n");
-        logString.append("maxAllowedLockTimeout = ").append(maxAllowedLockTimeout).append("\n");
-        logString.append("maxAllowedClockDrift = ").append(maxAllowedClockDrift).append("\n");
-        logString.append("maxAllowedBlockingDuration = ").append(maxAllowedBlockingDuration).append("\n");
-        logString.append("randomBitCount = ").append(randomBitCount).append("\n");
+        StringBuilder logString = getGeneralLockStats();
         for (Pair<String, ? extends Collection<?>> nameValuePair : ImmutableList.of(
                 Pair.create("descriptorToLockMap", descriptorToLockMap.asMap().entrySet()),
                 Pair.create("outstandingLockRequestMultimap", outstandingLockRequestMultimap.asMap().entrySet()),
@@ -1006,6 +1002,43 @@ import com.palantir.util.Pair;
         }
         logString.append("Finished logging current state. Time = ").append(currentTimeMillis());
         log.error(logString.toString());
+    }
+
+    @Override
+    public void logCurrentHeldLocks(String descriptorRegex, boolean versionIdNecessary) {
+        StringBuilder logString = getGeneralLockStats();
+        Pattern pattern = Pattern.compile(descriptorRegex);
+        Set<ExpiringToken> heldLocksTokens = ImmutableSet.<ExpiringToken>builder()
+                .addAll(heldLocksTokenMap.keySet())
+                .addAll(heldLocksGrantMap.keySet())
+                .build();
+
+        for (ExpiringToken heldLocksToken : heldLocksTokens) {
+            if (!versionIdNecessary || heldLocksToken.getVersionId() != null) {
+                for (LockDescriptor lockDescriptor : heldLocksToken.getLockDescriptors()) {
+                    String lockId = lockDescriptor.getLockIdAsString();
+                    Matcher matcher = pattern.matcher(lockId);
+                    if (matcher.matches()) {
+                        logString.append("Lock descriptor: ").append(lockDescriptor)
+                                .append(" Held locks token for the lock: ").append(heldLocksToken).append("\n");
+                    }
+                }
+            }
+        }
+
+        log.error("Current state with descriptor regex: [{}], version ID necessary: [{}]. Locks matching:\n {}",
+                descriptorRegex, versionIdNecessary, logString.toString());
+    }
+
+    private StringBuilder getGeneralLockStats() {
+        StringBuilder logString = new StringBuilder();
+        logString.append("Logging current state. Time = ").append(currentTimeMillis()).append("\n");
+        logString.append("isStandaloneServer = ").append(isStandaloneServer).append("\n");
+        logString.append("maxAllowedLockTimeout = ").append(maxAllowedLockTimeout).append("\n");
+        logString.append("maxAllowedClockDrift = ").append(maxAllowedClockDrift).append("\n");
+        logString.append("maxAllowedBlockingDuration = ").append(maxAllowedBlockingDuration).append("\n");
+        logString.append("randomBitCount = ").append(randomBitCount).append("\n");
+        return logString;
     }
 
     @Override

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceImplTest.java
@@ -908,7 +908,7 @@ public final class LockServiceImplTest {
         HeldLocksGrant grant = server.convertToGrant(token);
         Assert.assertNotNull(grant);
         Assert.assertNull(grant.getClient());
-        Assert.assertEquals(request.getLockDescriptors(), grant.getLocks());
+        Assert.assertEquals(request.getLockDescriptors(), grant.getLockDescriptors());
         Thread.sleep(51);
         Assert.assertTrue(grant.getExpirationDateMs() - System.currentTimeMillis() < 450);
         grant = server.refreshGrant(grant);


### PR DESCRIPTION
This was ported from datval:log-lock-server (PR #1448) to aid work on internal lock issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1588)
<!-- Reviewable:end -->
