### PR TITLE
Docs/release notes 0.36.0

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -90,6 +90,15 @@ v0.36.0
            Clients who have implemented a concrete ``TransactionManager`` throwing checked exceptions are encouraged to wrap said exceptions as unchecked exceptions.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1677>`__)
 
+    *    - |new|
+         - Added benchmarks for paging over columns of a very wide row.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1684>`__)
+
+    *    - |deprecated|
+         - The public ``PaxosLeaderElectionService`` constructor is now deprecated, to mitigate risks of users supplying parameters in the wrong order.
+           ``PaxosLeaderElectionServiceBuilder`` should be used instead.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1681>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -149,15 +158,6 @@ v0.35.0
     *    - |devbreak|
          - The persistent lock release endpoint has now been renamed to ``releaseBackupLock`` since it is currently only supposed to be used for the backup lock.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1674>`__)
-
-    *    - |deprecated|
-         - The public ``PaxosLeaderElectionService`` constructor is now deprecated, to mitigate risks of users supplying parameters in the wrong order.
-           ``PaxosLeaderElectionServiceBuilder`` should be used instead.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1681>`__)
-
-    *    - |new|
-         - Added benchmarks for paging over columns of a very wide row.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1684>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,7 +41,9 @@ develop
          - Change
 
     *    - |fixed|
-         - Fixed DbKvs sweep OOM issue (`#982 <https://github.com/palantir/atlasdb/issues/982>`__) caused by very wide rows. ``DbKvs.getRangeOfTimestamps`` now uses an adjustable cell batch size to avoid loading too many timestamps. In case of a single row that is too wide, this may result in ``getRangeOfTimestamps`` returning multiple ``RowResult`` to include all timestamps. It is, however, guaranteed that each ``RowResult`` will contain all timestamps for each included column.
+         - Fixed DbKvs sweep OOM issue (`#982 <https://github.com/palantir/atlasdb/issues/982>`__) caused by very wide rows. ``DbKvs.getRangeOfTimestamps`` now uses an adjustable cell batch size to avoid loading too many timestamps.
+           In case of a single row that is too wide, this may result in ``getRangeOfTimestamps`` returning multiple ``RowResult`` to include all timestamps.
+           It is, however, guaranteed that each ``RowResult`` will contain all timestamps for each included column.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1678>`__)
 
     *    - |fixed|
@@ -63,6 +65,12 @@ develop
     *    - |new|
          - AtlasDB now instruments services to expose aggregate response time and service call metrics for key value, timestamp, and lock services.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1685>`__)
+
+    *    - |devbreak| |improved|
+         - ``TransactionManager`` now explicitly declares a ``close`` method that does not throw exceptions.
+           This makes ``TransactionManager``'s significantly easier to develop against.
+           Clients who have implemented a concrete ``TransactionManager`` throwing checked exceptions are encouraged to wrap said exceptions as unchecked exceptions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1677>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
@@ -129,11 +137,6 @@ v0.35.0
            ``PaxosLeaderElectionServiceBuilder`` should be used instead.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1681>`__)
 
-    *    - |devbreak| |improved|
-         - ``TransactionManager`` now explicitly declares a ``close`` method that does not throw exceptions.
-           This makes ``TransactionManager``s significantly easier to develop against.
-           Clients who have implemented a concrete ``TransactionManager`` throwing checked exceptions are encouraged to wrap said exceptions as unchecked exceptions.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1677>`__)
 
     *    - |new|
          - Added benchmarks for paging over columns of a very wide row.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -59,7 +59,8 @@ v0.36.0
          - Change
 
     *    - |fixed|
-         - Fixed DbKvs sweep OOM issue (`#982 <https://github.com/palantir/atlasdb/issues/982>`__) caused by very wide rows. ``DbKvs.getRangeOfTimestamps`` now uses an adjustable cell batch size to avoid loading too many timestamps.
+         - Fixed DBKVS sweep OOM issue (`#982 <https://github.com/palantir/atlasdb/issues/982>`__) caused by very wide rows.
+           ``DbKvs.getRangeOfTimestamps`` now uses an adjustable cell batch size to avoid loading too many timestamps.
            In case of a single row that is too wide, this may result in ``getRangeOfTimestamps`` returning multiple ``RowResult`` to include all timestamps.
            It is, however, guaranteed that each ``RowResult`` will contain all timestamps for each included column.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1678>`__)
@@ -77,25 +78,30 @@ v0.36.0
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1687>`__)
 
     *    - |fixed|
