### PR TITLE
Episode II: Attack of the Retries

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbErrorDecoder.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbErrorDecoder.java
@@ -15,9 +15,6 @@
  */
 package com.palantir.atlasdb.http;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.annotations.VisibleForTesting;
 
 import feign.Response;
@@ -25,7 +22,6 @@ import feign.RetryableException;
 import feign.codec.ErrorDecoder;
 
 public class AtlasDbErrorDecoder implements ErrorDecoder {
-    private static final Logger log = LoggerFactory.getLogger(AtlasDbErrorDecoder.class);
     private ErrorDecoder defaultErrorDecoder = new ErrorDecoder.Default();
 
     public AtlasDbErrorDecoder() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbErrorDecoder.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbErrorDecoder.java
@@ -41,11 +41,7 @@ public class AtlasDbErrorDecoder implements ErrorDecoder {
         Exception exception = defaultErrorDecoder.decode(methodKey, response);
         log.error("Decode({}, {}) yields......", methodKey, response, exception);
         if (response503ButExceptionIsNotRetryable(response, exception)) {
-            log.error("503, but exception is not retryable. Proceeding");
-            return new RetryableException(exception.getMessage(), exception, null);
-        }
-        if (response.status() == 503) {
-            log.error("503, and exception is retryable. Proceeding");
+            return new PotentialFollowerException(exception.getMessage(), exception, null);
         }
         return exception;
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbErrorDecoder.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbErrorDecoder.java
@@ -39,7 +39,6 @@ public class AtlasDbErrorDecoder implements ErrorDecoder {
     @Override
     public Exception decode(String methodKey, Response response) {
         Exception exception = defaultErrorDecoder.decode(methodKey, response);
-        log.error("Decode({}, {}) yields......", methodKey, response, exception);
         if (response503ButExceptionIsNotRetryable(response, exception)) {
             return new PotentialFollowerException(exception.getMessage(), exception, null);
         }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -91,7 +91,6 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     @Override
     public void continueOrPropagate(RetryableException ex) {
         boolean isFastFailoverException = isFastFailoverException(ex);
-        log.error("{} is fast failover? {}", ex, isFastFailoverException);
         synchronized (this) {
             if (!isFastFailoverException && retrySemantics == RetrySemantics.NEVER_EXCEPT_ON_NON_LEADERS) {
                 throw hardFailOwingToFailureOnLeader(ex);
@@ -151,7 +150,8 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
         }
     }
 
-    private static boolean isFastFailoverException(RetryableException ex) {
+    @VisibleForTesting
+    static boolean isFastFailoverException(RetryableException ex) {
         // If this is not-null, then we interpret this to mean that the server has thrown a 503 (so it might
         // not have been the leader).
         return ex.retryAfter() != null || ex instanceof PotentialFollowerException;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -91,6 +91,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     @Override
     public void continueOrPropagate(RetryableException ex) {
         boolean isFastFailoverException = isFastFailoverException(ex);
+        log.error("{} is fast failover? {}", ex, isFastFailoverException);
         synchronized (this) {
             if (!isFastFailoverException && retrySemantics == RetrySemantics.NEVER_EXCEPT_ON_NON_LEADERS) {
                 throw hardFailOwingToFailureOnLeader(ex);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -154,7 +154,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     private static boolean isFastFailoverException(RetryableException ex) {
         // If this is not-null, then we interpret this to mean that the server has thrown a 503 (so it might
         // not have been the leader).
-        return ex.retryAfter() != null;
+        return ex.retryAfter() != null || ex instanceof PotentialFollowerException;
     }
 
     private void pauseForBackOff(RetryableException ex) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -20,9 +20,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -38,7 +35,6 @@ import feign.Client;
 import feign.okhttp.OkHttpClient;
 
 public final class FeignOkHttpClients {
-    private static final Logger log = LoggerFactory.getLogger(FeignOkHttpClients.class);
     @VisibleForTesting
     static final String USER_AGENT_HEADER = "User-Agent";
     private static final int CONNECTION_POOL_SIZE = 100;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -21,6 +21,9 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -38,6 +41,7 @@ import feign.Client;
 import feign.okhttp.OkHttpClient;
 
 public final class FeignOkHttpClients {
+    private static final Logger log = LoggerFactory.getLogger(FeignOkHttpClients.class);
     @VisibleForTesting
     static final String USER_AGENT_HEADER = "User-Agent";
     private static final int CONNECTION_POOL_SIZE = 100;
@@ -98,6 +102,7 @@ public final class FeignOkHttpClients {
             Optional<SSLSocketFactory> sslSocketFactory,
             String userAgent,
             Class<T> clazz) {
+        log.error("Creating an OkHttp client for class {}, with retryability {}", clazz, shouldAllowRetrying(clazz));
         return newOkHttpClient(sslSocketFactory, userAgent, shouldAllowRetrying(clazz));
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/PotentialFollowerException.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/PotentialFollowerException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import java.util.Date;
+
+import feign.RetryableException;
+
+public class PotentialFollowerException extends RetryableException {
+    public PotentialFollowerException(String message, Throwable cause, Date retryAfter) {
+        super(message, cause, retryAfter);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RetrySemantics.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RetrySemantics.java
@@ -21,8 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.lock.RemoteLockService;
 
-import feign.RetryableException;
-
 public enum RetrySemantics {
     DEFAULT (true),
     NEVER_EXCEPT_ON_NON_LEADERS (false);
@@ -46,12 +44,6 @@ public enum RetrySemantics {
 
     public static <T> boolean shouldRetryHttpConnections(Class<T> clazz) {
         return shouldRetryHttpConnections(getSemanticsFor(clazz));
-    }
-
-    public static boolean isFastFailoverException(RetryableException ex) {
-        // If this is not-null, then we interpret this to mean that the server has thrown a 503 (so it might
-        // not have been the leader).
-        return ex.retryAfter() != null;
     }
 
     private static boolean shouldRetryHttpConnections(RetrySemantics retrySemantics) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RetrySemantics.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RetrySemantics.java
@@ -22,12 +22,12 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.lock.RemoteLockService;
 
 public enum RetrySemantics {
-    DEFAULT (true),
-    NEVER_EXCEPT_ON_NON_LEADERS (false);
+    DEFAULT(true),
+    NEVER_EXCEPT_ON_NON_LEADERS(false);
 
     private final boolean shouldRetryHttpConnections;
 
-    private RetrySemantics(boolean shouldRetryHttpConnections) {
+    RetrySemantics(boolean shouldRetryHttpConnections) {
         this.shouldRetryHttpConnections = shouldRetryHttpConnections;
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RetrySemantics.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RetrySemantics.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.RemoteLockService;
+
+import feign.RetryableException;
+
+public enum RetrySemantics {
+    DEFAULT (true),
+    NEVER_EXCEPT_ON_NON_LEADERS (false);
+
+    private final boolean shouldRetryHttpConnections;
+
+    private RetrySemantics(boolean shouldRetryHttpConnections) {
+        this.shouldRetryHttpConnections = shouldRetryHttpConnections;
+    }
+
+    // See internal ticket PDS-50301, and/or #1680
+    @VisibleForTesting
+    static final Set<Class<?>> CLASSES_TO_NOT_RETRY = ImmutableSet.of(RemoteLockService.class);
+
+    public static <T> RetrySemantics getSemanticsFor(Class<T> clazz) {
+        if (CLASSES_TO_NOT_RETRY.contains(clazz)) {
+            return NEVER_EXCEPT_ON_NON_LEADERS;
+        }
+        return DEFAULT;
+    }
+
+    public static <T> boolean shouldRetryHttpConnections(Class<T> clazz) {
+        return shouldRetryHttpConnections(getSemanticsFor(clazz));
+    }
+
+    public static boolean isFastFailoverException(RetryableException ex) {
+        // If this is not-null, then we interpret this to mean that the server has thrown a 503 (so it might
+        // not have been the leader).
+        return ex.retryAfter() != null;
+    }
+
+    private static boolean shouldRetryHttpConnections(RetrySemantics retrySemantics) {
+        return retrySemantics.shouldRetryHttpConnections;
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbErrorDecoderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbErrorDecoderTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.http;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertNull;
@@ -61,6 +62,7 @@ public class AtlasDbErrorDecoderTest {
         Response response = makeDefaultDecoderReplyWhenReceivingResponse(STATUS_503, NON_RETRYABLE_EXCEPTION);
         Exception exception = atlasDbDecoder.decode(EMPTY_METHOD_KEY, response);
         assertNull(((RetryableException) exception).retryAfter());
+        assertThat(exception, is(instanceOf(PotentialFollowerException.class)));
     }
 
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import feign.RetryableException;
+
+public class FailoverFeignTargetTest {
+    private static final int FAILOVERS = 1000;
+    private static final int CLUSTER_SIZE = 3;
+
+    private static final String SERVER_1 = "server1";
+    private static final String SERVER_2 = "server2";
+    private static final String SERVER_3 = "server3";
+    private static final List<String> SERVERS = ImmutableList.of(SERVER_1, SERVER_2, SERVER_3);
+
+    private static final RetryableException FAST_FAILOVER_EXCEPTION = mock(RetryableException.class);
+    private static final RetryableException NON_FAST_FAILOVER_EXCEPTION = mock(RetryableException.class);
+
+    private final FailoverFeignTarget<Object> defaultSemanticsTarget = new FailoverFeignTarget<>(
+            SERVERS, 1, Object.class, RetrySemantics.DEFAULT);
+    private final FailoverFeignTarget<Object> onlyNonLeadersSemanticsTarget = new FailoverFeignTarget<>(
+            SERVERS, 1, Object.class, RetrySemantics.NEVER_EXCEPT_ON_NON_LEADERS);
+
+    static {
+        when(FAST_FAILOVER_EXCEPTION.retryAfter()).thenReturn(Date.valueOf(LocalDate.MAX));
+        when(NON_FAST_FAILOVER_EXCEPTION.retryAfter()).thenReturn(null);
+    }
+
+    @Test
+    public void failsOverOnFastFailoverException() {
+        String initialUrl = defaultSemanticsTarget.url();
+        defaultSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+        assertThat(defaultSemanticsTarget.url()).isNotEqualTo(initialUrl);
+    }
+
+    @Test
+    public void failsOverMultipleTimesOnFastFailoverException() {
+        String previousUrl;
+        for (int i = 0; i < FAILOVERS; i++) {
+            previousUrl = defaultSemanticsTarget.url();
+            defaultSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+            assertThat(defaultSemanticsTarget.url()).isNotEqualTo(previousUrl);
+        }
+    }
+
+    @Test
+    public void failsOverMultipleTimesWithFailingLeader() {
+        for (int i = 0; i < FAILOVERS; i++) {
+            defaultSemanticsTarget.continueOrPropagate(
+                    i % CLUSTER_SIZE == 0 ? NON_FAST_FAILOVER_EXCEPTION : FAST_FAILOVER_EXCEPTION);
+        }
+    }
+
+    @Test
+    public void doesNotImmediatelyFailOverOnNonFastFailoverException() {
+        String initialUrl = defaultSemanticsTarget.url();
+        defaultSemanticsTarget.continueOrPropagate(NON_FAST_FAILOVER_EXCEPTION);
+        assertThat(defaultSemanticsTarget.url()).isEqualTo(initialUrl);
+    }
+
+    @Test
+    public void rethrowsNonFastFailoverExceptionAfterExceedingRetryLimit() {
+        assertThatThrownBy(() -> {
+            for (int i = 0; i < FAILOVERS; i++) {
+                defaultSemanticsTarget.url();
+                defaultSemanticsTarget.continueOrPropagate(NON_FAST_FAILOVER_EXCEPTION);
+            }
+        }).isEqualTo(NON_FAST_FAILOVER_EXCEPTION);
+    }
+
+    @Test
+    public void failsOverOnFastFailoverExceptionEvenIfOnlyRetryingOnNonLeaders() {
+        String initialUrl = onlyNonLeadersSemanticsTarget.url();
+        onlyNonLeadersSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+        assertThat(onlyNonLeadersSemanticsTarget.url()).isNotEqualTo(initialUrl);
+    }
+
+    @Test
+    public void failsOverMultipleTimesOnFastFailoverExceptionEvenIfOnlyRetryingOnNonLeaders() {
+        String previousUrl;
+        for (int i = 0; i < FAILOVERS; i++) {
+            previousUrl = onlyNonLeadersSemanticsTarget.url();
+            onlyNonLeadersSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+            assertThat(onlyNonLeadersSemanticsTarget.url()).isNotEqualTo(previousUrl);
+        }
+    }
+
+    @Test
+    public void rethrowsNonFastFailoverExceptionIfOnlyRetryingOnNonLeaders() {
+        assertThatThrownBy(() -> onlyNonLeadersSemanticsTarget.continueOrPropagate(NON_FAST_FAILOVER_EXCEPTION))
+                .isEqualTo(NON_FAST_FAILOVER_EXCEPTION);
+    }
+
+    @Test
+    public void rethrowsNonFastFailoverExceptionAfterMultipleFastFailoverExceptionsIfOnlyRetryingOnNonLeaders() {
+        for (int i = 0; i < FAILOVERS; i++) {
+            onlyNonLeadersSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+        }
+        assertThatThrownBy(() -> onlyNonLeadersSemanticsTarget.continueOrPropagate(NON_FAST_FAILOVER_EXCEPTION))
+                .isEqualTo(NON_FAST_FAILOVER_EXCEPTION);
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RetrySemanticsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RetrySemanticsTest.java
@@ -24,27 +24,27 @@ import org.junit.Test;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.client.LockRefreshingRemoteLockService;
 
-public class FeignOkHttpClientsTest {
+public class RetrySemanticsTest {
     @Test
     public void classesSpecifiedNotToRetryAreNotRetriable() {
-        FeignOkHttpClients.CLASSES_TO_NOT_RETRY.forEach(
-                clazz -> assertThat(FeignOkHttpClients.shouldAllowRetrying(clazz)).isFalse());
+        RetrySemantics.CLASSES_TO_NOT_RETRY.forEach(
+                clazz -> assertThat(RetrySemantics.shouldRetryHttpConnections(clazz)).isFalse());
     }
 
     @Test
     public void remoteLockServiceIsNotRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(RemoteLockService.class)).isFalse();
+        assertThat(RetrySemantics.shouldRetryHttpConnections(RemoteLockService.class)).isFalse();
     }
 
     @Test
     public void subclassesOfClassesSpecifiedNotToRetryAreRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(ExtendedRemoteLockService.class)).isTrue();
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(LockRefreshingRemoteLockService.class)).isTrue();
+        assertThat(RetrySemantics.shouldRetryHttpConnections(ExtendedRemoteLockService.class)).isTrue();
+        assertThat(RetrySemantics.shouldRetryHttpConnections(LockRefreshingRemoteLockService.class)).isTrue();
     }
 
     @Test
     public void classesNotSpecifiedNotToRetryAreRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(AtomicReference.class)).isTrue();
+        assertThat(RetrySemantics.shouldRetryHttpConnections(AtomicReference.class)).isTrue();
     }
 
     private interface ExtendedRemoteLockService extends RemoteLockService {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,8 +45,8 @@ v0.35.1
            This is used to mitigate issues with frequent leadership changes owing to `#1680 <https://github.com/palantir/atlasdb/issues/1680>`__.
            Previously, because of Jetty's idle timeout and OkHttp's silent connection retrying, we would generate an endless stream of lock requests if using HTTP/2 and blocking for more than the Jetty idle timeout for a single lock.
            This would lead to starvation of other requests on the TimeLock server, since a lock request blocked on acquiring a lock consumes a server thread.
-           (`Pull Request 1<https://github.com/palantir/atlasdb/pull/1727>`__,
-            `Pull Request 2<https://github.com/palantir/atlasdb/pull/1737>`__)
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/1727>`__,
+           `Pull Request 2 <https://github.com/palantir/atlasdb/pull/1737>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,11 +41,12 @@ v0.35.1
          - Change
 
     *    - |fixed|
-         - RemoteLockService clients will no longer silently retry on connection failures.
+         - RemoteLockService clients will no longer silently retry on connection failures, and will also no longer retry exceptions other than 503s.
            This is used to mitigate issues with frequent leadership changes owing to `#1680 <https://github.com/palantir/atlasdb/issues/1680>`__.
            Previously, because of Jetty's idle timeout and OkHttp's silent connection retrying, we would generate an endless stream of lock requests if using HTTP/2 and blocking for more than the Jetty idle timeout for a single lock.
            This would lead to starvation of other requests on the TimeLock server, since a lock request blocked on acquiring a lock consumes a server thread.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1727>`__)
+           (`Pull Request 1<https://github.com/palantir/atlasdb/pull/1727>`__,
+            `Pull Request 2<https://github.com/palantir/atlasdb/pull/1737>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**:

* Fix #1680 (see discussion of ticket for further diagnosis)

**Implementation Description (bullets)**:

* Don't retry infinitely in the FailoverFeignTarget, for clients that aren't supposed to retry stuff at all. Instead hard-fail if obtaining an exception on the leader.
* New unit tests for FailoverFeignTarget exploring its retry capabilities.

**Concerns (what feedback would you like?)**:

* Hard-fail might be too aggressive, we could do retry 2 or 3 times at most, but I'm concerned it might overload the leader even if only done 2 or 3x.
* Long run might be better to rewrite the hard-fail check somewhere else.

**Where should we start reviewing?**:

* RetrySemantics, then probably FailoverFeignTargetTest

**Priority (whenever / two weeks / yesterday)**:

* Ideally by midday tomorrow