### PR TITLE
Log getFreshTimestamp failure at warn

### DIFF
--- a/timestamp-impl/src/main/java/com/palantir/timestamp/RateLimitedTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/RateLimitedTimestampService.java
@@ -78,7 +78,7 @@ public class RateLimitedTimestampService implements TimestampService {
             try {
                 batch.awaitPopulation();
             } catch (InterruptedException e) {
-                log.error("Interrupted waiting for timestamp batch to populate. Trying another batch.", e);
+                log.warn("Interrupted waiting for timestamp batch to populate. Trying another batch.", e);
                 throw Throwables.rewrapAndThrowUncheckedException(e);
             }
             if (!batch.isFailed()) {


### PR DESCRIPTION
Unforked copy of #1628, which itself is a backport of #720.