### PR TITLE
Docs Improvements (largely around TimeLock)

### DIFF
--- a/docs/source/cluster_management/clis.rst
+++ b/docs/source/cluster_management/clis.rst
@@ -14,7 +14,8 @@ tasks as well as help resolve problems encountered during operation.
 Download The CLI
 ================
 
-The CLI now comes prebuild as an SLS distribution to be used with any AtlasDB back product.  You can find the versions `here <https://palantir.bintray.com/releases/com/palantir/atlasdb/atlasdb-cli-distribution/>`__ for download.
+The CLI now comes prebuilt as an SLS distribution to be used with any AtlasDB-backed product.
+You can find the versions `here <https://palantir.bintray.com/releases/com/palantir/atlasdb/atlasdb-cli-distribution/>`__ for download.
 You can use the CLI by unpacking the tar ball and running the executable in ``service/bin/atlasdb-cli``.
 
 Compiling The CLI
@@ -68,7 +69,7 @@ For more information run ``./bin/atlasdb help migrate`` for more information.
 Offline CLIs
 ============
 
-Due to their potentially destructive nature if run concurrently with active AtlasDB services, there a number of CLIs which can only be run when AtlasDB is offline. These are:
+Due to their potentially destructive nature if run concurrently with active AtlasDB services, there are a number of CLIs which can only be run when AtlasDB is offline. These are:
 
   - ``clean-cass-locks-state``
   - ``migrate``
@@ -79,13 +80,18 @@ To run these CLIs, first ensure that all of your AtlasDB clients are shut down, 
 
 For example, to run the ``fast-forward`` command with default settings, run ``./bin/atlasdb --offline -c <path/to/atlasConfig.yaml> timestamp -t <targetTimestamp> fast-forward``.
 
-The ``--offline`` flag will make the CLI ignore the leader, timestamp, and lock configuration blocks, and start an embedded timestamp and lock server.
+The ``--offline`` flag will make the CLI ignore the leader, timestamp, and lock configuration blocks.
+If using :ref:`external Timelock Services<external-timelock-service>`, the Timelock Servers must be up even when running offline CLIs.
+Otherwise, offline CLIs will start an embedded timestamp and lock server.
 Once the CLI has completed, you can resume your AtlasDB clients.
 
 Running commands without any servers being up
 ---------------------------------------------
 
-If you want a command to run without any servers being up, you can either use the ``--offline`` flag, or pass in a configuration file without leader, lock, or timestamp blocks. Either option will start an embedded timestamp and lock server.
+If you want a command to run without any servers being up, you can either use the ``--offline`` flag, or pass in a configuration file without leader, lock, or timestamp blocks.
+Either option will start an embedded timestamp and lock server.
+Note that if you are using external Timelock Services, as stated above we require the Timelock Services to be up when running offline CLIs.
+We do not support running CLIs with Timelock down, as we will not have enough information from the key-value services to determine timestamps.
 
 Writing Your Own
 ================

--- a/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
@@ -135,5 +135,28 @@ Further Configuration Parameters
 --------------------------------
 
 The Timelock Server is implemented as a Dropwizard application, and may thus be suitably configured with a ``server``
-block following `Dropwizard's configuration <http://www.dropwizard.io/0.9.3/docs/manual/configuration.html>`__. This
+block following `Dropwizard's configuration <http://www.dropwizard.io/1.0.6/docs/manual/configuration.html>`__. This
 may be useful if, for example, one needs to change the application and/or admin ports for the Timelock Server.
+
+.. _timelock-server-config-http2:
+
+Configuring HTTP/2
+==================
+
+HTTP/2 is a newer version of the HTTP protocol that supports, among other features, connection multiplexing. This is
+extremely useful in improving the latency of timestamp and lock requests. Timelock Server is compatible with HTTP/2
+as of AtlasDB v0.34.0; to configure this, one should change the protocol used by the Dropwizard application and
+admin connectors to ``h2`` instead of ``https``. For example, this block can be added to the root of the Timelock
+server configuration:
+
+.. code:: yaml
+   server:
+     applicationConnectors:
+       - type: h2
+         port: 8421
+     adminConnectors:
+       - type: h2
+         port: 8422
+
+Note that because Timelock Server uses the OkHttp library, it is currently not compatible with HTTP/2 via cleartext
+(the ``h2c`` protocol).

--- a/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
@@ -143,15 +143,7 @@ may be useful if, for example, one needs to change the application and/or admin 
 Configuring HTTP/2
 ~~~~~~~~~~~~~~~~~~
 
