### PR TITLE
Fix version reference for timestamp debug logging.

### DIFF
--- a/docs/source/configuration/logging.rst
+++ b/docs/source/configuration/logging.rst
@@ -19,7 +19,7 @@ For more information, see :ref:`enabling-cassandra-tracing`.
 Debug Logging for Multiple Timestamp Services Error
 ===================================================
 
-From version 0.22, it is recommended that you send logging related to the timestamp service to a separate appender.
+From version 0.23.0, it is recommended that you send logging related to the timestamp service to a separate appender.
 To do this, add the following to your logging configuration:
 
 .. code:: yaml


### PR DESCRIPTION
The timestamp logging was introduced from version 0.23.0, not 0.22.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1592)
<!-- Reviewable:end -->
