### PR TITLE
Instrument timelock resources with Dropwizard timings

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,6 +62,10 @@ develop
     *    - |fixed|
          - Persisted locks table is now considered an Atomic Table and will not get KVS migrated
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1610>`__)
+           
+    *    - |new|
+         - Instrument timelock resources with Dropwizard timings.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1625>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -21,6 +21,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
+import com.codahale.metrics.annotation.Timed;
 import com.palantir.lock.LockService;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
@@ -33,16 +34,19 @@ public class TimeLockResource {
         this.clientToServices = clientToServices;
     }
 
+    @Timed
     @Path("/lock")
     public LockService getLockService(@PathParam("client") String client) {
         return getTimeLockServicesForClient(client).getLockService();
     }
 
+    @Timed
     @Path("/timestamp")
     public TimestampService getTimeService(@PathParam("client") String client) {
         return getTimeLockServicesForClient(client).getTimestampService();
     }
 
+    @Timed
     @Path("/timestamp-management")
     public TimestampManagementService getTimestampManagementService(@PathParam("client") String client) {
         return getTimeLockServicesForClient(client).getTimestampManagementService();

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipResource.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/LeadershipResource.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.timelock.paxos;
 
 import javax.ws.rs.Path;
 
+import com.codahale.metrics.annotation.Timed;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 
@@ -33,11 +34,13 @@ public class LeadershipResource {
         this.learner = learner;
     }
 
+    @Timed
     @Path("/acceptor")
     public PaxosAcceptor getAcceptor() {
         return acceptor;
     }
 
+    @Timed
     @Path("/learner")
     public PaxosLearner getLearner() {
         return learner;

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResource.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResource.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.palantir.paxos.PaxosAcceptor;
@@ -61,11 +62,13 @@ public final class PaxosResource {
                 Paths.get(logDirectory, client, PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH).toString()));
     }
 
+    @Timed
     @Path("/learner")
     public PaxosLearner getPaxosLearner(@PathParam("client") String client) {
         return paxosLearners.get(client);
     }
 
+    @Timed
     @Path("/acceptor")
     public PaxosAcceptor getPaxosAcceptor(@PathParam("client") String client) {
         return paxosAcceptors.get(client);


### PR DESCRIPTION
**Goals (what / why)**: Instrument timelock resources so that we capture endpoint timer metrics.

**How**: Utilize Dropwizard `@Timed` annotations on endpoints

**Concerns**: none

**Priority**: this week

**Entrypoint**: n/a


<!---
Please remember to:
- Assign someone to review this PR
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
- Note what this change does and why it is needed
- Include details of who this change helps (without including internal product names)
- Include the Atlas release or date you need this by
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1625)
<!-- Reviewable:end -->
