### PR TITLE
bump baseline-java to 0.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.4'
         classpath 'com.palantir.gradle.javadist:gradle-java-distribution:1.3.0'
         classpath 'gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.8.0'
-        classpath 'com.palantir:gradle-baseline-java:0.7.1'
+        classpath 'com.palantir:gradle-baseline-java:0.10.0'
         classpath 'com.palantir:jacoco-coverage:0.4.0'
         classpath "com.netflix.nebula:gradle-dependency-lock-plugin:4.3.2"
         classpath 'com.netflix.nebula:nebula-dependency-recommender:3.6.3'


### PR DESCRIPTION
**Goals (and why)**: Make eclipse actually work again. There were issues with how generated files were being added to classpaths.

**Implementation Description (bullets)**: bump version of baseline-java

**Concerns (what feedback would you like?)**: Hopefully this doesn't break because of other baseline changes.

**Where should we start reviewing?**: build.gradle

**Priority (whenever / two weeks / yesterday)**: meh, I would like to be able to read the code in eclipse again.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
