### PR TITLE
add docs for dropwizard metrics

### DIFF
--- a/docs/source/miscellaneous/dropwizard-metrics.rst
+++ b/docs/source/miscellaneous/dropwizard-metrics.rst
@@ -5,8 +5,8 @@ Dropwizard Metrics
 ==================
 
 AtlasDB makes use of the Dropwizard `Metrics library <http://metrics.dropwizard.io/>`__ to
-expose a global ``MetricRegistry`` called ``AtlasDbRegistry``. Users of AtlasDB should use ``AtlasDbMetrics.setMetricsRegistry``
-to make use of our ``MetricRegistry``.
+expose a global ``MetricRegistry`` called ``AtlasDbRegistry``. Users of AtlasDB should use ``AtlasDbMetrics.setMetricRegistry``
+to inject their own ``MetricRegistry`` for their application prior to initializing the AtlasDB transaction manager.
 
 We expose the metrics below. For the Cassandra client metrics with ``<host>``, we will expose metrics specific to every
 Cassandra node in your cluster. For more details on what information each type of metric provides, we recommend reading
@@ -38,17 +38,15 @@ the Metrics `Getting Started Guide <http://metrics.dropwizard.io/3.1.0/getting-s
 - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestExceptions``
 - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requests``
 - ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskReadOnly.failures``
-- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskReadOnly.failures.java.lang.IllegalArgumentException``
 - ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry.failures``
-- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry.failures.feign.FeignException``
-- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry.failures.java.lang.IllegalArgumentException``
+
+Additional failure counts will be dynamically generated based on the returned exceptions, so you may see metrics like
+the following:
+
 - ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry.failures.java.lang.IllegalStateException``
 
 **Timers**
 
-- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.getLockService``
-- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskReadOnly``
-- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitAcquireLocks``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitCheckingForConflicts``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitPutCommitTs``
@@ -57,5 +55,3 @@ the Metrics `Getting Started Guide <http://metrics.dropwizard.io/3.1.0/getting-s
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.getRows``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.millisForPunch``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.processedRangeMillis``
-- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.transactionMillis``
-- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.waitForCommitTsMillis``

--- a/docs/source/miscellaneous/dropwizard-metrics.rst
+++ b/docs/source/miscellaneous/dropwizard-metrics.rst
@@ -52,6 +52,9 @@ the following:
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitPutCommitTs``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitTotalTimeSinceTxCreation``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitWrite``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.get``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.getRows``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.millisForPunch``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.processedRangeMillis``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.transactionMillis``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.waitForCommitTsMillis``

--- a/docs/source/miscellaneous/dropwizard-metrics.rst
+++ b/docs/source/miscellaneous/dropwizard-metrics.rst
@@ -24,6 +24,16 @@ the Metrics `Getting Started Guide <http://metrics.dropwizard.io/3.1.0/getting-s
  - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.meanIdleTimeMillis``
  - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.proportionDestroyedByBorrower``
  - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.proportionDestroyedByEvictor``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.estimated.size``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.eviction.count``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.hit.count``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.hit.ratio``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.load.average.millis``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.load.failure.count``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.load.success.count``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.miss.count``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.miss.ratio``
+ - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.request.count``
 
 **Histograms**
 
@@ -47,6 +57,37 @@ the following:
 
 **Timers**
 
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.addGarbageCollectionSentinelValues``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.checkAndSet``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.close``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.compactInternally``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.createTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.createTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.delete``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.deleteRange``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.dropTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.dropTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.get``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getAllTableNames``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getAllTimestamps``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getDelegates``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getFirstBatchForRanges``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getLatestTimestamps``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getMetadataForTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getMetadataForTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getRange``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getRangeOfTimestamps``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getRows``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getRowsColumnRange``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.multiPut``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.put``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.putMetadataForTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.putMetadataForTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.putUnlessExists``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.putWithTimestamps``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.supportsCheckAndSet``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.truncateTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.truncateTables``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitAcquireLocks``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitCheckingForConflicts``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitPutCommitTs``

--- a/docs/source/miscellaneous/dropwizard-metrics.rst
+++ b/docs/source/miscellaneous/dropwizard-metrics.rst
@@ -1,0 +1,61 @@
+.. _dropwizard-metrics:
+
+==================
+Dropwizard Metrics
+==================
+
+AtlasDB makes use of the Dropwizard `Metrics library <http://metrics.dropwizard.io/>`__ to
+expose a global ``MetricRegistry`` called ``AtlasDbRegistry``. Users of AtlasDB should use ``AtlasDbMetrics.setMetricsRegistry``
+to make use of our ``MetricRegistry``.
+
+We expose the metrics below. For the Cassandra client metrics with ``<host>``, we will expose metrics specific to every
+Cassandra node in your cluster. For more details on what information each type of metric provides, we recommend reading
+the Metrics `Getting Started Guide <http://metrics.dropwizard.io/3.1.0/getting-started/#>`__.
+
+**Gauges**
+
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.numBlacklistedHosts``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requestConnectionExceptionProportion``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requestFailureProportion``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestConnectionExceptionProportion``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestFailureProportion``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.meanActiveTimeMillis``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.meanBorrowWaitTimeMillis``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.meanIdleTimeMillis``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.proportionDestroyedByBorrower``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.proportionDestroyedByEvictor``
+
+**Histograms**
+
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.byteSizeTx``
+
+**Meters**
+
+- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requestConnectionExceptions``
+- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requestExceptions``
+- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requests``
+- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestConnectionExceptions``
+- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestExceptions``
+- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requests``
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskReadOnly.failures``
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskReadOnly.failures.java.lang.IllegalArgumentException``
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry.failures``
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry.failures.feign.FeignException``
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry.failures.java.lang.IllegalArgumentException``
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry.failures.java.lang.IllegalStateException``
+
+**Timers**
+
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.getLockService``
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskReadOnly``
+- ``com.palantir.atlasdb.transaction.api.LockAwareTransactionManager.runTaskWithRetry``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitAcquireLocks``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitCheckingForConflicts``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitPutCommitTs``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitTotalTimeSinceTxCreation``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitWrite``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.getRows``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.millisForPunch``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.processedRangeMillis``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.transactionMillis``
+- ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.waitForCommitTsMillis``

--- a/docs/source/miscellaneous/index.rst
+++ b/docs/source/miscellaneous/index.rst
@@ -8,3 +8,4 @@ Miscellaneous
 
    contributing
    doc/adr/index
+   dropwizard-metrics


### PR DESCRIPTION
Fixes #1429. 

**Goals (and why)**: Document what metrics you should expect to see from AtlasDB.

**Implementation Description (bullets)**: Brief brief description of what the metrics are, how to add them, and a list of which methods expose which type of metrics.

**Concerns (what feedback would you like?)**: I grabbed the actual methods from an exposed metrics endpoint on one of our products, and then filtered out just the AtlasDB metrics, so it should be accurate as of 0.34.0. I'm largely talking about things I've never used personally, so not sure if the wording of my description makes sense.

**Where should we start reviewing?**: docs/source/miscellaneous/dropwizard-metrics.rst

**Priority (whenever / two weeks / yesterday)**: whenever.