-.. warning::
-
-   Although HTTP/2 does offer a performance boost with connection multiplexing, it also mandates that the Galois/Counter
-   Mode (GCM) cipher-suites are used, which suffer from a relatively unperformant implementation in the Oracle JDK.
-   Thus, clients that are unable to use HTTP/2 may see a significant slowdown when the Timelock Server switches from an
-   ``https`` connector to an ``h2`` connector. It may be possible to get around this by exposing multiple application
-   connectors, though the AtlasDB team has not tested this approach.
-
-HTTP/2 is a newer version of the HTTP protocol that supports, among other features, connection multiplexing. This is
+`HTTP/2 <https://http2.github.io/>`__ is a newer version of the HTTP protocol that supports, among other features, connection multiplexing. This is
 extremely useful in improving the latency of timestamp and lock requests, which are usually fairly small.
 Timelock Server is compatible with HTTP/2 as of AtlasDB v0.34.0; to configure this, one should change the protocol
 used by the Dropwizard application and admin connectors to ``h2`` instead of ``https``. For example, this block can be
@@ -169,3 +161,11 @@ added to the root of the Timelock server configuration:
 
 Note that because Timelock Server uses the OkHttp library, it is currently not compatible with HTTP/2 via cleartext
 (the ``h2c`` protocol).
+
+.. warning::
+
+   Although HTTP/2 does offer a performance boost with connection multiplexing, it also mandates that the Galois/Counter
+   Mode (GCM) cipher-suites are used, which suffer from a relatively unperformant implementation in the Oracle JDK.
+   Thus, clients that are unable to use HTTP/2 may see a significant slowdown when the Timelock Server switches from an
+   ``https`` connector to an ``h2`` connector. It may be possible to get around this by exposing multiple application
+   connectors, though the AtlasDB team has not tested this approach.

--- a/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
@@ -141,15 +141,24 @@ may be useful if, for example, one needs to change the application and/or admin 
 .. _timelock-server-config-http2:
 
 Configuring HTTP/2
-==================
+~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+   Although HTTP/2 does offer a performance boost with connection multiplexing, it also mandates that the Galois/Counter
+   Mode (GCM) cipher-suites are used, which suffer from a relatively unperformant implementation in the Oracle JDK.
+   Thus, clients that are unable to use HTTP/2 may see a significant slowdown when the Timelock Server switches from an
+   ``https`` connector to an ``h2`` connector. It may be possible to get around this by exposing multiple application
+   connectors, though the AtlasDB team has not tested this approach.
 
 HTTP/2 is a newer version of the HTTP protocol that supports, among other features, connection multiplexing. This is
-extremely useful in improving the latency of timestamp and lock requests. Timelock Server is compatible with HTTP/2
-as of AtlasDB v0.34.0; to configure this, one should change the protocol used by the Dropwizard application and
-admin connectors to ``h2`` instead of ``https``. For example, this block can be added to the root of the Timelock
-server configuration:
+extremely useful in improving the latency of timestamp and lock requests, which are usually fairly small.
+Timelock Server is compatible with HTTP/2 as of AtlasDB v0.34.0; to configure this, one should change the protocol
+used by the Dropwizard application and admin connectors to ``h2`` instead of ``https``. For example, this block can be
+added to the root of the Timelock server configuration:
 
 .. code:: yaml
+
    server:
      applicationConnectors:
        - type: h2

--- a/docs/source/services/timelock_service/index.rst
+++ b/docs/source/services/timelock_service/index.rst
@@ -25,7 +25,7 @@ services embedded within one's clients) provides several benefits:
 - Additional reliability; we have subjected our new implementation to Jepsen testing, and do not rely on the
   consistency of the user's key-value services.
 - The number of AtlasDB clients can scale independently of AtlasDB's timestamp and lock services, and an odd number of
-  AtlasDB clients is no longer required. An odd number of Timelock servers is still required.
+  AtlasDB clients is no longer necessarily preferred. An odd number of Timelock servers is still preferred.
 - Resource contention between your AtlasDB clients and the timestamp and lock services can be better managed,
   because external timestamp services may be run on separate servers and/or JVMs (while the old embedded services
   had to be run on the same server, and within the same JVM).

--- a/docs/source/services/timelock_service/index.rst
+++ b/docs/source/services/timelock_service/index.rst
@@ -17,6 +17,7 @@ External Timelock Service
     migration
     manual-migration
     product-changes
