### PR TITLE
Fix/silent mrtse

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,6 +41,10 @@ develop
          - Change
 
     *    - |fixed|
+         - Fixed an issue where a ``MultipleRunningTimestampServicesError`` would be ignored, resulting in a state where two timestamp services would be able to simultaneously hand out timestamps. Also changed the logic for increasing the timestamp bound when the allocation buffer is exhausted.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/????>`__)
+
+    *    - |fixed|
          - Fixed DbKvs sweep OOM issue (`#982 <https://github.com/palantir/atlasdb/issues/982>`__) caused by very wide rows. ``DbKvs.getRangeOfTimestamps`` now uses an adjustable cell batch size to avoid loading too many timestamps. In case of a single row that is too wide, this may result in ``getRangeOfTimestamps`` returning multiple ``RowResult`` to include all timestamps. It is, however, guaranteed that each ``RowResult`` will contain all timestamps for each included column.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1678>`__)
 

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
@@ -25,7 +25,7 @@ public class AvailableTimestamps {
     static final long ALLOCATION_BUFFER_SIZE = 1000 * 1000;
     static final long MINIMUM_BUFFER = ALLOCATION_BUFFER_SIZE / 2;
     private static final long MAX_TIMESTAMPS_TO_HAND_OUT = 10 * 1000;
-    private final Object lock;
+    private final Object issueTimestampLock;
 
     @GuardedBy("this")
     private final LastReturnedTimestamp lastReturnedTimestamp;
@@ -37,7 +37,7 @@ public class AvailableTimestamps {
                 Thread.currentThread().getName());
         this.lastReturnedTimestamp = lastReturnedTimestamp;
         this.upperLimit = upperLimit;
-        this.lock = new Object();
+        this.issueTimestampLock = new Object();
     }
 
     private static void checkValidTimestampRangeRequest(long numberToHandOut) {
@@ -49,34 +49,67 @@ public class AvailableTimestamps {
         }
     }
 
