### PR TITLE
Hide the persisted locks table

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTables.java
@@ -24,7 +24,8 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 public class HiddenTables {
     private static final Set<TableReference> HIDDEN_TABLES = ImmutableSet.of(
             AtlasDbConstants.TIMESTAMP_TABLE,
-            AtlasDbConstants.DEFAULT_METADATA_TABLE);
+            AtlasDbConstants.DEFAULT_METADATA_TABLE,
+            AtlasDbConstants.PERSISTED_LOCKS_TABLE);
 
     public boolean isHidden(TableReference tableReference) {
         return HIDDEN_TABLES.contains(tableReference)

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
@@ -27,33 +27,38 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 public class HiddenTablesTest {
     private final HiddenTables hiddenTables = new HiddenTables();
 
-    @Test public void
-    shouldSayTimestampIsHidden() {
+    @Test
+    public void shouldSayTimestampIsHidden() {
         assertThat(hiddenTables.isHidden(AtlasDbConstants.TIMESTAMP_TABLE), is(true));
     }
 
-    @Test public void
-    shouldSayMetadataIsHidden() {
+    @Test
+    public void shouldSayMetadataIsHidden() {
         assertThat(hiddenTables.isHidden(AtlasDbConstants.DEFAULT_METADATA_TABLE), is(true));
     }
 
-    @Test public void
-    shouldSayAnOldStyleLocksTableIsHidden() {
+    @Test
+    public void shouldSayAnOldStyleLocksTableIsHidden() {
         assertThat(hiddenTables.isHidden(TableReference.createWithEmptyNamespace("_locks")), is(true));
     }
 
-    @Test public void
-    shouldSayANewStyleLocksTableIsHidden() {
+    @Test
+    public void shouldSayANewStyleLocksTableIsHidden() {
         assertThat(hiddenTables.isHidden(TableReference.createWithEmptyNamespace("_locks_aaaa_123")), is(true));
     }
 
-    @Test public void
-    shouldSayANamespacedTableIsNotHidden() {
+    @Test
+    public void shouldSayANamespacedTableIsNotHidden() {
         assertThat(hiddenTables.isHidden(TableReference.createFromFullyQualifiedName("namespace.table")), is(false));
     }
 
-    @Test public void
-    shouldSayANonNamespacedVisibleTableIsNotHidden() {
+    @Test
+    public void shouldSayANonNamespacedVisibleTableIsNotHidden() {
         assertThat(hiddenTables.isHidden(TableReference.createWithEmptyNamespace("table")), is(false));
+    }
+
+    @Test
+    public void shouldSayPersistedLocksTableIsHidden() {
+        assertThat(hiddenTables.isHidden(AtlasDbConstants.PERSISTED_LOCKS_TABLE), is(true));
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,6 +52,10 @@ develop
          - Fixed an issue where we excessively log after successful transactions.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1687>`__)
 
+    *    - |fixed|
+         - Fixed an issue where the ``_persisted_locks`` table was erroneously reported not to have persisted metadata.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1696>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
**Goals (and why)**:
This fixes an issue reported by our navigational product where the _persisted_locks table was erroneously reported not to have persisted metadata. It actually doesn't have
persisted metadata, but it also doesn't need any, so we shouldn't be
throwing an error.

**Implementation Description (bullets)**: added this table to `HiddenTables`.

**Concerns (what feedback would you like?)**: Sanity check if this table needs metadata (I'm sure it doesn't)

**Where should we start reviewing?**: HiddenTables

**Priority (whenever / two weeks / yesterday)**: Yesterday!

