### PR TITLE
Fix release lock endpoint for PersistentLockService

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockService.java
@@ -50,7 +50,7 @@ public class KvsBackedPersistentLockService implements PersistentLockService {
 
         try {
             lockStore.releaseLock(lockEntry);
-            return "The lock was released successfully.\n";
+            return "\"The lock was released successfully.\\n\"";
         } catch (CheckAndSetException e) {
             log.error("Failed to release the persistent lock. This means that somebody already cleared this lock. "
                     + "You should investigate this, as this means your operation didn't necessarily hold the lock when "

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockStore.java
@@ -98,7 +98,7 @@ public class LockStore {
                 LOCK_OPEN.value());
 
         keyValueService.checkAndSet(request);
-        log.info("Successfully released the persistent lock.");
+        log.info("Successfully released the persistent lock: {}", lockEntry);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
**Goals (and why)**: Fixes the release endpoint to make it return valid JSON.

**Implementation Description (bullets)**: wraps returned string in quotes and escapes the newline at the end. Also tweaks the release lock log message to be consistent with the acquire log and.

**Concerns (what feedback would you like?)**: none

**Where should we start reviewing?**: KvsBackedPersistentLockService.java

**Priority (whenever / two weeks / yesterday)**: asap

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1652)
<!-- Reviewable:end -->
