### PR TITLE
Set timelock-server min/max heap to 512 MB

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,6 +44,10 @@ develop
          - Cassandra now attempts to truncate when performing a ``deleteRange(RangeRequest.All())`` in an effort to build up less garbage.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1617>`__)
 
+    *    - |fixed|
+         - Timelock server now specifies minimum and maximum heap size of 512 MB.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1647>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -52,7 +52,7 @@ distribution {
     serviceName "timelock-server"
     mainClass 'com.palantir.atlasdb.timelock.TimeLockServerLauncher'
     args 'server', 'var/conf/timelock.yml'
-    defaultJvmOpts "-javaagent:service/lib/jetty-alpn-agent-${libVersions.jetty_alpn_agent}.jar"
+    defaultJvmOpts "-Xms512m", "-Xmx512m", "-javaagent:service/lib/jetty-alpn-agent-${libVersions.jetty_alpn_agent}.jar"
 }
 
 dependencyRecommendations {


### PR DESCRIPTION
Based on analysis of timelock-server GC logs under load, we now specify default minimum and maximum heap size of 512 MB.

Closes #1646

**Goals (and why)**: Tune the heap size JVM opts for the timelock server distribution

**Implementation Description (bullets)**: specify default JVM options including min & max heap size of 512 MB

**Concerns (what feedback would you like?)**: sanity check

**Where should we start reviewing?**: `timelock-server/build.gradle`

**Priority (whenever / two weeks / yesterday)**: 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1647)
<!-- Reviewable:end -->