+    paxos
 
 The AtlasDB Timelock Service is an external implementation of the :ref:`Timestamp <timestamp-service>` and
 :ref:`Lock <lock-service>` services. Running an external Timelock Service (as opposed to running timestamp and lock

--- a/docs/source/services/timelock_service/paxos.rst
+++ b/docs/source/services/timelock_service/paxos.rst
@@ -1,0 +1,40 @@
+.. _timelock-paxos:
+
+=====
+Paxos
+=====
+
+Paxos is an algorithm for *distributed consensus* - that is, getting servers to agree on a value that some server
+*proposes*, in the presence of communication and server failures. Its guarantees include:
+
+#. Safety: All servers will agree on the same value.
+#. Nontriviality: The value must have been *proposed* by at least one of the servers.
+#. Liveness: If a majority of servers is up and able to communicate, then the protocol can make progress.
+
+If the Timelock Server is configured to use Paxos, it will actually use separate instances of Paxos to agree on the
+current cluster leader (which is the only node allowed to give out timestamps and locks), as well as the timestamp
+bound for each client supported by the Timelock server. This could be multiplexed, but we decided to separate them to
+reduce contention as well as allow future optimisations involving load balancing.
+
+Leader Election
+===============
+
+Paxos is a symmetric consensus protocol; technically speaking, each server (which plays all of the proposer, acceptor
+and learner roles) behaves in the same way. However, this can potentially lead to a situation known as the
+*dueling proposers* problem, where servers behave as follows:
+
+#. Server A proposes a value V1, with term (1, A)
+#. It receives a majority of promises not to accept values with terms greater than (1, A)
+#. Server B proposes a value V2, with term (1, B)
+#. It receives a majority of promises for (1, B)
+#. Server A requests servers to accept V1; servers reject
+#. Server A proposes V1 with term (2, A)
+#. It receives a majority of promises for (2, A)
+#. Server B requests servers to accept V2; servers reject
+
+This can be (and is in AtlasDB) mitigated by having a random backoff between proposals. However, leader election is
+often preferable for performance reasons; we use a round of Paxos which is symmetric to perform this election. The
+leader is the only node allowed to propose timestamp bounds for each clients.
+
+We are considering extending this notion of leader election to agreeing on a balanced scheme of work across nodes
+in the future, to relieve load on the leader.

--- a/docs/source/services/timelock_service/paxos.rst
+++ b/docs/source/services/timelock_service/paxos.rst
@@ -4,12 +4,12 @@
 Paxos
 =====
 
-Paxos is an algorithm for *distributed consensus* - that is, getting servers to agree on a value that some server
+`Paxos <https://www.microsoft.com/en-us/research/wp-content/uploads/2016/12/paxos-simple-Copy.pdf>`__ is an algorithm for *distributed consensus* - that is, getting servers to agree on a value that some server
 *proposes*, in the presence of communication and server failures. Its guarantees include:
 
 #. Safety: All servers will agree on the same value.
 #. Nontriviality: The value must have been *proposed* by at least one of the servers.
-#. Liveness: If a majority of servers is up and able to communicate, then the protocol can make progress.
+#. Liveness: If a majority of servers are up and able to communicate, then the protocol can make progress.
 
 If the Timelock Server is configured to use Paxos, it will actually use separate instances of Paxos to agree on the
 current cluster leader (which is the only node allowed to give out timestamps and locks), as well as the timestamp

--- a/docs/source/services/timelock_service/paxos.rst
+++ b/docs/source/services/timelock_service/paxos.rst
@@ -1,23 +1,19 @@
 .. _timelock-paxos:
 
-=====
-Paxos
-=====
+=================
+Paxos and AtlasDB
+=================
 
-`Paxos <https://www.microsoft.com/en-us/research/wp-content/uploads/2016/12/paxos-simple-Copy.pdf>`__ is an algorithm for *distributed consensus* - that is, getting servers to agree on a value that some server
-*proposes*, in the presence of communication and server failures. Its guarantees include:
+The Paxos Algorithm
+===================
+
+`Paxos <https://www.microsoft.com/en-us/research/wp-content/uploads/2016/12/paxos-simple-Copy.pdf>`__ is an algorithm
+for *distributed consensus* - that is, getting servers to agree on a value that some server *proposes*, in the presence
+of communication and server failures. Its guarantees include:
 
 #. Safety: All servers will agree on the same value.
 #. Nontriviality: The value must have been *proposed* by at least one of the servers.
 #. Liveness: If a majority of servers are up and able to communicate, then the protocol can make progress.
-
-If the Timelock Server is configured to use Paxos, it will actually use separate instances of Paxos to agree on the
-current cluster leader (which is the only node allowed to give out timestamps and locks), as well as the timestamp
-bound for each client supported by the Timelock server. This could be multiplexed, but we decided to separate them to
-reduce contention as well as allow future optimisations involving load balancing.
-
-Leader Election
-===============
 
 Paxos is a symmetric consensus protocol; technically speaking, each server (which plays all of the proposer, acceptor
 and learner roles) behaves in the same way. However, this can potentially lead to a situation known as the
@@ -32,9 +28,19 @@ and learner roles) behaves in the same way. However, this can potentially lead t
 #. It receives a majority of promises for (2, A)
 #. Server B requests servers to accept V2; servers reject
 
