### PR TITLE
Add date to 0.32 release tag

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,8 @@ develop
 v0.32.0
 =======
 
+16 Feb 2017
+
 .. list-table::
     :widths: 5 40
     :header-rows: 1


### PR DESCRIPTION
Adding date of when we tagged 0.32.0

```
localhost:atlasdb rhero$ git log --tags --simplify-by-decoration --pretty="format:%ai %d" | grep tag | head
2017-02-16 13:15:38 +0000  (tag: 0.32.0)
2017-02-08 11:37:37 +0000  (tag: 0.31.0)
2017-01-27 17:19:24 +0000  (tag: 0.30.0, origin/temp/pointer-to-0.30)
2017-01-17 18:24:24 -0800  (tag: 0.29.0)
2017-01-13 17:37:07 +0000  (tag: 0.28.0)
2017-02-14 11:43:58 +0000  (tag: 0.4.5, origin/0.4.x)
2016-09-12 12:43:03 -0700  (tag: 0.4.4)
2016-06-08 11:06:52 +0100  (tag: 0.4.3)
2016-05-19 15:46:43 -0700  (tag: 0.4.2)
2016-05-17 12:52:45 -0700  (tag: 0.4.1)
```

<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
- Note what this change does and why it is needed
- Include details of who this change helps (without including internal product names)
- Include the Atlas release or date you need this by
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1615)
<!-- Reviewable:end -->
