### PR TITLE
Add benchmarks for getRowsColumnRange() over a single wide row

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
@@ -35,8 +35,8 @@ import com.google.common.primitives.Ints;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.performance.benchmarks.table.ModeratelyWideRowTable;
 import com.palantir.atlasdb.performance.benchmarks.table.Tables;
-import com.palantir.atlasdb.performance.benchmarks.table.WideRowTable;
 
 /**
  * Performance benchmarks for KVS get with dynamic columns.
@@ -50,31 +50,31 @@ public class KvsGetDynamicBenchmarks {
     @Benchmark
     @Warmup(time = 20, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 180, timeUnit = TimeUnit.SECONDS)
-    public Object getAllColumnsExplicitly(WideRowTable table) {
+    public Object getAllColumnsExplicitly(ModeratelyWideRowTable table) {
         Map<Cell, Value> result = table.getKvs().get(table.getTableRef(), table.getAllCellsAtMaxTimestamp());
-        Preconditions.checkState(result.size() == WideRowTable.NUM_COLS,
-                "Should be %s columns, but were: %s", WideRowTable.NUM_COLS, result.size());
+        Preconditions.checkState(result.size() == table.getNumCols(),
+                "Should be %s columns, but were: %s", table.getNumCols(), result.size());
         return result;
     }
 
     @Benchmark
     @Warmup(time = 6, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 60, timeUnit = TimeUnit.SECONDS)
-    public Object getAllColumnsImplicitly(WideRowTable table) throws UnsupportedEncodingException {
+    public Object getAllColumnsImplicitly(ModeratelyWideRowTable table) throws UnsupportedEncodingException {
         Map<Cell, Value> result = table.getKvs().getRows(
                 table.getTableRef(),
                 Collections.singleton(Tables.ROW_BYTES.array()),
                 ColumnSelection.all(),
                 Long.MAX_VALUE);
-        Preconditions.checkState(result.size() == WideRowTable.NUM_COLS,
-                "Should be %s columns, but were: %s", WideRowTable.NUM_COLS, result.size());
+        Preconditions.checkState(result.size() == table.getNumCols(),
+                "Should be %s columns, but were: %s", table.getNumCols(), result.size());
         return result;
     }
 
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
-    public Object getFirstColumnExplicitly(WideRowTable table) {
+    public Object getFirstColumnExplicitly(ModeratelyWideRowTable table) {
         Map<Cell, Value> result = table.getKvs().get(table.getTableRef(), table.getFirstCellAtMaxTimestampAsMap());
         Preconditions.checkState(result.size() == 1, "Should be %s column, but were: %s", 1, result.size());
         int value = Ints.fromByteArray(Iterables.getOnlyElement(result.values()).getContents());
@@ -85,7 +85,7 @@ public class KvsGetDynamicBenchmarks {
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
-    public Object getFirstColumnExplicitlyGetRows(WideRowTable table) throws UnsupportedEncodingException {
+    public Object getFirstColumnExplicitlyGetRows(ModeratelyWideRowTable table) throws UnsupportedEncodingException {
         Map<Cell, Value> result = table.getKvs()
                 .getRows(table.getTableRef(), Collections.singleton(Tables.ROW_BYTES.array()),
                         ColumnSelection.create(

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
@@ -34,8 +34,8 @@ import com.google.common.primitives.Ints;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.performance.benchmarks.table.ModeratelyWideRowTable;
 import com.palantir.atlasdb.performance.benchmarks.table.Tables;
-import com.palantir.atlasdb.performance.benchmarks.table.WideRowTable;
 
 /**
  * Performance benchmarks for KVS get with dynamic columns.
@@ -49,11 +49,11 @@ public class TransactionGetDynamicBenchmarks {
     @Benchmark
     @Warmup(time = 25, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 180, timeUnit = TimeUnit.SECONDS)
-    public Object getAllColumnsExplicitly(WideRowTable table) {
+    public Object getAllColumnsExplicitly(ModeratelyWideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Map<Cell, byte[]> result = txn.get(table.getTableRef(), table.getAllCells());
-            Preconditions.checkState(result.values().size() == WideRowTable.NUM_COLS,
-                    "Should be %s columns, but were: %s", WideRowTable.NUM_COLS, result.values().size());
+            Preconditions.checkState(result.values().size() == table.getNumCols(),
+                    "Should be %s columns, but were: %s", table.getNumCols(), result.values().size());
             return result;
         });
     }
@@ -61,14 +61,14 @@ public class TransactionGetDynamicBenchmarks {
     @Benchmark
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 65, timeUnit = TimeUnit.SECONDS)
-    public Object getAllColumnsImplicitly(WideRowTable table) {
+    public Object getAllColumnsImplicitly(ModeratelyWideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             SortedMap<byte[], RowResult<byte[]>> result = txn.getRows(table.getTableRef(),
                     Collections.singleton(Tables.ROW_BYTES.array()),
                     ColumnSelection.all());
             int count = Iterables.getOnlyElement(result.values()).getColumns().size();
-            Preconditions.checkState(count == WideRowTable.NUM_COLS,
-                    "Should be %s columns, but were: %s", WideRowTable.NUM_COLS, count);
+            Preconditions.checkState(count == table.getNumCols(),
+                    "Should be %s columns, but were: %s", table.getNumCols(), count);
             return result;
         });
     }
@@ -76,7 +76,7 @@ public class TransactionGetDynamicBenchmarks {
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
-    public Object getFirstColumnExplicitly(WideRowTable table) {
+    public Object getFirstColumnExplicitly(ModeratelyWideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Map<Cell, byte[]> result = txn.get(table.getTableRef(), table.getFirstCellAsSet());
             Preconditions.checkState(result.values().size() == 1,
@@ -90,7 +90,7 @@ public class TransactionGetDynamicBenchmarks {
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
-    public Object getFirstColumnExplicitlyGetRows(WideRowTable table) {
+    public Object getFirstColumnExplicitlyGetRows(ModeratelyWideRowTable table) {
         return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             SortedMap<byte[], RowResult<byte[]>> result = txn.getRows(table.getTableRef(),
                     Collections.singleton(Tables.ROW_BYTES.array()),

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetRowsColumnRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetRowsColumnRangeBenchmarks.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance.benchmarks;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.performance.benchmarks.table.Tables;
+import com.palantir.atlasdb.performance.benchmarks.table.VeryWideRowTable;
+
+@State(Scope.Benchmark)
+public class TransactionGetRowsColumnRangeBenchmarks {
+
+    @Benchmark
+    @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
+    public Object getAllColumnsSingleBigRow(VeryWideRowTable table, Blackhole blackhole) {
+        return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Iterator<Map.Entry<Cell, byte[]>> iter = txn.getRowsColumnRange(
+                    table.getTableRef(),
+                    Collections.singleton(Tables.ROW_BYTES.array()),
+                    new ColumnRangeSelection(null, null),
+                    10000);
+            int count = 0;
+            while (iter.hasNext()) {
+                blackhole.consume(iter.next());
+                ++count;
+            }
+            Preconditions.checkState(count == table.getNumCols(),
+                    "Should be %s columns, but were: %s", table.getNumCols(), count);
+            return count;
+        });
+    }
+
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ModeratelyWideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ModeratelyWideRowTable.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance.benchmarks.table;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class ModeratelyWideRowTable extends WideRowTable {
+    @Override
+    public int getNumCols() {
+        return 50000;
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ModeratelyWideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ModeratelyWideRowTable.java
@@ -22,6 +22,6 @@ import org.openjdk.jmh.annotations.State;
 public class ModeratelyWideRowTable extends WideRowTable {
     @Override
     public int getNumCols() {
-        return 50000;
+        return 50_000;
     }
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/VeryWideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/VeryWideRowTable.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance.benchmarks.table;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class VeryWideRowTable extends WideRowTable {
+    @Override
+    public int getNumCols() {
+        return 1000000;
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/VeryWideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/VeryWideRowTable.java
@@ -22,6 +22,6 @@ import org.openjdk.jmh.annotations.State;
 public class VeryWideRowTable extends WideRowTable {
     @Override
     public int getNumCols() {
-        return 1000000;
+        return 1_000_000;
     }
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTable.java
@@ -40,9 +40,7 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
  * State class for creating a single Atlas table with one wide row.
  */
 @State(Scope.Benchmark)
