### PR TITLE
Make SweepStatsKVS count deleteRange(all()) as a truncate

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueService.java
@@ -30,6 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
@@ -44,6 +45,7 @@ import com.google.common.collect.Sets;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.schema.SweepSchema;
@@ -73,7 +75,10 @@ public class SweepStatsKeyValueService extends ForwardingKeyValueService {
     private final KeyValueService delegate;
     private final TimestampService timestampService;
     private final Multiset<TableReference> writesByTable = ConcurrentHashMultiset.create();
-    private final Set<TableReference> clearedTables = Collections.newSetFromMap(new ConcurrentHashMap<TableReference, Boolean>());
+
+    @VisibleForTesting
+    final Set<TableReference> clearedTables = Collections.newSetFromMap(new ConcurrentHashMap<TableReference, Boolean>());
+
     private final AtomicInteger totalModifications = new AtomicInteger();
     private final Lock flushLock = new ReentrantLock();
     private final ScheduledExecutorService flushExecutor = PTExecutors.newSingleThreadScheduledExecutor();
@@ -120,10 +125,18 @@ public class SweepStatsKeyValueService extends ForwardingKeyValueService {
     }
 
     @Override
+    public void deleteRange(TableReference tableRef, RangeRequest request) {
+        delegate().deleteRange(tableRef, request);
+        if (RangeRequest.all().equals(request)) {
+            // This is equivalent to truncate.
+            recordClear(tableRef);
+        }
+    }
+
+    @Override
     public void truncateTable(TableReference tableRef) {
         delegate().truncateTable(tableRef);
-        clearedTables.add(tableRef);
-        recordModifications(CLEAR_WEIGHT);
+        recordClear(tableRef);
     }
 
     @Override
@@ -136,8 +149,7 @@ public class SweepStatsKeyValueService extends ForwardingKeyValueService {
     @Override
     public void dropTable(TableReference tableRef) {
         delegate().dropTable(tableRef);
-        clearedTables.add(tableRef);
-        recordModifications(CLEAR_WEIGHT);
+        recordClear(tableRef);
     }
 
     @Override
@@ -151,9 +163,13 @@ public class SweepStatsKeyValueService extends ForwardingKeyValueService {
     // updates could be clobbered), and it makes little effort to ensure that
     // all updates are flushed. It is intended only to be "good enough" for
     // determining what tables have been written to a lot.
-
     private void recordModifications(int newWrites) {
         totalModifications.addAndGet(newWrites);
+    }
+
+    private void recordClear(TableReference tableRef) {
+        clearedTables.add(tableRef);
+        recordModifications(CLEAR_WEIGHT);
     }
 
     private Runnable createFlushTask() {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueServiceTest.java
@@ -45,13 +45,13 @@ public class SweepStatsKeyValueServiceTest {
     @Test
     public void deleteRangeAllCountsAsClearingTheTable() throws Exception {
         kvs.deleteRange(TABLE, RangeRequest.all());
-        assertTrue(kvs.clearedTables.contains(TABLE));
+        assertTrue(kvs.hasBeenCleared(TABLE));
     }
 
     @Test
     public void otherDeleteRangeDoesNotCountAsClearingTheTable() throws Exception {
         RangeRequest request = RangeRequest.builder().startRowInclusive(ROW).build();
         kvs.deleteRange(TABLE, request);
-        assertFalse(kvs.clearedTables.contains(TABLE));
+        assertFalse(kvs.hasBeenCleared(TABLE));
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueServiceTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.timestamp.TimestampService;
+
+public class SweepStatsKeyValueServiceTest {
+    private static final byte[] ROW = "row".getBytes(StandardCharsets.UTF_8);
+    private static final TableReference TABLE = TableReference.createWithEmptyNamespace("table");
+
+    private SweepStatsKeyValueService kvs;
+
+    @Before
+    public void before() {
+        KeyValueService delegate = mock(KeyValueService.class);
+        TimestampService timestampService = mock(TimestampService.class);
+        kvs = SweepStatsKeyValueService.create(delegate, timestampService);
+    }
+
+    @Test
+    public void deleteRangeAllCountsAsClearingTheTable() throws Exception {
+        kvs.deleteRange(TABLE, RangeRequest.all());
+        assertTrue(kvs.clearedTables.contains(TABLE));
+    }
+
+    @Test
+    public void otherDeleteRangeDoesNotCountAsClearingTheTable() throws Exception {
+        RangeRequest request = RangeRequest.builder().startRowInclusive(ROW).build();
+        kvs.deleteRange(TABLE, request);
+        assertFalse(kvs.clearedTables.contains(TABLE));
+    }
+}


### PR DESCRIPTION
[no release notes]

**Goals (and why)**: Follow-up from #1617, where @tjwilson90 suggested that we could keep our sweep stats up to date in this way. `truncate` and `deleteRange(ALL)` are equivalent, so this helps us to keep track of cleared tables more accurately.

**Implementation Description (bullets)**:
* On deleteRange, if the RangeRequest is all, add the same stats as truncate.

**Concerns (what feedback would you like?)**: n/a

**Where should we start reviewing?**: Whenever

**Priority (whenever / two weeks / yesterday)**: Not urgent, but it's a tiny PR

