### PR TITLE
Episode III: Revenge of the Retries (0.36.0 + Retry Logic Fixes)

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbErrorDecoder.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbErrorDecoder.java
@@ -36,7 +36,7 @@ public class AtlasDbErrorDecoder implements ErrorDecoder {
     public Exception decode(String methodKey, Response response) {
         Exception exception = defaultErrorDecoder.decode(methodKey, response);
         if (response503ButExceptionIsNotRetryable(response, exception)) {
-            return new RetryableException(exception.getMessage(), exception, null);
+            return new PotentialFollowerException(exception.getMessage(), exception, null);
         }
         return exception;
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -15,10 +15,8 @@
  */
 package com.palantir.atlasdb.http;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
 
@@ -26,16 +24,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
-import com.squareup.okhttp.CipherSuite;
-import com.squareup.okhttp.ConnectionPool;
-import com.squareup.okhttp.ConnectionSpec;
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.Response;
-import com.squareup.okhttp.TlsVersion;
 
 import feign.Client;
 import feign.Contract;
@@ -47,11 +37,8 @@ import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.jaxrs.JAXRSContract;
-import feign.okhttp.OkHttpClient;
 
 public final class AtlasDbHttpClients {
-    private static final int CONNECTION_POOL_SIZE = 100;
-    private static final long KEEP_ALIVE_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
     private static final int QUICK_FEIGN_TIMEOUT_MILLIS = 1000;
     private static final int QUICK_MAX_BACKOFF_MILLIS = 1000;
     private static final Request.Options DEFAULT_FEIGN_OPTIONS = new Request.Options();
@@ -61,48 +48,6 @@ public final class AtlasDbHttpClients {
     private static final Encoder encoder = new JacksonEncoder(mapper);
     private static final Decoder decoder = new TextDelegateDecoder(new JacksonDecoder(mapper));
     private static final ErrorDecoder errorDecoder = new AtlasDbErrorDecoder();
-
-    private static final ImmutableList<ConnectionSpec> CONNECTION_SPEC_WITH_CYPHER_SUITES = ImmutableList.of(
-            new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                    .tlsVersions(TlsVersion.TLS_1_2)
-                    .cipherSuites(
-                            // This GCM cipher suite is for HTTP/2 over TLS1.2 as clients have to
-                            // enable at least one cipher suite not in the blacklist.
-                            // (https://http2.github.io/http2-spec/index.html#BadCipherSuites)
-                            // Timelock server will support HTTP/2 connections, and this will ensure
-                            // all AtlasDB clients have one supported cipher suite.
-                            // See also:
-                            //    - https://http2.github.io/http2-spec/index.html#rfc.section.9.2.2
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                            // In an ideal world, we'd use GCM suites, but they're an order of
-                            // magnitude slower than the CBC suites, which have JVM optimizations
-                            // already. We should revisit with JDK9.
-                            // See also:
-                            //  - http://openjdk.java.net/jeps/246
-                            //  - https://bugs.openjdk.java.net/secure/attachment/25422/GCM%20Analysis.pdf
-                            // CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                            // CipherSuite.TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
-                            // CipherSuite.TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
-                            // CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
-                            // CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-                            CipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
-                            CipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
-                            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
-                            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-                            CipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
-                            CipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
-                            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
-                            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
-                            CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
-                    .build(),
-            ConnectionSpec.CLEARTEXT);
-
-    @VisibleForTesting
-    static final String USER_AGENT_HEADER = "User-Agent";
 
     private AtlasDbHttpClients() {
         // Utility class
@@ -128,7 +73,7 @@ public final class AtlasDbHttpClients {
                         .encoder(encoder)
                         .decoder(decoder)
                         .errorDecoder(errorDecoder)
-                        .client(newOkHttpClient(sslSocketFactory, userAgent))
+                        .client(FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent, type))
                         .target(type, uri),
                 MetricRegistry.name(type, userAgent));
     }
@@ -196,19 +141,19 @@ public final class AtlasDbHttpClients {
             Optional<SSLSocketFactory> sslSocketFactory, Collection<String> endpointUris,
             Request.Options feignOptions, int maxBackoffMillis, Class<T> type, String userAgent) {
         FailoverFeignTarget<T> failoverFeignTarget = new FailoverFeignTarget<>(endpointUris, maxBackoffMillis, type);
-        Client client = failoverFeignTarget.wrapClient(newOkHttpClient(sslSocketFactory, userAgent));
+        Client client = failoverFeignTarget.wrapClient(
+                FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent, type));
         return AtlasDbMetrics.instrument(
                 type,
                 Feign.builder()
-                        .contract(contract)
-                        .encoder(encoder)
-                        .decoder(decoder)
-                        .errorDecoder(errorDecoder)
-                        .client(client)
-                        .retryer(failoverFeignTarget)
-                        .options(feignOptions)
-                        .target(failoverFeignTarget),
-                MetricRegistry.name(type, userAgent));
+                .contract(contract)
+                .encoder(encoder)
+                .decoder(decoder)
+                .errorDecoder(errorDecoder)
+                .client(client)
+                .retryer(failoverFeignTarget)
+                .options(feignOptions)
+                .target(failoverFeignTarget));
     }
 
     @VisibleForTesting
@@ -222,37 +167,5 @@ public final class AtlasDbHttpClients {
                 QUICK_MAX_BACKOFF_MILLIS,
                 type,
                 UserAgents.DEFAULT_USER_AGENT);
-    }
-
-    /**
-     * Returns a feign {@link Client} wrapping a {@link com.squareup.okhttp.OkHttpClient} client with optionally
-     * specified {@link SSLSocketFactory}.
-     */
-    private static Client newOkHttpClient(Optional<SSLSocketFactory> sslSocketFactory, String userAgent) {
-        com.squareup.okhttp.OkHttpClient client = new com.squareup.okhttp.OkHttpClient();
-
-        client.setConnectionSpecs(CONNECTION_SPEC_WITH_CYPHER_SUITES);
-        client.setConnectionPool(new ConnectionPool(CONNECTION_POOL_SIZE, KEEP_ALIVE_TIME_MILLIS));
-        client.setSslSocketFactory(sslSocketFactory.orNull());
-        client.interceptors().add(new UserAgentAddingInterceptor(userAgent));
-        return new OkHttpClient(client);
-    }
-
-    private static final class UserAgentAddingInterceptor implements Interceptor {
-        private final String userAgent;
-
-        private UserAgentAddingInterceptor(String userAgent) {
-            Preconditions.checkNotNull(userAgent, "User Agent should never be null.");
-            this.userAgent = userAgent;
-        }
-
-        @Override
-        public Response intercept(Chain chain) throws IOException {
-            com.squareup.okhttp.Request requestWithUserAgent = chain.request()
-                    .newBuilder()
-                    .addHeader(USER_AGENT_HEADER, userAgent)
-                    .build();
-            return chain.proceed(requestWithUserAgent);
-        }
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -52,6 +53,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     private final int numServersToTryBeforeFailing = 14;
     private final int fastFailoverTimeoutMillis = 10000;
     private final int maxBackoffMillis;
+    private final RetrySemantics retrySemantics;
 
     private final AtomicLong failuresSinceLastSwitch = new AtomicLong();
     private final AtomicLong numSwitches = new AtomicLong();
@@ -64,13 +66,23 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     }
 
     public FailoverFeignTarget(Collection<String> servers, int maxBackoffMillis, Class<T> type) {
+        this(servers, maxBackoffMillis, type, RetrySemantics.getSemanticsFor(type));
+    }
+
+    @VisibleForTesting
+    FailoverFeignTarget(
+            Collection<String> servers,
+            int maxBackoffMillis,
+            Class<T> type,
+            RetrySemantics retrySemantics) {
         Preconditions.checkArgument(maxBackoffMillis > 0);
         this.servers = ImmutableList.copyOf(ImmutableSet.copyOf(servers));
         this.type = type;
         this.maxBackoffMillis = maxBackoffMillis;
+        this.retrySemantics = retrySemantics;
     }
 
-    public void sucessfulCall() {
+    public void successfulCall() {
         numSwitches.set(0);
         failuresSinceLastSwitch.set(0);
         startTimeOfFastFailover.set(0);
@@ -78,16 +90,11 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
 
     @Override
     public void continueOrPropagate(RetryableException ex) {
-        boolean isFastFailoverException;
-        if (ex.retryAfter() == null) {
-            // This is the case where we have failed due to networking or other IOException error.
-            isFastFailoverException = false;
-        } else {
-            // This is the case where the server has returned a 503.
-            // This is done when we want to do fast failover because we aren't the leader or we are shutting down.
-            isFastFailoverException = true;
-        }
+        boolean isFastFailoverException = isFastFailoverException(ex);
         synchronized (this) {
+            if (!isFastFailoverException && retrySemantics == RetrySemantics.NEVER_EXCEPT_ON_NON_LEADERS) {
+                throw hardFailOwingToFailureOnLeader(ex);
+            }
             // Only fail over if this failure was to the current server.
             // This means that no one on another thread has failed us over already.
             if (mostRecentServerIndex.get() != null && mostRecentServerIndex.get() == failoverCount.get()) {
@@ -114,6 +121,13 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
         }
     }
 
+    private RuntimeException hardFailOwingToFailureOnLeader(RetryableException ex) {
+        // Failure on a leader
+        log.error("This connection has failed on a leader when its semantics instruct it not to retry"
+                + " except on a non-leader.", ex);
+        return ex == null ? new IllegalStateException("continueOrPropagate a null") : ex;
+    }
+
     private void checkAndHandleFailure(RetryableException ex) {
         final long fastFailoverStartTime = startTimeOfFastFailover.get();
         final long currentTime = System.currentTimeMillis();
@@ -136,6 +150,12 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
         }
     }
 
+    @VisibleForTesting
+    static boolean isFastFailoverException(RetryableException ex) {
+        // If this is not-null, then we interpret this to mean that the server has thrown a 503 (so it might
+        // not have been the leader).
+        return ex.retryAfter() != null || ex instanceof PotentialFollowerException;
+    }
 
     private void pauseForBackOff(RetryableException ex) {
         double pow = Math.pow(
@@ -191,7 +211,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
             public Response execute(Request request, Options options) throws IOException {
                 Response response = client.execute(request, options);
                 if (response.status() >= 200 && response.status() < 300) {
-                    sucessfulCall();
+                    successfulCall();
                 }
                 return response;
             }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.RemoteLockService;
+import com.squareup.okhttp.CipherSuite;
+import com.squareup.okhttp.ConnectionPool;
+import com.squareup.okhttp.ConnectionSpec;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.TlsVersion;
+
+import feign.Client;
+import feign.okhttp.OkHttpClient;
+
+public final class FeignOkHttpClients {
+    @VisibleForTesting
+    static final String USER_AGENT_HEADER = "User-Agent";
+    private static final int CONNECTION_POOL_SIZE = 100;
+    private static final long KEEP_ALIVE_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
+
+    // See internal ticket PDS-50301, and/or #1680
+    @VisibleForTesting
+    static final Set<Class<?>> CLASSES_TO_NOT_RETRY = ImmutableSet.of(RemoteLockService.class);
+
+    private static final ImmutableList<ConnectionSpec> CONNECTION_SPEC_WITH_CYPHER_SUITES = ImmutableList.of(
+            new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                    .tlsVersions(TlsVersion.TLS_1_2)
+                    .cipherSuites(
+                            // This GCM cipher suite is for HTTP/2 over TLS1.2 as clients have to
+                            // enable at least one cipher suite not in the blacklist.
+                            // (https://http2.github.io/http2-spec/index.html#BadCipherSuites)
+                            // Timelock server will support HTTP/2 connections, and this will ensure
+                            // all AtlasDB clients have one supported cipher suite.
+                            // See also:
+                            //    - https://http2.github.io/http2-spec/index.html#rfc.section.9.2.2
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                            // In an ideal world, we'd use GCM suites, but they're an order of
+                            // magnitude slower than the CBC suites, which have JVM optimizations
+                            // already. We should revisit with JDK9.
+                            // See also:
+                            //  - http://openjdk.java.net/jeps/246
+                            //  - https://bugs.openjdk.java.net/secure/attachment/25422/GCM%20Analysis.pdf
+                            // CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                            // CipherSuite.TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+                            // CipherSuite.TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+                            // CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+                            // CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+                            CipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+                            CipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+                            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
+                            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+                            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+                            CipherSuite.TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
+                            CipherSuite.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,
+                            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+                            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                            CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
+                    .build(),
+            ConnectionSpec.CLEARTEXT);
+
+    private FeignOkHttpClients() {
+        // factory
+    }
+
+    /**
+     * Returns a feign {@link Client} wrapping a {@link com.squareup.okhttp.OkHttpClient} client with optionally
+     * specified {@link SSLSocketFactory}.
+     */
+    public static <T> Client newOkHttpClient(
+            Optional<SSLSocketFactory> sslSocketFactory,
+            String userAgent,
+            Class<T> clazz) {
+        return newOkHttpClient(sslSocketFactory, userAgent, shouldAllowRetrying(clazz));
+    }
+
+    private static Client newOkHttpClient(
+            Optional<SSLSocketFactory> sslSocketFactory,
+            String userAgent,
+            boolean retryOnConnectionFailure) {
+        com.squareup.okhttp.OkHttpClient client = new com.squareup.okhttp.OkHttpClient();
+
+        client.setConnectionSpecs(CONNECTION_SPEC_WITH_CYPHER_SUITES);
+        client.setConnectionPool(new ConnectionPool(CONNECTION_POOL_SIZE, KEEP_ALIVE_TIME_MILLIS));
+        client.setSslSocketFactory(sslSocketFactory.orNull());
+        client.setRetryOnConnectionFailure(retryOnConnectionFailure);
+        client.interceptors().add(new UserAgentAddingInterceptor(userAgent));
+        return new OkHttpClient(client);
+    }
+
+    @VisibleForTesting
+    static <T> boolean shouldAllowRetrying(Class<T> clazz) {
+        // Subclasses of this class should NOT be considered for retrying.
+        return !CLASSES_TO_NOT_RETRY.contains(clazz);
+    }
+
+    private static final class UserAgentAddingInterceptor implements Interceptor {
+        private final String userAgent;
+
+        private UserAgentAddingInterceptor(String userAgent) {
+            Preconditions.checkNotNull(userAgent, "User Agent should never be null.");
+            this.userAgent = userAgent;
+        }
+
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            com.squareup.okhttp.Request requestWithUserAgent = chain.request()
+                    .newBuilder()
+                    .addHeader(USER_AGENT_HEADER, userAgent)
+                    .build();
+            return chain.proceed(requestWithUserAgent);
+        }
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.http;
 
 import java.io.IOException;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
@@ -25,8 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.palantir.lock.RemoteLockService;
 import com.squareup.okhttp.CipherSuite;
 import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.ConnectionSpec;
@@ -42,10 +39,6 @@ public final class FeignOkHttpClients {
     static final String USER_AGENT_HEADER = "User-Agent";
     private static final int CONNECTION_POOL_SIZE = 100;
     private static final long KEEP_ALIVE_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
-
-    // See internal ticket PDS-50301, and/or #1680
-    @VisibleForTesting
-    static final Set<Class<?>> CLASSES_TO_NOT_RETRY = ImmutableSet.of(RemoteLockService.class);
 
     private static final ImmutableList<ConnectionSpec> CONNECTION_SPEC_WITH_CYPHER_SUITES = ImmutableList.of(
             new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
@@ -98,7 +91,7 @@ public final class FeignOkHttpClients {
             Optional<SSLSocketFactory> sslSocketFactory,
             String userAgent,
             Class<T> clazz) {
-        return newOkHttpClient(sslSocketFactory, userAgent, shouldAllowRetrying(clazz));
+        return newOkHttpClient(sslSocketFactory, userAgent, RetrySemantics.shouldRetryHttpConnections(clazz));
     }
 
     private static Client newOkHttpClient(
@@ -113,12 +106,6 @@ public final class FeignOkHttpClients {
         client.setRetryOnConnectionFailure(retryOnConnectionFailure);
         client.interceptors().add(new UserAgentAddingInterceptor(userAgent));
         return new OkHttpClient(client);
-    }
-
-    @VisibleForTesting
-    static <T> boolean shouldAllowRetrying(Class<T> clazz) {
-        // Subclasses of this class should NOT be considered for retrying.
-        return !CLASSES_TO_NOT_RETRY.contains(clazz);
     }
 
     private static final class UserAgentAddingInterceptor implements Interceptor {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/PotentialFollowerException.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/PotentialFollowerException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import java.util.Date;
+
+import feign.RetryableException;
+
+public class PotentialFollowerException extends RetryableException {
+    public PotentialFollowerException(String message, Throwable cause, Date retryAfter) {
+        super(message, cause, retryAfter);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RetrySemantics.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/RetrySemantics.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.RemoteLockService;
+
+public enum RetrySemantics {
+    DEFAULT(true),
+    NEVER_EXCEPT_ON_NON_LEADERS(false);
+
+    private final boolean shouldRetryHttpConnections;
+
+    RetrySemantics(boolean shouldRetryHttpConnections) {
+        this.shouldRetryHttpConnections = shouldRetryHttpConnections;
+    }
+
+    // See internal ticket PDS-50301, and/or #1680
+    @VisibleForTesting
+    static final Set<Class<?>> CLASSES_TO_NOT_RETRY = ImmutableSet.of(RemoteLockService.class);
+
+    public static <T> RetrySemantics getSemanticsFor(Class<T> clazz) {
+        if (CLASSES_TO_NOT_RETRY.contains(clazz)) {
+            return NEVER_EXCEPT_ON_NON_LEADERS;
+        }
+        return DEFAULT;
+    }
+
+    public static <T> boolean shouldRetryHttpConnections(Class<T> clazz) {
+        return shouldRetryHttpConnections(getSemanticsFor(clazz));
+    }
+
+    private static boolean shouldRetryHttpConnections(RetrySemantics retrySemantics) {
+        return retrySemantics.shouldRetryHttpConnections;
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbErrorDecoderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbErrorDecoderTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.http;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertNull;
@@ -61,6 +62,7 @@ public class AtlasDbErrorDecoderTest {
         Response response = makeDefaultDecoderReplyWhenReceivingResponse(STATUS_503, NON_RETRYABLE_EXCEPTION);
         Exception exception = atlasDbDecoder.decode(EMPTY_METHOD_KEY, response);
         assertNull(((RetryableException) exception).retryAfter());
+        assertThat(exception, is(instanceOf(PotentialFollowerException.class)));
     }
 
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -92,7 +92,7 @@ public class AtlasDbHttpClientsTest {
 
         String defaultUserAgent = UserAgents.fromStrings(UserAgents.DEFAULT_VALUE, UserAgents.DEFAULT_VALUE);
         availableServer.verify(getRequestedFor(urlMatching(TEST_ENDPOINT))
-                .withHeader(AtlasDbHttpClients.USER_AGENT_HEADER, WireMock.equalTo(defaultUserAgent)));
+                .withHeader(FeignOkHttpClients.USER_AGENT_HEADER, WireMock.equalTo(defaultUserAgent)));
     }
 
     private static String getUriForPort(int port) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import feign.RetryableException;
+
+public class FailoverFeignTargetTest {
+    private static final int FAILOVERS = 1000;
+    private static final int CLUSTER_SIZE = 3;
+
+    private static final String SERVER_1 = "server1";
+    private static final String SERVER_2 = "server2";
+    private static final String SERVER_3 = "server3";
+    private static final List<String> SERVERS = ImmutableList.of(SERVER_1, SERVER_2, SERVER_3);
+
+    private static final RetryableException FAST_FAILOVER_EXCEPTION = mock(RetryableException.class);
+    private static final RetryableException NON_FAST_FAILOVER_EXCEPTION = mock(RetryableException.class);
+    public static final String MESSAGE = "foo";
+
+    private final FailoverFeignTarget<Object> defaultSemanticsTarget = new FailoverFeignTarget<>(
+            SERVERS, 1, Object.class, RetrySemantics.DEFAULT);
+    private final FailoverFeignTarget<Object> onlyNonLeadersSemanticsTarget = new FailoverFeignTarget<>(
+            SERVERS, 1, Object.class, RetrySemantics.NEVER_EXCEPT_ON_NON_LEADERS);
+
+    static {
+        when(FAST_FAILOVER_EXCEPTION.retryAfter()).thenReturn(Date.valueOf(LocalDate.MAX));
+        when(NON_FAST_FAILOVER_EXCEPTION.retryAfter()).thenReturn(null);
+    }
+
+    @Test
+    public void retryableExceptionWithoutRetryAfterIsNotFastFailover() {
+        assertThat(FailoverFeignTarget.isFastFailoverException(new RetryableException(MESSAGE, null, null)))
+                .isFalse();
+    }
+
+    @Test
+    public void retryableExceptionWithRetryAfterIsFastFailover() {
+        assertThat(FailoverFeignTarget.isFastFailoverException(
+                new RetryableException(MESSAGE, null, Date.from(Instant.EPOCH))))
+                .isTrue();
+    }
+
+    @Test
+    public void potentialFollowerExceptionWithoutRetryIsFastFailover() {
+        assertThat(FailoverFeignTarget.isFastFailoverException(new PotentialFollowerException(MESSAGE, null, null)))
+                .isTrue();
+    }
+
+    @Test
+    public void failsOverOnFastFailoverException() {
+        String initialUrl = defaultSemanticsTarget.url();
+        defaultSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+        assertThat(defaultSemanticsTarget.url()).isNotEqualTo(initialUrl);
+    }
+
+    @Test
+    public void failsOverMultipleTimesOnFastFailoverException() {
+        String previousUrl;
+        for (int i = 0; i < FAILOVERS; i++) {
+            previousUrl = defaultSemanticsTarget.url();
+            defaultSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+            assertThat(defaultSemanticsTarget.url()).isNotEqualTo(previousUrl);
+        }
+    }
+
+    @Test
+    public void failsOverMultipleTimesWithFailingLeader() {
+        for (int i = 0; i < FAILOVERS; i++) {
+            defaultSemanticsTarget.continueOrPropagate(
+                    i % CLUSTER_SIZE == 0 ? NON_FAST_FAILOVER_EXCEPTION : FAST_FAILOVER_EXCEPTION);
+        }
+    }
+
+    @Test
+    public void doesNotImmediatelyFailOverOnNonFastFailoverException() {
+        String initialUrl = defaultSemanticsTarget.url();
+        defaultSemanticsTarget.continueOrPropagate(NON_FAST_FAILOVER_EXCEPTION);
+        assertThat(defaultSemanticsTarget.url()).isEqualTo(initialUrl);
+    }
+
+    @Test
+    public void rethrowsNonFastFailoverExceptionAfterExceedingRetryLimit() {
+        assertThatThrownBy(() -> {
+            for (int i = 0; i < FAILOVERS; i++) {
+                defaultSemanticsTarget.url();
+                defaultSemanticsTarget.continueOrPropagate(NON_FAST_FAILOVER_EXCEPTION);
+            }
+        }).isEqualTo(NON_FAST_FAILOVER_EXCEPTION);
+    }
+
+    @Test
+    public void failsOverOnFastFailoverExceptionEvenIfOnlyRetryingOnNonLeaders() {
+        String initialUrl = onlyNonLeadersSemanticsTarget.url();
+        onlyNonLeadersSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+        assertThat(onlyNonLeadersSemanticsTarget.url()).isNotEqualTo(initialUrl);
+    }
+
+    @Test
+    public void failsOverMultipleTimesOnFastFailoverExceptionEvenIfOnlyRetryingOnNonLeaders() {
+        String previousUrl;
+        for (int i = 0; i < FAILOVERS; i++) {
+            previousUrl = onlyNonLeadersSemanticsTarget.url();
+            onlyNonLeadersSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+            assertThat(onlyNonLeadersSemanticsTarget.url()).isNotEqualTo(previousUrl);
+        }
+    }
+
+    @Test
+    public void rethrowsNonFastFailoverExceptionIfOnlyRetryingOnNonLeaders() {
+        assertThatThrownBy(() -> onlyNonLeadersSemanticsTarget.continueOrPropagate(NON_FAST_FAILOVER_EXCEPTION))
+                .isEqualTo(NON_FAST_FAILOVER_EXCEPTION);
+    }
+
+    @Test
+    public void rethrowsNonFastFailoverExceptionAfterMultipleFastFailoverExceptionsIfOnlyRetryingOnNonLeaders() {
+        for (int i = 0; i < FAILOVERS; i++) {
+            onlyNonLeadersSemanticsTarget.continueOrPropagate(FAST_FAILOVER_EXCEPTION);
+        }
+        assertThatThrownBy(() -> onlyNonLeadersSemanticsTarget.continueOrPropagate(NON_FAST_FAILOVER_EXCEPTION))
+                .isEqualTo(NON_FAST_FAILOVER_EXCEPTION);
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FeignOkHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FeignOkHttpClientsTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.client.LockRefreshingRemoteLockService;
+
+public class FeignOkHttpClientsTest {
+    @Test
+    public void classesSpecifiedNotToRetryAreNotRetriable() {
+        FeignOkHttpClients.CLASSES_TO_NOT_RETRY.forEach(
+                clazz -> assertThat(FeignOkHttpClients.shouldAllowRetrying(clazz)).isFalse());
+    }
+
+    @Test
+    public void remoteLockServiceIsNotRetriable() {
+        assertThat(FeignOkHttpClients.shouldAllowRetrying(RemoteLockService.class)).isFalse();
+    }
+
+    @Test
+    public void subclassesOfClassesSpecifiedNotToRetryAreRetriable() {
+        assertThat(FeignOkHttpClients.shouldAllowRetrying(ExtendedRemoteLockService.class)).isTrue();
+        assertThat(FeignOkHttpClients.shouldAllowRetrying(LockRefreshingRemoteLockService.class)).isTrue();
+    }
+
+    @Test
+    public void classesNotSpecifiedNotToRetryAreRetriable() {
+        assertThat(FeignOkHttpClients.shouldAllowRetrying(AtomicReference.class)).isTrue();
+    }
+
+    private interface ExtendedRemoteLockService extends RemoteLockService {
+        // Marker interface used for testing that subclasses aren't affected
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RetrySemanticsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RetrySemanticsTest.java
@@ -24,27 +24,27 @@ import org.junit.Test;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.client.LockRefreshingRemoteLockService;
 
-public class FeignOkHttpClientsTest {
+public class RetrySemanticsTest {
     @Test
     public void classesSpecifiedNotToRetryAreNotRetriable() {
-        FeignOkHttpClients.CLASSES_TO_NOT_RETRY.forEach(
-                clazz -> assertThat(FeignOkHttpClients.shouldAllowRetrying(clazz)).isFalse());
+        RetrySemantics.CLASSES_TO_NOT_RETRY.forEach(
+                clazz -> assertThat(RetrySemantics.shouldRetryHttpConnections(clazz)).isFalse());
     }
 
     @Test
     public void remoteLockServiceIsNotRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(RemoteLockService.class)).isFalse();
+        assertThat(RetrySemantics.shouldRetryHttpConnections(RemoteLockService.class)).isFalse();
     }
 
     @Test
     public void subclassesOfClassesSpecifiedNotToRetryAreRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(ExtendedRemoteLockService.class)).isTrue();
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(LockRefreshingRemoteLockService.class)).isTrue();
+        assertThat(RetrySemantics.shouldRetryHttpConnections(ExtendedRemoteLockService.class)).isTrue();
+        assertThat(RetrySemantics.shouldRetryHttpConnections(LockRefreshingRemoteLockService.class)).isTrue();
     }
 
     @Test
     public void classesNotSpecifiedNotToRetryAreRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(AtomicReference.class)).isTrue();
+        assertThat(RetrySemantics.shouldRetryHttpConnections(AtomicReference.class)).isTrue();
     }
 
     private interface ExtendedRemoteLockService extends RemoteLockService {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,6 +49,25 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1521>`__)
 
     *    - |fixed|
+         - RemoteLockService clients will no longer silently retry on connection failures.
+           This is used to mitigate issues with frequent leadership changes owing to `#1680 <https://github.com/palantir/atlasdb/issues/1680>`__.
+           Previously, because of Jetty's idle timeout and OkHttp's silent connection retrying, we would generate an endless stream of lock requests if using HTTP/2 and blocking for more than the Jetty idle timeout for a single lock.
+           This would lead to starvation of other requests on the TimeLock server, since a lock request blocked on acquiring a lock consumes a server thread.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1727>`__)
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
+v0.36.0
+=======
+
+3 Mar 2017
+
+    *    - |new|
+         - Cassandra now attempts to truncate when performing a ``deleteRange(RangeRequest.All())`` in an effort to build up less garbage.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1617>`__)
+
+    *    - |fixed|
          - Fixed an unnecessarily long-held connection in Oracle table name mapping code.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1593>`__)
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,11 +49,12 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1521>`__)
 
     *    - |fixed|
-         - RemoteLockService clients will no longer silently retry on connection failures.
+         - RemoteLockService clients will no longer silently retry on connection failures, and will also no longer retry exceptions other than 503s.
            This is used to mitigate issues with frequent leadership changes owing to `#1680 <https://github.com/palantir/atlasdb/issues/1680>`__.
            Previously, because of Jetty's idle timeout and OkHttp's silent connection retrying, we would generate an endless stream of lock requests if using HTTP/2 and blocking for more than the Jetty idle timeout for a single lock.
            This would lead to starvation of other requests on the TimeLock server, since a lock request blocked on acquiring a lock consumes a server thread.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1727>`__)
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/1727>`__,
+           `Pull Request 2 <https://github.com/palantir/atlasdb/pull/1737>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**:

* Fix #1680 (see discussion of ticket for further diagnosis)
* This is #1737 for 0.36.0 which we want to test internally.

**Implementation Description (bullets)**:

* Don't retry infinitely in the FailoverFeignTarget, for clients that aren't supposed to retry stuff at all. Instead hard-fail if obtaining an exception on the leader.
* New unit tests for FailoverFeignTarget exploring its retry capabilities.

**Concerns (what feedback would you like?)**:

* Hard-fail might be too aggressive, we could do retry 2 or 3 times at most, but I'm concerned it might overload the leader even if only done 2 or 3x.
* Long run might be better to rewrite the hard-fail check somewhere else.

**Where should we start reviewing?**:

* RetrySemantics, then probably FailoverFeignTargetTest

**Priority (whenever / two weeks / yesterday)**:

* Not super high since we can test the build without merging this in, but assuming this fixes the issue should make its way down to develop soon.