### PR TITLE
moved #1618 release notes from develop to 0.33.0

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,7 +49,7 @@ develop
 v0.33.0
 =======
 
-21 Feb 2017
+22 Feb 2017
 
 .. list-table::
     :widths: 5 40

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -40,9 +40,8 @@ develop
     *    - Type
          - Change
 
-    *    - |improved|
-         - Reduced contention on PersistentTimestampService.getFreshTimestamps.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1618>`__)
+    *    -
+         -
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
@@ -94,6 +93,10 @@ v0.33.0
            We will merge a fix for MRTSE once we have a solution that allows a seamless rollback process.
            This change is also reverted on 0.32.1.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1622>`__)
+
+    *    - |improved|
+         - Reduced contention on ``PersistentTimestampService.getFreshTimestamps`` to provide performance improvements to the Timestamp service under heavy request load.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1618>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
Fixing release notes from #1618. Also added that it provides performance improvements to the timestamp service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1632)
<!-- Reviewable:end -->
