### PR TITLE
Declare TransactionManager.close() explicitly (so it will throw no checked exceptions)

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -126,4 +126,7 @@ public interface TransactionManager extends AutoCloseable {
      * the cache, although this can also be used to free up some memory.
      */
     void clearTimestampCache();
+
+    @Override
+    void close();
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManager.java
@@ -58,7 +58,7 @@ public abstract class ForwardingTransactionManager extends ForwardingObject impl
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         delegate().close();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ThreadLocalWrappingTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ThreadLocalWrappingTransactionManager.java
@@ -40,7 +40,7 @@ public class ThreadLocalWrappingTransactionManager extends WrappingTransactionMa
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         super.close();
         wrapper.remove();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTransactionManager.java
@@ -104,7 +104,7 @@ public abstract class WrappingTransactionManager extends ForwardingLockAwareTran
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         delegate().close();
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -80,6 +80,12 @@ develop
     *    - |devbreak|
          - The persistent lock release endpoint has now been renamed to ``releaseBackupLock`` since it is currently only supposed to be used for the backup lock.
 
+    *    - |devbreak| |improved|
+         - ``TransactionManager`` now explicitly declares a ``close`` method that does not throw exceptions.
+           This makes ``TransactionManager``s significantly easier to develop against.
+           Clients who have implemented a concrete ``TransactionManager`` throwing checked exceptions are encouraged to wrap said exceptions as unchecked exceptions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1677>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Internal port of #1675 so the CircleCI builds will run.

The main concern is if someone implemented TransactionManager with its close method throwing a checked exception. This will actually affect internal streamy product which has its own delegating implementation (this is easy to fix, but worth being aware of).

@chrisalice @jboreiko 

---

**Goals (and why)**:

Currently, no real (non-forwarding) implementation of TransactionManager.close throws any checked exceptions, but TransactionManager inherits AutoClose's close signature, which is declared as throwing Exception. This makes it hard to use, as catching all checked exceptions is not safe in a try-with-resources block, since it masks other checked exceptions declared in the block, and even when calling close in a dedicated try/catch block, users will have to handle InterruptedException separately (calling `Thread.currentThread().interrupt()` before wrapping the exception), leading to a lot of unnecessary code bloat.

**Implementation Description (bullets)**:

* Declare close() on TransactionManager, throwing no checked exceptions.
* Remove `throws Exception` from the forwarding TransactionManager implementations

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**: It's pretty short

**Priority**: Whenever
