### PR TITLE
Benchmark/fix tables

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -67,14 +67,14 @@ public class KvsDeleteBenchmarks {
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
-    public Object batchRangeDelete(ConsecutiveNarrowTable.CleanNarrowTable table) {
+    public Object batchRangeDelete(ConsecutiveNarrowTable.RegeneratingCleanNarrowTable table) {
         return doDeleteRange(table, 4);
     }
 
     @Benchmark
     @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
-    public Object allRangeDelete(ConsecutiveNarrowTable.CleanNarrowTable table) {
+    public Object allRangeDelete(ConsecutiveNarrowTable.RegeneratingCleanNarrowTable table) {
         return doDeleteRange(table, 1);
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsDeleteBenchmarks.java
@@ -65,15 +65,15 @@ public class KvsDeleteBenchmarks {
     }
 
     @Benchmark
-    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
+    @Warmup(time = 6, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 60, timeUnit = TimeUnit.SECONDS)
     public Object batchRangeDelete(ConsecutiveNarrowTable.RegeneratingCleanNarrowTable table) {
         return doDeleteRange(table, 4);
     }
 
     @Benchmark
-    @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 45, timeUnit = TimeUnit.SECONDS)
     public Object allRangeDelete(ConsecutiveNarrowTable.RegeneratingCleanNarrowTable table) {
         return doDeleteRange(table, 1);
     }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -49,6 +49,7 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 public abstract class ConsecutiveNarrowTable {
 
     private static final int DEFAULT_NUM_ROWS = 10000;
+    private static final int REGENERATING_NUM_ROWS = 500;
 
     private Random random = new Random(Tables.RANDOM_SEED);
 
@@ -105,16 +106,21 @@ public abstract class ConsecutiveNarrowTable {
 
     @State(Scope.Benchmark)
     public static class RegeneratingCleanNarrowTable extends CleanNarrowTable {
+        @TearDown(Level.Invocation)
+        public void regenerateTable() {
+            getKvs().truncateTable(getTableRef());
+            setupData();
+        }
+
         @Override
         public void cleanup() throws Exception {
             getKvs().dropTable(getTableRef());
             super.cleanup();
         }
 
-        @TearDown(Level.Invocation)
-        public void regenerateTable() {
-            getKvs().truncateTable(getTableRef());
-            setupData();
+        @Override
+        public int getNumRows() {
+            return REGENERATING_NUM_ROWS;
         }
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -113,6 +113,11 @@ public abstract class ConsecutiveNarrowTable {
         }
 
         @Override
+        public TableReference getTableRef() {
+            return TableReference.createFromFullyQualifiedName("performance.regenerating_table_clean");
+        }
+
+        @Override
         public void cleanup() throws Exception {
             getKvs().dropTable(getTableRef());
             super.cleanup();

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -92,7 +92,6 @@ public abstract class ConsecutiveNarrowTable {
 
     @State(Scope.Benchmark)
     public static class CleanNarrowTable extends ConsecutiveNarrowTable {
-
         @Override
         public void cleanup() throws Exception {
             getKvs().dropTable(getTableRef());

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -93,12 +93,6 @@ public abstract class ConsecutiveNarrowTable {
     @State(Scope.Benchmark)
     public static class CleanNarrowTable extends ConsecutiveNarrowTable {
         @Override
-        public void cleanup() throws Exception {
-            getKvs().dropTable(getTableRef());
-            super.cleanup();
-        }
-
-        @Override
         public TableReference getTableRef() {
             return TableReference.createFromFullyQualifiedName("performance.persistent_table_clean");
         }
@@ -106,6 +100,21 @@ public abstract class ConsecutiveNarrowTable {
         @Override
         protected void setupData() {
             storeDataInTable(this, 1);
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class RegeneratingCleanNarrowTable extends CleanNarrowTable {
+        @Override
+        public void cleanup() throws Exception {
+            getKvs().dropTable(getTableRef());
+            super.cleanup();
+        }
+
+        @TearDown(Level.Invocation)
+        public void regenerateTable() {
+            getKvs().truncateTable(getTableRef());
+            setupData();
         }
     }
 


### PR DESCRIPTION
**Goals (and why)**:

Fix broken range delete benchmarks and also reduce the runtime of benchmarks by an hour.

**Implementation Description (bullets)**:

For the delete benchmarks we need to regenerate the table after every invocation, otherwise we keep deleting from an empty table. In contrast, the dirty table must not be droped and recreated as it is very expensive to do so.

**Concerns (what feedback would you like?)**:

Is a table with only 500 rows representative for range deletes?

**Where should we start reviewing?**:

ConsecutiveNarrowTable.java, also check out RegeneratingTable for reference

**Priority (whenever / two weeks / yesterday)**:

High