### PR TITLE
Document Learnings from Deployment to the Field

### DIFF
--- a/docs/source/cluster_management/backup-restore.rst
+++ b/docs/source/cluster_management/backup-restore.rst
@@ -35,7 +35,7 @@ Call the ``persistent-lock/acquire-backup-lock`` endpoint, supplying your reason
 
 .. code:: bash
 
-  $ curl -X GET --header 'Accept: application/json' '<product-base-url>/persistent-lock/acquire-backup-lock?reason=manual-backup'
+  $ curl -X POST --header 'Accept: application/json' '<product-base-url>/persistent-lock/acquire-backup-lock?reason=manual-backup'
 
 If the request succeeds, you will receive a ``PersistentLockId`` back. It is essential that you save this lock somewhere, so that you can release it later in the process.
 

--- a/docs/source/configuration/logging.rst
+++ b/docs/source/configuration/logging.rst
@@ -16,6 +16,8 @@ the logging, simply enable ``TRACE`` logging for
 If you are using ``CassandraKeyValueService``, you can use additional tracing for deeper analysis.
 For more information, see :ref:`enabling-cassandra-tracing`.
 
+.. _debug-logging:
+
 Debug Logging for Multiple Timestamp Services Error
 ===================================================
 

--- a/docs/source/services/timelock_service/migration.rst
+++ b/docs/source/services/timelock_service/migration.rst
@@ -30,6 +30,21 @@ migration occurred correctly.
 1. **Request Logs**: Find the TimeLock leader, and search its request logs for calls to the ``fastForwardTimestamp``
    endpoint. These should be called with a ``currentTimestamp`` query parameter, which should be the bound in the
    embedded timestamp bound store before the migration.
+
+   This bound should be noted down before an upgrade, perhaps with ``cqlsh`` or other interface to the DB:
+
+   .. code-block:: none
+
+      cqlsh> USE keyspace;
+      cqlsh:keyspace> SELECT * FROM "_timestamp";
+
+       key    | column1 | column2 | value
+      --------+---------+---------+---------------------
+       0x7473 |  0x7473 |      -1 | 0x0001020304050607
+
+   Otherwise, if using Cassandra we can attempt to determine this bound, by finding the most recent occurrence of
+   ``[CAS] Setting cached limit to {}.`` in the AtlasDB client logs (across all AtlasDB clients).
+
 2. **Key-Value Service table state**: Check the state of the key-value service. For Cassandra, you should expect
    to see two rows: ``oldTs`` (the backed up value of the timestamp bound) and
    ``ts`` (a bogus one byte array indicating that the timestamp table has been invalidated). The ``oldTs`` value
@@ -44,6 +59,17 @@ migration occurred correctly.
       --------+--------------+---------+---------------------
        0x7473 | 0x6f6c645473 |      -1 | 0x0001020304050607
        0x7473 |       0x7473 |      -1 |               0x00
+
+   We store timestamps as blobs in Cassandra, but the entry in the request logs is in decimal. One way of checking
+   they are equal is by converting the ``oldTs`` value to decimal through the shell:
+
+   .. code-block:: none
+
+      $ echo $((0x0001020304050607))
+      283686952306183
+
+3. **AtlasDB Client Logs**: Search for ``[BACKUP] Backed up the value {}`` in the AtlasDB client logs. This should
+   occur precisely once, and the value should match that as retrieved by the aforementioned methods.
 
 Reverse Migration
 -----------------

--- a/docs/source/services/timelock_service/migration.rst
+++ b/docs/source/services/timelock_service/migration.rst
@@ -35,15 +35,15 @@ migration occurred correctly.
    ``ts`` (a bogus one byte array indicating that the timestamp table has been invalidated). The ``oldTs`` value
    should match the ``currentTimestamp`` values in the request logs.
 
-.. code-block:: none
+   .. code-block:: none
 
-   cqlsh> USE keyspace;
-   cqlsh:keyspace> SELECT * FROM "_timestamp";
+      cqlsh> USE keyspace;
+      cqlsh:keyspace> SELECT * FROM "_timestamp";
 
-    key    | column1      | column2 | value
-   --------+--------------+---------+---------------------
-    0x7473 | 0x6f6c645473 |      -1 | 0x0001020304050607
-    0x7473 |       0x7473 |      -1 |               0x00
+       key    | column1      | column2 | value
+      --------+--------------+---------+---------------------
+       0x7473 | 0x6f6c645473 |      -1 | 0x0001020304050607
+       0x7473 |       0x7473 |      -1 |               0x00
 
 Reverse Migration
 -----------------

--- a/docs/source/services/timelock_service/migration.rst
+++ b/docs/source/services/timelock_service/migration.rst
@@ -13,12 +13,37 @@ Otherwise, this can lead to serious data corruption.
 
 Automated Migration
 -------------------
