### PR TITLE
[no release notes] Don't break InMemoryAtlasDbConfig API since others…

### DIFF
--- a/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommandTest.java
+++ b/atlasdb-dropwizard-bundle/src/test/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbConsoleCommandTest.java
@@ -33,7 +33,7 @@ import com.palantir.atlasdb.config.AtlasDbConfigs;
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.dropwizard.AtlasDbConfigurationProvider;
-import com.palantir.atlasdb.memory.ImmutableInMemoryAtlasDbConfig;
+import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
@@ -47,7 +47,7 @@ public class AtlasDbConsoleCommandTest {
                     .addLeaders(LOCAL_SERVER_NAME)
                     .localServer(LOCAL_SERVER_NAME)
                     .build())
-            .keyValueService(ImmutableInMemoryAtlasDbConfig.builder().build())
+            .keyValueService(new InMemoryAtlasDbConfig())
             .build();
 
     private static final Map<String, Object> ONLINE_PARAMS = Collections

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
@@ -30,8 +30,8 @@ public final class InMemoryAtlasDbConfig implements KeyValueServiceConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
-        return this == o || (o != null && this.getClass() == o.getClass());
+    public boolean equals(Object other) {
+        return this == other || (other != null && this.getClass() == other.getClass());
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfig.java
@@ -15,22 +15,27 @@
  */
 package com.palantir.atlasdb.memory;
 
-import org.immutables.value.Value;
-
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.service.AutoService;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
-@JsonDeserialize(as = ImmutableInMemoryAtlasDbConfig.class)
 @JsonTypeName(InMemoryAtlasDbConfig.TYPE)
 @AutoService(KeyValueServiceConfig.class)
-@Value.Immutable
-public abstract class InMemoryAtlasDbConfig implements KeyValueServiceConfig {
+public final class InMemoryAtlasDbConfig implements KeyValueServiceConfig {
     public static final String TYPE = "memory";
 
     @Override
     public String type() {
         return TYPE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || (o != null && this.getClass() == o.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return InMemoryAtlasDbConfig.class.hashCode();
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 public class InMemoryAtlasDbConfigTest {
-    private final InMemoryAtlasDbConfig CONFIG_1 = new InMemoryAtlasDbConfig();
-    private final InMemoryAtlasDbConfig CONFIG_2 = new InMemoryAtlasDbConfig();
+    private static final InMemoryAtlasDbConfig CONFIG_1 = new InMemoryAtlasDbConfig();
+    private static  final InMemoryAtlasDbConfig CONFIG_2 = new InMemoryAtlasDbConfig();
 
     @Test
     public void twoDistinctInstancesOfInMemoryConfigsAreEqual() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class InMemoryAtlasDbConfigTest {
+    private final InMemoryAtlasDbConfig CONFIG_1 = new InMemoryAtlasDbConfig();
+    private final InMemoryAtlasDbConfig CONFIG_2 = new InMemoryAtlasDbConfig();
+
+    @Test
+    public void twoDistinctInstancesOfInMemoryConfigsAreEqual() {
+        assertThat(CONFIG_1).isEqualTo(CONFIG_2).isNotSameAs(CONFIG_2);
+    }
+
+    @Test
+    public void twoInstancesOfInMemoryConfigsHaveEqualHashCodes() {
+        assertThat(CONFIG_1.hashCode()).isEqualTo(CONFIG_2.hashCode());
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 public class InMemoryAtlasDbConfigTest {
     private static final InMemoryAtlasDbConfig CONFIG_1 = new InMemoryAtlasDbConfig();
-    private static  final InMemoryAtlasDbConfig CONFIG_2 = new InMemoryAtlasDbConfig();
+    private static final InMemoryAtlasDbConfig CONFIG_2 = new InMemoryAtlasDbConfig();
 
     @Test
     public void twoDistinctInstancesOfInMemoryConfigsAreEqual() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+
 public class InMemoryAtlasDbConfigTest {
     private static final InMemoryAtlasDbConfig CONFIG_1 = new InMemoryAtlasDbConfig();
     private static final InMemoryAtlasDbConfig CONFIG_2 = new InMemoryAtlasDbConfig();
@@ -31,5 +33,11 @@ public class InMemoryAtlasDbConfigTest {
     @Test
     public void twoInstancesOfInMemoryConfigsHaveEqualHashCodes() {
         assertThat(CONFIG_1.hashCode()).isEqualTo(CONFIG_2.hashCode());
+    }
+
+    @Test
+    public void inMemoryConfigNotEqualToOtherKeyValueServiceConfig() {
+        KeyValueServiceConfig otherKvsConfig = () -> "FooDB";
+        assertThat(CONFIG_1).isNotEqualTo(otherKvsConfig);
     }
 }


### PR DESCRIPTION
… do instantiate these directly

**Goals (what / why)**: 

- Don't break internal security product, possibly others who compile directly with `InMemoryAtlasDbConfig`
- Support InMemoryAtlasDbConfigs being equal for another internal product

**How**:

- Override `equals()` in `InMemoryAtlasDbConfig`

**Concerns**:

- Nothing in particular

**Priority**:

- Before next release, to avoid having a pair of dev breaks in 0.33.0 and 0.34.0

**Entrypoint**:

- `InMemoryAtlasDbConfig.java`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1627)
<!-- Reviewable:end -->