-         - Fixed an issue where the ``_persisted_locks`` table was erroneously reported not to have persisted metadata.
+         - Fixed an issue where the ``_persisted_locks`` table was unnecessarily logged as not have persisted metadata.
+           The ``_persisted_locks`` table is a hidden table, and thus it does not need to have persisted metadata.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1696>`__)
 
     *    - |new|
-         - AtlasDB now instruments services to expose aggregate response time and service call metrics for key value, timestamp, and lock services.
+         - AtlasDB now instruments services to expose aggregate response time and service call metrics for keyvalue, timestamp, and lock services.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1685>`__)
 
     *    - |devbreak| |improved|
          - ``TransactionManager`` now explicitly declares a ``close`` method that does not throw exceptions.
-           This makes ``TransactionManager``'s significantly easier to develop against.
+           This makes the ``TransactionManager`` significantly easier to develop against.
            Clients who have implemented a concrete ``TransactionManager`` throwing checked exceptions are encouraged to wrap said exceptions as unchecked exceptions.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1677>`__)
 
     *    - |new|
-         - Added benchmarks for paging over columns of a very wide row.
+         - Added the following benchmarks for paging over columns of a very wide row:
+
+             - ``TransactionGetRowsColumnRangeBenchmarks``
+             - ``KvsGetRowsColumnRangeBenchmarks``
+
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1684>`__)
 
     *    - |deprecated|
-         - The public ``PaxosLeaderElectionService`` constructor is now deprecated, to mitigate risks of users supplying parameters in the wrong order.
+         - The public ``PaxosLeaderElectionService`` constructor is now deprecated to mitigate risks of users supplying parameters in the wrong order.
            ``PaxosLeaderElectionServiceBuilder`` should be used instead.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1681>`__)
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,7 +60,9 @@ v0.36.0
 
     *    - |fixed|
          - Fixed DBKVS sweep OOM issue (`#982 <https://github.com/palantir/atlasdb/issues/982>`__) caused by very wide rows.
-           ``DbKvs.getRangeOfTimestamps`` now uses an adjustable cell batch size to avoid loading too many timestamps.
+           ``DbKvs.getRangeOfTimestamps`` uses an adjustable cell batch size to avoid loading too many timestamps.
+           One can set the batch size by calling ``dbKvs.setMaxRangeOfTimestampsBatchSize``.
+
            In case of a single row that is too wide, this may result in ``getRangeOfTimestamps`` returning multiple ``RowResult`` to include all timestamps.
            It is, however, guaranteed that each ``RowResult`` will contain all timestamps for each included column.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1678>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -66,7 +66,8 @@ v0.36.0
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1678>`__)
 
     *    - |fixed|
-         - Actions run by the ``ReadOnlyTransactionManager`` can no longer bypass necessary protections when using ``getRowsColumnRange()``.
+         - Actions run by the ``ReadOnlyTransactionManager`` can no longer bypass necessary protections when using ``getRowsColumnRange()``.  
+           These protections disallow reads against ``THOROUGH`` swept tables as ``ReadOnlyTransaction``s do not acquire the appropriate locks to guarantee transactionality.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1521>`__)
 
     *    - |fixed|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -61,15 +61,15 @@ v0.36.0
     *    - |fixed|
          - Fixed DBKVS sweep OOM issue (`#982 <https://github.com/palantir/atlasdb/issues/982>`__) caused by very wide rows.
            ``DbKvs.getRangeOfTimestamps`` uses an adjustable cell batch size to avoid loading too many timestamps.
-           One can set the batch size by calling ``dbKvs.setMaxRangeOfTimestampsBatchSize``.
+           One can set the batch size by calling ``DbKvs.setMaxRangeOfTimestampsBatchSize``.
 
            In case of a single row that is too wide, this may result in ``getRangeOfTimestamps`` returning multiple ``RowResult`` to include all timestamps.
            It is, however, guaranteed that each ``RowResult`` will contain all timestamps for each included column.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1678>`__)
 
     *    - |fixed|
-         - Actions run by the ``ReadOnlyTransactionManager`` can no longer bypass necessary protections when using ``getRowsColumnRange()``.  
-           These protections disallow reads against ``THOROUGH`` swept tables as ``ReadOnlyTransaction``s do not acquire the appropriate locks to guarantee transactionality.
+         - Actions run by the ``ReadOnlyTransactionManager`` can no longer bypass necessary protections when using ``getRowsColumnRange()``.
+           These protections disallow reads against ``THOROUGH`` swept tables as read only transactions do not acquire the appropriate locks to guarantee transactionality.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1521>`__)
 
     *    - |fixed|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -79,7 +79,7 @@ v0.36.0
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1687>`__)
 
     *    - |fixed|
-         - Fixed an issue where the ``_persisted_locks`` table was unnecessarily logged as not have persisted metadata.
+         - Fixed an issue where the ``_persisted_locks`` table was unnecessarily logged as not having persisted metadata.
            The ``_persisted_locks`` table is a hidden table, and thus it does not need to have persisted metadata.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1696>`__)
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -40,6 +40,24 @@ develop
     *    - Type
          - Change
 
