### PR TITLE
Remove tracing from Java 1.6 modules atlasdb-commons & lock-api

### DIFF
--- a/atlasdb-api/versions.lock
+++ b/atlasdb-api/versions.lock
@@ -11,30 +11,13 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -54,9 +37,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
             ]
         },
@@ -71,12 +52,6 @@
         },
         "com.palantir.atlasdb:timestamp-api": {
             "project": true
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0"
@@ -111,7 +86,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
@@ -128,30 +102,13 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -171,9 +128,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
             ]
         },
@@ -188,12 +143,6 @@
         },
         "com.palantir.atlasdb:timestamp-api": {
             "project": true
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0"
@@ -228,7 +177,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   compile 'org.apache.commons:commons-pool2:2.4.2'
 
   compile group: 'com.palantir.remoting', name: 'ssl-config'
+  compile group: 'com.palantir.remoting1', name: 'tracing'
 
   compile group: 'com.google.code.findbugs', name: 'annotations'
 

--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -174,7 +174,6 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -495,7 +494,6 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -430,8 +430,12 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -355,8 +355,11 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -924,8 +927,11 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-client/versions.lock
+++ b/atlasdb-client/versions.lock
@@ -117,10 +117,7 @@
             ]
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
@@ -295,10 +292,7 @@
             ]
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -8,7 +8,6 @@ ideaSetModuleLevel(idea, targetCompatibility)
 dependencies {
     compile group: 'com.google.code.findbugs', name: 'jsr305'
     compile group: 'com.google.guava', name: 'guava'
-    compile group: 'com.palantir.remoting1', name: 'tracing'
     compile group: 'org.slf4j', name: 'slf4j-api'
     compile project(":commons-executors")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'

--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/InterruptibleProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/InterruptibleProxy.java
@@ -27,7 +27,6 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.exception.PalantirInterruptedException;
-import com.palantir.remoting1.tracing.Tracers;
 
 /**
  * Proxy that calls the requested method in another thread waits on a Future.
@@ -48,8 +47,8 @@ public final class InterruptibleProxy implements DelegatingInvocationHandler {
     }
 
     private final Object delegate;
-    private static final ExecutorService executor = Tracers.wrap(PTExecutors.newCachedThreadPool(
-            new NamedThreadFactory("Interruptible Proxy", true /* isDaemon */ )));
+    private static final ExecutorService executor = PTExecutors.newCachedThreadPool(
+            new NamedThreadFactory("Interruptible Proxy", true /* isDaemon */ ));
 
     private InterruptibleProxy(Object delegate, CancelDelegate cancel) {
         this.delegate = delegate;

--- a/atlasdb-commons/versions.lock
+++ b/atlasdb-commons/versions.lock
@@ -1,38 +1,7 @@
 {
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
+            "locked": "2.6.7"
         },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
@@ -44,17 +13,10 @@
             "locked": "1.3.9"
         },
         "com.google.guava:guava": {
-            "locked": "18.0",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.remoting1:tracing"
-            ]
+            "locked": "18.0"
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3"
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1"
@@ -69,45 +31,13 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
+            "locked": "2.6.7"
         },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
@@ -119,17 +49,10 @@
             "locked": "1.3.9"
         },
         "com.google.guava:guava": {
-            "locked": "18.0",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.remoting1:tracing"
-            ]
+            "locked": "18.0"
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3"
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1"
@@ -144,7 +67,6 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }

--- a/atlasdb-config/versions.lock
+++ b/atlasdb-config/versions.lock
@@ -273,7 +273,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -655,7 +657,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -419,8 +419,12 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-console/versions.lock
+++ b/atlasdb-console/versions.lock
@@ -304,7 +304,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -741,7 +743,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -227,8 +227,8 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -655,8 +655,8 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-dagger/versions.lock
+++ b/atlasdb-dagger/versions.lock
@@ -307,7 +307,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -734,7 +736,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/atlasdb-dbkvs-hikari/versions.lock
+++ b/atlasdb-dbkvs-hikari/versions.lock
@@ -111,7 +111,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:commons-db"
             ]
         },
         "com.zaxxer:HikariCP": {
@@ -298,7 +298,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:commons-db"
             ]
         },
         "com.zaxxer:HikariCP": {

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -246,7 +246,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -598,7 +600,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -399,8 +399,11 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -1429,8 +1432,11 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -431,8 +431,11 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -1567,8 +1570,12 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-exec/versions.lock
+++ b/atlasdb-exec/versions.lock
@@ -144,8 +144,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -363,8 +362,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/atlasdb-hikari/versions.lock
+++ b/atlasdb-hikari/versions.lock
@@ -162,7 +162,6 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -399,7 +398,6 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   compile project(":lock-impl")
 
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
+  compile group: 'com.palantir.remoting1', name: 'tracing'
 
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'

--- a/atlasdb-impl-shared/versions.lock
+++ b/atlasdb-impl-shared/versions.lock
@@ -173,7 +173,7 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -416,7 +416,7 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/atlasdb-jdbc/versions.lock
+++ b/atlasdb-jdbc/versions.lock
@@ -151,7 +151,6 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -370,7 +369,6 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-jepsen-tests/versions.lock
+++ b/atlasdb-jepsen-tests/versions.lock
@@ -300,7 +300,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -719,7 +721,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/atlasdb-lock-api/versions.lock
+++ b/atlasdb-lock-api/versions.lock
@@ -13,32 +13,15 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -60,9 +43,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
             ]
         },
