### PR TITLE
Fix/benchmarks

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -75,18 +75,18 @@ public abstract class ConsecutiveNarrowTable {
 
     protected abstract void setupData();
 
-    @TearDown(Level.Trial)
-    public void cleanup() throws Exception {
-        this.services.getKeyValueService().dropTable(getTableRef());
-        this.connector.close();
-    }
-
     @Setup(Level.Trial)
     public void setup(AtlasDbServicesConnector conn) {
         this.connector = conn;
         services = conn.connect();
         Benchmarks.createTable(getKvs(), getTableRef(), Tables.ROW_COMPONENT, Tables.COLUMN_NAME);
         setupData();
+    }
+
+    @TearDown(Level.Trial)
+    public void cleanup() throws Exception {
+        this.services.getKeyValueService().dropTable(getTableRef());
+        this.connector.close();
     }
 
     @State(Scope.Benchmark)

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -77,6 +77,7 @@ public abstract class ConsecutiveNarrowTable {
 
     @TearDown(Level.Trial)
     public void cleanup() throws Exception {
+        this.services.getKeyValueService().dropTable(getTableRef());
         this.connector.close();
     }
 
@@ -84,10 +85,8 @@ public abstract class ConsecutiveNarrowTable {
     public void setup(AtlasDbServicesConnector conn) {
         this.connector = conn;
         services = conn.connect();
-        if (!services.getKeyValueService().getAllTableNames().contains(getTableRef())) {
-            Benchmarks.createTable(getKvs(), getTableRef(), Tables.ROW_COMPONENT, Tables.COLUMN_NAME);
-            setupData();
-        }
+        Benchmarks.createTable(getKvs(), getTableRef(), Tables.ROW_COMPONENT, Tables.COLUMN_NAME);
+        setupData();
     }
 
     @State(Scope.Benchmark)


### PR DESCRIPTION
**Goals (and why)**:

Fix the benchmarks that are currently failing

**Implementation Description (bullets)**:

Table wasn't being dropped as part of the cleanup. This was fine when you run KvsDeleteBenchmarks  and KvsGetRangeBenchmarks in isolation, but if you run KvsDeleteBenchmarks followed by KvsGetRangeBenchmarks, the table wasn't being set up properly for KvsGetRangeBenchmarks and an assert would fail.

**Concerns (what feedback would you like?)**:

None

**Where should we start reviewing?**:

ConsecutiveNarrowTable.java

**Priority (whenever / two weeks / yesterday)**:

Yesterday
