### PR TITLE
Add metrics for active/idle connections and the state of the cassandr…

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -270,5 +270,43 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 CassandraClientPoolingContainer.class,
                 metricPrefix, "proportionDestroyedByBorrower",
                 () -> ((double) pool.getDestroyedByBorrowValidationCount()) / ((double) pool.getCreatedCount()));
+
+        // Count of active or idle threads in the pool
+        metricsManager.registerMetric(
+                CassandraClientPoolingContainer.class,
+                metricPrefix, "numActive",
+                pool::getNumActive);
+        metricsManager.registerMetric(
+                CassandraClientPoolingContainer.class,
+                metricPrefix, "numIdle",
+                pool::getNumIdle);
+
+        // Proportion of active and idle threads in the pool
+        metricsManager.registerMetric(
+                CassandraClientPoolingContainer.class,
+                metricPrefix, "proportionActiveThreads",
+                () -> ((double) pool.getNumActive()) / ((double) pool.getCreatedCount()));
+        metricsManager.registerMetric(
+                CassandraClientPoolingContainer.class,
+                metricPrefix, "proportionIdleThreads",
+                () -> ((double) pool.getNumIdle()) / ((double) pool.getCreatedCount()));
+
+        // Metrics for the state of the cassandra client pool
+        metricsManager.registerMetric(
+                CassandraClientPoolingContainer.class,
+                metricPrefix, "borrowedCount",
+                pool::getBorrowedCount);
+        metricsManager.registerMetric(
+                CassandraClientPoolingContainer.class,
+                metricPrefix, "returnedCount",
+                pool::getReturnedCount);
+        metricsManager.registerMetric(
+                CassandraClientPoolingContainer.class,
+                metricPrefix, "createdCount",
+                pool::getCreatedCount);
+        metricsManager.registerMetric(
+                CassandraClientPoolingContainer.class,
+                metricPrefix, "destroyedByEvictorCount",
+                pool::getDestroyedCount);
     }
 }


### PR DESCRIPTION
…a pool

**Goals (and why)**: We want to debug issues where we see cassandra pool exhausted errors and request failures but cant look at how a client is managing all connections to each cassandra host.

**Implementation Description (bullets)**: 
1. More gauges with counts of idle and active threads. Also, proportions of Active and idle threads.
2. Count of borrowed, returned, created and destroyed threads.

**Concerns (what feedback would you like?)**: Any other metrics that will be useful?

**Where should we start reviewing?**: CassandraClientPool

**Priority (whenever / two weeks / yesterday)**: today/early tomorrow