### PR TITLE
remove getting started notes and replaced with actual startup command

### DIFF
--- a/docs/source/cluster_management/console.rst
+++ b/docs/source/cluster_management/console.rst
@@ -20,14 +20,13 @@ perform both safe and destructive (read dangerous) operations.
 Getting Started
 ===============
 
-This section provides basic instructions for navigating AtlasDB Console.
-By following the steps below, you can learn how to import sample data
-and run basic queries that will give you some insight into how your data
-is stored in AtlasDB. If you have not used Groovy or GroovyShell before,
-you may wish to refer to `using
-Groovy <#using-groovy-in-atlasdb-console>`__ before you start.
+To start AtlasDB console via the AtlasDB Dropwizard bundle, you should run a command like the following:
 
-Incomplete - pending transfer from internal documentation.
+.. code-block:: bash
+
+    ./service/bin/<service> atlasdb console var/conf/<service>.yml
+
+To exit the console, you can type ``:exit`` or enter ctrl + c.
 
 Using Groovy in AtlasDB Console
 ===============================


### PR DESCRIPTION
Fixes #1585.

**Goals (and why)**: Add a command to start a supported AtlasDB tool.

**Implementation Description (bullets)**:

- added a start-up command where there was none before
- removed reference to porting internal documentation (as we are probably not going to do this)

**Concerns (what feedback would you like?)**: I tested the command on an internal service, so I'm confident it works. Could make a reference to a leader block, but our error logging is pretty helpful in pointing that out.

**Where should we start reviewing?**: only one page

**Priority (whenever / two weeks / yesterday)**: Whenever, should take 2 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1663)
<!-- Reviewable:end -->
