### PR TITLE
add benchmarks for deleteRange

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -24,8 +24,11 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.performance.benchmarks.table.ConsecutiveNarrowTable;
 import com.palantir.atlasdb.performance.benchmarks.table.RegeneratingTable;
 
 @State(Scope.Benchmark)
@@ -34,6 +37,18 @@ public class KvsDeleteBenchmarks {
     private Object doDelete(RegeneratingTable<Multimap<Cell, Long>> table) {
         table.getKvs().delete(table.getTableRef(), table.getTableCells());
         return table.getTableCells();
+    }
+
+    private Object doDeleteRange(ConsecutiveNarrowTable table, int numBatches) {
+        Iterable<RangeRequest> rangeRequests;
+        if (numBatches == 1) {
+            rangeRequests = ImmutableList.of(RangeRequest.all());
+        } else {
+            rangeRequests = table.getRangeRequests(1, table.getNumRows() / numBatches);
+        }
+        rangeRequests.forEach(rangeRequest -> table.getKvs().deleteRange(table.getTableRef(), rangeRequest));
+
+        return rangeRequests;
     }
 
     @Benchmark
@@ -48,6 +63,20 @@ public class KvsDeleteBenchmarks {
     @Measurement(time = 22, timeUnit = TimeUnit.SECONDS)
     public Object batchDelete(RegeneratingTable.KvsBatchRegeneratingTable table) {
         return doDelete(table);
+    }
+
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
+    public Object batchRangeDelete(ConsecutiveNarrowTable.CleanNarrowTable table) {
+        return doDeleteRange(table, 4);
+    }
+
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
+    public Object allRangeDelete(ConsecutiveNarrowTable.CleanNarrowTable table) {
+        return doDeleteRange(table, 1);
     }
 
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -40,12 +40,11 @@ public class KvsDeleteBenchmarks {
     }
 
     private Object doDeleteRange(ConsecutiveNarrowTable table, int numBatches) {
-        Iterable<RangeRequest> rangeRequests;
-        if (numBatches == 1) {
-            rangeRequests = ImmutableList.of(RangeRequest.all());
-        } else {
-            rangeRequests = table.getRangeRequests(1, table.getNumRows() / numBatches);
-        }
+        Iterable<RangeRequest> rangeRequests =
+                numBatches == 1
+                        ? ImmutableList.of(RangeRequest.all())
+                        : table.getRangeRequests(1, table.getNumRows() / numBatches);
+
         rangeRequests.forEach(rangeRequest -> table.getKvs().deleteRange(table.getTableRef(), rangeRequest));
 
         return rangeRequests;


### PR DESCRIPTION
**Goals (and why)**:
No current benchmark coverage, and we have plans in the future to screw with the impls behind this feature and it'd be nice to see performance changes.

**Implementation Description (bullets)**:
Test ran them, on my laptop/Cassandra the histogram and execution counts look adequate for good statistical feedback.

**Priority (whenever / two weeks / yesterday)**:
<= 2 weeks

