### PR TITLE
Feature/instrument metrics for timelock server

### DIFF
--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -128,7 +128,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,
@@ -448,7 +451,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -257,7 +257,8 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
-                "com.palantir.atlasdb:atlasdb-rocksdb"
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -219,7 +219,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -806,7 +807,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 
 public class MetricsManager {
 
@@ -35,6 +36,11 @@ public class MetricsManager {
     public MetricsManager() {
         this.metricRegistry = AtlasDbMetrics.getMetricRegistry();
         this.registeredMetrics = new HashSet<>();
+    }
+
+
+    public Timer registerTimer(Class clazz, String timerName) {
+        return metricRegistry.timer(MetricRegistry.name(clazz, timerName));
     }
 
     public void registerMetric(Class clazz, String metricPrefix, String metricName, Gauge gauge) {

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -249,7 +249,8 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
-                "com.palantir.atlasdb:atlasdb-rocksdb"
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -165,7 +165,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -598,7 +599,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -150,7 +150,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -513,7 +514,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -256,7 +256,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -1304,7 +1305,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -267,7 +267,8 @@
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
-                "com.palantir.atlasdb:atlasdb-rocksdb"
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -1395,7 +1396,8 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
-                "com.palantir.atlasdb:atlasdb-rocksdb"
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-hikari/versions.lock
+++ b/atlasdb-hikari/versions.lock
@@ -119,7 +119,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-jdbc"
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -355,7 +356,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-jdbc"
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-jdbc/versions.lock
+++ b/atlasdb-jdbc/versions.lock
@@ -115,7 +115,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,
@@ -333,7 +336,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -267,7 +267,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -1025,7 +1026,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-rocksdb/versions.lock
+++ b/atlasdb-rocksdb/versions.lock
@@ -115,7 +115,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,
@@ -333,7 +336,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -1121,7 +1121,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:atlasdb-rocksdb"
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
+import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.remoting1.servers.jersey.HttpRemotingJerseyFeature;
 
 import io.dropwizard.Application;
@@ -35,6 +36,7 @@ public class TimeLockServerLauncher extends Application<TimeLockServerConfigurat
 
     @Override
     public void run(TimeLockServerConfiguration configuration, Environment environment) {
+        AtlasDbMetrics.setMetricRegistry(environment.metrics());
         TimeLockServer serverImpl = configuration.algorithm().createServerImpl(environment);
         try {
             serverImpl.onStartup(configuration);

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -260,7 +260,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -1393,7 +1394,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -3,6 +3,7 @@ apply from: "../gradle/shared.gradle"
 
 dependencies {
   compile(project(":timestamp-api"))
+  compile(project(":atlasdb-client"))
   compile(project(":atlasdb-commons"))
 
   compile group: 'com.palantir.remoting1', name: 'tracing'

--- a/timestamp-impl/versions.lock
+++ b/timestamp-impl/versions.lock
@@ -4,6 +4,7 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-api"
             ]
@@ -13,7 +14,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -21,12 +23,17 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
+                "com.netflix.feign:feign-jackson",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting1:tracing",
+                "com.palantir.remoting:ssl-config"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
             "locked": "2.6.7",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting1:tracing"
             ]
         },
@@ -39,6 +46,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:timestamp-api"
@@ -55,11 +65,69 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing"
+                "com.palantir.remoting1:tracing",
+                "com.palantir.remoting:ssl-config"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "2.6.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.json-simple:json-simple": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.googlecode.protobuf-java-format:protobuf-java-format": {
+            "locked": "1.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.netflix.feign:feign-core": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.netflix.feign:feign-jackson",
+                "com.netflix.feign:feign-jaxrs"
+            ]
+        },
+        "com.netflix.feign:feign-jackson": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.netflix.feign:feign-jaxrs": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-client": {
+            "project": true
+        },
+        "com.palantir.atlasdb:atlasdb-client-protobufs": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.atlasdb:atlasdb-commons": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
@@ -68,10 +136,28 @@
             ]
         },
         "com.palantir.atlasdb:timestamp-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3"
+            "locked": "1.0.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.remoting:ssl-config": {
+            "locked": "0.13.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
@@ -79,9 +165,16 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-api"
             ]
@@ -92,12 +185,24 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
+            ]
+        },
+        "org.xerial.snappy:snappy-java": {
+            "locked": "1.1.1.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         }
     },
@@ -106,6 +211,7 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-api"
             ]
@@ -115,7 +221,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -123,12 +230,17 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
-                "com.palantir.remoting1:tracing"
+                "com.netflix.feign:feign-jackson",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting1:tracing",
+                "com.palantir.remoting:ssl-config"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
             "locked": "2.6.7",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting1:tracing"
             ]
         },
@@ -141,6 +253,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:timestamp-api"
@@ -157,11 +272,69 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting1:tracing"
+                "com.palantir.remoting1:tracing",
+                "com.palantir.remoting:ssl-config"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "2.6.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.json-simple:json-simple": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.googlecode.protobuf-java-format:protobuf-java-format": {
+            "locked": "1.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.netflix.feign:feign-core": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.netflix.feign:feign-jackson",
+                "com.netflix.feign:feign-jaxrs"
+            ]
+        },
+        "com.netflix.feign:feign-jackson": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.netflix.feign:feign-jaxrs": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-client": {
+            "project": true
+        },
+        "com.palantir.atlasdb:atlasdb-client-protobufs": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.atlasdb:atlasdb-commons": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
@@ -170,10 +343,28 @@
             ]
         },
         "com.palantir.atlasdb:timestamp-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
         },
         "com.palantir.remoting1:tracing": {
-            "locked": "1.0.3"
+            "locked": "1.0.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.remoting:ssl-config": {
+            "locked": "0.13.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
@@ -181,9 +372,16 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-api"
             ]
@@ -194,12 +392,24 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
+            ]
+        },
+        "org.xerial.snappy:snappy-java": {
+            "locked": "1.1.1.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         }
     }


### PR DESCRIPTION
**Goals (and why)**: Client side metrics for the timelock server to have a clear picture of the change in performance with the timelock server migration.

**Implementation Description (bullets)**:
1. Add dropwizard timers and meters to see the request rates and the change in latency.

**Concerns (what feedback would you like?)**:
1. The overhead added due to timers is probably not worth the value or there should be some way to reduce the overhead.

<img width="1161" alt="screen shot 2017-03-02 at 4 00 46 pm" src="https://cloud.githubusercontent.com/assets/20421615/23516669/d1df7c0c-ff65-11e6-996f-5d9c79c841ce.png">

<img width="1165" alt="screen shot 2017-03-02 at 4 03 29 pm" src="https://cloud.githubusercontent.com/assets/20421615/23516674/d4056208-ff65-11e6-870e-638a695477eb.png">

2.  ``AtlasDbMetrics`` should be moved from ``atlasdb-client`` to some other place to avoid the  dependency of ``timestamp-api`` on ``atlasdb-client``. (this will be a devbreak as products register their dropwizard metricRegistry with AtlasDbMetrics).

**Where should we start reviewing?**: PersistentTimestampService.

**Priority (whenever / two weeks / yesterday)**: this week.

TODO:

- [ ] Reduce the overhead due to registering metrics

- [ ] Add metrics for lockService 
