### PR TITLE
(0.4.x) Blacklisted tables in BackgroundSweeperImpl

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.factory;
 
+import java.util.Collections;
 import java.util.ServiceLoader;
 import java.util.Set;
 
@@ -159,7 +160,8 @@ public class TransactionManagers {
                 Suppliers.ofInstance(config.enableSweep()),
                 Suppliers.ofInstance(config.getSweepPauseMillis()),
                 Suppliers.ofInstance(config.getSweepBatchSize()),
-                SweepTableFactory.of());
+                SweepTableFactory.of(),
+                () -> Collections.emptySet());
         backgroundSweeper.runInBackground();
 
         return transactionManager;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/cleaner/AbstractSweeperTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/cleaner/AbstractSweeperTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.cleaner;
 
 import static com.palantir.atlasdb.schema.generated.SweepProgressTable.SweepProgressRowResult;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -117,7 +118,7 @@ public abstract class AbstractSweeperTest {
         Supplier<Boolean> sweepEnabledSupplier = () -> true;
         Supplier<Long> sweepNoPause = () -> 0L;
         Supplier<Integer> batchSizeSupplier = () -> batchSize;
-        backgroundSweeper = new BackgroundSweeperImpl(txManager, kvs, sweepRunner, sweepEnabledSupplier, sweepNoPause, batchSizeSupplier, SweepTableFactory.of());
+        backgroundSweeper = new BackgroundSweeperImpl(txManager, kvs, sweepRunner, sweepEnabledSupplier, sweepNoPause, batchSizeSupplier, SweepTableFactory.of(), () -> Collections.emptySet());
     }
 
     @After


### PR DESCRIPTION
Don't cherry-pick this to develop. This is a workaround for the
notorious sweep OOM issue, which should get fixed on develop soon.