-public class WideRowTable {
-    public static final int NUM_COLS = 50000;
-
+public abstract class WideRowTable {
     private AtlasDbServicesConnector connector;
     private AtlasDbServices services;
 
@@ -79,6 +77,8 @@ public class WideRowTable {
         return firstCellAtMaxTimestamp.keySet();
     }
 
+    public abstract int getNumCols();
+
     @Setup
     public void setup(AtlasDbServicesConnector conn) throws UnsupportedEncodingException {
         this.connector = conn;
@@ -103,7 +103,7 @@ public class WideRowTable {
             allCellsAtMaxTimestamp = Maps.newHashMap();
             firstCellAtMaxTimestamp = Maps.newHashMap();
             firstCellAtMaxTimestamp.put(cell(0), Long.MAX_VALUE);
-            for (int i = 0; i < NUM_COLS; i++) {
+            for (int i = 0; i < getNumCols(); i++) {
                 Cell curCell = cell(i);
                 values.put(curCell, Ints.toByteArray(i));
                 allCellsAtMaxTimestamp.put(curCell, Long.MAX_VALUE);

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTable.java
@@ -20,9 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 
-import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
 import com.google.common.collect.Maps;
@@ -39,7 +37,6 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 /**
  * State class for creating a single Atlas table with one wide row.
  */
-@State(Scope.Benchmark)
 public abstract class WideRowTable {
     private AtlasDbServicesConnector connector;
     private AtlasDbServices services;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -80,6 +80,10 @@ develop
     *    - |devbreak|
          - The persistent lock release endpoint has now been renamed to ``releaseBackupLock`` since it is currently only supposed to be used for the backup lock.
 
+    *    - |new|
+         - Added benchmarks for paging over columns of a very wide row.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1684>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Currently, paging over a wide row takes quadratic time because
of an inefficient Oracle query. We expose this in a benchmark,
however we need a fairly large row to make a valuable measurement.

I have a fix to make this much faster, but I want the benchmark to get merged first so that we can measure the improvement. 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
