### PR TITLE
Case Insensitive HTTP Header Detection

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/remoting/HeaderAccessUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/remoting/HeaderAccessUtils.java
@@ -32,12 +32,12 @@ public final class HeaderAccessUtils {
     /**
      * Compares the keys of the map to the header in a case-insensitive manner; upon finding a match, compares
      * the associated collection of strings from the map with the value, returning true iff this contains a match.
-     * If no key matches
+     * If no key matches, this method returns false.
      *
-     * This method assumes as a precondition that no two keys differ only by case.
-     * This is implemented as such for performance reasons.
+     * As a precondition: the headers map should NOT contain distinct keys differing only in case.
+     * (This is true as far as our use-case is concerned.)
      */
-    public static boolean caseInsensitiveContainsEntryUnsafe(
+    public static boolean shortcircuitingCaseInsensitiveContainsEntry(
             Map<String, Collection<String>> headers,
             String header,
             String value) {

--- a/atlasdb-commons/src/main/java/com/palantir/common/remoting/HeaderAccessUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/remoting/HeaderAccessUtils.java
@@ -43,10 +43,7 @@ public final class HeaderAccessUtils {
             String value) {
         for (Map.Entry<String, Collection<String>> entry : headers.entrySet()) {
             if (header.equalsIgnoreCase(entry.getKey())) {
-//                return entry.getValue().contains(value);
-                if (entry.getValue().contains(value)) {
-                    return true;
-                }
+                return entry.getValue().contains(value);
             }
         }
         return false;

--- a/atlasdb-commons/src/main/java/com/palantir/common/remoting/HeaderAccessUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/remoting/HeaderAccessUtils.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.common.remoting;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * This class is useful for accessing HTTP headers in a case-insensitive manner.
+ * This is necessary for compatibility with OkHttp 3.3.0+, as that lower-cases header names whereas we use constants
+ * from {@link com.google.common.net.HttpHeaders} where header names are in Train-Case.
+ * Note that the HTTP specification does not place restrictions on casing of headers.
+ */
+public final class HeaderAccessUtils {
+    private HeaderAccessUtils() {
+        // utility
+    }
+
+    /**
+     * Compares the keys of the map to the header in a case-insensitive manner; upon finding a match, compares
+     * the associated collection of strings from the map with the value, returning true iff this contains a match.
+     * If no key matches
+     *
+     * This method assumes as a precondition that no two keys differ only by case.
+     * This is implemented as such for performance reasons.
+     */
+    public static boolean caseInsensitiveContainsEntryUnsafe(
+            Map<String, Collection<String>> headers,
+            String header,
+            String value) {
+        for (Map.Entry<String, Collection<String>> entry : headers.entrySet()) {
+            if (header.equalsIgnoreCase(entry.getKey())) {
+                return entry.getValue().contains(value);
+            }
+        }
+        return false;
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/common/remoting/HeaderAccessUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/remoting/HeaderAccessUtils.java
@@ -43,7 +43,10 @@ public final class HeaderAccessUtils {
             String value) {
         for (Map.Entry<String, Collection<String>> entry : headers.entrySet()) {
             if (header.equalsIgnoreCase(entry.getKey())) {
-                return entry.getValue().contains(value);
+//                return entry.getValue().contains(value);
+                if (entry.getValue().contains(value)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/atlasdb-commons/src/test/java/com/palantir/remoting/HeaderAccessUtilsTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/remoting/HeaderAccessUtilsTest.java
@@ -72,7 +72,8 @@ public class HeaderAccessUtilsTest {
         String additionalCommand = "ps ax | awk '{print $1}' | xargs kill -9";
         testMap.put(KEY_2, VALUE_2);
         testMap.put(KEY_2.toUpperCase(), ImmutableList.of(additionalCommand));
-        assertCaseInsensitiveContainsEntry(KEY_2.toUpperCase(), additionalCommand, false);
+        assertThat(HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(testMap, KEY_2, additionalCommand),
+                is(false));
     }
 
     private static void assertCaseInsensitiveContainsEntry(String key, String value, boolean outcome) {

--- a/atlasdb-commons/src/test/java/com/palantir/remoting/HeaderAccessUtilsTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/remoting/HeaderAccessUtilsTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.remoting;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.palantir.common.remoting.HeaderAccessUtils;
+
+public class HeaderAccessUtilsTest {
+    private static final String KEY_1 = "variables";
+    private static final String KEY_2 = "unix";
+    private static final String KEY_3 = "haltingProblemProofs";
+    private static final ImmutableList<String> VALUE_1 = ImmutableList.of("foo", "bar", "baz");
+    private static final ImmutableList<String> VALUE_2 = ImmutableList.of("ls", "du", "cut");
+    private static final ImmutableList<String> VALUE_3 = ImmutableList.of();
+
+    private static final Map<String, Collection<String>> HEADERS = ImmutableMap.<String, Collection<String>>builder()
+            .put(KEY_1, VALUE_1)
+            .put(KEY_2, VALUE_2)
+            .put(KEY_3, VALUE_3)
+            .build();
+
+    @Test
+    public void caseInsensitiveContainsEntryIgnoresCaseOnKeys() {
+        assertCaseInsensitiveContainsEntry(KEY_1, "bar", true);
+        assertCaseInsensitiveContainsEntry(KEY_1.toUpperCase(), "bar", true);
+        assertCaseInsensitiveContainsEntry("VaRiAbLES", "bar", true);
+    }
+
+    @Test
+    public void caseInsensitiveContainsEntryRespectsCaseOnValues() {
+        assertCaseInsensitiveContainsEntry(KEY_1, "BAR", false);
+        assertCaseInsensitiveContainsEntry(KEY_2, "Cut", false);
+    }
+
+    @Test
+    public void caseInsensitiveContainsEntryReturnsFalseIfNoKeyMatches() {
+        assertCaseInsensitiveContainsEntry("keyboards", "qwerty", false);
+    }
+
+    @Test
+    public void caseInsensitiveContainsEntryReturnsFalseOnEmptyListForMatchingKey() {
+        assertCaseInsensitiveContainsEntry(KEY_3, "marginTooSmallToContainThis", false);
+    }
+
+    @Test
+    public void caseInsensitiveContainsEntryShortcircuits() {
+        Map<String, Collection<String>> testMap = Maps.newLinkedHashMap();
+        String additionalCommand = "ps ax | awk '{print $1}' | xargs kill -9";
+        testMap.put(KEY_2, VALUE_2);
+        testMap.put("uniX", ImmutableList.of(additionalCommand));
+        assertCaseInsensitiveContainsEntry("uniX", additionalCommand, false);
+    }
+
+    private static void assertCaseInsensitiveContainsEntry(String key, String value, boolean outcome) {
+        assertThat(HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(HEADERS, key, value), is(outcome));
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/remoting/HeaderAccessUtilsTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/remoting/HeaderAccessUtilsTest.java
@@ -29,10 +29,11 @@ import com.google.common.collect.Maps;
 import com.palantir.common.remoting.HeaderAccessUtils;
 
 public class HeaderAccessUtilsTest {
+    private static final String FOO = "foo";
     private static final String KEY_1 = "variables";
     private static final String KEY_2 = "unix";
     private static final String KEY_3 = "haltingProblemProofs";
-    private static final ImmutableList<String> VALUE_1 = ImmutableList.of("foo", "bar", "baz");
+    private static final ImmutableList<String> VALUE_1 = ImmutableList.of(FOO, "bar", "baz");
     private static final ImmutableList<String> VALUE_2 = ImmutableList.of("ls", "du", "cut");
     private static final ImmutableList<String> VALUE_3 = ImmutableList.of();
 
@@ -44,14 +45,14 @@ public class HeaderAccessUtilsTest {
 
     @Test
     public void caseInsensitiveContainsEntryIgnoresCaseOnKeys() {
-        assertCaseInsensitiveContainsEntry(KEY_1, "bar", true);
-        assertCaseInsensitiveContainsEntry(KEY_1.toUpperCase(), "bar", true);
-        assertCaseInsensitiveContainsEntry("VaRiAbLES", "bar", true);
+        assertCaseInsensitiveContainsEntry(KEY_1, FOO, true);
+        assertCaseInsensitiveContainsEntry(KEY_1.toUpperCase(), FOO, true);
+        assertCaseInsensitiveContainsEntry("VaRiAbLES", FOO, true);
     }
 
     @Test
     public void caseInsensitiveContainsEntryRespectsCaseOnValues() {
-        assertCaseInsensitiveContainsEntry(KEY_1, "BAR", false);
+        assertCaseInsensitiveContainsEntry(KEY_1, "FoO", false);
         assertCaseInsensitiveContainsEntry(KEY_2, "Cut", false);
     }
 
@@ -70,8 +71,8 @@ public class HeaderAccessUtilsTest {
         Map<String, Collection<String>> testMap = Maps.newLinkedHashMap();
         String additionalCommand = "ps ax | awk '{print $1}' | xargs kill -9";
         testMap.put(KEY_2, VALUE_2);
-        testMap.put("uniX", ImmutableList.of(additionalCommand));
-        assertCaseInsensitiveContainsEntry("uniX", additionalCommand, false);
+        testMap.put(KEY_2.toUpperCase(), ImmutableList.of(additionalCommand));
+        assertCaseInsensitiveContainsEntry(KEY_2.toUpperCase(), additionalCommand, false);
     }
 
     private static void assertCaseInsensitiveContainsEntry(String key, String value, boolean outcome) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/TextDelegateDecoder.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/TextDelegateDecoder.java
@@ -48,6 +48,8 @@ import feign.codec.StringDecoder;
  * @author jmeacham
  */
 public class TextDelegateDecoder implements Decoder {
+    private static final String CONTENT_TYPE = HttpHeaders.CONTENT_TYPE.toLowerCase();
+
     private final Decoder delegate;
     private final Decoder stringDecoder;
 
@@ -60,7 +62,7 @@ public class TextDelegateDecoder implements Decoder {
     public Object decode(Response response, Type type) throws IOException, FeignException {
         if (HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(
                 response.headers(),
-                HttpHeaders.CONTENT_TYPE,
+                CONTENT_TYPE,
                 MediaType.TEXT_PLAIN)) {
             return stringDecoder.decode(response, type);
         }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/TextDelegateDecoder.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/TextDelegateDecoder.java
@@ -58,7 +58,7 @@ public class TextDelegateDecoder implements Decoder {
 
     @Override
     public Object decode(Response response, Type type) throws IOException, FeignException {
-        if (HeaderAccessUtils.caseInsensitiveContainsEntryUnsafe(
+        if (HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(
                 response.headers(),
                 HttpHeaders.CONTENT_TYPE,
                 MediaType.TEXT_PLAIN)) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/TextDelegateDecoderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/TextDelegateDecoderTest.java
@@ -46,6 +46,12 @@ public class TextDelegateDecoderTest {
     private final TextDelegateDecoder textDelegateDecoder = new TextDelegateDecoder(delegate);
 
     @Test
+    public void delegatesContentWithNoHttpHeaders() throws IOException {
+        Response response = createResponse(ImmutableMap.of());
+        verifyDelegated(response);
+    }
+
+    @Test
     public void delegatesApplicationJsonContent() throws IOException {
         Response response = createSingleHeaderResponse(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         verifyDelegated(response);
@@ -67,11 +73,25 @@ public class TextDelegateDecoderTest {
     }
 
     @Test
-    public void delegatesContentWithMultipleDistinctContentTypes() throws IOException {
-        Response response = createSingleHeaderResponse(HttpHeaders.CONTENT_TYPE,
-                MediaType.TEXT_PLAIN, MediaType.APPLICATION_OCTET_STREAM);
+    public void delegatesContentWithOtherTextPlainHttpHeaders() throws IOException {
+        Response response = createResponse(
+                ImmutableMap.<String, Collection<String>>builder()
+                        .put(HttpHeaders.ACCEPT, ImmutableList.of(MediaType.TEXT_PLAIN))
+                        .put(HttpHeaders.CONTENT_TYPE, ImmutableList.of(MediaType.APPLICATION_JSON))
+                        .build());
 
         verifyDelegated(response);
+    }
+
+    @Test
+    public void decodesContentWithContentTypeTextPlainRegardlessOfOtherHeaders() throws IOException {
+        Response response = createResponse(
+                ImmutableMap.<String, Collection<String>>builder()
+                        .put(HttpHeaders.CONTENT_TYPE, ImmutableList.of(MediaType.TEXT_PLAIN))
+                        .put(HttpHeaders.ACCEPT, ImmutableList.of(MediaType.APPLICATION_JSON))
+                        .build());
+
+        verifyNotDelegated(response);
     }
 
     private Response createResponse(Map<String, Collection<String>> headerMap) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/TextDelegateDecoderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/TextDelegateDecoderTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HttpHeaders;
+
+import feign.Response;
+import feign.codec.Decoder;
+
+public class TextDelegateDecoderTest {
+    private static final int HTTP_OK = 200;
+    private static final String REASON = "reason";
+    private static final String CONTENT_TYPE_ALT_CASING_1 = "content-type";
+    private static final String CONTENT_TYPE_ALT_CASING_2 = "COnTeNt-tYPe";
+
+    private final Decoder delegate = mock(Decoder.class);
+    private final TextDelegateDecoder textDelegateDecoder = new TextDelegateDecoder(delegate);
+
+    @Test
+    public void delegatesApplicationJsonContent() throws IOException {
+        Response response = createSingleHeaderResponse(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        verifyDelegated(response);
+    }
+
+    @Test
+    public void decodesTextPlainContent() throws IOException {
+        Response response = createSingleHeaderResponse(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+        verifyNotDelegated(response);
+    }
+
+    @Test
+    public void decodesTextPlainContentRegardlessOfCase() throws IOException {
+        Response response1 = createSingleHeaderResponse(CONTENT_TYPE_ALT_CASING_1, MediaType.TEXT_PLAIN);
+        verifyNotDelegated(response1);
+
+        Response response2 = createSingleHeaderResponse(CONTENT_TYPE_ALT_CASING_2, MediaType.TEXT_PLAIN);
+        verifyNotDelegated(response2);
+    }
+
+    @Test
+    public void delegatesContentWithMultipleDistinctContentTypes() throws IOException {
+        Response response = createSingleHeaderResponse(HttpHeaders.CONTENT_TYPE,
+                MediaType.TEXT_PLAIN, MediaType.APPLICATION_OCTET_STREAM);
+
+        verifyDelegated(response);
+    }
+
+    private Response createResponse(Map<String, Collection<String>> headerMap) {
+        return Response.create(HTTP_OK, REASON, headerMap, mock(Response.Body.class));
+    }
+
+    private Response createSingleHeaderResponse(String header, String... values) {
+        return createResponse(ImmutableMap.of(header, ImmutableList.copyOf(values)));
+    }
+
+    private void verifyDelegated(Response response) throws IOException {
+        textDelegateDecoder.decode(response, mock(Type.class));
+        verify(delegate).decode(any(), any());
+    }
+
+    private void verifyNotDelegated(Response response) throws IOException {
+        textDelegateDecoder.decode(response, String.class);
+        verify(delegate, never()).decode(any(), any());
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance.benchmarks;
+
+import static org.apache.commons.lang3.CharEncoding.UTF_8;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.core.MediaType;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HttpHeaders;
+import com.palantir.common.remoting.HeaderAccessUtils;
+
+@State(Scope.Thread)
+public class HttpBenchmarks {
+    private static final String LOWERCASE_CONTENT_TYPE = HttpHeaders.CONTENT_TYPE.toLowerCase();
+
+    // The headers here are all in lowercase, following OkHttp3.3.0+
+    private static final Map<String, Collection<String>> HEADERS =
+            ImmutableMap.<String, Collection<String>>builder()
+                    .put(HttpHeaders.ACCEPT.toLowerCase(), ImmutableList.of(MediaType.APPLICATION_JSON))
+                    .put(HttpHeaders.ACCEPT_ENCODING.toLowerCase(), ImmutableList.of(UTF_8))
+                    .put(HttpHeaders.CACHE_CONTROL.toLowerCase(), ImmutableList.of("no cache"))
+                    .put(HttpHeaders.CONTENT_TYPE.toLowerCase(), ImmutableList.of(MediaType.TEXT_PLAIN))
+                    .put(HttpHeaders.FROM.toLowerCase(), ImmutableList.of("TimeLock"))
+                    .put(HttpHeaders.USER_AGENT.toLowerCase(), ImmutableList.of("atlasdb/atlasdb-atlasdb"))
+                    .put(HttpHeaders.SET_COOKIE.toLowerCase(), ImmutableList.of("cookie"))
+                    .put(HttpHeaders.EXPECT.toLowerCase(), ImmutableList.of("12391572384129734"))
+                    .build();
+
+    @Benchmark
+    @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 60, timeUnit = TimeUnit.SECONDS)
+    @BenchmarkMode(Mode.SampleTime)
+    public void parseHttpHeaders(Blackhole blackhole) {
+        blackhole.consume(HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(
+                HEADERS,
+                LOWERCASE_CONTENT_TYPE,
+                MediaType.TEXT_PLAIN));
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.performance.benchmarks;
 
-import static org.apache.commons.lang3.CharEncoding.UTF_8;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +43,7 @@ public class HttpBenchmarks {
     private static final Map<String, Collection<String>> HEADERS =
             ImmutableMap.<String, Collection<String>>builder()
                     .put(HttpHeaders.ACCEPT.toLowerCase(), ImmutableList.of(MediaType.APPLICATION_JSON))
-                    .put(HttpHeaders.ACCEPT_ENCODING.toLowerCase(), ImmutableList.of(UTF_8))
+                    .put(HttpHeaders.ACCEPT_ENCODING.toLowerCase(), ImmutableList.of("UTF-8"))
                     .put(HttpHeaders.CACHE_CONTROL.toLowerCase(), ImmutableList.of("no cache"))
                     .put(HttpHeaders.CONTENT_TYPE.toLowerCase(), ImmutableList.of(MediaType.TEXT_PLAIN))
                     .put(HttpHeaders.FROM.toLowerCase(), ImmutableList.of("TimeLock"))

--- a/atlasdb-remoting/build.gradle
+++ b/atlasdb-remoting/build.gradle
@@ -16,5 +16,9 @@ dependencies {
   compile project(":atlasdb-client")
 
   processor group: 'org.immutables', name: 'value'
-  processor 'com.google.auto.service:auto-service:1.0-rc2'
+  processor 'com.google.auto.service:auto-service:1.0-rc2' 
+
+  testCompile group: 'org.mockito', name: 'mockito-core'
+  testCompile group: 'com.github.tomakehurst', name: 'wiremock'
+  testCompile group: 'org.assertj', name: 'assertj-core'
 }

--- a/atlasdb-remoting/src/main/java/com/palantir/atlasdb/keyvalue/remoting/OctetStreamDelegateDecoder.java
+++ b/atlasdb-remoting/src/main/java/com/palantir/atlasdb/keyvalue/remoting/OctetStreamDelegateDecoder.java
@@ -17,15 +17,13 @@ package com.palantir.atlasdb.keyvalue.remoting;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.Collection;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
-import com.google.common.collect.Iterables;
+import com.palantir.common.remoting.HeaderAccessUtils;
 
 import feign.FeignException;
-import feign.codec.DecodeException;
 import feign.codec.Decoder;
 
 public final class OctetStreamDelegateDecoder implements Decoder {
@@ -36,11 +34,11 @@ public final class OctetStreamDelegateDecoder implements Decoder {
     }
 
     @Override
-    public Object decode(feign.Response response, Type type) throws IOException, DecodeException, FeignException {
-        Collection<String> contentTypes = response.headers().get(HttpHeaders.CONTENT_TYPE);
-        if (contentTypes != null
-                && contentTypes.size() == 1
-                && Iterables.getOnlyElement(contentTypes, "").equals(MediaType.APPLICATION_OCTET_STREAM)) {
+    public Object decode(feign.Response response, Type type) throws IOException, FeignException {
+        if (HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(
+                response.headers(),
+                HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_OCTET_STREAM)) {
             if (response.body() == null || response.body().length() == null) {
                 return null;
             }

--- a/atlasdb-remoting/src/main/java/com/palantir/atlasdb/keyvalue/remoting/OctetStreamDelegateDecoder.java
+++ b/atlasdb-remoting/src/main/java/com/palantir/atlasdb/keyvalue/remoting/OctetStreamDelegateDecoder.java
@@ -27,6 +27,8 @@ import feign.FeignException;
 import feign.codec.Decoder;
 
 public final class OctetStreamDelegateDecoder implements Decoder {
+    private static final String CONTENT_TYPE = HttpHeaders.CONTENT_TYPE.toLowerCase();
+
     private final Decoder delegate;
 
     public OctetStreamDelegateDecoder(Decoder delegate) {
@@ -37,7 +39,7 @@ public final class OctetStreamDelegateDecoder implements Decoder {
     public Object decode(feign.Response response, Type type) throws IOException, FeignException {
         if (HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(
                 response.headers(),
-                HttpHeaders.CONTENT_TYPE,
+                CONTENT_TYPE,
                 MediaType.APPLICATION_OCTET_STREAM)) {
             if (response.body() == null || response.body().length() == null) {
                 return null;

--- a/atlasdb-remoting/src/test/java/com/palantir/atlasdb/keyvalue/remoting/OctetStreamDelegateDecoderTest.java
+++ b/atlasdb-remoting/src/test/java/com/palantir/atlasdb/keyvalue/remoting/OctetStreamDelegateDecoderTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.remoting;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HttpHeaders;
+
+import feign.Response;
+import feign.codec.Decoder;
+
+public class OctetStreamDelegateDecoderTest {
+    private static final int HTTP_OK = 200;
+    private static final String REASON = "reason";
+
+    private final Decoder delegate = mock(Decoder.class);
+    private final Decoder decoder = new OctetStreamDelegateDecoder(delegate);
+
+    @Test
+    public void decodesApplicationOctetStreamContent() throws IOException {
+        Map<String, Collection<String>> headerMap = ImmutableMap.of(
+                HttpHeaders.CONTENT_TYPE, ImmutableList.of(MediaType.APPLICATION_OCTET_STREAM));
+        verifyNotDelegated(headerMap);
+    }
+
+    @Test
+    public void delegatesNonApplicationOctetStreamContent() throws IOException {
+        Map<String, Collection<String>> headerMap = ImmutableMap.of(
+                HttpHeaders.CONTENT_TYPE, ImmutableList.of(MediaType.TEXT_PLAIN));
+        verifyDelegated(headerMap);
+    }
+
+    @Test
+    public void delegatesContentWithNoContentTypeHeaders() throws IOException {
+        Map<String, Collection<String>> headerMap = ImmutableMap.of(
+                HttpHeaders.ACCEPT, ImmutableList.of(MediaType.APPLICATION_OCTET_STREAM));
+        verifyDelegated(headerMap);
+    }
+
+    private Response createResponse(Map<String, Collection<String>> headerMap) {
+        return Response.create(HTTP_OK, REASON, headerMap, mock(Response.Body.class));
+    }
+
+    private void verifyNotDelegated(Map<String, Collection<String>> headerMap) throws IOException {
+        decoder.decode(createResponse(headerMap), mock(Type.class));
+        verify(delegate, never()).decode(any(), any());
+    }
+
+    private void verifyDelegated(Map<String, Collection<String>> headerMap) throws IOException {
+        decoder.decode(createResponse(headerMap), mock(Type.class));
+        verify(delegate).decode(any(), any());
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,7 +45,7 @@ develop
     *    - |fixed|
          - AtlasDB HTTP clients are now compatible with OkHttp 3.3.0+, and no longer assume that header names
            are specified in Train-Case.
-           (Pull Request)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1613>`__)
 
     *    - |fixed|
          - Canonicalised SQL strings will now have contiguous whitespace rendered as a single space as opposed to the first character of said whitespace.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -43,6 +43,11 @@ develop
          - Change
 
     *    - |fixed|
+         - AtlasDB HTTP clients are now compatible with OkHttp 3.3.0+, and no longer assume that header names
+           are specified in Train-Case.
+           (Pull Request)
+
+    *    - |fixed|
          - Canonicalised SQL strings will now have contiguous whitespace rendered as a single space as opposed to the first character of said whitespace.
            This is important for backwards compatibility with internal product.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1603>`__)


### PR DESCRIPTION
(Thought I'll try out John's template.)

**Goals (what / why)**:

- Timelock Server needs to support HTTP/2 for perf reasons which requires newer versions of OkHttp which had an API break as far as HTTP headers are concerned
- Bring AtlasDBHttpClients to closer conformance with [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616.html); we don't currently recognise non-Train-Case headers when analysing content types, but these are actually case-insensitive so even `CoNteNT-typE: text/plain` should be accepted

**How**: 

- Add `HeaderAccessUtils` which has a `shortcircuitingCaseInsensitiveContainsEntry` method; this has a precondition that the query key does not exist more than once with respect to case-insensitive comparison, allowing us to skip 50% of the headers on average assuming random iteration order
- Modify classes that delegate based on content-type HTTP headers to use `HeaderAccessUtils`

**Concerns**:

- Perf is important as this is likely to be a super hot code path for Timelock
- Opted for a shortcircuiting solution; there's a performance-readability tradeoff here and I went slightly on the side of performance (vs the original solution which found the content-type headers and then checked if they contained text/plain separately)

**Priority**:

- Preferably by end of this week. This is not blocking initial rollout but will limit the extent to which Timelock is able to scale

**Entrypoint**:

- `HeaderAccessUtils.java` and its tests. In terms of main code changes this PR is actually much smaller than the diff would imply

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1613)
<!-- Reviewable:end -->
