### PR TITLE
Remove stack traces from large logging warnings

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -39,7 +39,6 @@ public class TransactionConstants {
     public static final long FAILED_COMMIT_TS = -1L;
 
     public static final long WARN_LEVEL_FOR_QUEUED_BYTES = 10*1024*1024;
-    public static final long ERROR_LEVEL_FOR_QUEUED_BYTES = 10*WARN_LEVEL_FOR_QUEUED_BYTES;
 
     public static final long APPROX_IN_MEM_CELL_OVERHEAD_BYTES = 16;
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1122,8 +1122,12 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 long newVal = byteCount.addAndGet(toAdd);
                 if (newVal >= TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES
                         && newVal - toAdd < TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES) {
-                    log.warn("A single transaction has put quite a few bytes: {}", newVal, new RuntimeException(
-                            "This exception and stack trace are provided for debugging purposes."));
+                    log.warn("A single transaction has put quite a few bytes: {}. "
+                            + " Enable debug logging for more information", newVal);
+                    if (log.isDebugEnabled()) {
+                        log.debug("This exception and stack trace are provided for debugging purposes.",
+                                new RuntimeException());
+                    }
                 }
             }
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -951,7 +951,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
         if (bytes > TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES && log.isWarnEnabled()) {
             log.warn("A single get had quite a few bytes: {} for table {}. The number of results was {}. "
-                    + " Enable debug logging for more information.",
+                    + "Enable debug logging for more information.",
                     bytes, tableRef.getQualifiedName(), rawResults.size());
             if (log.isDebugEnabled()) {
                 log.debug("The first 10 results of your request were {}.", Iterables.limit(rawResults.entrySet(), 10),
@@ -1123,7 +1123,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 if (newVal >= TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES
                         && newVal - toAdd < TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES) {
                     log.warn("A single transaction has put quite a few bytes: {}. "
-                            + " Enable debug logging for more information", newVal);
+                            + "Enable debug logging for more information", newVal);
                     if (log.isDebugEnabled()) {
                         log.debug("This exception and stack trace are provided for debugging purposes.",
                                 new RuntimeException());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -949,17 +949,14 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
             bytes += e.getValue().getContents().length + Cells.getApproxSizeOfCell(e.getKey());
         }
-        if (bytes > TransactionConstants.ERROR_LEVEL_FOR_QUEUED_BYTES
-                && !AtlasDbConstants.TABLES_KNOWN_TO_BE_POORLY_DESIGNED.contains(tableRef)) {
-            log.error("A single get had a lot of bytes: {} for table {}. The number of results was {}. "
-                            + "The first 10 results were {}. This can potentially cause out-of-memory errors.",
-                    bytes, tableRef.getQualifiedName(), rawResults.size(), Iterables.limit(rawResults.entrySet(), 10),
-                    new RuntimeException("This exception and stack trace are provided for debugging purposes."));
-        } else if (bytes > TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES && log.isWarnEnabled()) {
+        if (bytes > TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES && log.isWarnEnabled()) {
             log.warn("A single get had quite a few bytes: {} for table {}. The number of results was {}. "
-                            + "The first 10 results were {}.",
-                    bytes, tableRef.getQualifiedName(), rawResults.size(), Iterables.limit(rawResults.entrySet(), 10),
-                    new RuntimeException("This exception and stack trace are provided for debugging purposes."));
+                    + " Enable debug logging for more information.",
+                    bytes, tableRef.getQualifiedName(), rawResults.size());
+            if (log.isDebugEnabled()) {
+                log.debug("The first 10 results of your request were {}.", Iterables.limit(rawResults.entrySet(), 10),
+                        new RuntimeException("This exception and stack trace are provided for debugging purposes."));
+            }
         }
 
         Map<Cell, Value> remainingResultsToPostfilter = rawResults;
@@ -1126,12 +1123,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 if (newVal >= TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES
                         && newVal - toAdd < TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES) {
                     log.warn("A single transaction has put quite a few bytes: {}", newVal, new RuntimeException(
-                            "This exception and stack trace are provided for debugging purposes."));
-                }
-                if (newVal >= TransactionConstants.ERROR_LEVEL_FOR_QUEUED_BYTES
-                        && newVal - toAdd < TransactionConstants.ERROR_LEVEL_FOR_QUEUED_BYTES) {
-                    log.warn("A single transaction has put too many bytes: {}. This can potentially cause"
-                            + " out-of-memory errors.", newVal, new RuntimeException(
                             "This exception and stack trace are provided for debugging purposes."));
                 }
             }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -66,6 +66,11 @@ develop
            please file a ticket on the AtlasDB github page.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1582>`__)
 
+    *    - |improved|
+         - Reduced logging noise from large Cassandra gets and puts by removing ERROR messages and only providing stacktraces at DEBUG.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1590>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Moved scary stack traces from large put/get warnings to debug, get rid of error logs here.

Fixes #1416. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1590)
<!-- Reviewable:end -->
