### PR TITLE
remove deprecated guavaisms

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
@@ -37,14 +37,6 @@ public class TimestampCache {
         return timestampCache;
     }
 
-    /**
-     * @deprecated Use {@link #create()}
-     */
-    @Deprecated
-    public TimestampCache() {
-        this(createDefaultCache());
-    }
-
     @VisibleForTesting
     TimestampCache(Cache<Long, Long> cache) {
         this.startToCommitTimestampCache = cache;

--- a/atlasdb-commons/src/main/java/com/palantir/common/collect/EmptyQueue.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/collect/EmptyQueue.java
@@ -18,7 +18,7 @@ package com.palantir.common.collect;
 import java.util.AbstractQueue;
 import java.util.Iterator;
 
-import com.google.common.collect.Iterators;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * This queue is empty and will neither return nor accept any elements
@@ -45,7 +45,7 @@ public class EmptyQueue<E> extends AbstractQueue<E> {
 
     @Override
     public Iterator<E> iterator() {
-        return Iterators.emptyIterator();
+        return ImmutableSet.<E>of().iterator();
     }
 
     @Override

--- a/atlasdb-commons/src/main/java/com/palantir/common/collect/IteratorUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/collect/IteratorUtils.java
@@ -30,6 +30,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ForwardingIterator;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.PeekingIterator;
@@ -220,7 +221,7 @@ public class IteratorUtils {
                                                      final Comparator<? super T> ordering) {
         Preconditions.checkNotNull(ordering);
         if (!a.hasNext()) {
-            return Iterators.emptyIterator();
+            return ImmutableSet.<T>of().iterator();
         }
         if (!b.hasNext()) {
             return IteratorUtils.wrap(a);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/ClosableMergedIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/ClosableMergedIterator.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.impl;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -45,7 +46,7 @@ import com.palantir.util.Pair;
     private final RangeRequest request;
     private final ClosableIterator<RowResult<T>> primaryIter;
     private final Function<RangeRequest, ClosableIterator<RowResult<T>>> secondaryResultProducer;
-    private ClosableIterator<RowResult<T>> mergedIter = ClosableIterators.wrap(Iterators.<RowResult<T>>emptyIterator());
+    private ClosableIterator<RowResult<T>> mergedIter = ClosableIterators.wrap(Collections.emptyIterator());
     private byte[] nextSecondaryStart;
     private boolean primaryCompleted = false;
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -82,7 +82,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
 public abstract class AbstractTransactionTest extends TransactionTestSetup {
 
-    protected final TimestampCache timestampCache = new TimestampCache();
+    protected final TimestampCache timestampCache = TimestampCache.create();
     protected boolean supportsReverse() {
         return true;
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -114,7 +114,7 @@ import com.palantir.lock.TimeDuration;
 import com.palantir.remoting1.tracing.Tracers;
 
 public class SnapshotTransactionTest extends AtlasDbTestCase {
-    protected final TimestampCache timestampCache = new TimestampCache();
+    protected final TimestampCache timestampCache = TimestampCache.create();
 
     private class UnstableKeyValueService extends ForwardingKeyValueService {
         private final KeyValueService delegate;

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
@@ -122,7 +122,7 @@ public class ExecutorInheritableThreadLocalTest extends Assert {
     @Test
     public void testSameThread() {
         local.set("whatup");
-        ListeningExecutorService sameThreadExecutor = MoreExecutors.sameThreadExecutor();
+        ListeningExecutorService sameThreadExecutor = MoreExecutors.newDirectExecutorService();
         sameThreadExecutor.submit(PTExecutors.wrap(Callables.returning(null)));
         Assert.assertEquals("whatup", local.get());
     }


### PR DESCRIPTION
(and a bonus why-did-someone-deprecate-this-and-not-just-fix-it)

**Goals (and why)**:
Looking out for the unlucky person who will be the next to bump guava.

**Implementation Description (bullets)**:
`ImmutableSet.<E>of().iterator()` is gross, but it's the google recommended way, and not all usages here can use `Collections.emptyIterator()` because that entails Java 7+

