### PR TITLE
Amend PR template to change focus

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,15 @@
+**Goals (and why)**:
+
+**How**:
+
+**Concerns**:
+
+**Priority (whenever / two weeks / yesterday)**:
+
+**Entrypoint (where should we start reviewing?)**:
+
 <!---
 Please remember to:
-- Assign someone to review this PR
 - Add any necessary release notes (including breaking changes)
 - Make sure the documentation is up to date for your change
-- Note what this change does and why it is needed
-- Include details of who this change helps (without including internal product names)
-- Include the Atlas release or date you need this by
 --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 **Goals (and why)**:
 
-**How**:
+**Implementation Description (bullets)**:
 
-**Concerns**:
+**Concerns (what feedback would you like?)**:
+
+**Where should we start reviewing?**:
 
 **Priority (whenever / two weeks / yesterday)**:
-
-**Entrypoint (where should we start reviewing?)**:
 
 <!---
 Please remember to:


### PR DESCRIPTION
**Goals (what / why)**: to keep PRs focused not on the code / diff but on the outcome

**How**: change the PR template so that people don't just delete it

**Concerns**: to make this effective it will style require team members to push for its use

**Priority**: after the retrospective tomorrow

**Entrypoint**: .github/PULL_REQUEST_TEMPLATE.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1601)
<!-- Reviewable:end -->
