### PR TITLE
Don't silent-retry RemoteLockService connections

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -15,10 +15,8 @@
  */
 package com.palantir.atlasdb.http;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
 
@@ -26,16 +24,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
-import com.squareup.okhttp.CipherSuite;
-import com.squareup.okhttp.ConnectionPool;
-import com.squareup.okhttp.ConnectionSpec;
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.Response;
-import com.squareup.okhttp.TlsVersion;
 
 import feign.Client;
 import feign.Contract;
@@ -47,11 +37,8 @@ import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.jaxrs.JAXRSContract;
-import feign.okhttp.OkHttpClient;
 
 public final class AtlasDbHttpClients {
-    private static final int CONNECTION_POOL_SIZE = 100;
-    private static final long KEEP_ALIVE_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
     private static final int QUICK_FEIGN_TIMEOUT_MILLIS = 1000;
     private static final int QUICK_MAX_BACKOFF_MILLIS = 1000;
     private static final Request.Options DEFAULT_FEIGN_OPTIONS = new Request.Options();
@@ -61,48 +48,6 @@ public final class AtlasDbHttpClients {
     private static final Encoder encoder = new JacksonEncoder(mapper);
     private static final Decoder decoder = new TextDelegateDecoder(new JacksonDecoder(mapper));
     private static final ErrorDecoder errorDecoder = new AtlasDbErrorDecoder();
-
-    private static final ImmutableList<ConnectionSpec> CONNECTION_SPEC_WITH_CYPHER_SUITES = ImmutableList.of(
-            new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                    .tlsVersions(TlsVersion.TLS_1_2)
-                    .cipherSuites(
-                            // This GCM cipher suite is for HTTP/2 over TLS1.2 as clients have to
-                            // enable at least one cipher suite not in the blacklist.
-                            // (https://http2.github.io/http2-spec/index.html#BadCipherSuites)
-                            // Timelock server will support HTTP/2 connections, and this will ensure
-                            // all AtlasDB clients have one supported cipher suite.
-                            // See also:
-                            //    - https://http2.github.io/http2-spec/index.html#rfc.section.9.2.2
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                            // In an ideal world, we'd use GCM suites, but they're an order of
-                            // magnitude slower than the CBC suites, which have JVM optimizations
-                            // already. We should revisit with JDK9.
-                            // See also:
-                            //  - http://openjdk.java.net/jeps/246
-                            //  - https://bugs.openjdk.java.net/secure/attachment/25422/GCM%20Analysis.pdf
-                            // CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                            // CipherSuite.TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
-                            // CipherSuite.TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
-                            // CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
-                            // CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-                            CipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
-                            CipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
-                            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
-                            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-                            CipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
-                            CipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
-                            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
-                            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
-                            CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
-                    .build(),
-            ConnectionSpec.CLEARTEXT);
-
-    @VisibleForTesting
-    static final String USER_AGENT_HEADER = "User-Agent";
 
     private AtlasDbHttpClients() {
         // Utility class
@@ -128,7 +73,7 @@ public final class AtlasDbHttpClients {
                         .encoder(encoder)
                         .decoder(decoder)
                         .errorDecoder(errorDecoder)
-                        .client(newOkHttpClient(sslSocketFactory, userAgent))
+                        .client(FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent, type))
                         .target(type, uri),
                 MetricRegistry.name(type, userAgent));
     }
@@ -196,7 +141,8 @@ public final class AtlasDbHttpClients {
             Optional<SSLSocketFactory> sslSocketFactory, Collection<String> endpointUris,
             Request.Options feignOptions, int maxBackoffMillis, Class<T> type, String userAgent) {
         FailoverFeignTarget<T> failoverFeignTarget = new FailoverFeignTarget<>(endpointUris, maxBackoffMillis, type);
-        Client client = failoverFeignTarget.wrapClient(newOkHttpClient(sslSocketFactory, userAgent));
+        Client client = failoverFeignTarget.wrapClient(
+                FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent, type));
         return AtlasDbMetrics.instrument(
                 type,
                 Feign.builder()
@@ -222,37 +168,5 @@ public final class AtlasDbHttpClients {
                 QUICK_MAX_BACKOFF_MILLIS,
                 type,
                 UserAgents.DEFAULT_USER_AGENT);
-    }
-
-    /**
-     * Returns a feign {@link Client} wrapping a {@link com.squareup.okhttp.OkHttpClient} client with optionally
-     * specified {@link SSLSocketFactory}.
-     */
-    private static Client newOkHttpClient(Optional<SSLSocketFactory> sslSocketFactory, String userAgent) {
-        com.squareup.okhttp.OkHttpClient client = new com.squareup.okhttp.OkHttpClient();
-
-        client.setConnectionSpecs(CONNECTION_SPEC_WITH_CYPHER_SUITES);
-        client.setConnectionPool(new ConnectionPool(CONNECTION_POOL_SIZE, KEEP_ALIVE_TIME_MILLIS));
-        client.setSslSocketFactory(sslSocketFactory.orNull());
-        client.interceptors().add(new UserAgentAddingInterceptor(userAgent));
-        return new OkHttpClient(client);
-    }
-
-    private static final class UserAgentAddingInterceptor implements Interceptor {
-        private final String userAgent;
-
-        private UserAgentAddingInterceptor(String userAgent) {
-            Preconditions.checkNotNull(userAgent, "User Agent should never be null.");
-            this.userAgent = userAgent;
-        }
-
-        @Override
-        public Response intercept(Chain chain) throws IOException {
-            com.squareup.okhttp.Request requestWithUserAgent = chain.request()
-                    .newBuilder()
-                    .addHeader(USER_AGENT_HEADER, userAgent)
-                    .build();
-            return chain.proceed(requestWithUserAgent);
-        }
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -44,7 +44,8 @@ public final class FeignOkHttpClients {
     private static final long KEEP_ALIVE_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
 
     // See internal ticket PDS-50301, and/or #1680
-    private static final Set<Class<?>> CLASSES_TO_NOT_RETRY = ImmutableSet.of(RemoteLockService.class);
+    @VisibleForTesting
+    static final Set<Class<?>> CLASSES_TO_NOT_RETRY = ImmutableSet.of(RemoteLockService.class);
 
     private static final ImmutableList<ConnectionSpec> CONNECTION_SPEC_WITH_CYPHER_SUITES = ImmutableList.of(
             new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
@@ -114,9 +115,10 @@ public final class FeignOkHttpClients {
         return new OkHttpClient(client);
     }
 
-    private static <T> boolean shouldAllowRetrying(Class<T> clazz) {
+    @VisibleForTesting
+    static <T> boolean shouldAllowRetrying(Class<T> clazz) {
         // Subclasses of this class should NOT be considered for retrying.
-        return CLASSES_TO_NOT_RETRY.contains(clazz);
+        return !CLASSES_TO_NOT_RETRY.contains(clazz);
     }
 
     private static final class UserAgentAddingInterceptor implements Interceptor {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.RemoteLockService;
+import com.squareup.okhttp.CipherSuite;
+import com.squareup.okhttp.ConnectionPool;
+import com.squareup.okhttp.ConnectionSpec;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.TlsVersion;
+
+import feign.Client;
+import feign.okhttp.OkHttpClient;
+
+public final class FeignOkHttpClients {
+    @VisibleForTesting
+    static final String USER_AGENT_HEADER = "User-Agent";
+    private static final int CONNECTION_POOL_SIZE = 100;
+    private static final long KEEP_ALIVE_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
+
+    // See internal ticket PDS-50301, and/or #1680
+    private static final Set<Class<?>> CLASSES_TO_NOT_RETRY = ImmutableSet.of(RemoteLockService.class);
+
+    private static final ImmutableList<ConnectionSpec> CONNECTION_SPEC_WITH_CYPHER_SUITES = ImmutableList.of(
+            new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                    .tlsVersions(TlsVersion.TLS_1_2)
+                    .cipherSuites(
+                            // This GCM cipher suite is for HTTP/2 over TLS1.2 as clients have to
+                            // enable at least one cipher suite not in the blacklist.
+                            // (https://http2.github.io/http2-spec/index.html#BadCipherSuites)
+                            // Timelock server will support HTTP/2 connections, and this will ensure
+                            // all AtlasDB clients have one supported cipher suite.
+                            // See also:
+                            //    - https://http2.github.io/http2-spec/index.html#rfc.section.9.2.2
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                            // In an ideal world, we'd use GCM suites, but they're an order of
+                            // magnitude slower than the CBC suites, which have JVM optimizations
+                            // already. We should revisit with JDK9.
+                            // See also:
+                            //  - http://openjdk.java.net/jeps/246
+                            //  - https://bugs.openjdk.java.net/secure/attachment/25422/GCM%20Analysis.pdf
+                            // CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                            // CipherSuite.TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+                            // CipherSuite.TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+                            // CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+                            // CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+                            CipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+                            CipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+                            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
+                            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+                            CipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
+                            CipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
+                            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+                            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                            CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
+                    .build(),
+            ConnectionSpec.CLEARTEXT);
+
+    private FeignOkHttpClients() {
+        // factory
+    }
+
+    /**
+     * Returns a feign {@link Client} wrapping a {@link com.squareup.okhttp.OkHttpClient} client with optionally
+     * specified {@link SSLSocketFactory}.
+     */
+    public static <T> Client newOkHttpClient(
+            Optional<SSLSocketFactory> sslSocketFactory,
+            String userAgent,
+            Class<T> clazz) {
+        return newOkHttpClient(sslSocketFactory, userAgent, shouldAllowRetrying(clazz));
+    }
+
+    private static Client newOkHttpClient(
+            Optional<SSLSocketFactory> sslSocketFactory,
+            String userAgent,
+            boolean retryOnConnectionFailure) {
+        com.squareup.okhttp.OkHttpClient client = new com.squareup.okhttp.OkHttpClient();
+
+        client.setConnectionSpecs(CONNECTION_SPEC_WITH_CYPHER_SUITES);
+        client.setConnectionPool(new ConnectionPool(CONNECTION_POOL_SIZE, KEEP_ALIVE_TIME_MILLIS));
+        client.setSslSocketFactory(sslSocketFactory.orNull());
+        client.setRetryOnConnectionFailure(retryOnConnectionFailure);
+        client.interceptors().add(new UserAgentAddingInterceptor(userAgent));
+        return new OkHttpClient(client);
+    }
+
+    private static <T> boolean shouldAllowRetrying(Class<T> clazz) {
+        // Subclasses of this class should NOT be considered for retrying.
+        return CLASSES_TO_NOT_RETRY.contains(clazz);
+    }
+
+    private static final class UserAgentAddingInterceptor implements Interceptor {
+        private final String userAgent;
+
+        private UserAgentAddingInterceptor(String userAgent) {
+            Preconditions.checkNotNull(userAgent, "User Agent should never be null.");
+            this.userAgent = userAgent;
+        }
+
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            com.squareup.okhttp.Request requestWithUserAgent = chain.request()
+                    .newBuilder()
+                    .addHeader(USER_AGENT_HEADER, userAgent)
+                    .build();
+            return chain.proceed(requestWithUserAgent);
+        }
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -92,7 +92,7 @@ public class AtlasDbHttpClientsTest {
 
         String defaultUserAgent = UserAgents.fromStrings(UserAgents.DEFAULT_VALUE, UserAgents.DEFAULT_VALUE);
         availableServer.verify(getRequestedFor(urlMatching(TEST_ENDPOINT))
-                .withHeader(AtlasDbHttpClients.USER_AGENT_HEADER, WireMock.equalTo(defaultUserAgent)));
+                .withHeader(FeignOkHttpClients.USER_AGENT_HEADER, WireMock.equalTo(defaultUserAgent)));
     }
 
     private static String getUriForPort(int port) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FeignOkHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FeignOkHttpClientsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.client.LockRefreshingRemoteLockService;
+
+public class FeignOkHttpClientsTest {
+    @Test
+    public void classesSpecifiedNotToRetryAreNotRetriable() {
+        FeignOkHttpClients.CLASSES_TO_NOT_RETRY.forEach(
+                clazz -> assertThat(FeignOkHttpClients.shouldAllowRetrying(clazz)).isFalse());
+    }
+
+    @Test
+    public void subclassesOfClassesSpecifiedNotToRetryAreRetriable() {
+        assertThat(FeignOkHttpClients.shouldAllowRetrying(ExtendedRemoteLockService.class)).isTrue();
+        assertThat(FeignOkHttpClients.shouldAllowRetrying(LockRefreshingRemoteLockService.class)).isTrue();
+    }
+
+    @Test
+    public void classesNotSpecifiedNotToRetryAreRetriable() {
+        assertThat(FeignOkHttpClients.shouldAllowRetrying(AtomicReference.class)).isTrue();
+    }
+
+    private interface ExtendedRemoteLockService extends RemoteLockService {
+        // Marker interface used for testing that subclasses aren't affected
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FeignOkHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FeignOkHttpClientsTest.java
@@ -32,6 +32,11 @@ public class FeignOkHttpClientsTest {
     }
 
     @Test
+    public void remoteLockServiceIsNotRetriable() {
+        assertThat(FeignOkHttpClients.shouldAllowRetrying(RemoteLockService.class)).isFalse();
+    }
+
+    @Test
     public void subclassesOfClassesSpecifiedNotToRetryAreRetriable() {
         assertThat(FeignOkHttpClients.shouldAllowRetrying(ExtendedRemoteLockService.class)).isTrue();
         assertThat(FeignOkHttpClients.shouldAllowRetrying(LockRefreshingRemoteLockService.class)).isTrue();

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,13 @@ develop
            removal please file a ticket with the dev team for immediate support (as we did not take the time to properly deprecate the methods).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1689>`__)
 
+    *    - |fixed|
+         - RemoteLockService clients will no longer silently retry on connection failures.
+           This is used to mitigate issues with frequent leadership changes owing to `#1680 <https://github.com/palantir/atlasdb/issues/1680>`__.
+           Previously, because of Jetty's idle timeout and OkHttp's silent connection retrying, we would generate an endless stream of lock requests if using HTTP/2 and blocking for more than the Jetty idle timeout for a single lock.
+           This would lead to starvation of other requests on the TimeLock server, since a lock request blocked on acquiring a lock consumes a server thread.
+           (Pull Request)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,7 +65,7 @@ develop
            This is used to mitigate issues with frequent leadership changes owing to `#1680 <https://github.com/palantir/atlasdb/issues/1680>`__.
            Previously, because of Jetty's idle timeout and OkHttp's silent connection retrying, we would generate an endless stream of lock requests if using HTTP/2 and blocking for more than the Jetty idle timeout for a single lock.
            This would lead to starvation of other requests on the TimeLock server, since a lock request blocked on acquiring a lock consumes a server thread.
-           (Pull Request)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1727>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**:

- Fix #1680 (though admittedly not in the best way; long term fix tracked at #1724)
- Prevent a single request that blocks for >30s from taking down an entire TimeLock server
- Unblock rollout of TimeLock for internal product

**Implementation Description (bullets)**:

- Disable silent retries for RemoteLockService only. I went for the minimal change. Silent retries for fresh timestamps are fine (sequence doesn't need to be continuous.)

**Concerns (what feedback would you like?)**:

- What should we do about subclasses of RemoteLockService? I opted not to apply the restriction, but I have no idea if that's even a thing in practice.
- Does this otherwise hurt liveness?
- Test coverage is a little poor, because this really only manifests under HTTP/2 and we don't have a framework for testing that at the moment.

**Where should we start reviewing?**:

- FeignOkHttpClients#newOkHttpClient is probably where to start.

**Priority (whenever / two weeks / yesterday)**:

- This week.