### PR TITLE
Speed up dynamic column paging on Oracle

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleOverflowQueryFactory.java
@@ -35,11 +35,6 @@ public class OracleOverflowQueryFactory extends OracleQueryFactory {
     }
 
     @Override
-    protected String getValueSubselect(String tableAlias, boolean includeValue) {
-        return includeValue ? ", " + tableAlias + ".val, " + tableAlias + ".overflow " : " ";
-    }
-
-    @Override
     public boolean hasOverflowValues() {
         return true;
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
@@ -353,15 +353,16 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
             long ts,
             BatchColumnRangeSelection columnRangeSelection) {
         String query = " /* GET_ROWS_COLUMN_RANGE (" + tableName + ") */ "
-                + "SELECT * FROM ( SELECT m.row_name, m.col_name, max(m.ts) as ts"
-                + getValueSubselectForGroupBy("m", true)
+                + "SELECT s.row_name, s.col_name, s.ts" + getValueSubselect("s", true)
+                + " FROM ( SELECT m.row_name, m.col_name, max(m.ts) as ts"
+                +         getValueSubselectForGroupBy("m")
                 + "   FROM " + tableName + " m"
                 + "  WHERE m.row_name = ?"
                 + "    AND m.ts < ? "
                 + (columnRangeSelection.getStartCol().length > 0 ? " AND m.col_name >= ?" : "")
                 + (columnRangeSelection.getEndCol().length > 0 ? " AND m.col_name < ?" : "")
                 + " GROUP BY m.row_name, m.col_name"
-                + " ORDER BY m.row_name ASC, m.col_name ASC ) WHERE rownum <= " + columnRangeSelection.getBatchHint();
+                + " ORDER BY m.row_name ASC, m.col_name ASC ) s WHERE rownum <= " + columnRangeSelection.getBatchHint();
         FullQuery fullQuery = new FullQuery(query).withArg(row).withArg(ts);
         if (columnRangeSelection.getStartCol().length > 0) {
             fullQuery = fullQuery.withArg(columnRangeSelection.getStartCol());
@@ -426,31 +427,27 @@ public abstract class OracleQueryFactory extends AbstractDbQueryFactory {
         }
     }
 
-    private String getValueSubselectForGroupBy(String tableAlias, boolean includeValue) {
-        if (includeValue) {
-            List<String> colNames = getValueColumnNames();
-            StringBuilder ret = new StringBuilder(70 * colNames.size());
-            for (String colName : colNames) {
-                // E.g., ", MAX(m.val) KEEP (DENSE_RANK LAST ORDER BY m.ts ASC) AS val".
-                // How this works, assuming we have a "GROUP BY row_name, col_name" clause:
-                //  1) Among each group of rows with the same (row_name, col_name) pair,
-                //     "KEEP (DENSE_RANK LAST ORDER BY m.ts ASC)" will select the subset
-                //     of rows with the biggest 'ts' value. Since (row_name, col_name, ts)
-                //     is the primary key, that subset will always contain exactly one
-                //     element in our case.
-                //  2) For that subset of rows, we take an aggregate function "MAX(m.val)".
-                //     It doesn't make a difference which function we use since our subset
-                //     is a singleton, so MAX will simply return the only element in that set.
-                //  To sum it up: for each (row_name, col_name) group, this will select
-                //  the value of the row that has the largest 'ts' value within that group.
-                ret.append(", MAX(").append(tableAlias).append('.').append(colName)
-                        .append(") KEEP (DENSE_RANK LAST ORDER BY ")
-                        .append(tableAlias).append(".ts ASC) AS ").append(colName);
-            }
-            return ret.toString();
-        } else {
-            return "";
+    private String getValueSubselectForGroupBy(String tableAlias) {
+        List<String> colNames = getValueColumnNames();
+        StringBuilder ret = new StringBuilder(70 * colNames.size());
+        for (String colName : colNames) {
+            // E.g., ", MAX(m.val) KEEP (DENSE_RANK LAST ORDER BY m.ts ASC) AS val".
+            // How this works, assuming we have a "GROUP BY row_name, col_name" clause:
+            //  1) Among each group of rows with the same (row_name, col_name) pair,
+            //     "KEEP (DENSE_RANK LAST ORDER BY m.ts ASC)" will select the subset
+            //     of rows with the biggest 'ts' value. Since (row_name, col_name, ts)
+            //     is the primary key, that subset will always contain exactly one
+            //     element in our case.
+            //  2) For that subset of rows, we take an aggregate function "MAX(m.val)".
+            //     It doesn't make a difference which function we use since our subset
+            //     is a singleton, so MAX will simply return the only element in that set.
+            //  To sum it up: for each (row_name, col_name) group, this will select
+            //  the value of the row that has the largest 'ts' value within that group.
+            ret.append(", MAX(").append(tableAlias).append('.').append(colName)
+                    .append(") KEEP (DENSE_RANK LAST ORDER BY ")
+                    .append(tableAlias).append(".ts ASC) AS ").append(colName);
         }
+        return ret.toString();
     }
 
     private List<String> getValueColumnNames() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleRawQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleRawQueryFactory.java
@@ -27,11 +27,6 @@ public class OracleRawQueryFactory extends OracleQueryFactory {
     }
 
     @Override
-    String getValueSubselect(String tableAlias, boolean includeValue) {
-        return includeValue ? ", " + tableAlias + ".val " : " ";
-    }
-
-    @Override
     public boolean hasOverflowValues() {
         return false;
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,7 +65,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1685>`__)
 
     *    - |improved|
-         - Improved performance of paging over dynamic columns on Oracle DbKvs.
+         - Improved performance of paging over dynamic columns on Oracle DbKvs: the time required to page through a large wide row is now linear rather than quadratic in the length of the row.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1702>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -64,6 +64,10 @@ develop
          - AtlasDB now instruments services to expose aggregate response time and service call metrics for key value, timestamp, and lock services.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1685>`__)
 
+    *    - |improved|
+         - Improved performance of paging over dynamic columns on Oracle DbKvs.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1702>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
An extra self-join to load the values is slow for two reasons:
1) It requires multiple index range scans in the DB (one per cell)
2) Unclear why, but it causes Oracle to fetch more data than it needs,
   which seems to make paging through a large wide row quadratic
   time in the length of the row.

**Goals (and why)**:
As we discovered at our customer's deployment, the existing query for paging over dynamic columns performs very poorly on very large rows.
**Implementation Description (bullets)**:
Change the query to eliminate an extra self-join and use the obscure KEEP DENSE_RANK LAST feature in Oracle instead.
**Concerns (what feedback would you like?)**:
Hopefully the new query is correct, and you guys have tests, right?
**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
I want the new benchmark I wrote to run a few times to get a baseline before we merge this. But after that's done, I'll need this merged sooner rather than later.

