### PR TITLE
Feature/ts benchmark

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
@@ -71,7 +71,6 @@ public class PerformanceResults {
                 .samples(rs.getPrimaryResult().getStatistics().getN())
                 .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
                 .mean(rs.getPrimaryResult().getStatistics().getMean())
-                .data(getData(rs))
                 .units(rs.getParams().getTimeUnit())
                 .p50(rs.getPrimaryResult().getStatistics().getPercentile(50.0))
                 .p90(rs.getPrimaryResult().getStatistics().getPercentile(90.0))
@@ -127,7 +126,6 @@ public class PerformanceResults {
         public abstract long samples();
         public abstract double std();
         public abstract double mean();
-        public abstract List<Double> data();
         public abstract TimeUnit units();
         public abstract double p50();
         public abstract double p90();

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/HttpBenchmarks.java
@@ -25,6 +25,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -51,6 +52,7 @@ public class HttpBenchmarks {
                     .build();
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public void parseHttpHeaders(Blackhole blackhole) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -22,6 +22,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.collect.ImmutableList;
@@ -51,6 +52,7 @@ public class KvsDeleteBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 6, timeUnit = TimeUnit.SECONDS)
     public Object singleDelete(RegeneratingTable.KvsRowRegeneratingTable table) {
@@ -58,6 +60,7 @@ public class KvsDeleteBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 22, timeUnit = TimeUnit.SECONDS)
     public Object batchDelete(RegeneratingTable.KvsBatchRegeneratingTable table) {
@@ -65,6 +68,7 @@ public class KvsDeleteBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
     public Object batchRangeDelete(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -72,6 +76,7 @@ public class KvsDeleteBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
     public Object allRangeDelete(ConsecutiveNarrowTable.CleanNarrowTable table) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -68,6 +68,7 @@ public class KvsDeleteBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 6, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 60, timeUnit = TimeUnit.SECONDS)
     public Object batchRangeDelete(ConsecutiveNarrowTable.RegeneratingCleanNarrowTable table) {
@@ -75,6 +76,7 @@ public class KvsDeleteBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
     public Object allRangeDelete(ConsecutiveNarrowTable.RegeneratingCleanNarrowTable table) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetDynamicBenchmarks.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.base.Preconditions;
@@ -48,6 +49,7 @@ import com.palantir.atlasdb.performance.benchmarks.table.Tables;
 public class KvsGetDynamicBenchmarks {
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 20, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 180, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsExplicitly(ModeratelyWideRowTable table) {
@@ -58,6 +60,7 @@ public class KvsGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 6, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 60, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsImplicitly(ModeratelyWideRowTable table) throws UnsupportedEncodingException {
@@ -72,6 +75,7 @@ public class KvsGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitly(ModeratelyWideRowTable table) {
@@ -83,6 +87,7 @@ public class KvsGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitlyGetRows(ModeratelyWideRowTable table) throws UnsupportedEncodingException {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRangeBenchmarks.java
@@ -26,6 +26,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.base.Preconditions;
@@ -86,6 +87,7 @@ public class KvsGetRangeBenchmarks {
 
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getSingleRange(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -93,6 +95,7 @@ public class KvsGetRangeBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getSingleRangeDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
@@ -101,6 +104,7 @@ public class KvsGetRangeBenchmarks {
 
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getSingleLargeRange(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -108,6 +112,7 @@ public class KvsGetRangeBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 20, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 120, timeUnit = TimeUnit.SECONDS)
     public Object getSingleLargeRangeDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
@@ -116,6 +121,7 @@ public class KvsGetRangeBenchmarks {
 
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
     public Object getMultiRange(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -123,6 +129,7 @@ public class KvsGetRangeBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 60, timeUnit = TimeUnit.SECONDS)
     public Object getMultiRangeDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsColumnRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsColumnRangeBenchmarks.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -45,6 +46,7 @@ import com.palantir.atlasdb.performance.benchmarks.table.WideRowsTable;
 public class KvsGetRowsColumnRangeBenchmarks {
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsAligned(WideRowsTable table) {
@@ -70,6 +72,7 @@ public class KvsGetRowsColumnRangeBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsUnaligned(WideRowsTable table) {
@@ -95,6 +98,7 @@ public class KvsGetRowsColumnRangeBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsSingleBigRow(VeryWideRowTable table,

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsPutBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsPutBenchmarks.java
@@ -24,6 +24,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.base.Preconditions;
@@ -45,6 +46,7 @@ public class KvsPutBenchmarks {
     private static final int BATCH_SIZE = 250;
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 6, timeUnit = TimeUnit.SECONDS)
     public Object singleRandomPut(EmptyTables tables) {
@@ -54,6 +56,7 @@ public class KvsPutBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public Object batchRandomPut(EmptyTables tables) {
@@ -63,6 +66,7 @@ public class KvsPutBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 25, timeUnit = TimeUnit.SECONDS)
     public Object batchRandomMultiPut(EmptyTables tables) {
@@ -74,6 +78,7 @@ public class KvsPutBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Map<Cell, byte[]> putUnlessExistsAndExists(EmptyTables tables) {
@@ -89,6 +94,7 @@ public class KvsPutBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Map<Cell, byte[]> putUnlessExistsDoesNotExist(EmptyTables tables) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/SweepBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/SweepBenchmarks.java
@@ -21,6 +21,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.palantir.atlasdb.keyvalue.api.SweepResults;
@@ -53,6 +54,7 @@ public class SweepBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public Object singleSweepRun(RegeneratingTable.SweepRegeneratingTable table) {
@@ -60,6 +62,7 @@ public class SweepBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public Object batchedUniformSingleSweepRun(RegeneratingTable.SweepBatchUniformMultipleRegeneratingTable table) {
@@ -67,6 +70,7 @@ public class SweepBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 75, timeUnit = TimeUnit.SECONDS)
     public Object batchedSingleSweepRun(RegeneratingTable.SweepBatchNonUniformMultipleSeparateRegeneratingTable table) {
@@ -74,6 +78,7 @@ public class SweepBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 25, timeUnit = TimeUnit.SECONDS)
     public Object multipleUniformSweepRun(RegeneratingTable.SweepBatchUniformMultipleRegeneratingTable table) {
@@ -81,6 +86,7 @@ public class SweepBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 15, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 90, timeUnit = TimeUnit.SECONDS)
     public Object multipleSweepRun(RegeneratingTable.SweepBatchNonUniformMultipleSeparateRegeneratingTable table) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
@@ -65,6 +65,6 @@ public class TimestampServiceBenchmarks {
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     @Threads(32)
     public TimestampRange manyThreadsGetBatchOfTimestamps(TimestampServiceEndpoint timestampService) {
-        return timestampService.getFreshTimestamps(10000);
+        return timestampService.getFreshTimestamps(500);
     }
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
@@ -28,7 +28,7 @@ public class TimestampServiceBenchmarks {
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 25, timeUnit = TimeUnit.SECONDS)
-    @Threads(8)
+    @Threads(512)
     public long parallelGetFreshTimestamp(TimestampServiceEndpoint timestampService) {
         return timestampService.getFreshTimestamp();
     }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.palantir.atlasdb.performance.benchmarks.endpoint.TimestampServiceEndpoint;
+
+public class TimestampServiceBenchmarks {
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 25, timeUnit = TimeUnit.SECONDS)
+    @Threads(8)
+    public long parallelGetFreshTimestamp(TimestampServiceEndpoint timestampService) {
+        return timestampService.getFreshTimestamp();
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
@@ -21,6 +21,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 
 import com.palantir.atlasdb.performance.benchmarks.endpoint.TimestampServiceEndpoint;
 import com.palantir.timestamp.TimestampRange;
@@ -28,17 +29,42 @@ import com.palantir.timestamp.TimestampRange;
 public class TimestampServiceBenchmarks {
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 25, timeUnit = TimeUnit.SECONDS)
-    @Threads(128)
-    public long parallelGetFreshTimestamp(TimestampServiceEndpoint timestampService) {
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
+    @Threads(4)
+    public long fewThreadsGetFreshTimestamp(TimestampServiceEndpoint timestampService) {
         return timestampService.getFreshTimestamp();
     }
 
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
+    @Threads(64)
+    public long manyThreadsGetFreshTimestamp(TimestampServiceEndpoint timestampService) {
+        return timestampService.getFreshTimestamp();
+    }
+
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 120, timeUnit = TimeUnit.SECONDS)
+    @Threads(64)
+    public long manyThreadsGetFreshTimestampWithBackoff(TimestampServiceEndpoint timestampService) {
+        Blackhole.consumeCPU(20000);
+        return timestampService.getFreshTimestamp();
+    }
+
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
+    @Threads(4)
+    public TimestampRange fewThreadsGetBatchOfTimestamps(TimestampServiceEndpoint timestampService) {
+        return timestampService.getFreshTimestamps(10000);
+    }
+
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     @Threads(32)
-    public TimestampRange parallelGetFreshTimestamps(TimestampServiceEndpoint timestampService) {
+    public TimestampRange manyThreadsGetBatchOfTimestamps(TimestampServiceEndpoint timestampService) {
         return timestampService.getFreshTimestamps(10000);
     }
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TimestampServiceBenchmarks.java
@@ -23,13 +23,22 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.palantir.atlasdb.performance.benchmarks.endpoint.TimestampServiceEndpoint;
+import com.palantir.timestamp.TimestampRange;
 
 public class TimestampServiceBenchmarks {
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 25, timeUnit = TimeUnit.SECONDS)
-    @Threads(512)
+    @Threads(128)
     public long parallelGetFreshTimestamp(TimestampServiceEndpoint timestampService) {
         return timestampService.getFreshTimestamp();
+    }
+
+    @Benchmark
+    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
+    @Threads(32)
+    public TimestampRange parallelGetFreshTimestamps(TimestampServiceEndpoint timestampService) {
+        return timestampService.getFreshTimestamps(10000);
     }
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionDeleteBenchmarks.java
@@ -23,6 +23,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -39,6 +40,7 @@ public class TransactionDeleteBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object singleDelete(RegeneratingTable.TransactionRowRegeneratingTable table) {
@@ -46,6 +48,7 @@ public class TransactionDeleteBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 4, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 20, timeUnit = TimeUnit.SECONDS)
     public Object batchDelete(RegeneratingTable.TransactionBatchRegeneratingTable table) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetBenchmarks.java
@@ -25,6 +25,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.base.Preconditions;
@@ -108,6 +109,7 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getCells(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -115,6 +117,7 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getCellsDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
@@ -123,6 +126,7 @@ public class TransactionGetBenchmarks {
 
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getSingleRowWithRangeQuery(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -130,6 +134,7 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getSingleRowWithRangeQueryDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
@@ -138,6 +143,7 @@ public class TransactionGetBenchmarks {
 
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object getRange(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -145,6 +151,7 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 8, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
     public Object getRangeDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
@@ -153,6 +160,7 @@ public class TransactionGetBenchmarks {
 
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getSingleCell(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -160,6 +168,7 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getSingleCellDirty(ConsecutiveNarrowTable.DirtyNarrowTable table) {
@@ -168,6 +177,7 @@ public class TransactionGetBenchmarks {
 
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 8, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 40, timeUnit = TimeUnit.SECONDS)
     public Object getRanges(ConsecutiveNarrowTable.CleanNarrowTable table) {
@@ -175,6 +185,7 @@ public class TransactionGetBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 15, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 70, timeUnit = TimeUnit.SECONDS)
     public Object getRangesDirty(

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetDynamicBenchmarks.java
@@ -26,6 +26,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.base.Preconditions;
@@ -47,6 +48,7 @@ import com.palantir.atlasdb.performance.benchmarks.table.Tables;
 public class TransactionGetDynamicBenchmarks {
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 25, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 180, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsExplicitly(ModeratelyWideRowTable table) {
@@ -59,6 +61,7 @@ public class TransactionGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 10, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 65, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsImplicitly(ModeratelyWideRowTable table) {
@@ -74,6 +77,7 @@ public class TransactionGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitly(ModeratelyWideRowTable table) {
@@ -88,6 +92,7 @@ public class TransactionGetDynamicBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
     public Object getFirstColumnExplicitlyGetRows(ModeratelyWideRowTable table) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetRowsColumnRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetRowsColumnRangeBenchmarks.java
@@ -24,6 +24,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -37,6 +38,7 @@ import com.palantir.atlasdb.performance.benchmarks.table.VeryWideRowTable;
 public class TransactionGetRowsColumnRangeBenchmarks {
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
     public Object getAllColumnsSingleBigRow(VeryWideRowTable table, Blackhole blackhole) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionPutBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionPutBenchmarks.java
@@ -23,6 +23,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -39,6 +40,7 @@ public class TransactionPutBenchmarks {
     private static final int BATCH_SIZE = 250;
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 2, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
     public Object singleRandomPut(EmptyTables tables) {
@@ -50,6 +52,7 @@ public class TransactionPutBenchmarks {
     }
 
     @Benchmark
+    @Threads(1)
     @Warmup(time = 3, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public Object batchRandomPut(EmptyTables tables) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/endpoint/TimestampServiceEndpoint.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/endpoint/TimestampServiceEndpoint.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance.benchmarks.endpoint;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.palantir.atlasdb.performance.backend.AtlasDbServicesConnector;
+import com.palantir.atlasdb.services.AtlasDbServices;
+import com.palantir.timestamp.TimestampService;
+
+@State(Scope.Benchmark)
+public class TimestampServiceEndpoint {
+
+    private AtlasDbServicesConnector connector;
+    private AtlasDbServices services;
+    private TimestampService timestampService;
+
+    public long getFreshTimestamp() {
+        return timestampService.getFreshTimestamp();
+    }
+
+    @Setup(Level.Trial)
+    public void setup(AtlasDbServicesConnector conn) {
+        this.connector = conn;
+        this.services = conn.connect();
+        this.timestampService = services.getTimestampService();
+    }
+
+    @TearDown(Level.Trial)
+    public void cleanup() throws Exception {
+        this.connector.close();
+    }
+}
+

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/endpoint/TimestampServiceEndpoint.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/endpoint/TimestampServiceEndpoint.java
@@ -22,25 +22,27 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
 import com.palantir.atlasdb.performance.backend.AtlasDbServicesConnector;
-import com.palantir.atlasdb.services.AtlasDbServices;
+import com.palantir.timestamp.TimestampRange;
 import com.palantir.timestamp.TimestampService;
 
 @State(Scope.Benchmark)
 public class TimestampServiceEndpoint {
 
     private AtlasDbServicesConnector connector;
-    private AtlasDbServices services;
     private TimestampService timestampService;
 
     public long getFreshTimestamp() {
         return timestampService.getFreshTimestamp();
     }
 
+    public TimestampRange getFreshTimestamps(int num) {
+        return timestampService.getFreshTimestamps(num);
+    }
+
     @Setup(Level.Trial)
     public void setup(AtlasDbServicesConnector conn) {
         this.connector = conn;
-        this.services = conn.connect();
-        this.timestampService = services.getTimestampService();
+        this.timestampService = conn.connect().getTimestampService();
     }
 
     @TearDown(Level.Trial)

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/cli/AtlasDbPerfCli.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/cli/AtlasDbPerfCli.java
@@ -119,7 +119,6 @@ public class AtlasDbPerfCli {
     private static void runJmh(AtlasDbPerfCli cli, List<DockerizedDatabaseUri> uris) throws Exception {
         ChainedOptionsBuilder optBuilder = new OptionsBuilder()
                 .forks(1)
-                .threads(1)
                 .warmupIterations(1)
                 .measurementIterations(1)
                 .mode(Mode.SampleTime)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,7 +42,7 @@ develop
 
     *    - |new|
          - Added a benchmark ``TimestampServiceBenchmarks`` for parallel requesting of fresh timestamps from the TimestampService.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1719>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1720>`__)
 
     *    - |fixed|
          - KVS migrations where timestamp data was co-located with AtlasDB data now respect the timestamp service contract.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -40,6 +40,10 @@ develop
     *    - Type
          - Change
 
+    *    - |new|
+         - Added a benchmark ``TimestampServiceBenchmarks`` for parallel requesting of fresh timestamps from the TimestampService.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1719>`__)
+
     *    - |fixed|
          - KVS migrations where timestamp data was co-located with AtlasDB data now respect the timestamp service contract.
            Previously, doing a KVS migration with an embedded timestamp service whose timestamp data is co-located with the AtlasDB data causes timestamps to reset to the logical beginning of time.


### PR DESCRIPTION
**Goals (and why)**:

Having benchmarks for concurrent requesting of timestamps since we are about to perform several changes to the concurrency logic.

**Implementation Description (bullets)**:

We are just running 8 threads in parallel requesting timestamps.

**Concerns (what feedback would you like?)**:

Is this an unrealistic load? Are we using the wrong number of threads, are we requesting timestamps too fast?

**Where should we start reviewing?**:

TimestampServiceBenchmarks

**Priority (whenever / two weeks / yesterday)**:

ASAP