### PR TITLE
ETE Tests of TimeLock Migration [TimeLock ETE Tests, Part III]

### DIFF
--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -30,8 +30,9 @@ dependencies {
     testCompile project(':atlasdb-docker-test-utils')
     testCompile project(':atlasdb-ete-test-utils')
 
-    testCompile group: 'io.dropwizard', name: 'dropwizard-testing'
     testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
+    testCompile group: 'io.dropwizard', name: 'dropwizard-testing'
+    testCompile group: 'org.assertj', name: 'assertj-core'
 }
 
 task prepareForEteTests(type: Copy, dependsOn: 'distTar') {

--- a/atlasdb-ete-tests/docker-compose.timelock-migration.cassandra.yml
+++ b/atlasdb-ete-tests/docker-compose.timelock-migration.cassandra.yml
@@ -20,11 +20,14 @@ services:
 
   ete1:
     build: .
-    command: [bash, -c, 'cp var/conf/atlasdb-ete.no-leader.cassandra.yml var/conf/atlasdb-ete.yml && dockerize -timeout 120s -wait tcp://cassandra:9160 && service/bin/init.sh console']
+    # We don't use console, because we might want to start/stop/restart the service.
+    command: [bash, -c, 'dockerize -timeout 120s -wait tcp://cassandra:9160 && service/bin/init.sh start && sleep 99999999']
     ports:
       - "3828"
     depends_on:
       - cassandra
       - timelock
+    volumes:
+      - $CONFIG_FILE_MOUNTPOINT:/atlasdb-ete/atlasdb-ete-snapshot/var/conf/
     environment:
       - ME=ete1

--- a/atlasdb-ete-tests/docker-compose.timelock-migration.cassandra.yml
+++ b/atlasdb-ete-tests/docker-compose.timelock-migration.cassandra.yml
@@ -1,0 +1,30 @@
+version: '2'
+
+services:
+  timelock:
+    image: palantirtechnologies/timelock-server
+    ports:
+      - "8421"
+      - "8422"
+
+  cassandra:
+    image: palantirtechnologies/docker-cassandra-atlasdb:$CASSANDRA_VERSION
+    ports:
+      - "9160"
+      - "9042"
+      - "7199"
+    environment:
+      - MAX_HEAP_SIZE=512m
+      - HEAP_NEWSIZE=64m
+      - LOCAL_JMX=no
+
+  ete1:
+    build: .
+    command: [bash, -c, 'cp var/conf/atlasdb-ete.no-leader.cassandra.yml var/conf/atlasdb-ete.yml && dockerize -timeout 120s -wait tcp://cassandra:9160 && service/bin/init.sh console']
+    ports:
+      - "3828"
+    depends_on:
+      - cassandra
+      - timelock
+    environment:
+      - ME=ete1

--- a/atlasdb-ete-tests/docker-compose.timelock-migration.cassandra.yml
+++ b/atlasdb-ete-tests/docker-compose.timelock-migration.cassandra.yml
@@ -21,7 +21,7 @@ services:
   ete1:
     build: .
     # We don't use console, because we might want to start/stop/restart the service.
-    command: [bash, -c, 'dockerize -timeout 120s -wait tcp://cassandra:9160 && service/bin/init.sh start && sleep 99999999']
+    command: [bash, -c, 'dockerize -timeout 120s -wait tcp://cassandra:9160 && service/bin/init.sh start && tail -f var/log/atlasdb-ete-startup.log']
     ports:
       - "3828"
     depends_on:

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraMultinodeTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraMultinodeTestSuite.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.containers.CassandraVersion;
 @Suite.SuiteClasses({
         TodoEteTest.class,
         ServiceExposureEteTest.class,
-        DropwizardEteTest.class
+        CommandLineEteTest.class
 })
 public class CassandraMultinodeTestSuite extends EteSetup {
     private static final List<String> CLIENTS = ImmutableList.of("ete1", "ete2", "ete3");

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraNoLeaderTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraNoLeaderTestSuite.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.containers.CassandraVersion;
 @Suite.SuiteClasses({
         TodoEteTest.class,
         ServiceExposureEteTest.class,
-        DropwizardEteTest.class
+        CommandLineEteTest.class
 })
 public class CassandraNoLeaderTestSuite extends EteSetup {
     private static final List<String> CLIENTS = ImmutableList.of("ete1");

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimeLockTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimeLockTestSuite.java
@@ -28,7 +28,7 @@ import com.palantir.atlasdb.containers.CassandraVersion;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         TodoEteTest.class,
-        DropwizardEteTest.class
+        CommandLineEteTest.class
 })
 public class CassandraTimeLockTestSuite extends EteSetup {
     private static final List<String> CLIENTS = ImmutableList.of("ete1");

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CommandLineEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CommandLineEteTest.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 
 import org.junit.Test;
 
-public class DropwizardEteTest {
+public class CommandLineEteTest {
     private static final Pattern TIMESTAMP_REGEX = Pattern.compile("The Fresh timestamp is: (\\d+)");
 
     @Test

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DbKvsTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DbKvsTestSuite.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableList;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         TodoEteTest.class,
-        DropwizardEteTest.class
+        CommandLineEteTest.class
 })
 public class DbKvsTestSuite extends EteSetup {
     private static final List<String> CLIENTS = ImmutableList.of("ete1", "ete2", "ete3");

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DockerClientOrchestrationRule.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DockerClientOrchestrationRule.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.ete;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.joda.time.Duration;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.containers.CassandraVersion;
+import com.palantir.atlasdb.testing.DockerProxyRule;
+import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.connection.DockerMachine;
+import com.palantir.docker.compose.connection.waiting.ClusterHealthCheck;
+import com.palantir.docker.compose.connection.waiting.ClusterWait;
+import com.palantir.docker.compose.connection.waiting.HealthChecks;
+import com.palantir.docker.compose.execution.DockerComposeExecOption;
+import com.palantir.docker.compose.execution.ImmutableDockerComposeExecArgument;
+import com.palantir.docker.compose.logging.LogDirectory;
+
+public class DockerClientOrchestrationRule extends ExternalResource {
+    public static final String CONTAINER_NAME = "ete1";
+    private final TemporaryFolder temporaryFolder;
+
+    private DockerComposeRule dockerComposeRule;
+    private DockerProxyRule dockerProxyRule;
+    private File configFile;
+
+    public DockerClientOrchestrationRule(TemporaryFolder temporaryFolder) {
+        this.temporaryFolder = temporaryFolder;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        try {
+            configFile = temporaryFolder.newFile("atlasdb-ete.yml");
+            updateClientConfig(new File("docker/conf/atlasdb-ete.no-leader.cassandra.yml"));
+
+            DockerMachine dockerMachine = createDockerMachine();
+
+            dockerComposeRule = DockerComposeRule.builder()
+                    .machine(dockerMachine)
+                    .file("docker-compose.timelock-migration.cassandra.yml")
+                    .waitingForService("cassandra", HealthChecks.toHaveAllPortsOpen())
+                    .saveLogsTo(LogDirectory.circleAwareLogDirectory(TimeLockMigrationEteTest.class.getSimpleName()))
+                    .addClusterWait(new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), Duration.standardMinutes(100)))
+                    .build();
+
+            dockerProxyRule = new DockerProxyRule(dockerComposeRule.projectName(), TimeLockMigrationEteTest.class);
+
+            dockerComposeRule.before();
+            dockerProxyRule.before();
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    protected void after() {
+        dockerProxyRule.after();
+        dockerComposeRule.after();
+    }
+
+    public void updateProcessLivenessScript() {
+        // Go-Java-Launcher's functionality for seeing if a process is running is not correct with respect to busybox.
+        // See also https://github.com/palantir/sls-packaging/issues/185
+        try {
+            dockerComposeRule.exec(
+                    DockerComposeExecOption.noOptions(),
+                    CONTAINER_NAME,
+                    ImmutableDockerComposeExecArgument.arguments(
+                            "sed", "-i", "s/ps $PID > \\/dev\\/null;/kill -0 $PID/", "service/bin/init.sh"));
+        } catch (IOException | InterruptedException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public void updateClientConfig(File file) {
+        try {
+            FileUtils.writeStringToFile(configFile, FileUtils.readFileToString(file));
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public void restartAtlasClient() throws IOException, InterruptedException {
+        dockerComposeRule.exec(
+                DockerComposeExecOption.noOptions(),
+                CONTAINER_NAME,
+                ImmutableDockerComposeExecArgument.arguments(
+                        "bash", "-c", "nohup service/bin/init.sh restart"));
+    }
+
+    public String getClientLogs() throws IOException, InterruptedException {
+        return dockerComposeRule.exec(
+                DockerComposeExecOption.noOptions(),
+                CONTAINER_NAME,
+                ImmutableDockerComposeExecArgument.arguments(
+                        "cat", "var/log/atlasdb-ete-startup.log"));
+    }
+
+
+    private DockerMachine createDockerMachine() {
+        Map<String, String> environment = getEnvironment();
+        return DockerMachine.localMachine()
+                .withEnvironment(environment)
+                .build();
+    }
+
+    private Map<String, String> getEnvironment() {
+        Map<String, String> environment = Maps.newHashMap(CassandraVersion.getEnvironment());
+        environment.put("CONFIG_FILE_MOUNTPOINT", temporaryFolder.getRoot().getAbsolutePath());
+        return environment;
+    }
+
+}

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DockerClientOrchestrationRule.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DockerClientOrchestrationRule.java
@@ -66,24 +66,22 @@ public class DockerClientOrchestrationRule extends ExternalResource {
         try {
             configFile = temporaryFolder.newFile("atlasdb-ete.yml");
             updateClientConfig(EMBEDDED_CONFIG);
-
-            DockerMachine dockerMachine = createDockerMachine();
-
-            dockerComposeRule = DockerComposeRule.builder()
-                    .machine(dockerMachine)
-                    .file("docker-compose.timelock-migration.cassandra.yml")
-                    .waitingForService("cassandra", HealthChecks.toHaveAllPortsOpen())
-                    .saveLogsTo(LogDirectory.circleAwareLogDirectory(TimeLockMigrationEteTest.class.getSimpleName()))
-                    .addClusterWait(new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), WAIT_TIMEOUT))
-                    .build();
-
-            dockerProxyRule = new DockerProxyRule(dockerComposeRule.projectName(), TimeLockMigrationEteTest.class);
-
-            dockerComposeRule.before();
-            dockerProxyRule.before();
         } catch (IOException e) {
             throw Throwables.propagate(e);
         }
+
+        DockerMachine dockerMachine = createDockerMachine();
+        dockerComposeRule = DockerComposeRule.builder()
+                .machine(dockerMachine)
+                .file("docker-compose.timelock-migration.cassandra.yml")
+                .waitingForService("cassandra", HealthChecks.toHaveAllPortsOpen())
+                .saveLogsTo(LogDirectory.circleAwareLogDirectory(TimeLockMigrationEteTest.class.getSimpleName()))
+                .addClusterWait(new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), WAIT_TIMEOUT))
+                .build();
+        dockerProxyRule = new DockerProxyRule(dockerComposeRule.projectName(), TimeLockMigrationEteTest.class);
+
+        dockerComposeRule.before();
+        dockerProxyRule.before();
     }
 
     @Override

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraTestSuite.java
@@ -34,7 +34,7 @@ import com.palantir.docker.compose.connection.DockerPort;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         TodoEteTest.class,
-        DropwizardEteTest.class,
+        CommandLineEteTest.class,
         ServiceExposureEteTest.class,
         MultiCassandraSingleNodeDownEteTest.class,
         MultiCassandraDoubleNodeDownEteTest.class

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -50,6 +50,7 @@ public class TimeLockMigrationEteTest {
     private static final Todo TODO = ImmutableTodo.of("some stuff to do");
     private static final Todo TODO_2 = ImmutableTodo.of("more stuff to do");
     private static final Todo TODO_3 = ImmutableTodo.of("even more stuff to do");
+    private static final int TEN_MILLION = 10_000_000;
 
     private static final int ETE_PORT = 3828;
     private static final String ETE_CONTAINER = "ete1";
@@ -87,6 +88,8 @@ public class TimeLockMigrationEteTest {
 
         upgradeAtlasClientToTimelock();
 
+        assertTimeLockGivesHigherTimestampThan(embeddedTimestamp);
+
         softAssertions.assertThat(todoClient.getTodoList())
                 .as("can still read todo after migration to TimeLock")
                 .contains(TODO);
@@ -97,8 +100,6 @@ public class TimeLockMigrationEteTest {
                 .contains(TODO, TODO_2);
 
         assertNoLongerExposesEmbeddedTimestampService();
-
-        assertTimeLockGivesHigherTimestampThan(embeddedTimestamp);
 
         downgradeAtlasClientFromTimelock();
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -41,7 +41,7 @@ import com.palantir.timestamp.TimestampService;
 // ETE tests where the general idea is "set up all the containers, and fire".
 public class TimeLockMigrationEteTest {
     // Docker Engine daemon only has limited access to the filesystem, if the user is using Docker-Machine
-    // Thus root the temporary folder as a subdirectory of the user's home directory
+    // Thus ensure the temporary folder is a subdirectory of the user's home directory
     private static final TemporaryFolder TEMPORARY_FOLDER
             = new TemporaryFolder(new File(System.getProperty("user.home")));
     private static final DockerClientOrchestrationRule CLIENT_ORCHESTRATION_RULE
@@ -50,7 +50,6 @@ public class TimeLockMigrationEteTest {
     private static final Todo TODO = ImmutableTodo.of("some stuff to do");
     private static final Todo TODO_2 = ImmutableTodo.of("more stuff to do");
     private static final Todo TODO_3 = ImmutableTodo.of("even more stuff to do");
-    private static final int TEN_MILLION = 10_000_000;
 
     private static final int ETE_PORT = 3828;
     private static final String ETE_CONTAINER = "ete1";
@@ -101,7 +100,7 @@ public class TimeLockMigrationEteTest {
 
         assertNoLongerExposesEmbeddedTimestampService();
 
-        downgradeAtlasClientFromTimelock();
+        downgradeAtlasClientFromTimelockWithoutMigration();
 
         assertCanNeitherReadNorWrite();
     }
@@ -112,7 +111,7 @@ public class TimeLockMigrationEteTest {
         waitUntil(serversAreReady());
     }
 
-    private void downgradeAtlasClientFromTimelock() {
+    private void downgradeAtlasClientFromTimelockWithoutMigration() {
         CLIENT_ORCHESTRATION_RULE.updateClientConfig(DockerClientOrchestrationRule.EMBEDDED_CONFIG);
         CLIENT_ORCHESTRATION_RULE.restartAtlasClient();
         waitForTransactionManagerCreationError();

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -17,17 +17,27 @@ package com.palantir.atlasdb.ete;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
+import org.apache.commons.io.FileUtils;
 import org.joda.time.Duration;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
 import com.jayway.awaitility.Awaitility;
 import com.palantir.atlasdb.containers.CassandraVersion;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
@@ -40,43 +50,111 @@ import com.palantir.docker.compose.connection.DockerMachine;
 import com.palantir.docker.compose.connection.waiting.ClusterHealthCheck;
 import com.palantir.docker.compose.connection.waiting.ClusterWait;
 import com.palantir.docker.compose.connection.waiting.HealthChecks;
+import com.palantir.docker.compose.execution.DockerComposeExecOption;
+import com.palantir.docker.compose.execution.ImmutableDockerComposeExecArgument;
 import com.palantir.docker.compose.logging.LogDirectory;
+import com.palantir.timestamp.TimestampService;
+
+import feign.FeignException;
 
 // We don't use EteSetup because we need much finer-grained control of the orchestration here, compared to the other
 // ETE tests where the general idea is "set up all the containers, and fire".
 public class TimeLockMigrationEteTest {
-    private static final DockerMachine DOCKER_MACHINE = DockerMachine.localMachine()
-            .withEnvironment(CassandraVersion.getEnvironment())
-            .build();
+    private static final Map<String, String> ENVIRONMENT = Maps.newHashMap();
 
-    private static final DockerComposeRule DOCKER_COMPOSE_RULE = DockerComposeRule.builder()
-            .machine(DOCKER_MACHINE)
-            .file("docker-compose.timelock-migration.cassandra.yml")
-            .waitingForService("cassandra", HealthChecks.toHaveAllPortsOpen())
-            .saveLogsTo(LogDirectory.circleAwareLogDirectory(TimeLockMigrationEteTest.class.getSimpleName()))
-            .addClusterWait(new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), Duration.standardMinutes(1)))
-            .build();
-    private static final DockerProxyRule DOCKER_PROXY_RULE
-            = new DockerProxyRule(DOCKER_COMPOSE_RULE.projectName(), TimeLockMigrationEteTest.class);
+    // Docker Engine daemon only has limited access to the filesystem, if the user is using Docker-Machine
+    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder(new File(System.getProperty("user.home")));
+
+    private static DockerMachine dockerMachine;
+    private static DockerComposeRule dockerComposeRule;
+    private static DockerProxyRule dockerProxyRule;
+    private static File configFile;
 
     private static final Todo TODO = ImmutableTodo.of("some stuff to do");
+    private static final Todo TODO_2 = ImmutableTodo.of("more stuff to do");
     private static final int DEFAULT_PORT = 3828;
 
+    private static final ExternalResource SETUP_VARIABLES_RULE = new ExternalResource() {
+        @Override
+        protected void before() throws Throwable {
+            try {
+                configFile = TEMPORARY_FOLDER.newFile("atlasdb-ete.yml");
+                FileUtils.writeStringToFile(configFile, FileUtils.readFileToString(
+                        new File("docker/conf/atlasdb-ete.no-leader.cassandra.yml")));
+                ENVIRONMENT.put("CONFIG_FILE_MOUNTPOINT", TEMPORARY_FOLDER.getRoot().getAbsolutePath());
+                ENVIRONMENT.putAll(CassandraVersion.getEnvironment());
+                System.out.println(ENVIRONMENT);
+
+                dockerMachine = DockerMachine.localMachine()
+                        .withEnvironment(ENVIRONMENT)
+                        .build();
+
+                dockerComposeRule = DockerComposeRule.builder()
+                        .machine(dockerMachine)
+                        .file("docker-compose.timelock-migration.cassandra.yml")
+                        .waitingForService("cassandra", HealthChecks.toHaveAllPortsOpen())
+                        .saveLogsTo(LogDirectory.circleAwareLogDirectory(TimeLockMigrationEteTest.class.getSimpleName()))
+                        .addClusterWait(new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), Duration.standardMinutes(100)))
+                        .build();
+
+                dockerProxyRule = new DockerProxyRule(dockerComposeRule.projectName(), TimeLockMigrationEteTest.class);
+
+                dockerComposeRule.before();
+                dockerProxyRule.before();
+            } catch (IOException e) {
+                throw Throwables.propagate(e);
+            }
+        }
+
+        @Override
+        protected void after() {
+            dockerProxyRule.after();
+            dockerComposeRule.after();
+        }
+    };
+
     @ClassRule
-    public static final RuleChain RULE_CHAIN = RuleChain.outerRule(DOCKER_COMPOSE_RULE)
-            .around(DOCKER_PROXY_RULE)
+    public static final RuleChain RULE_CHAIN = RuleChain.outerRule(TEMPORARY_FOLDER)
+            .around(SETUP_VARIABLES_RULE)
             .around(waitForServersToBeReady());
 
     @Test
-    public void canAutomaticallyMigrateTimestamps() throws IOException, InterruptedException {
+    public void canAutomaticallyMigrateTimestamps()
+            throws IOException, InterruptedException, NoSuchFieldException, NoSuchMethodException,
+            IllegalAccessException, InvocationTargetException {
         TodoResource todoClient = createClientFor(TodoResource.class, "ete1", DEFAULT_PORT);
 
         todoClient.addTodo(TODO);
         assertThat(todoClient.getTodoList(), hasItem(TODO));
 
-        DOCKER_COMPOSE_RULE.dockerCompose().stop(DOCKER_COMPOSE_RULE.containers().container("ete1"));
+        // change config!
+        FileUtils.writeStringToFile(configFile, FileUtils.readFileToString(
+                new File("docker/conf/atlasdb-ete.timelock.cassandra.yml")));
 
-        todoClient.addTodo(TODO);
+        System.out.println(dockerComposeRule.exec(DockerComposeExecOption.noOptions(),
+                "ete1",
+                ImmutableDockerComposeExecArgument.arguments("bash", "-c", "sed -i 's/ps $PID > \\/dev\\/null;/kill -0 $PID/' service/bin/init.sh")));
+        System.out.println(dockerComposeRule.exec(DockerComposeExecOption.noOptions(),
+                "ete1",
+                ImmutableDockerComposeExecArgument.arguments("nohup", "service/bin/init.sh", "restart")));
+
+        Awaitility.await()
+                .ignoreExceptions()
+                .atMost(com.jayway.awaitility.Duration.TEN_MINUTES)
+                .pollInterval(com.jayway.awaitility.Duration.ONE_SECOND)
+                .until(serversAreReady());
+
+        todoClient.addTodo(TODO_2);
+        assertThat(todoClient.getTodoList(), hasItems(TODO, TODO_2));
+
+        TimestampService timestampClient = createClientFor(TimestampService.class, "ete1", DEFAULT_PORT);
+        try {
+            timestampClient.getFreshTimestamp();
+            fail();
+        } catch (FeignException e) {
+            // Expected
+            assertThat(e.getMessage().contains("404"), is(true));
+        }
     }
 
     private static <T> T createClientFor(Class<T> clazz, String host, int port) {
@@ -90,7 +168,7 @@ public class TimeLockMigrationEteTest {
             protected void before() throws Throwable {
                 Awaitility.await()
                         .ignoreExceptions()
-                        .atMost(com.jayway.awaitility.Duration.ONE_MINUTE)
+                        .atMost(com.jayway.awaitility.Duration.TEN_MINUTES)
                         .pollInterval(com.jayway.awaitility.Duration.ONE_SECOND)
                         .until(serversAreReady());
             }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.ete;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import org.joda.time.Duration;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+
+import com.google.common.base.Optional;
+import com.jayway.awaitility.Awaitility;
+import com.palantir.atlasdb.containers.CassandraVersion;
+import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.atlasdb.testing.DockerProxyRule;
+import com.palantir.atlasdb.todo.ImmutableTodo;
+import com.palantir.atlasdb.todo.Todo;
+import com.palantir.atlasdb.todo.TodoResource;
+import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.connection.DockerMachine;
+import com.palantir.docker.compose.connection.waiting.ClusterHealthCheck;
+import com.palantir.docker.compose.connection.waiting.ClusterWait;
+import com.palantir.docker.compose.connection.waiting.HealthChecks;
+import com.palantir.docker.compose.logging.LogDirectory;
+
+// We don't use EteSetup because we need much finer-grained control of the orchestration here, compared to the other
+// ETE tests where the general idea is "set up all the containers, and fire".
+public class TimeLockMigrationEteTest {
+    private static final DockerMachine DOCKER_MACHINE = DockerMachine.localMachine()
+            .withEnvironment(CassandraVersion.getEnvironment())
+            .build();
+
+    private static final DockerComposeRule DOCKER_COMPOSE_RULE = DockerComposeRule.builder()
+            .machine(DOCKER_MACHINE)
+            .file("docker-compose.timelock-migration.cassandra.yml")
+            .waitingForService("cassandra", HealthChecks.toHaveAllPortsOpen())
+            .saveLogsTo(LogDirectory.circleAwareLogDirectory(TimeLockMigrationEteTest.class.getSimpleName()))
+            .addClusterWait(new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), Duration.standardMinutes(1)))
+            .build();
+    private static final DockerProxyRule DOCKER_PROXY_RULE
+            = new DockerProxyRule(DOCKER_COMPOSE_RULE.projectName(), TimeLockMigrationEteTest.class);
+
+    private static final Todo TODO = ImmutableTodo.of("some stuff to do");
+    private static final int DEFAULT_PORT = 3828;
+
+    @ClassRule
+    public static final RuleChain RULE_CHAIN = RuleChain.outerRule(DOCKER_COMPOSE_RULE)
+            .around(DOCKER_PROXY_RULE)
+            .around(waitForServersToBeReady());
+
+    @Test
+    public void canAutomaticallyMigrateTimestamps() throws IOException, InterruptedException {
+        TodoResource todoClient = createClientFor(TodoResource.class, "ete1", DEFAULT_PORT);
+
+        todoClient.addTodo(TODO);
+        assertThat(todoClient.getTodoList(), hasItem(TODO));
+
+        DOCKER_COMPOSE_RULE.dockerCompose().stop(DOCKER_COMPOSE_RULE.containers().container("ete1"));
+
+        todoClient.addTodo(TODO);
+    }
+
+    private static <T> T createClientFor(Class<T> clazz, String host, int port) {
+        String uri = String.format("http://%s:%s", host, port);
+        return AtlasDbHttpClients.createProxy(Optional.absent(), uri, clazz);
+    }
+
+    private static ExternalResource waitForServersToBeReady() {
+        return new ExternalResource() {
+            @Override
+            protected void before() throws Throwable {
+                Awaitility.await()
+                        .ignoreExceptions()
+                        .atMost(com.jayway.awaitility.Duration.ONE_MINUTE)
+                        .pollInterval(com.jayway.awaitility.Duration.ONE_SECOND)
+                        .until(serversAreReady());
+            }
+        };
+    }
+
+    private static Callable<Boolean> serversAreReady() {
+        return () -> {
+            TodoResource todos = createClientFor(TodoResource.class, "ete1", DEFAULT_PORT);
+            todos.isHealthy();
+            return true;
+        };
+    }
+}

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -64,9 +64,9 @@ public class TimeLockMigrationEteTest {
 
     // Docker Engine daemon only has limited access to the filesystem, if the user is using Docker-Machine
     // Thus root the temporary folder as a subdirectory of the user's home directory
-    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder(new File(System.getProperty("user.home")));
+    private static final TemporaryFolder TEMPORARY_FOLDER
+            = new TemporaryFolder(new File(System.getProperty("user.home")));
 
-    private static DockerMachine dockerMachine;
     private static DockerComposeRule dockerComposeRule;
     private static DockerProxyRule dockerProxyRule;
     private static File configFile;
@@ -87,7 +87,7 @@ public class TimeLockMigrationEteTest {
                 ENVIRONMENT.putAll(CassandraVersion.getEnvironment());
                 System.out.println(ENVIRONMENT);
 
-                dockerMachine = DockerMachine.localMachine()
+                DockerMachine dockerMachine = DockerMachine.localMachine()
                         .withEnvironment(ENVIRONMENT)
                         .build();
 
@@ -121,7 +121,7 @@ public class TimeLockMigrationEteTest {
             .around(waitForServersToBeReady());
 
     @Test
-    public void canAutomaticallyMigrateTimestamps()
+    public void canAutomaticallyMigrateTimestampsAndFailsOnRestart()
             throws IOException, InterruptedException, NoSuchFieldException, NoSuchMethodException,
             IllegalAccessException, InvocationTargetException {
         TodoResource todoClient = createClientFor(TodoResource.class, "ete1", DEFAULT_PORT);


### PR DESCRIPTION
**Goals (and why)**:

* Add end-to-end tests for automated migrations of the AtlasDB TimeLock Server. This allows us to more easily check that automated migrations behave as we expect them to. There are already tests for major pieces of the puzzle (TimeLockMigrator, CassandraTimestampInvalidatorStore), but we don't have a full end-to-end workflow.

**Implementation Description (bullets)**:

* `TimeLockMigrationEteTest` executes the following workflow:
  1. sets up three containers: a Cassandra, a TimeLock, and an AtlasDbEteServer (an Atlas client) configured with embedded services
  2. executes a write and a read on the Atlas client (`"contains one todo pre-migration"`)
  3. gets a timestamp `TS` from the Atlas client
  4. reconfigures the Atlas client to use TimeLock and bounces it
  11. gets a timestamp directly from TimeLock `TS'`, verifies `TS' > TS` (`"timestamp was migrated to TimeLock"`)
  5. executes a read on the Atlas client (`"can still read after migration to TimeLock"`)
  6. executes a write and a read on the Atlas client (`"can add a new todo using TimeLock"`)
  7. attempts to get a fresh timestamp from the Atlas client, expecting failure (`"no longer exposes an embedded timestamp service"`)
  8. downgrades the Atlas client to embedded services, without doing any kind of reverse migration, and bounces it
  9. checks that the Atlas client can't create a transaction manager by parsing its logs
  10. attempts to read/write todos from the Atlas client, expecting failure (`"cannot read/write using embedded service after migration to TimeLock"`)

* `DockerClientOrchestrationRule` is the underlying glue to make things work, setting up/tearing down the various containers as well as executing code, pulling down logs, etc.

**Concerns (what feedback would you like?)**:

* `DockerClientOrchestrationRule` was pretty painful to write (basically, you cannot just use a `RuleChain` to setup the DCR and DPR, since they can only be created once the TemporaryFolder's location is known - and that only happens once its `before()` method executes). I hope it's not too unreadable.
* There is some duplication with `EteSetup` which I couldn't use directly because I needed better control of the orchestration.

**Where should we start reviewing?**:

* `TimeLockMigrationEteTest` is probably the best start point.

**Priority (whenever / two weeks / yesterday)**:

* Next week please. Not massively urgent.