+
 .. warning::
     Automated migrations are only implemented for Cassandra.
 
 1. If you are using the Casssandra key value service and have added the :ref:`Timelock client configuration <timelock-client-configuration>`, then starting/re-starting the service will automatically migrate the service.
 2. If you are using any other KVS, please follow the instructions at :ref:`manual-timelock-migration`.
 
+Verification
+~~~~~~~~~~~~
+
+It may be useful to verify that an automatic migration was carried out successfully. In addition to simply performing
+smoke tests of your clients and checking that they still work, there are a few other ways of checking that the
+migration occurred correctly.
+
+1. **Request Logs**: Find the TimeLock leader, and search its request logs for calls to the ``fastForwardTimestamp``
+   endpoint. These should be called with a ``currentTimestamp`` query parameter, which should be the bound in the
+   embedded timestamp bound store before the migration.
+2. **Key-Value Service table state**: Check the state of the key-value service. For Cassandra, you should expect
+   to see two rows: ``oldTs`` (the backed up value of the timestamp bound) and
+   ``ts`` (a bogus one byte array indicating that the timestamp table has been invalidated). The ``oldTs`` value
+   should match the ``currentTimestamp`` values in the request logs.
+
+.. code-block:: none
+
+   cqlsh> USE keyspace;
+   cqlsh:keyspace> SELECT * FROM "_timestamp";
+
+    key    | column1      | column2 | value
+   --------+--------------+---------+---------------------
+    0x7473 | 0x6f6c645473 |      -1 | 0x0001020304050607
+    0x7473 |       0x7473 |      -1 |               0x00
 
 Reverse Migration
 -----------------

--- a/docs/source/services/timelock_service/migration.rst
+++ b/docs/source/services/timelock_service/migration.rst
@@ -43,7 +43,9 @@ migration occurred correctly.
        0x7473 |  0x7473 |      -1 | 0x0001020304050607
 
    Otherwise, if using Cassandra we can attempt to determine this bound, by finding the most recent occurrence of
-   ``[CAS] Setting cached limit to {}.`` in the AtlasDB client logs (across all AtlasDB clients).
+   ``[CAS] Setting cached limit to {}.`` in the AtlasDB client logs (across all AtlasDB clients). Note that this is
+   logged at INFO level by the :ref:`DebugLogger<debug-logging>`, so if you have directed that to a separate
+   appender you will need to search in those logs instead.
 
 2. **Key-Value Service table state**: Check the state of the key-value service. For Cassandra, you should expect
    to see two rows: ``oldTs`` (the backed up value of the timestamp bound) and

--- a/docs/source/troubleshooting/index.rst
+++ b/docs/source/troubleshooting/index.rst
@@ -117,8 +117,8 @@ Clear with cURL
 
    $ curl -X POST --header 'content-type: application/json' '<product-base-url>/persistent-lock/release' -d '"427eb02a-f017-40cd-8d08-0a163315029a"'
 
-Clear with CQL (for Cassandra)
-------------------------------
+Clear with CQL
+--------------
 
 .. warning::
 
@@ -162,10 +162,15 @@ AtlasDB interprets a specific ``LockEntry`` value as meaning that the lock is av
                .reason("Available")
                .build();
 
-Thus, we can set the relevant cell to be the serialised value of the backup lock.
+Thus, we can set the relevant cell to be the serialised value of the backup lock. To be safe, we recommend using a
+compare-and-set operation here.
 
 .. code-block:: none
 
-   cqlsh:keyspace> UPDATE "_persisted_locks" SET value=0x7b226c6f636b4e616d65223a224261636b75704c6f636b222c22696e7374616e63654964223a2230303030303030302d303030302d303030302d303030302d303030303030303030303030222c22726561736f6e223a22417661696c61626c65227d WHERE key=0x4261636b75704c6f636b AND column1=0x6c6f636b AND column2=-1 ;
+   cqlsh:keyspace> UPDATE "_persisted_locks" SET value=0x7b226c6f636b4e616d65223a224261636b75704c6f636b222c22696e7374616e63654964223a2230303030303030302d303030302d303030302d303030302d303030303030303030303030222c22726561736f6e223a22417661696c61626c65227d WHERE key=0x4261636b75704c6f636b AND column1=0x6c6f636b AND column2=-1 IF value=0x7b226c6f636b4e616d65223a224261636b75704c6f636b222c22696e7374616e63654964223a2234323765623032612d663031372d343063642d386430382d306131363333313530323961222c22726561736f6e223a22666f6f227d;
+
+    [applied]
+   -----------
+         True
 
 Clients should be able to take the backup lock again after this step.

--- a/docs/source/troubleshooting/index.rst
+++ b/docs/source/troubleshooting/index.rst
@@ -101,16 +101,71 @@ If this happens, then you should follow these remediation steps:
    This process should only be attempted if you are sure that the process has died, being aware that it may be running on another machine.
    Releasing the lock of a running process would invalidate the consistency guarantees of any backups that are started while that process is still running!
 