-This can be (and is in AtlasDB) mitigated by having a random backoff between proposals. However, leader election is
-often preferable for performance reasons; we use a round of Paxos which is symmetric to perform this election. The
-leader is the only node allowed to propose timestamp bounds for each clients.
+This can be (and is in AtlasDB) mitigated by having a random backoff between proposals.
 
-We are considering extending this notion of leader election to agreeing on a balanced scheme of work across nodes
-in the future, to relieve load on the leader.
+How we use Paxos
+================
+
+The Timelock servers uses a Paxos based algorithm for two purposes:
+
+#. **Leadership election:** We choose who will be the leader in the Timelock cluster. The leader is the only server capable
+   of responding to lock and timestamp requests. Leader election is often preferable for performance reasons confirming
+   you are the leader is more efficient than choosing the value to respond with.
+#. **Timestamp bound:** Timelock has an asynchronous process to increase the upper bound of timestamps that the leader is
+   allowed to hand out, and we choose this bound via Paxos.
+
+It is worth noting that the Paxos implementations differ slightly for choosing a leader and choosing a timestamp bound.
+When choosing a leader, all servers can propose leadership and have the potential to be elected. However, once a leader
+is established, only that server is allowed to propose timestamp bounds.

--- a/docs/source/services/timelock_service/product-changes.rst
+++ b/docs/source/services/timelock_service/product-changes.rst
@@ -14,7 +14,7 @@ All products deploying against the AtlasDB Timelock service should adhere to the
 
         java -javaagent:service/lib/jetty-alpn-agent-2.0.6.jar
 
-3. Further to the above, ensure that the Timelock Server is configured to use HTTP/2; see :ref:`Configuring HTTP/2 <_timelock-server-config-http2>` for more details.
+3. Further to the above, ensure that the Timelock Server is configured to use HTTP/2; see :ref:`Configuring HTTP/2 <timelock-server-config-http2>` for more details.
 4. Ensure that the Timelock server has added the product as a client in its :ref:`client <timelock-server-clients>` block.
    The client name should be same as the ``client`` field in the :ref:`Timelock client configuration <timelock-client-configuration>`.
 5. All users of the product should :ref:`migrate <timelock-migration>` from embedded timestamp/lock services to the timelock server post-upgrade.

--- a/docs/source/services/timelock_service/product-changes.rst
+++ b/docs/source/services/timelock_service/product-changes.rst
@@ -8,12 +8,15 @@ All products deploying against the AtlasDB Timelock service should adhere to the
 1. Ensure that the AtlasDB client config contains the ``timelock`` :ref:`config block <timelock-client-configuration>`.
 2. The `Jetty ALPN agent <https://github.com/jetty-project/jetty-alpn-agent#usage>`__ is added as a javaagent JVM argument.
    All AtlasDB clients will already have ``jetty-alpn-agent-2.0.6.jar`` in the classpath. This is required to establish
-   HTTP/2 connections, and failure to include this will result in falling back to HTTP/1.1 connections and see significant perf degradation.
+   HTTP/2 connections, and failure to include this will result in falling back to HTTP/1.1 connections and significant performance degradation.
 
     .. code-block:: yaml
 
         java -javaagent:service/lib/jetty-alpn-agent-2.0.6.jar
 
-3. Ensure that the Timelock server has added the product as a client in its :ref:`client <timelock-server-clients>` block.
+3. Further to the above, ensure that the Timelock Server is configured to use HTTP/2; see :ref:`Configuring HTTP/2 <_timelock-server-config-http2>` for more details.
+4. Ensure that the Timelock server has added the product as a client in its :ref:`client <timelock-server-clients>` block.
    The client name should be same as the ``client`` field in the :ref:`Timelock client configuration <timelock-client-configuration>`.
-4. All users of the product should :ref:`migrate <timelock-migration>` from embedded timestamp/lock services to the timelock server post-upgrade.
+5. All users of the product should :ref:`migrate <timelock-migration>` from embedded timestamp/lock services to the timelock server post-upgrade.
+
+If HTTP/2 is not required, then one may skip steps 2 and 3.


### PR DESCRIPTION
**Goals (and why)**:

* Fix various issues in TimeLock documentation (and in other places which may have changed in behaviour because of timelock, like the CLIs)
  - Update Manual Migration docs for Cassandra which were previously flawed
  - Update CLI Docs
  - Explain how to configure servers to use HTTP2
  - Add a section explaining how we use Paxos
* Fix unintuitive formatting in Transaction Protocol documentation

**Implementation Description (bullets)**:

* Added documentation to address the problems above.

**Concerns (what feedback would you like?)**:

* Nothing in particular. There is a bit of repetition at the end of the CLIs file, perhaps.

**Where should we start reviewing?**:

* Anywhere

**Priority (whenever / two weeks / yesterday)**:

* Whenever