### PR TITLE
Set/unset loadedConfig for tracing file correctly

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingPrefsConfig.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingPrefsConfig.java
@@ -73,11 +73,13 @@ public class TracingPrefsConfig implements Runnable {
                                 tracingMinDurationToTraceMillis,
                                 tracedTables);
                     }
+                    loadedConfig = true;
                 } catch (IOException e) {
                     log.error("Could not load a malformed " + TRACING_PREF_FILENAME + ".");
                     loadedConfig = false;
                 }
-                loadedConfig = true;
+            } else {
+                loadedConfig = false;
             }
         } catch (Throwable t) {
             log.error("Error occurred while refreshing {}: {}", TRACING_PREF_FILENAME, t, t);


### PR DESCRIPTION
**Goals (and why)**:
The log line should be printed each time the prefs file is discovered or it should be printed the next time if loading the file gives an IOException.

**Implementation Description (bullets)**:
1. Set loadedConfig to fasle if the file is not found.
2. Set loaded config to true at the end in the try block

**Concerns (what feedback would you like?)**: na

**Where should we start reviewing?**: TracingPrefsConfig

**Priority (whenever / two weeks / yesterday)**: anytime