### PR TITLE
Timelock block should be removed in offline clis

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -200,6 +200,7 @@ public abstract class AtlasDbConfig {
                 .leader(Optional.absent())
                 .lock(Optional.absent())
                 .timestamp(Optional.absent())
+                .timelock(Optional.absent())
                 .build();
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,6 +49,10 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1647>`__)
 
     *    - |fixed|
+         - CLIs can now work in the offline mode when the client config includes the timelock block.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1657>`__)
+
+    *    - |fixed|
          - The background sweeper now uses deleteRange instead of truncate when clearing the ``sweep.progress`` table.
            This prevents the operation from interfering with concurrently running Postgres backups.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1616>`__)


### PR DESCRIPTION
**Goals (and why)**: Offline CLIs with `timelock` block should be functional

**Implementation Description (bullets)**:
1. kill the timelock block when getting offline config.
2. Add tests as part of #1657.

**Concerns (what feedback would you like?)**: Quite straigh-forward.

**Where should we start reviewing?**: ``AtlasDbConfig.java``

**Priority (whenever / two weeks / yesterday)**: anytime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1658)
<!-- Reviewable:end -->
