### PR TITLE
Handle KVS-Agnostic Perf Benchmarks Correctly

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
@@ -27,11 +27,14 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
 
 import org.immutables.value.Value;
+import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.util.Multiset;
 import org.openjdk.jmh.util.Statistics;
@@ -52,46 +55,65 @@ public class PerformanceResults {
 
     public void writeToFile(File file) throws IOException {
         try (BufferedWriter fout = openFileWriter(file)) {
-            long date = System.currentTimeMillis();
-            List<ImmutablePerformanceResult> newResults = results.stream().map(rs -> {
-                DockerizedDatabaseUri uri =
-                        DockerizedDatabaseUri.fromUriString(rs.getParams().getParam(BenchmarkParam.URI.getKey()));
-                String benchmark = getBenchmarkStr(rs.getParams().getBenchmark(), uri);
-                return ImmutablePerformanceResult.builder()
-                        .date(date)
-                        .benchmark(benchmark)
-                        .samples(rs.getPrimaryResult().getStatistics().getN())
-                        .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
-                        .mean(rs.getPrimaryResult().getStatistics().getMean())
-                        .data(getData(rs))
-                        .units(rs.getParams().getTimeUnit())
-                        .p50(rs.getPrimaryResult().getStatistics().getPercentile(50.0))
-                        .p90(rs.getPrimaryResult().getStatistics().getPercentile(90.0))
-                        .p99(rs.getPrimaryResult().getStatistics().getPercentile(99.0))
-                        .build();
-            }).collect(Collectors.toList());
+            List<ImmutablePerformanceResult> newResults = getPerformanceResults(results);
             new ObjectMapper().writeValue(fout, newResults);
         }
     }
 
-    private String getBenchmarkStr(String benchmark, DockerizedDatabaseUri uri) {
+    private static List<ImmutablePerformanceResult> getPerformanceResults(Collection<RunResult> results) {
+        long date = System.currentTimeMillis();
+        return results.stream().flatMap(rs -> {
+                    try {
+                        String benchmark = getBenchmarkName(rs.getParams());
+                        return Stream.of(ImmutablePerformanceResult.builder()
+                                .date(date)
+                                .benchmark(benchmark)
+                                .samples(rs.getPrimaryResult().getStatistics().getN())
+                                .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
+                                .mean(rs.getPrimaryResult().getStatistics().getMean())
+                                .data(getData(rs))
+                                .units(rs.getParams().getTimeUnit())
+                                .p50(rs.getPrimaryResult().getStatistics().getPercentile(50.0))
+                                .p90(rs.getPrimaryResult().getStatistics().getPercentile(90.0))
+                                .p99(rs.getPrimaryResult().getStatistics().getPercentile(99.0))
+                                .build());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return Stream.of();
+                    }
+                }).collect(Collectors.toList());
+    }
+
+    private static String getBenchmarkName(BenchmarkParams params) {
+        Optional<String> benchmarkUriSuffix = Optional.ofNullable(params.getParam(BenchmarkParam.URI.getKey()))
+                .map(DockerizedDatabaseUri::fromUriString)
+                .map(uri -> uri.getKeyValueServiceInstrumentation().toString());
+        return formatBenchmarkString(params.getBenchmark(), benchmarkUriSuffix);
+    }
+
+    private static String formatBenchmarkString(String benchmark, Optional<String> uriSuffix) {
         String[] benchmarkParts = benchmark.split("\\.");
         String benchmarkSuite = benchmarkParts[benchmarkParts.length - 2];
         String benchmarkName = benchmarkParts[benchmarkParts.length - 1];
-        return benchmarkSuite + "#" + benchmarkName + "-" + uri.getKeyValueServiceInstrumentation().toString();
+
+        StringBuilder result = new StringBuilder();
+        result.append(benchmarkSuite).append("#").append(benchmarkName);
+        uriSuffix.ifPresent(suffix -> result.append("-").append(suffix));
+
+        return result.toString();
     }
 
-    private BufferedWriter openFileWriter(File file) throws FileNotFoundException {
+    private static BufferedWriter openFileWriter(File file) throws FileNotFoundException {
         return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
     }
 
-    private List<Double> getData(RunResult result) {
+    private static List<Double> getData(RunResult result) {
         return result.getBenchmarkResults().stream()
                 .flatMap(b -> getRawResults(b.getPrimaryResult().getStatistics()).stream())
                 .collect(Collectors.toList());
     }
 
-    private List<Double> getRawResults(Statistics statistics) {
+    private static List<Double> getRawResults(Statistics statistics) {
         try {
             Field field = statistics.getClass().getDeclaredField("values");
             field.setAccessible(true);

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
@@ -63,25 +63,18 @@ public class PerformanceResults {
 
     private static List<ImmutablePerformanceResult> getPerformanceResults(Collection<RunResult> results) {
         long date = System.currentTimeMillis();
-        return results.stream().flatMap(rs -> {
-                    try {
-                        return Stream.of(ImmutablePerformanceResult.builder()
-                                .date(date)
-                                .benchmark(getBenchmarkName(rs.getParams()))
-                                .samples(rs.getPrimaryResult().getStatistics().getN())
-                                .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
-                                .mean(rs.getPrimaryResult().getStatistics().getMean())
-                                .data(getData(rs))
-                                .units(rs.getParams().getTimeUnit())
-                                .p50(rs.getPrimaryResult().getStatistics().getPercentile(50.0))
-                                .p90(rs.getPrimaryResult().getStatistics().getPercentile(90.0))
-                                .p99(rs.getPrimaryResult().getStatistics().getPercentile(99.0))
-                                .build());
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                        return Stream.of();
-                    }
-                }).collect(Collectors.toList());
+        return results.stream().flatMap(rs -> Stream.of(ImmutablePerformanceResult.builder()
+                .date(date)
+                .benchmark(getBenchmarkName(rs.getParams()))
+                .samples(rs.getPrimaryResult().getStatistics().getN())
+                .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
+                .mean(rs.getPrimaryResult().getStatistics().getMean())
+                .data(getData(rs))
+                .units(rs.getParams().getTimeUnit())
+                .p50(rs.getPrimaryResult().getStatistics().getPercentile(50.0))
+                .p90(rs.getPrimaryResult().getStatistics().getPercentile(90.0))
+                .p99(rs.getPrimaryResult().getStatistics().getPercentile(99.0))
+                .build())).collect(Collectors.toList());
     }
 
     @VisibleForTesting

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
@@ -42,6 +42,7 @@ import org.openjdk.jmh.util.Statistics;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.performance.backend.DockerizedDatabaseUri;
 
@@ -64,10 +65,9 @@ public class PerformanceResults {
         long date = System.currentTimeMillis();
         return results.stream().flatMap(rs -> {
                     try {
-                        String benchmark = getBenchmarkName(rs.getParams());
                         return Stream.of(ImmutablePerformanceResult.builder()
                                 .date(date)
-                                .benchmark(benchmark)
+                                .benchmark(getBenchmarkName(rs.getParams()))
                                 .samples(rs.getPrimaryResult().getStatistics().getN())
                                 .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
                                 .mean(rs.getPrimaryResult().getStatistics().getMean())
@@ -84,7 +84,8 @@ public class PerformanceResults {
                 }).collect(Collectors.toList());
     }
 
-    private static String getBenchmarkName(BenchmarkParams params) {
+    @VisibleForTesting
+    static String getBenchmarkName(BenchmarkParams params) {
         Optional<String> benchmarkUriSuffix = Optional.ofNullable(params.getParam(BenchmarkParam.URI.getKey()))
                 .map(DockerizedDatabaseUri::fromUriString)
                 .map(uri -> uri.getKeyValueServiceInstrumentation().toString());

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
@@ -22,9 +22,7 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.MediaType;
 
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
@@ -55,7 +53,6 @@ public class HttpBenchmarks {
     @Benchmark
     @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 60, timeUnit = TimeUnit.SECONDS)
-    @BenchmarkMode(Mode.SampleTime)
     public void parseHttpHeaders(Blackhole blackhole) {
         blackhole.consume(HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(
                 HEADERS,

--- a/atlasdb-perf/src/test/java/com/palantir/atlasdb/performance/PerformanceResultsTest.java
+++ b/atlasdb-perf/src/test/java/com/palantir/atlasdb/performance/PerformanceResultsTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.runner.WorkloadParams;
+
+import com.palantir.atlasdb.performance.backend.CassandraKeyValueServiceInstrumentation;
+
+public class PerformanceResultsTest {
+    private static final String SUITE_NAME = "PerformanceResults";
+    private static final String BENCHMARK_NAME = "doStuff";
+    private static final String FULL_BENCHMARK_NAME
+            = "com.palantir.atlasdb.performance." + SUITE_NAME + "." + BENCHMARK_NAME;
+    private static final String FORMATTED_BENCHMARK_NAME = SUITE_NAME + "#" + BENCHMARK_NAME;
+
+    private static final String DOCKERIZED_CASSANDRA_URI
+            = CassandraKeyValueServiceInstrumentation.class.getCanonicalName() + "@192.168.99.100:9160";
+    private static final String FORMATTED_BENCHMARK_NAME_CASSANDRA
+            = FORMATTED_BENCHMARK_NAME + "-" + new CassandraKeyValueServiceInstrumentation().toString();
+
+    @Test
+    public void canGenerateBenchmarkNameForTestWithoutKeyValueService() {
+        BenchmarkParams params = createBenchmarkParams(FULL_BENCHMARK_NAME, "foo", "bar");
+
+        assertThat(PerformanceResults.getBenchmarkName(params)).isEqualTo(FORMATTED_BENCHMARK_NAME);
+    }
+
+    @Test
+    public void canGenerateBenchmarkNameForTestWithKeyValueService() {
+        BenchmarkParams params = createBenchmarkParams("PerformanceResults.doStuff",
+                BenchmarkParam.URI.getKey(),
+                DOCKERIZED_CASSANDRA_URI);
+
+        assertThat(PerformanceResults.getBenchmarkName(params)).isEqualTo(FORMATTED_BENCHMARK_NAME_CASSANDRA);
+    }
+
+    private static BenchmarkParams createBenchmarkParams(String benchmarkName, String paramKey, String paramValue) {
+        WorkloadParams workloadParams = new WorkloadParams();
+        workloadParams.put(paramKey, paramValue, 0);
+
+        // Sorry, JMH API doesn't have a builder. Isolating the badness to just here.
+        return new BenchmarkParams(benchmarkName,
+                null,
+                false,
+                0,
+                null,
+                null,
+                1,
+                1,
+                null,
+                null,
+                null,
+                workloadParams,
+                null,
+                1,
+                null,
+                null,
+                null);
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -40,8 +40,10 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - AtlasDB Perf Cli can now run output KVS-agnostic benchmark data (such as ``HttpBenchmarks``) to a file.
+           Previously running these benchmarks whilst writing output to a file would fail.
+           (Pull Request)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,9 +41,9 @@ develop
          - Change
 
     *    - |fixed|
-         - AtlasDB Perf Cli can now run output KVS-agnostic benchmark data (such as ``HttpBenchmarks``) to a file.
-           Previously running these benchmarks whilst writing output to a file would fail.
-           (Pull Request)
+         - AtlasDB Perf Cli can now output KVS-agnostic benchmark data (such as ``HttpBenchmarks``) to a file.
+           Previously running these benchmarks whilst attempting to write output to a file would fail.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1635>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**:

- Fix benchmarking builds, which are all broken in the wake of #1613 
- Support running benchmarks which don't depend on a key value service, without running them N times where N is the number of KVSs

**Implementation Description (bullets)**:

- Modify parsing logic which always assumes a URI to be there, to include it only if it is relevant
- Add unit tests for bits of the parsing logic

**Concerns (what feedback would you like?)**:

- Nothing specific

**Where should we start reviewing?**:

- `PerformanceResults.java`

**Priority (whenever / two weeks / yesterday)**:

- Preferably today or tomorrow (I'm tempted to use "yesterday"...)
- Until this is merged, we will not get any benchmarking results

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1635)
<!-- Reviewable:end -->