+    *    -
+         -
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
+v0.36.0
+=======
+
+15 Mar 2017
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
     *    - |fixed|
          - Fixed DbKvs sweep OOM issue (`#982 <https://github.com/palantir/atlasdb/issues/982>`__) caused by very wide rows. ``DbKvs.getRangeOfTimestamps`` now uses an adjustable cell batch size to avoid loading too many timestamps.
            In case of a single row that is too wide, this may result in ``getRangeOfTimestamps`` returning multiple ``RowResult`` to include all timestamps.
@@ -136,7 +154,6 @@ v0.35.0
          - The public ``PaxosLeaderElectionService`` constructor is now deprecated, to mitigate risks of users supplying parameters in the wrong order.
            ``PaxosLeaderElectionServiceBuilder`` should be used instead.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1681>`__)
-
 
     *    - |new|
          - Added benchmarks for paging over columns of a very wide row.


### PR DESCRIPTION
**Goals (and why)**: Cleaning up 0.36.0 release notes so I can email them out.

**Implementation Description (bullets)**:

- made 0.36.0 table
- cleaned up wording for notes in current release
- moved a few release notes that were in the wrong section. Here are the changes in this release for reference.

```
rhero$ git log --pretty=format:"%h%x09%an%x09%ad%x09%s" --date=short 0.35.0...0.36.0 | grep "#"
5462f1b	Glenn Sheasby	2017-03-15	Merge pull request #1703 from palantir/fix/dbkvs-test-locks
b0a85ec	Jeremy Kong	2017-03-14	Docs Improvements (largely around TimeLock) (#1700)
9bd97bf	Greg Bonik	2017-03-13	Add benchmarks for getRowsColumnRange() over a single wide row (#1684)
e772f8c	Glenn Sheasby	2017-03-10	Merge pull request #1696 from palantir/fix/hide-persisted-locks-table
643a5e1	Glenn Sheasby	2017-03-10	Merge pull request #1678 from palantir/fix/dbkvs-oom
54baa02	Himangi Saraogi	2017-03-10	Merge pull request #1685 from palantir/ds/tritium
8239e7f	Jeremy Kong	2017-03-09	Declare TransactionManager.close() explicitly (so it will throw no checked exceptions) (#1677)
05371eb	Glenn Sheasby	2017-03-08	Merge pull request #1681 from palantir/devex/paxos-leader-election-service
6201a71	Robert Hero	2017-03-08	Merge pull request #1692 from palantir/rhero-patch-1
e422c8e	Glenn Sheasby	2017-03-08	Merge pull request #1682 from palantir/fix/sweep-stats-count-delete-range-all
255b38f	Robert Hero	2017-03-08	Merge pull request #1691 from palantir/docs/release-notes-0.35.0
95f9eab	Robert Hero	2017-03-08	remove getting started notes and replaced with actual startup command (#1663)
314c46c	Glenn Sheasby	2017-03-07	Merge pull request #1521 from palantir/fix/keep-read-only-safe
74e4360	Jeremy Kong	2017-03-07	ETE Tests of TimeLock Migration [TimeLock ETE Tests, Part III] (#1676)
26610d8	Glenn Sheasby	2017-03-07	Merge pull request #1687 from palantir/fix_crappy_logging
4df45d2	Robert Hero	2017-03-06	Merge pull request #1662 from palantir/docs/update-tx-protocol
f39387e	Glenn Sheasby	2017-03-06	Merge pull request #1489 from palantir/add/publish-protos-used-internally
3735163	John Boreiko	2017-03-06	Merge pull request #1593 from palantir/fix/prefixed-table-names
```

**Concerns (what feedback would you like?)**: Make sure spelling and wording make sense. Would like a response to specific comments as well. 

**Where should we start reviewing?**: release-notes.rst

**Priority (whenever / two weeks / yesterday)**: asap please!
