### PR TITLE
[no release notes] Don't Break Format-Assuming Analytical Tools on HTTP Benchmarks

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
@@ -47,6 +47,8 @@ import com.google.common.collect.Lists;
 import com.palantir.atlasdb.performance.backend.DockerizedDatabaseUri;
 
 public class PerformanceResults {
+    @VisibleForTesting
+    static final String KVS_AGNOSTIC_SUFFIX = "N/A";
 
     private final Collection<RunResult> results;
 
@@ -90,11 +92,7 @@ public class PerformanceResults {
         String benchmarkSuite = benchmarkParts[benchmarkParts.length - 2];
         String benchmarkName = benchmarkParts[benchmarkParts.length - 1];
 
-        StringBuilder result = new StringBuilder();
-        result.append(benchmarkSuite).append("#").append(benchmarkName);
-        uriSuffix.ifPresent(suffix -> result.append("-").append(suffix));
-
-        return result.toString();
+        return String.format("%s#%s-%s", benchmarkSuite, benchmarkName, uriSuffix.orElse(KVS_AGNOSTIC_SUFFIX));
     }
 
     private static BufferedWriter openFileWriter(File file) throws FileNotFoundException {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
@@ -52,7 +52,7 @@ public class HttpBenchmarks {
 
     @Benchmark
     @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 60, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public void parseHttpHeaders(Blackhole blackhole) {
         blackhole.consume(HeaderAccessUtils.shortcircuitingCaseInsensitiveContainsEntry(
                 HEADERS,

--- a/atlasdb-perf/src/test/java/com/palantir/atlasdb/performance/PerformanceResultsTest.java
+++ b/atlasdb-perf/src/test/java/com/palantir/atlasdb/performance/PerformanceResultsTest.java
@@ -30,6 +30,9 @@ public class PerformanceResultsTest {
             = "com.palantir.atlasdb.performance." + SUITE_NAME + "." + BENCHMARK_NAME;
     private static final String FORMATTED_BENCHMARK_NAME = SUITE_NAME + "#" + BENCHMARK_NAME;
 
+    private static final String FORMATTED_BENCHMARK_NAME_AGNOSTIC
+            = FORMATTED_BENCHMARK_NAME + "-" + PerformanceResults.KVS_AGNOSTIC_SUFFIX;
+
     private static final String DOCKERIZED_CASSANDRA_URI
             = CassandraKeyValueServiceInstrumentation.class.getCanonicalName() + "@192.168.99.100:9160";
     private static final String FORMATTED_BENCHMARK_NAME_CASSANDRA
@@ -39,7 +42,7 @@ public class PerformanceResultsTest {
     public void canGenerateBenchmarkNameForTestWithoutKeyValueService() {
         BenchmarkParams params = createBenchmarkParams(FULL_BENCHMARK_NAME, "foo", "bar");
 
-        assertThat(PerformanceResults.getBenchmarkName(params)).isEqualTo(FORMATTED_BENCHMARK_NAME);
+        assertThat(PerformanceResults.getBenchmarkName(params)).isEqualTo(FORMATTED_BENCHMARK_NAME_AGNOSTIC);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:

- Fix #1641
- Avoid breaking internal tools that make assumptions about the format of benchmarking strings 

**Implementation Description (bullets)**:

- Slash benchmark times
- Add KVS agnostic suffix

**Concerns (what feedback would you like?)**:

- Nothing in particular. Maybe 5s is still too long, but I think it's fine

**Where should we start reviewing?**:

- Anywhere, this is very small

**Priority (whenever / two weeks / yesterday)**:

- Ideally this week
- Benchmarking now works, so we're out of P0/P1-land, but still worth cleaning up

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1642)
<!-- Reviewable:end -->
