### PR TITLE
Don't store ConnectionSupplier in OraclePrefixedTableNames

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/AbstractDbWriteTable.java
@@ -75,7 +75,7 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
 
     private void put(List<Object[]> args) {
         try {
-            String prefixedTableName = prefixedTableNames.get(tableRef);
+            String prefixedTableName = prefixedTableNames.get(tableRef, conns);
             conns.get().insertManyUnregisteredQuery("/* INSERT_ONE (" + prefixedTableName + ") */"
                     + " INSERT INTO " + prefixedTableName + " (row_name, col_name, ts, val) "
                     + " VALUES (?, ?, ?, ?) ",
@@ -100,7 +100,7 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
             }
             while (true) {
                 try {
-                    String prefixedTableName = prefixedTableNames.get(tableRef);
+                    String prefixedTableName = prefixedTableNames.get(tableRef, conns);
                     conns.get().insertManyUnregisteredQuery("/* INSERT_WHERE_NOT_EXISTS (" + prefixedTableName + ") */"
                             + " INSERT INTO " + prefixedTableName + " (row_name, col_name, ts, val) "
                             + " SELECT ?, ?, ?, ? FROM DUAL"
@@ -134,7 +134,7 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
             args.add(new Object[] {cell.getRowName(), cell.getColumnName(), entry.getValue()});
         }
 
-        String prefixedTableName = prefixedTableNames.get(tableRef);
+        String prefixedTableName = prefixedTableNames.get(tableRef, conns);
         conns.get().updateManyUnregisteredQuery(" /* DELETE_ONE (" + prefixedTableName + ") */ "
                 + " DELETE /*+ INDEX(m " + PrimaryKeyConstraintNames.get(prefixedTableName) + ") */ "
                 + " FROM " + prefixedTableName + " m "
@@ -146,7 +146,7 @@ public abstract class AbstractDbWriteTable implements DbWriteTable {
 
     @Override
     public void delete(RangeRequest range) {
-        String prefixedTableName = prefixedTableNames.get(tableRef);
+        String prefixedTableName = prefixedTableNames.get(tableRef, conns);
         StringBuilder query = new StringBuilder();
         query.append(" /* DELETE_RANGE (").append(prefixedTableName).append(") */ ");
         query.append(" DELETE FROM ").append(prefixedTableName).append(" m ");

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -89,6 +89,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.batch.BatchingStrategies;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.batch.BatchingTaskRunner;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.batch.ImmediateSingleBatchTaskRunner;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.batch.ParallelTaskRunner;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresPrefixedTableNames;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ranges.DbKvsGetRanges;
 import com.palantir.atlasdb.keyvalue.dbkvs.util.DbKvsPartitioners;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
@@ -140,12 +141,10 @@ public class DbKvs extends AbstractKeyValueService {
         this.connections = connections;
         if (DBType.ORACLE.equals(dbTables.getDbType())) {
             prefixedTableNames = new OraclePrefixedTableNames(
-                    config,
-                    new ConnectionSupplier(connections),
                     ((OracleDbTableFactory) dbTables).getOracleTableNameGetter());
             batchingQueryRunner = new ImmediateSingleBatchTaskRunner();
         } else {
-            prefixedTableNames = new PrefixedTableNames(config);
+            prefixedTableNames = new PostgresPrefixedTableNames(config);
             batchingQueryRunner = new ParallelTaskRunner(
                     newFixedThreadPool(config.poolSize()),
                     config.fetchBatchSize());

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbTableFactory.java
@@ -27,6 +27,7 @@ public interface DbTableFactory extends Closeable {
     DbReadTable createRead(TableReference tableRef, ConnectionSupplier conns);
     DbWriteTable createWrite(TableReference tableRef, ConnectionSupplier conns);
     DBType getDbType();
+    PrefixedTableNames getPrefixedTableNames();
     @Override
     void close();
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
@@ -100,7 +100,7 @@ public class OracleDbTableFactory implements DbTableFactory {
                 return OracleOverflowWriteTable.create(
                         config, conns, oracleTableNameGetter, oraclePrefixedTableNames, tableRef);
             case RAW:
-                return new OracleWriteTable(config, conns, oracleTableNameGetter, tableRef);
+                return new OracleWriteTable(config, conns, oraclePrefixedTableNames, tableRef);
             default:
                 throw new EnumConstantNotPresentException(TableValueStyle.class, tableValueStyle.name());
         }
@@ -111,8 +111,9 @@ public class OracleDbTableFactory implements DbTableFactory {
         return DBType.ORACLE;
     }
 
-    public OracleTableNameGetter getOracleTableNameGetter() {
-        return oracleTableNameGetter;
+    @Override
+    public PrefixedTableNames getPrefixedTableNames() {
+        return oraclePrefixedTableNames;
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
@@ -30,12 +30,14 @@ import com.palantir.nexus.db.DBType;
 
 public class OracleDbTableFactory implements DbTableFactory {
     private final OracleDdlConfig config;
-    private OracleTableNameGetter oracleTableNameGetter;
-    private TableValueStyleCache valueStyleCache;
+    private final OracleTableNameGetter oracleTableNameGetter;
+    private final OraclePrefixedTableNames oraclePrefixedTableNames;
+    private final TableValueStyleCache valueStyleCache;
 
     public OracleDbTableFactory(OracleDdlConfig config) {
         this.config = config;
         oracleTableNameGetter = new OracleTableNameGetter(config);
+        oraclePrefixedTableNames = new OraclePrefixedTableNames(oracleTableNameGetter);
         valueStyleCache = new TableValueStyleCache();
     }
 
@@ -95,7 +97,8 @@ public class OracleDbTableFactory implements DbTableFactory {
         TableValueStyle tableValueStyle = valueStyleCache.getTableType(conns, tableRef, config.metadataTable());
         switch (tableValueStyle) {
             case OVERFLOW:
-                return OracleOverflowWriteTable.create(config, conns, oracleTableNameGetter, tableRef);
+                return OracleOverflowWriteTable.create(
+                        config, conns, oracleTableNameGetter, oraclePrefixedTableNames, tableRef);
             case RAW:
                 return new OracleWriteTable(config, conns, oracleTableNameGetter, tableRef);
             default:

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OraclePrefixedTableNames.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OraclePrefixedTableNames.java
@@ -17,25 +17,18 @@ package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
 import com.google.common.base.Throwables;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
 import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
 
-public class OraclePrefixedTableNames extends PrefixedTableNames {
-    private OracleTableNameGetter oracleTableNameGetter;
-    private ConnectionSupplier connectionSupplier;
+public class OraclePrefixedTableNames implements PrefixedTableNames {
+    private final OracleTableNameGetter oracleTableNameGetter;
 
-    public OraclePrefixedTableNames(
-            DdlConfig config,
-            ConnectionSupplier connectionSupplier,
-            OracleTableNameGetter oracleTableNameGetter) {
-        super(config);
-        this.connectionSupplier = connectionSupplier;
+    public OraclePrefixedTableNames(OracleTableNameGetter oracleTableNameGetter) {
         this.oracleTableNameGetter = oracleTableNameGetter;
     }
 
     @Override
-    public String get(TableReference tableRef) {
+    public String get(TableReference tableRef, ConnectionSupplier connectionSupplier) {
         try {
             return oracleTableNameGetter.getInternalShortTableName(connectionSupplier, tableRef);
         } catch (TableMappingNotFoundException e) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresDbTableFactory.java
@@ -27,9 +27,11 @@ import com.palantir.nexus.db.DBType;
 public class PostgresDbTableFactory implements DbTableFactory {
 
     private final PostgresDdlConfig config;
+    private final PostgresPrefixedTableNames prefixedTableNames;
 
     public PostgresDbTableFactory(PostgresDdlConfig config) {
         this.config = config;
+        this.prefixedTableNames = new PostgresPrefixedTableNames(config);
     }
 
     @Override
@@ -56,12 +58,17 @@ public class PostgresDbTableFactory implements DbTableFactory {
 
     @Override
     public DbWriteTable createWrite(TableReference tableRef, ConnectionSupplier conns) {
-        return new PostgresWriteTable(config, conns, tableRef, new PostgresPrefixedTableNames(config));
+        return new PostgresWriteTable(config, conns, tableRef, prefixedTableNames);
     }
 
     @Override
     public DBType getDbType() {
         return DBType.POSTGRESQL;
+    }
+
+    @Override
+    public PrefixedTableNames getPrefixedTableNames() {
+        return prefixedTableNames;
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PostgresDbTableFactory.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.PostgresDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresDdlTable;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresPrefixedTableNames;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresQueryFactory;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresTableInitializer;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.PostgresWriteTable;
@@ -55,7 +56,7 @@ public class PostgresDbTableFactory implements DbTableFactory {
 
     @Override
     public DbWriteTable createWrite(TableReference tableRef, ConnectionSupplier conns) {
-        return new PostgresWriteTable(config, conns, tableRef, new PrefixedTableNames(config));
+        return new PostgresWriteTable(config, conns, tableRef, new PostgresPrefixedTableNames(config));
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PrefixedTableNames.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PrefixedTableNames.java
@@ -18,7 +18,5 @@ package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 public interface PrefixedTableNames {
-
     String get(TableReference tableRef, ConnectionSupplier connectionSupplier);
-
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PrefixedTableNames.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/PrefixedTableNames.java
@@ -16,17 +16,9 @@
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
 
-public class PrefixedTableNames {
-    private DdlConfig config;
+public interface PrefixedTableNames {
 
-    public PrefixedTableNames(DdlConfig config) {
-        this.config = config;
-    }
-
-    public String get(TableReference tableRef) {
-        return config.tablePrefix() + DbKvs.internalTableName(tableRef);
-    }
+    String get(TableReference tableRef, ConnectionSupplier connectionSupplier);
 
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/UpdateExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/UpdateExecutor.java
@@ -44,7 +44,7 @@ public class UpdateExecutor {
                 oldValue
         };
 
-        String prefixedTableName = prefixedTableNames.get(tableRef);
+        String prefixedTableName = prefixedTableNames.get(tableRef, conns);
         String sqlString = "/* UPDATE (" + prefixedTableName + ") */"
                 + " UPDATE " + prefixedTableName + ""
                 + " SET row_name = ?, col_name = ?, ts = ?, val = ?"

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleWriteTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleWriteTable.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.AbstractDbWriteTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
@@ -26,8 +25,8 @@ public class OracleWriteTable extends AbstractDbWriteTable {
     public OracleWriteTable(
             DdlConfig config,
             ConnectionSupplier conns,
-            OracleTableNameGetter oracleTableNameGetter,
+            OraclePrefixedTableNames oraclePrefixedTableNames,
             TableReference tableRef) {
-        super(config, conns, tableRef, new OraclePrefixedTableNames(oracleTableNameGetter));
+        super(config, conns, tableRef, oraclePrefixedTableNames);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresPrefixedTableNames.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresPrefixedTableNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Palantir Technologies
+ * Copyright 2017 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.DdlConfig;
-import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.AbstractDbWriteTable;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.PrefixedTableNames;
 
-public class OracleWriteTable extends AbstractDbWriteTable {
-    public OracleWriteTable(
-            DdlConfig config,
-            ConnectionSupplier conns,
-            OracleTableNameGetter oracleTableNameGetter,
-            TableReference tableRef) {
-        super(config, conns, tableRef, new OraclePrefixedTableNames(oracleTableNameGetter));
+public class PostgresPrefixedTableNames implements PrefixedTableNames {
+
+    private final DdlConfig config;
+
+    public PostgresPrefixedTableNames(DdlConfig config) {
+        this.config = config;
     }
+
+    @Override
+    public String get(TableReference tableRef, ConnectionSupplier connectionSupplier) {
+        return config.tablePrefix() + DbKvs.internalTableName(tableRef);
+    }
+
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/DbKvsGetRanges.java
@@ -42,6 +42,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.PrefixedTableNames;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.PrimaryKeyConstraintNames;
@@ -192,23 +193,25 @@ public class DbKvsGetRanges {
         }
 
         String order = reverse ? "DESC" : "ASC";
-        if (numRowsToGet == 1) {
-            String minMax = reverse ? "max" : "min";
-            // QA-69854 Special case 1 row reads because oracle is terrible at optimizing queries
-            String query = dbType == DBType.ORACLE
-                    ? getSimpleRowSelectOneQueryOracle(tableRef, minMax, extraWhere)
-                    : getSimpleRowSelectOneQueryPostgres(tableRef, extraWhere, order);
-            return Pair.create(query, args);
-        } else {
-            String query = String.format(
-                    SIMPLE_ROW_SELECT_TEMPLATE,
-                    DbKvs.internalTableName(tableRef),
-                    getPrimaryKeyConstraintName(tableRef),
-                    getPrefixedTableName(tableRef),
-                    extraWhere,
-                    order);
-            String limitQuery = BasicSQLUtils.limitQuery(query, numRowsToGet, args, dbType);
-            return Pair.create(limitQuery, args);
+        try (ConnectionSupplier conns = new ConnectionSupplier(connectionSupplier)) {
+            if (numRowsToGet == 1) {
+                String minMax = reverse ? "max" : "min";
+                // QA-69854 Special case 1 row reads because oracle is terrible at optimizing queries
+                String query = dbType == DBType.ORACLE
+                        ? getSimpleRowSelectOneQueryOracle(tableRef, minMax, extraWhere, conns)
+                        : getSimpleRowSelectOneQueryPostgres(tableRef, extraWhere, order, conns);
+                return Pair.create(query, args);
+            } else {
+                String query = String.format(
+                        SIMPLE_ROW_SELECT_TEMPLATE,
+                        DbKvs.internalTableName(tableRef),
+                        getPrimaryKeyConstraintName(tableRef, conns),
+                        getPrefixedTableName(tableRef, conns),
+                        extraWhere,
+                        order);
+                String limitQuery = BasicSQLUtils.limitQuery(query, numRowsToGet, args, dbType);
+                return Pair.create(limitQuery, args);
+            }
         }
     }
     /**
@@ -303,11 +306,12 @@ public class DbKvsGetRanges {
     private String getSimpleRowSelectOneQueryPostgres(
             TableReference tableRef,
             String extraWhere,
-            String order) {
+            String order,
+            ConnectionSupplier conns) {
         return String.format(
                 SIMPLE_ROW_SELECT_ONE_POSTGRES_TEMPLATE,
                 DbKvs.internalTableName(tableRef),
-                getPrefixedTableName(tableRef),
+                getPrefixedTableName(tableRef, conns),
                 extraWhere,
                 order);
     }
@@ -315,22 +319,23 @@ public class DbKvsGetRanges {
     private String getSimpleRowSelectOneQueryOracle(
             TableReference tableRef,
             String minMax,
-            String extraWhere) {
+            String extraWhere,
+            ConnectionSupplier conns) {
         return String.format(
                 SIMPLE_ROW_SELECT_ONE_ORACLE_TEMPLATE,
                 DbKvs.internalTableName(tableRef),
-                getPrimaryKeyConstraintName(tableRef),
+                getPrimaryKeyConstraintName(tableRef, conns),
                 minMax,
-                getPrefixedTableName(tableRef),
+                getPrefixedTableName(tableRef, conns),
                 extraWhere);
     }
 
-    private String getPrimaryKeyConstraintName(TableReference tableRef) {
-        return PrimaryKeyConstraintNames.get(getPrefixedTableName(tableRef));
+    private String getPrimaryKeyConstraintName(TableReference tableRef, ConnectionSupplier conns) {
+        return PrimaryKeyConstraintNames.get(getPrefixedTableName(tableRef, conns));
     }
 
-    private String getPrefixedTableName(TableReference tableRef) {
-        return prefixedTableNames.get(tableRef);
+    private String getPrefixedTableName(TableReference tableRef, ConnectionSupplier conns) {
+        return prefixedTableNames.get(tableRef, conns);
     }
 
     private static final String SIMPLE_ROW_SELECT_TEMPLATE =

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -87,6 +87,10 @@ develop
          - Fixed multiple connection pool deadlocks in DbKvs
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1566>`__)
 
+    *    - |fixed|
+         - Fixed a long-held connection in Oracle table name mapping code
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1593>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
ConnectionSupplier is a (poorly named) short-lived lazy initializer for a
SQL connection, so it shouldn't be held by a DbKvs instance.

- Now we also don't have to create a new instance of
  OraclePrefixedTableNames every time in OracleOverflowWriteTable.

- Make PrefixedTableNames an interface with two implementations
  instead of using ugly class extension

<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
- Note what this change does and why it is needed
- Include details of who this change helps (without including internal product names)
- Include the Atlas release or date you need this by
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1593)
<!-- Reviewable:end -->