@@ -89,12 +70,6 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
-            ]
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -140,7 +115,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
@@ -159,32 +133,15 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -206,9 +163,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
             ]
         },
@@ -235,12 +190,6 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
-            ]
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -286,7 +235,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -433,8 +433,12 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -1167,8 +1171,12 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-remoting/versions.lock
+++ b/atlasdb-remoting/versions.lock
@@ -144,8 +144,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -352,8 +351,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/atlasdb-rocksdb-tests/build.gradle
+++ b/atlasdb-rocksdb-tests/build.gradle
@@ -4,4 +4,5 @@ apply from: "../gradle/shared.gradle"
 dependencies {
   testCompile project(":atlasdb-rocksdb")
   testCompile project(":atlasdb-tests-shared")
+  testCompile group: 'com.palantir.remoting1', name: 'tracing'
 }

--- a/atlasdb-rocksdb/versions.lock
+++ b/atlasdb-rocksdb/versions.lock
@@ -151,7 +151,6 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -370,7 +369,6 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -333,7 +333,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -1238,8 +1240,11 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-service/versions.lock
+++ b/atlasdb-service/versions.lock
@@ -295,7 +295,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -707,7 +709,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   compile (group: 'com.netflix.feign', name: 'feign-jaxrs') {
     exclude module: 'jsr311-api'
   }
+  compile group: 'com.palantir.remoting1', name: 'tracing'
 
   compile group: 'junit', name: 'junit'
   compile group: 'org.hamcrest', name: 'hamcrest-core'

--- a/atlasdb-tests-shared/versions.lock
+++ b/atlasdb-tests-shared/versions.lock
@@ -188,7 +188,8 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -462,7 +463,8 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/commons-api/versions.lock
+++ b/commons-api/versions.lock
@@ -3,36 +3,7 @@
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
                 "com.palantir.atlasdb:atlasdb-commons"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -52,9 +23,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.palantir.atlasdb:atlasdb-commons": {
@@ -65,12 +34,6 @@
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
@@ -97,7 +60,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
@@ -106,36 +68,7 @@
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
                 "com.palantir.atlasdb:atlasdb-commons"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -155,9 +88,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.palantir.atlasdb:atlasdb-commons": {
@@ -168,12 +99,6 @@
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
@@ -200,7 +125,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }

--- a/commons-db/build.gradle
+++ b/commons-db/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     transitive = false
   }
   compile group: 'com.mchange', name: 'c3p0', version: libVersions.c3p0
+  compile group: 'com.palantir.remoting1', name: 'tracing'
 
   // Danger, Will Robinson!
   //

--- a/commons-db/versions.lock
+++ b/commons-db/versions.lock
@@ -94,10 +94,7 @@
             "project": true
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.4.7",
@@ -248,10 +245,7 @@
             "project": true
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.4.7",

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -91,13 +91,17 @@ develop
 
            So far, automated migration is only supported for Cassandra KVS.
            If using DBKVS or other key-value services, it remains the user's responsibility to ensure that they have performed the migration detailed in :ref:`Migration to External Timelock Services <timelock-migration>`.
-           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/1569>`__, 
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/1569>`__,
            `Pull Request 2 <https://github.com/palantir/atlasdb/pull/1570>`__ and
            `Pull Request 3 <https://github.com/palantir/atlasdb/pull/1579>`__)