+    /**
+     * Hand out the requested timestampRange, only increase the upper bound if strictly necessary. Do not block on the
+     * refresh of buffer if the existing buffer is already large enough.
+     *
+     * Modifies lastReturnedTimestamp and possibly upperLimit (but obtains a lock on this if it does).
+     *
+     * Possible race condition with refreshBuffer:
+     * targetTimestamp > upperLimit.get(), indicating that we need to increase the timestamp bound, but upperLimit
+     * gets increased before we obtain the lock in allocateEnoughTimestampsToHandOut. This is, however, not a problem
+     * because the check in upperLimit.increaseToAtLeast will use the fresh value of upperLimit.get() and therefore
+     * exit the method without performing an unnecessary cas.
+     *
+     * @param numberToHandOut number of timestamps
+     * @return
+     */
     public TimestampRange handOut(long numberToHandOut) {
         checkValidTimestampRangeRequest(numberToHandOut);
         long targetTimestamp;
         TimestampRange timestampRange;
 
-        synchronized (lock) {
+        synchronized (issueTimestampLock) {
             /*
              * Under high concurrent load, this will be a hot critical section as clients request timestamps.
              * It is important to minimize contention as much as possible on this path.
              */
-            targetTimestamp = lastHandedOut() + numberToHandOut;
-            timestampRange = handOutTimestamp(targetTimestamp);
+            long lastHandedOut = lastReturnedTimestamp.get();
+            targetTimestamp = lastHandedOut + numberToHandOut;
+            timestampRange = TimestampRange.createInclusiveRange(lastHandedOut + 1, targetTimestamp);
+            if (targetTimestamp > upperLimit.get()) {
+                //this is the only situation where we actually must block and wait for CAS
+                allocateEnoughTimestampsToHandOut(targetTimestamp, ALLOCATION_BUFFER_SIZE);
+            }
+            lastReturnedTimestamp.increaseToAtLeast(targetTimestamp);
         }
 
-        DebugLogger.logger.trace("Handing out {} timestamps, taking us to {}.", numberToHandOut, targetTimestamp);
+        DebugLogger.logger.info("Handing out {} timestamps, taking us to {}.", numberToHandOut, targetTimestamp);
         return timestampRange;
     }
 
+    /**
+     * Refreshes the buffer by increasing the timestamp bound if the buffer has become too small or 1 minute has passed
+     * since the last increase.
+     *
+     * Modifies upperLimit.
+     *
+     * Possible race condition with handOut:
+     * lastReturnedTimestamp increases after lastHandedOut is fixed. As a consequence, we might think the buffer is
+     * larger than it is, and we may update upperLimit to a slightly lower bound. This is a good tradeoff since it means
+     * we avoided blocking handouts in the meantime and upperLimit.increaseToAtLeast makes sure the bound never
+     * decreases.
+     */
     public void refreshBuffer() {
         boolean needsRefresh;
         long currentUpperLimit;
-        long buffer;
+        long bufferUpperBound;
 
         synchronized (this) {
             currentUpperLimit = upperLimit.get();
-            long lastHandedOut = lastHandedOut();
-            buffer = currentUpperLimit - lastHandedOut;
-            needsRefresh = buffer < MINIMUM_BUFFER || !upperLimit.hasIncreasedWithin(1, TimeUnit.MINUTES);
+            long lastHandedOut = lastReturnedTimestamp.get();
+            bufferUpperBound = currentUpperLimit - lastHandedOut;
+            needsRefresh = bufferUpperBound < MINIMUM_BUFFER || !upperLimit.hasIncreasedWithin(1, TimeUnit.MINUTES);
             if (needsRefresh) {
                 allocateEnoughTimestampsToHandOut(lastHandedOut + ALLOCATION_BUFFER_SIZE, 0L);
             }
@@ -84,7 +117,7 @@ public class AvailableTimestamps {
 
         if (DebugLogger.logger.isTraceEnabled()) {
             // explicitly avoiding boxing when logging disabled
-            logRefresh(needsRefresh, currentUpperLimit, buffer);
+            logRefresh(needsRefresh, currentUpperLimit, bufferUpperBound);
         }
     }
 
@@ -98,44 +131,20 @@ public class AvailableTimestamps {
         }
     }
 
-    public synchronized void fastForwardTo(long newMinimum) {
-        lastReturnedTimestamp.increaseToAtLeast(newMinimum);
-        upperLimit.increaseToAtLeast(newMinimum + ALLOCATION_BUFFER_SIZE, 0L);
-    }
-
-    private long lastHandedOut() {
-        // de-synchronized
-        return lastReturnedTimestamp.get();
-    }
-
     /**
-     * Gets the range of timestamps to hand out.
-     * @return timestamp range to hand out
-     * @throws IllegalArgumentException if targetTimestamp is less than or equal to last handed out timestamp
+     * Fast forwards to newMinimum.
+     *
+     * The order of synchronization is important to avoid possible deadlock with handOut -- the lock on
+     * issueTimestampLock must be acquired before the lock on this.
+     *
+     * @param newMinimum new minimum timestamp
      */
-    private TimestampRange getRangeToHandOut(long targetTimestamp) {
-        synchronized (lock) {
-            long lastHandedOut = lastHandedOut();
-            if (targetTimestamp <= lastHandedOut) {
-                // explicitly not using Preconditions to optimize hot success path and avoid allocations
-                throw new IllegalArgumentException(String.format(
-                        "Could not hand out timestamp '%s' as it was earlier than the last handed out timestamp: %s",
-                        targetTimestamp, lastHandedOut));
+    public void fastForwardTo(long newMinimum) {
+        synchronized (issueTimestampLock) {
+            synchronized (this) {
+                lastReturnedTimestamp.increaseToAtLeast(newMinimum);
+                upperLimit.increaseToAtLeast(newMinimum + ALLOCATION_BUFFER_SIZE, 0L);
             }
-            return TimestampRange.createInclusiveRange(lastHandedOut + 1, targetTimestamp);
-        }
-    }
-
-    private TimestampRange handOutTimestamp(long targetTimestamp) {
-        synchronized (lock) {
-            TimestampRange rangeToHandOut = getRangeToHandOut(targetTimestamp);
-            if (targetTimestamp > upperLimit.get()) {
-                //this is the only situation where we actually need to block gets to wait for CAS
-                allocateEnoughTimestampsToHandOut(targetTimestamp, ALLOCATION_BUFFER_SIZE);
-            }
-            lastReturnedTimestamp.increaseToAtLeast(targetTimestamp);
-
-            return rangeToHandOut;
         }
     }
 

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
@@ -51,13 +51,14 @@ public class PersistentUpperLimit {
      * @return upper limit timestamp
      */
     public long get() {
+        allocationFailures.verifyWeShouldIssueMoreTimestamps();
         return cachedValue;
     }
 
-    public synchronized long increaseToAtLeast(long minimum) {
+    public synchronized long increaseToAtLeast(long minimum, long buffer) {
         long currentValue = get();
         if (currentValue < minimum) {
-            return store(minimum);
+            return store(minimum + buffer);
         } else {
             DebugLogger.logger.trace(
                     "Not storing upper limit of {}, as the cached value {} was higher.",
@@ -88,7 +89,7 @@ public class PersistentUpperLimit {
     private synchronized long store(long upperLimit) {
         DebugLogger.logger.trace("Storing new upper limit of {}.", upperLimit);
         checkWeHaveNotBeenInterrupted();
-        allocationFailures.verifyWeShouldTryToAllocateMoreTimestamps();
+        allocationFailures.verifyWeShouldIssueMoreTimestamps();
         persistNewUpperLimit(upperLimit);
         cachedValue = upperLimit;
         lastIncreasedTime = clock.getTimeMillis();

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/AvailableTimestampsTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/AvailableTimestampsTest.java
@@ -99,7 +99,7 @@ public class AvailableTimestampsTest {
                 availableTimestamps.handOut(INITIAL_REMAINING_TIMESTAMPS + 10).getUpperBound(),
                 is(UPPER_LIMIT + 10));
 
-        verify(persistentUpperLimit).increaseToAtLeast(UPPER_LIMIT + 10, AvailableTimestamps.MINIMUM_BUFFER);
+        verify(persistentUpperLimit).increaseToAtLeast(UPPER_LIMIT + 10, AvailableTimestamps.ALLOCATION_BUFFER_SIZE);
     }
 
     @Test public void

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/AvailableTimestampsTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/AvailableTimestampsTest.java
@@ -68,7 +68,7 @@ public class AvailableTimestampsTest {
         availableTimestamps.refreshBuffer();
 
         verify(persistentUpperLimit).increaseToAtLeast(
-                UPPER_LIMIT - 10 + AvailableTimestamps.ALLOCATION_BUFFER_SIZE
+                UPPER_LIMIT - 10 + AvailableTimestamps.ALLOCATION_BUFFER_SIZE, 0
         );
     }
 
@@ -79,7 +79,7 @@ public class AvailableTimestampsTest {
         availableTimestamps.refreshBuffer();
 
         verify(persistentUpperLimit).increaseToAtLeast(
-                longThat(is(greaterThan(UPPER_LIMIT)))
+                longThat(is(greaterThan(UPPER_LIMIT))), longThat(is(0L))
         );
     }
 
@@ -90,7 +90,7 @@ public class AvailableTimestampsTest {
 
         availableTimestamps.refreshBuffer();
 
-        verify(persistentUpperLimit, never()).increaseToAtLeast(anyLong());
+        verify(persistentUpperLimit, never()).increaseToAtLeast(anyLong(), anyLong());
     }
 
     @Test public void
@@ -99,7 +99,7 @@ public class AvailableTimestampsTest {
                 availableTimestamps.handOut(INITIAL_REMAINING_TIMESTAMPS + 10).getUpperBound(),
                 is(UPPER_LIMIT + 10));
 
-        verify(persistentUpperLimit).increaseToAtLeast(UPPER_LIMIT + 10);
+        verify(persistentUpperLimit).increaseToAtLeast(UPPER_LIMIT + 10, AvailableTimestamps.MINIMUM_BUFFER);
     }
 
     @Test public void
@@ -122,7 +122,7 @@ public class AvailableTimestampsTest {
         availableTimestamps.fastForwardTo(newMinimum);
 
         assertThat(lastReturnedTimestamp.get(), is(newMinimum));
-        verify(persistentUpperLimit).increaseToAtLeast(longGreaterThan(newMinimum));
+        verify(persistentUpperLimit).increaseToAtLeast(longGreaterThan(newMinimum), longThat(is(0L)));
     }
 
     private long longGreaterThan(long n) {

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentUpperLimitTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentUpperLimitTest.java
@@ -34,6 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.common.time.Clock;
 import com.palantir.exception.PalantirInterruptedException;
 
@@ -75,26 +76,42 @@ public class PersistentUpperLimitTest {
 
     @Test
     public void shouldIncreaseTheUpperLimitIfTheNewLimitIsBigger() {
-        upperLimit.increaseToAtLeast(TIMESTAMP);
+        upperLimit.increaseToAtLeast(TIMESTAMP, 0);
 
-        upperLimit.increaseToAtLeast(TIMESTAMP + 1000);
+        upperLimit.increaseToAtLeast(TIMESTAMP + 1000, 0);
         assertThat(upperLimit.get(), is(TIMESTAMP + 1000));
     }
 
     @Test
-    public void shouldNotIncreaseTheUpperLimitIfTheNewLimitIsSmaller() {
-        upperLimit.increaseToAtLeast(TIMESTAMP);
+    public void shouldIncreaseTheUpperLimitWithBufferIfTheNewLimitIsBigger() {
+        upperLimit.increaseToAtLeast(TIMESTAMP, 0);
 
-        upperLimit.increaseToAtLeast(TIMESTAMP - 1000);
+        upperLimit.increaseToAtLeast(TIMESTAMP + 1000, 1000);
+        assertThat(upperLimit.get(), is(TIMESTAMP + 2000));
+    }
+
+    @Test
+    public void shouldNotIncreaseTheUpperLimitIfTheNewLimitIsSmaller() {
+        upperLimit.increaseToAtLeast(TIMESTAMP, 0);
+
+        upperLimit.increaseToAtLeast(TIMESTAMP - 1000, 0);
+        assertThat(upperLimit.get(), is(TIMESTAMP));
+    }
+
+    @Test
+    public void shouldNotIncreaseTheUpperLimitIfTheNewLimitIsSmallerRegardlessOfBuffer() {
+        upperLimit.increaseToAtLeast(TIMESTAMP, 0);
+
+        upperLimit.increaseToAtLeast(TIMESTAMP - 1000, 2000);
         assertThat(upperLimit.get(), is(TIMESTAMP));
     }
 
     @Test
     public void shouldPersistAnIncreasedTimestamp() {
-        upperLimit.increaseToAtLeast(TIMESTAMP);
+        upperLimit.increaseToAtLeast(TIMESTAMP, 0);
 
-        upperLimit.increaseToAtLeast(TIMESTAMP + 1000);
-        verify(boundStore).storeUpperLimit(TIMESTAMP + 1000);
+        upperLimit.increaseToAtLeast(TIMESTAMP + 1000, 1000);
+        verify(boundStore).storeUpperLimit(TIMESTAMP + 2000);
     }
 
     @Test
@@ -102,7 +119,7 @@ public class PersistentUpperLimitTest {
         doThrow(RuntimeException.class).when(boundStore).storeUpperLimit(anyLong());
 
         try {
-            upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10);
+            upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10, 0);
         } catch (Exception e) {
             // We expect this to throw
         }
@@ -114,7 +131,7 @@ public class PersistentUpperLimitTest {
     public void shouldKnowIfItWasUpdateWithinACertainTimeframe() {
         whenTheTimeIs(1, MINUTES);
 
-        upperLimit.increaseToAtLeast(TIMESTAMP);
+        upperLimit.increaseToAtLeast(TIMESTAMP, 0);
 
         whenTheTimeIs(4, MINUTES);
 
@@ -125,7 +142,7 @@ public class PersistentUpperLimitTest {
     public void shouldKnowIfItWasNotUpdateWithinACertainTimeframe() {
         whenTheTimeIs(1, MINUTES);
 
-        upperLimit.increaseToAtLeast(TIMESTAMP);
+        upperLimit.increaseToAtLeast(TIMESTAMP, 0);
 
         whenTheTimeIs(2, MINUTES);
 
@@ -142,20 +159,29 @@ public class PersistentUpperLimitTest {
 
         exception.expect(is(expectedException));
 
-        upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10);
+        upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10, 0);
     }
 
     @Test
     public void shouldNotAllocateTimestampsIfAllocationFailuresDisallowsIt() {
-        doThrow(RuntimeException.class).when(allocationFailures).verifyWeShouldTryToAllocateMoreTimestamps();
+        doThrow(RuntimeException.class).when(allocationFailures).verifyWeShouldIssueMoreTimestamps();
 
         try {
-            upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10);
+            upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10, 0);
         } catch (Exception e) {
             // ignore expected exception
         }
 
         verify(boundStore, never()).storeUpperLimit(anyLong());
+    }
+
+    @Test
+    public void shouldNotIssueTimestampsIfAllocationFailuresDisallowsIt() {
+        doThrow(ServiceNotAvailableException.class).when(allocationFailures).verifyWeShouldIssueMoreTimestamps();
+
+        exception.expect(ServiceNotAvailableException.class);
+
+        upperLimit.get();
     }
 
     @Test
@@ -165,7 +191,7 @@ public class PersistentUpperLimitTest {
 
             Thread.currentThread().interrupt();
 
-            upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10);
+            upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10, 0);
         } finally {
             // Clear the interrupt
             Thread.interrupted();
@@ -176,7 +202,7 @@ public class PersistentUpperLimitTest {
     public void shouldNotTryToPersistANewLimitIfInterrupted() {
         try {
             Thread.currentThread().interrupt();
-            upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10);
+            upperLimit.increaseToAtLeast(INITIAL_UPPER_LIMIT + 10, 0);
         } catch (Exception e) {
             // Ingnore expected exception
         } finally {

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/TimestampAllocationFailuresTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/TimestampAllocationFailuresTest.java
@@ -61,19 +61,19 @@ public class TimestampAllocationFailuresTest {
     }
 
     @Test public void
-    shouldAllowTryingToAllocateMoreTimestampsAfterANormalRuntimeException() {
+    shouldAllowTryingToIssueMoreTimestampsAfterANormalRuntimeException() {
         ignoringExceptions(() -> allocationFailures.responseTo(FAILURE));
-        allocationFailures.verifyWeShouldTryToAllocateMoreTimestamps();
+        allocationFailures.verifyWeShouldIssueMoreTimestamps();
     }
 
     @Test public void
-    shouldDisallowTryingToAllocateMoreTimestampsAfterAMultipleRunningTimestampServicesFailure() {
+    shouldDisallowTryingToIssueMoreTimestampsAfterAMultipleRunningTimestampServicesFailure() {
         ignoringExceptions(() -> allocationFailures.responseTo(MULTIPLE_RUNNING_SERVICES_FAILURE));
 
         exception.expectCause(is(MULTIPLE_RUNNING_SERVICES_FAILURE));
         exception.expect(ServiceNotAvailableException.class);
 
-        allocationFailures.verifyWeShouldTryToAllocateMoreTimestamps();
+        allocationFailures.verifyWeShouldIssueMoreTimestamps();
     }
 
     @Test public void


### PR DESCRIPTION
**Goals (and why)**:

- Make sure that when a thread encounters a MRTSE in PersistentTimestampService.asynchronouslyRefreshBuffer(), that prevents PersistentTimestampService.getFreshTimestamp() from issuing timestamps. Otherwise, we can end up with multiple instances of PersistentTimestampService concurrently issuing timestamps.

- In addition, verify that the logic is sound.

**Implementation Description (bullets)**:

- PersistentUpperLimit.get() now checks if an instance of MRTSE has occurred before, and if yes, throws a ServiceNotAvailableException.

- AvailableTimestamps.handOutTimestamp(target) now increases the bound to target + MINIMUM_BUFFER, when the buffer is exhausted to avoid potentially having to perform multiple cas operations. 

**Concerns (what feedback would you like?)**:

- Do you think this will negatively affect performance?

- Should the bound in the case above be increased to target + ALLOCATION_BUFFER_SIZE instead?

- The concurrency logic seems good to me, but we should discuss it if you have reservations.

**Where should we start reviewing?**:

Probably AvailableTimestamps, or PersistentTimestampService.getFreshTimestamp().

**Priority (whenever / two weeks / yesterday)**:

- ASAP, it is small
