### PR TITLE
fix for internal artifactory publish NPEing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.3.1'
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.4'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.12'
         classpath 'com.palantir.gradle.javadist:gradle-java-distribution:1.3.0'
         classpath 'gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.8.0'
         classpath 'com.palantir:gradle-baseline-java:0.7.1'


### PR DESCRIPTION
see https://github.com/JFrogDev/build-info/issues/101

This change has been successfully tested as build 209 of the internal publishing agent (which I modified at that time to run directly off of this branch instead of develop)

Previous error was 
```
00:42:36 Caused by: java.lang.NullPointerException
00:42:36     at org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask.prepareAndDeploy(BuildInfoBaseTask.java:354)
00:42:36     at org.jfrog.gradle.plugin.artifactory.task.BuildInfoBaseTask.collectProjectBuildInfo(BuildInfoBaseTask.java:133)
00:42:36     at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:73)
00:42:36     at org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore$StandardTaskAction.doExecute(DefaultTaskClassInfoStore.java:141)
00:42:36     at org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore$StandardTaskAction.execute(DefaultTaskClassInfoStore.java:134)
00:42:36     at org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore$StandardTaskAction.execute(DefaultTaskClassInfoStore.java:123)
00:42:36     at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:624)
00:42:36     at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:607)
00:42:36     at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:95)
00:42:36     at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:76)
00:42:36     ... 69 more
```
**Priority (whenever / two weeks / yesterday)**:
yesterday