### PR TITLE
Improve error message encountered when reading invalidated timestamp.

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
@@ -221,7 +221,7 @@ public class CassandraTimestampBackupIntegrationTest {
     }
 
     private void assertBoundNotReadable() {
-        assertThatThrownBy(timestampBoundStore::getUpperLimit).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(timestampBoundStore::getUpperLimit).isInstanceOf(IllegalStateException.class);
     }
 
     private void setupTwoReadableBoundsInKv() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -116,7 +116,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                     return PtBytes.toLong(column.getValue());
                 } catch (IllegalArgumentException e) {
                     String msg = "Caught an IllegalArgumentException trying to convert the stored value to a long. "
-                            + "This can happen if you attempt to run AtlasDB with a leader block after having "
+                            + "This can happen if you attempt to run AtlasDB without a timelock block after having "
                             + "previously migrated to the TimeLock server. Please contact AtlasDB support. "
                             + "If you are attempting a reverse migration, please consult the documentation here: "
                             + "https://palantir.github.io/atlasdb/html/services/timelock_service/"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -105,10 +105,24 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                     cas(client, null, CassandraTimestampUtils.INITIAL_VALUE);
                     return CassandraTimestampUtils.INITIAL_VALUE;
                 }
-                Column column = result.getColumn();
-                currentLimit = PtBytes.toLong(column.getValue());
+                currentLimit = extractUpperLimit(result);
                 DebugLogger.logger.info("[GET] Setting cached timestamp limit to {}.", currentLimit);
                 return currentLimit;
+            }
+
+            private long extractUpperLimit(ColumnOrSuperColumn result) {
+                try {
+                    Column column = result.getColumn();
+                    return PtBytes.toLong(column.getValue());
+                } catch (IllegalArgumentException e) {
+                    String msg = "Caught an IllegalArgumentException trying to convert the stored value to a long. "
+                            + "This can happen if you attempt to run AtlasDB with a leader block after having "
+                            + "previously migrated to the TimeLock server. Please contact AtlasDB support. "
+                            + "If you are attempting a reverse migration, please consult the documentation here: "
+                            + "https://palantir.github.io/atlasdb/html/services/timelock_service/"
+                            + "reverse-migration.html (and also contact AtlasDB support).";
+                    throw new IllegalStateException(msg, e);
+                }
             }
         });
     }


### PR DESCRIPTION
**Goals (and why)**: See PR title. Fixes #1664.

**Implementation Description (bullets)**:
Catch the thrown IllegalArgumentException, and wrap it in an IllegalStateException.
The assumption here is that the user is probably using a leader block after having migrated (possibly after accidentally rolling back or reverse-migrating). Therefore, we spit out a message saying that we suspect this is the case.

[no release notes] (no users should've been affected by the uninformative message - we found it internally)

**Concerns (what feedback would you like?)**:
Should I add release notes?
As exposed by the tests (see full test file), there are a few cases in the middle of the invalidation/backup process where this error _could_ be thrown, however I didn't include this info in the error message as I don't think users should ever hit this case. Is that correct?

**Where should we start reviewing?**: the code, it's a small change

**Priority (whenever / two weeks / yesterday)**: ASAP - this clears a blocker towards TimeLock 1.0 (#1728)
