### PR TITLE
remove one layer of nested retries in CKVS.truncate

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -1177,7 +1177,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     public void truncateTables(final Set<TableReference> tablesToTruncate) {
         if (!tablesToTruncate.isEmpty()) {
             try {
-                clientPool.runWithRetry(new FunctionCheckedException<Client, Void, Exception>() {
+                clientPool.run(new FunctionCheckedException<Client, Void, Exception>() {
                     @Override
                     public Void apply(Client client) throws Exception {
                         for (TableReference tableRef : tablesToTruncate) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -1177,27 +1177,31 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     public void truncateTables(final Set<TableReference> tablesToTruncate) {
         if (!tablesToTruncate.isEmpty()) {
             try {
-                clientPool.run(new FunctionCheckedException<Client, Void, Exception>() {
-                    @Override
-                    public Void apply(Client client) throws Exception {
-                        for (TableReference tableRef : tablesToTruncate) {
-                            truncateInternal(client, tableRef);
-                        }
-                        return null;
-                    }
-
-                    @Override
-                    public String toString() {
-                        return "truncateTables(" + tablesToTruncate.size() + " tables)";
-                    }
-                });
+                runTruncateInternal(tablesToTruncate);
             } catch (UnavailableException e) {
                 throw new PalantirRuntimeException("Truncating tables requires all Cassandra nodes"
                         + " to be up and available.");
-            } catch (Exception e) {
+            } catch (TException e) {
                 throw Throwables.throwUncheckedException(e);
             }
         }
+    }
+
+    private void runTruncateInternal(final Set<TableReference> tablesToTruncate) throws TException {
+        clientPool.run(new FunctionCheckedException<Client, Void, TException>() {
+            @Override
+            public Void apply(Client client) throws TException {
+                for (TableReference tableRef : tablesToTruncate) {
+                    truncateInternal(client, tableRef);
+                }
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return "truncateTables(" + tablesToTruncate.size() + " tables)";
+            }
+        });
     }
 
     private void truncateInternal(Client client, TableReference tableRef) throws TException {
@@ -1905,19 +1909,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     public void deleteRange(final TableReference tableRef, final RangeRequest range) {
         if (range.equals(RangeRequest.all())) {
             try {
-                clientPool.run(
-                        new FunctionCheckedException<Client, Void, TException>() {
-                            @Override
-                            public Void apply(Client client) throws TException {
-                                truncateInternal(client, tableRef);
-                                return null;
-                            }
-
-                            @Override
-                            public String toString() {
-                                return "truncateTable(" + tableRef + ")";
-                            }
-                        });
+                runTruncateInternal(ImmutableSet.of(tableRef));
             } catch (TException e) {
                 log.info("Tried to make a deleteRange({}, RangeRequest.all())"
                         + " into a more garbage-cleanup friendly truncate(), but this failed.", tableRef, e);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,6 +53,10 @@ develop
            This prevents the operation from interfering with concurrently running Postgres backups.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1616>`__)
 
+    *    - |improved|
+         - Cassandra truncates that are going to fail will do so faster.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1660>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
**Goals (and why)**:
truncateInternal has its own retry logic, doing retries nested around retries ends up meaning that for timeout-related errors (which are not uncommon during truncate) it takes an incredibly long period of time to fail out of this code.
(i.e. instead of 3 tries that take 30 seconds each, we'd accidentally be doing 3 * 3 = 9 tries of 30 seconds each)

**Implementation Description**:
runWithRetry() --> run()

**Priority (whenever / two weeks / yesterday)**:
whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1660)
<!-- Reviewable:end -->
