### PR TITLE
add persisted locks table to atomic tables list

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -74,7 +74,8 @@ public class AtlasDbConstants {
      */
     public static final Set<TableReference> ATOMIC_TABLES = ImmutableSet.of(
             TransactionConstants.TRANSACTION_TABLE,
-            NAMESPACE_TABLE);
+            NAMESPACE_TABLE,
+            PERSISTED_LOCKS_TABLE);
 
     public static final Set<TableReference> TABLES_KNOWN_TO_BE_POORLY_DESIGNED = ImmutableSet.of(TableReference.createWithEmptyNamespace("resync_object"));
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,6 +54,10 @@ develop
          - Fixed atlasdb-commons Java 1.6 compatibility by removing tracing from InterruptibleProxy.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1599>`__)
 
+    *    - |fixed|
+         - Persisted locks table is now considered an Atomic Table and will not get KVS migrated
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1610>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
- Note what this change does and why it is needed
- Include details of who this change helps (without including internal product names)
- Include the Atlas release or date you need this by
--->

CC @abaker14

The persisted locks table needs to live on a KVS that actually supports CAS. The `ATOMIC_TABLES` variable is used by a large internal product to determine what tables have to live where when using TableSplittingKVS.

Part of stacktrace when this table ends up on Cassandra 1.2 which doesn't support CAS:

```
<product-specific-stacktrace>
Caused by: com.palantir.common.exception.PalantirRuntimeException: Invalid method name: 'cas'
        at com.palantir.common.base.Throwables.createPalantirRuntimeException(Throwables.java:100)
        at com.palantir.common.base.Throwables.createPalantirRuntimeException(Throwables.java:92)
        at com.palantir.common.base.Throwables.throwUncheckedException(Throwables.java:88)
        at com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService.checkAndSet(CassandraKeyValueService.java:2027)
....
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1610)
<!-- Reviewable:end -->