+Clear with cURL
+---------------
+
 1. Find the currently-held lock, by examining the logs. Attempting to acquire a lock will cause the currently held lock to be logged:
 
 .. code-block:: bash
 
   INFO  [2017-02-01 16:40:34,333] com.palantir.atlasdb.persistentlock.CheckAndSetExceptionMapper: Request failed.
-    Stored LockEntry: LockEntry{rowName=BackupLock, lockId=1e3a8db1-a1a6-4aae-96bd-e3107b709c5e, reason=manual-backup}
-
+    Stored persistent lock: LockEntry{lockName=BackupLock, instanceId=427eb02a-f017-40cd-8d08-0a163315029a, reason=manual-backup}
 
 2. Curl the ``release`` endpoint. Note that the required formatting is slightly different (keys and values must be surrounded with ``"``).
 
 .. code-block:: bash
 
-   $ curl -X POST --header 'content-type: application/json' '<product-base-url>/persistent-lock/release' -d '{"rowName":"BackupLock","lockId":"1e3a8db1-a1a6-4aae-96bd-e3107b709c5e","reason":"manual-backup"}'
+   $ curl -X POST --header 'content-type: application/json' '<product-base-url>/persistent-lock/release' -d '"427eb02a-f017-40cd-8d08-0a163315029a"'
+
+Clear with CQL (for Cassandra)
+------------------------------
+
+.. warning::
+
+   The Backup Lock is serialised differently than the Schema Mutation Lock. In particular, truncating the persisted
+   locks table will **not** release the Backup Lock, and will in fact put your cluster in a bad (though recoverable)
+   state!
+
+.. tip::
+
+   The steps below are Cassandra-specific, but the serialisation mechanics we use for other key-value services are very
+   similar. You will want to restore the relevant cell in your key-value service to the value documented below.
+
+If you are unable to find the currently-held lock in the logs, this approach may be helpful.
+The state of persisted locks is stored in the ``_persisted_locks`` table in your AtlasDB keyspace; specifically, the
+state of the backup lock is stored in a cell with row name ``BackupLock`` and column name ``lock``.
+
+.. code-block:: none
+
+   cqlsh> USE keyspace;
+   cqlsh:keyspace> SELECT * FROM "_persisted_locks";
+
+    key                    | column1    | column2 | value
+   ------------------------+------------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    0x4261636b75704c6f636b | 0x6c6f636b |      -1 | 0x7b226c6f636b4e616d65223a224261636b75704c6f636b222c22696e7374616e63654964223a2234323765623032612d663031372d343063642d386430382d306131363333313530323961222c22726561736f6e223a22666f6f227d
+
+The ``value`` stored here is a serialised representation of the JSON ``LockEntry``; that included in the table above
+actually deserialises to
+
+.. code-block:: none
+
+   '{"lockName":"BackupLock","instanceId":"427eb02a-f017-40cd-8d08-0a163315029a","reason":"foo"}'
+
+AtlasDB interprets a specific ``LockEntry`` value as meaning that the lock is available:
+
+.. code-block:: java
+
+   // '{"lockName":"BackupLock","instanceId":"00000000-0000-0000-0000-000000000000","reason":"Available"}'
+   public static final LockEntry LOCK_OPEN = ImmutableLockEntry.builder()
+               .lockName(BACKUP_LOCK_NAME)
+               .instanceId(UUID.fromString("0-0-0-0-0"))
+               .reason("Available")
+               .build();
+
+Thus, we can set the relevant cell to be the serialised value of the backup lock.
+
+.. code-block:: none
+
+   cqlsh:keyspace> UPDATE "_persisted_locks" SET value=0x7b226c6f636b4e616d65223a224261636b75704c6f636b222c22696e7374616e63654964223a2230303030303030302d303030302d303030302d303030302d303030303030303030303030222c22726561736f6e223a22417661696c61626c65227d WHERE key=0x4261636b75704c6f636b AND column1=0x6c6f636b AND column2=-1 ;
+
+Clients should be able to take the backup lock again after this step.


### PR DESCRIPTION
**Goals (and why)**:

* Document ways of verifying that an automated migration went smoothly
* Explain how to release the backup lock if you don't remember the lock ID and the logs are unavailable/you can't find it
* Fix bug where docs ask you to use the wrong HTTP method, leading to unnecessary user confusion in what's likely to already be a high stress situation

**Implementation Description (bullets)**:

* Document verification of automatic migrations (by request log parsing, cqlsh)
* Document releasing the backup lock via DB surgery which we did in the field
* Fix "bugs"/obsolete backup lock docs that changed because of API changes

**Concerns (what feedback would you like?)**:

* Backup Lock: do we want people to know this?
* Verification: readability.

**Where should we start reviewing?**:

* Either main piece. It's not too large a PR I think.

**Priority (whenever / two weeks / yesterday)**:

* Whenever. Ideally before we expect people to do this by themselves.