-           
+
     *    - |fixed|
          - Fixed multiple connection pool deadlocks in DbKvs
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1566>`__)
+
+    *    - |fixed|
+         - Fixed atlasdb-commons Java 1.6 compatibility by removing tracing from InterruptibleProxy
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1599>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/examples/profile-client/versions.lock
+++ b/examples/profile-client/versions.lock
@@ -149,8 +149,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.remoting:ssl-config": {
@@ -362,8 +361,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.remoting:ssl-config": {

--- a/leader-election-api/versions.lock
+++ b/leader-election-api/versions.lock
@@ -3,36 +3,7 @@
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
                 "com.palantir.atlasdb:atlasdb-commons"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -52,9 +23,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.google.protobuf:protobuf-java": {
@@ -74,12 +43,6 @@
         },
         "com.palantir.atlasdb:leader-election-api-protobufs": {
             "project": true
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
         },
         "commons-lang:commons-lang": {
             "locked": "2.6",
@@ -108,7 +71,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
@@ -117,36 +79,7 @@
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
                 "com.palantir.atlasdb:atlasdb-commons"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -166,9 +99,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.google.protobuf:protobuf-java": {
@@ -188,12 +119,6 @@
         },
         "com.palantir.atlasdb:leader-election-api-protobufs": {
             "project": true
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
         },
         "commons-lang:commons-lang": {
             "locked": "2.6",
@@ -222,7 +147,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile group: "com.google.protobuf", name: "protobuf-java", version: libVersions.protobuf
   compile group: "commons-lang", name: "commons-lang", version: libVersions.commons_lang
   compile group: "commons-io", name: "commons-io"
+  compile group: 'com.palantir.remoting1', name: 'tracing'
 
   testCompile group: 'org.mockito', name: 'mockito-core'
   testCompile group: 'org.assertj', name: 'assertj-core'

--- a/leader-election-impl/versions.lock
+++ b/leader-election-impl/versions.lock
@@ -88,10 +88,7 @@
             ]
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "commons-io:commons-io": {
             "locked": "2.1"
@@ -220,10 +217,7 @@
             ]
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "commons-io:commons-io": {
             "locked": "2.1"

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -33,7 +33,6 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockResponse;
 import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleHeldLocksToken;
-import com.palantir.remoting1.tracing.Tracers;
 
 public class LockRefreshingLockService extends ForwardingLockService {
     private static final Logger log = LoggerFactory.getLogger(LockRefreshingLockService.class);
@@ -73,7 +72,7 @@ public class LockRefreshingLockService extends ForwardingLockService {
     private LockRefreshingLockService(LockService delegate) {
         this.delegate = delegate;
         toRefresh = Sets.newConcurrentHashSet();
-        exec = Tracers.wrap(PTExecutors.newScheduledThreadPool(1, PTExecutors.newNamedThreadFactory(true)));
+        exec = PTExecutors.newScheduledThreadPool(1, PTExecutors.newNamedThreadFactory(true));
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingRemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingRemoteLockService.java
@@ -30,7 +30,6 @@ import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
-import com.palantir.remoting1.tracing.Tracers;
 
 public class LockRefreshingRemoteLockService extends ForwardingRemoteLockService {
     private static final Logger log = LoggerFactory.getLogger(LockRefreshingRemoteLockService.class);
@@ -70,7 +69,7 @@ public class LockRefreshingRemoteLockService extends ForwardingRemoteLockService
     private LockRefreshingRemoteLockService(RemoteLockService delegate) {
         this.delegate = delegate;
         toRefresh = Sets.newConcurrentHashSet();
-        exec = Tracers.wrap(PTExecutors.newScheduledThreadPool(1, PTExecutors.newNamedThreadFactory(true)));
+        exec = PTExecutors.newScheduledThreadPool(1, PTExecutors.newNamedThreadFactory(true));
     }
 
     @Override

--- a/lock-api/versions.lock
+++ b/lock-api/versions.lock
@@ -10,30 +10,11 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
+            "locked": "2.6.7"
         },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
@@ -51,9 +32,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.palantir.atlasdb:atlasdb-commons": {
@@ -61,12 +40,6 @@
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
@@ -94,7 +67,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }
@@ -110,30 +82,11 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.core:jackson-databind"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
-            "transitive": [
-                "com.palantir.remoting1:tracing"
-            ]
+            "locked": "2.6.7"
         },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
@@ -151,9 +104,7 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing"
+                "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
         "com.palantir.atlasdb:atlasdb-commons": {
@@ -161,12 +112,6 @@
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
-        },
-        "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
@@ -194,7 +139,6 @@
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
         }

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -5,5 +5,6 @@ dependencies {
   compile project(":lock-api")
   compile project(":atlasdb-commons")
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
+  compile group: 'com.palantir.remoting1', name: 'tracing'
   compile group: 'joda-time', name: 'joda-time'
 }

--- a/lock-impl/versions.lock
+++ b/lock-impl/versions.lock
@@ -79,10 +79,7 @@
             "requested": "3.0.3-p5"
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
@@ -195,10 +192,7 @@
             "requested": "3.0.3-p5"
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile group: 'com.github.rholder', name: 'guava-retrying'
     compile group: 'com.palantir.remoting1', name: 'jersey-servers'
     compile group: 'com.palantir.remoting1', name: 'ssl-config'
+    compile group: 'com.palantir.remoting1', name: 'tracing'
     compile group: 'io.atomix', name: 'atomix'
     compile group: 'io.atomix.catalyst', name: 'catalyst-netty'
     compile group: 'io.dropwizard', name: 'dropwizard-core'

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -371,7 +371,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting1:jersey-servers"
             ]
@@ -1435,7 +1437,9 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
-                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting1:jersey-servers"
             ]

--- a/timestamp-impl/versions.lock
+++ b/timestamp-impl/versions.lock
@@ -71,10 +71,7 @@
             "project": true
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
@@ -176,10 +173,7 @@
             "project": true
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
-            ]
+            "locked": "1.0.3"
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",


### PR DESCRIPTION
Several atlasdb modules require Java 1.6 target compatibility; however, tracing requires at least Java 7 bytecode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1599)
<!-- Reviewable:end -->
