### PR TITLE
Improve leader election logging

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -170,24 +170,24 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
                     leaderPingResponseWaitMs,
                     TimeUnit.MILLISECONDS);
             if (pingFuture == null) {
-                leaderLog.warn("Timed out pinging " + leaderName + " after " + leaderPingResponseWaitMs + "ms");
+                leaderLog.warn("Timed out pinging {} after {} ms", leaderName, leaderPingResponseWaitMs);
                 return false;
             }
             else if (pingFuture.get()) {
-                leaderLog.trace("Successfully pinged " + leaderName);
+                leaderLog.trace("Successfully pinged {}", leaderName);
                 return true;
             }
             else {
-                leaderLog.info("Pinged " + leaderName + " and it reported that it is no longer the leader");
+                leaderLog.info("Pinged {} and it reported that it is no longer the leader", leaderName);
                 return false;
             }
         } catch (InterruptedException e) {
-            log.warn("Interrupted while pinging " + leaderName);
-            leaderLog.warn("Interrupted while pinging " + leaderName);
+            log.warn("Interrupted while pinging {}", leaderName);
+            leaderLog.warn("Interrupted while pinging {}", leaderName);
             return false;
         } catch (ExecutionException e) {
-            log.warn("Cannot ping " + leaderName, e);
-            leaderLog.warn("Cannot ping " + leaderName, e);
+            log.warn("Cannot ping {}", leaderName, e);
+            leaderLog.warn("Cannot ping {}", leaderName, e);
             return false;
         }
     }
@@ -355,7 +355,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
                 seq = Defaults.defaultValue(long.class);
             }
 
-            leaderLog.info("Proposing leadership with sequence number " + seq + " (our UUID: " + getUUID() + ")");
+            leaderLog.info("Proposing leadership with sequence number {} (our UUID: {})", seq, getUUID());
             proposer.propose(seq, null);
         } catch (PaxosRoundFailureException e) {
             // We have failed trying to become the leader.
@@ -618,7 +618,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             for (PaxosValue value : values) {
                 PaxosValue currentLearnedValue = knowledge.getLearnedValue(value.getRound());
                 if (currentLearnedValue == null) {
-                    leaderLog.info("Peers taught us about leader #" + value.getRound() + ", with UUID " + value.getLeaderUUID());
+                    leaderLog.info("Peers taught us about leader #{}, with UUID {}", value.getRound(), value.getLeaderUUID());
                     knowledge.learn(value.getRound(), value);
                     learned = true;
                 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -151,6 +151,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             return false;
         }
         final PingableLeader leader = maybeLeader.get();
+        final HostAndPort leaderName = potentialLeadersToHosts.get(leader);
 
         CompletionService<Boolean> pingCompletionService = new ExecutorCompletionService<Boolean>(
                 executor);
@@ -159,6 +160,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
         pingCompletionService.submit(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
+                leaderLog.trace("Pinging suspected leader " + leaderName);
                 return leader.ping();
             }
         });
@@ -167,11 +169,25 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             Future<Boolean> pingFuture = pingCompletionService.poll(
                     leaderPingResponseWaitMs,
                     TimeUnit.MILLISECONDS);
-            return pingFuture != null && pingFuture.get();
+            if (pingFuture != null) {
+                if (pingFuture.get()) {
+                    leaderLog.trace("Successfully pinged " + leaderName);
+                        return true;
+                } else {
+                    leaderLog.info("Pinged " + leaderName + " and it reported that it is no longer the leader");
+                    return false;
+                }
+            } else {
+                leaderLog.warn("Timed out pinging " + leaderName + " after " + leaderPingResponseWaitMs + "ms");
+                return false;
+            }
         } catch (InterruptedException e) {
+            leaderLog.warn("Interrupted while pinging " + leaderName);
+            log.warn("Interrupted while pinging " + leaderName);
             return false;
         } catch (ExecutionException e) {
-            log.warn("cannot ping leader", e);
+            log.warn("Cannot ping " + leaderName, e);
+            leaderLog.warn("Cannot ping " + leaderName, e);
             return false;
         }
     }
@@ -339,7 +355,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
                 seq = Defaults.defaultValue(long.class);
             }
 
-            leaderLog.info("Proposing leadership with sequence number " + seq);
+            leaderLog.info("Proposing leadership with sequence number " + seq + " (our UUID: " + getUUID() + ")");
             proposer.propose(seq, null);
         } catch (PaxosRoundFailureException e) {
             // We have failed trying to become the leader.
@@ -602,6 +618,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             for (PaxosValue value : values) {
                 PaxosValue currentLearnedValue = knowledge.getLearnedValue(value.getRound());
                 if (currentLearnedValue == null) {
+                    leaderLog.info("Peers taught us about leader #" + value.getRound() + ", with UUID " + value.getLeaderUUID());
                     knowledge.learn(value.getRound(), value);
                     learned = true;
                 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -169,21 +169,21 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
             Future<Boolean> pingFuture = pingCompletionService.poll(
                     leaderPingResponseWaitMs,
                     TimeUnit.MILLISECONDS);
-            if (pingFuture != null) {
-                if (pingFuture.get()) {
-                    leaderLog.trace("Successfully pinged " + leaderName);
-                        return true;
-                } else {
-                    leaderLog.info("Pinged " + leaderName + " and it reported that it is no longer the leader");
-                    return false;
-                }
-            } else {
+            if (pingFuture == null) {
                 leaderLog.warn("Timed out pinging " + leaderName + " after " + leaderPingResponseWaitMs + "ms");
                 return false;
             }
+            else if (pingFuture.get()) {
+                leaderLog.trace("Successfully pinged " + leaderName);
+                return true;
+            }
+            else {
+                leaderLog.info("Pinged " + leaderName + " and it reported that it is no longer the leader");
+                return false;
+            }
         } catch (InterruptedException e) {
-            leaderLog.warn("Interrupted while pinging " + leaderName);
             log.warn("Interrupted while pinging " + leaderName);
+            leaderLog.warn("Interrupted while pinging " + leaderName);
             return false;
         } catch (ExecutionException e) {
             log.warn("Cannot ping " + leaderName, e);

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -236,43 +236,63 @@ public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
         }
 
         public void trace(String s, Throwable t) {
-            delegate.trace(tag + s, t);
+            if (delegate.isTraceEnabled()) {
+                delegate.trace(tag + s, t);
+            }
         }
 
         public void debug(String s, Throwable t) {
-            delegate.debug(tag + s, t);
+            if (delegate.isDebugEnabled()) {
+                delegate.debug(tag + s, t);
+            }
         }
 
         public void info(String s, Throwable t) {
-            delegate.info(tag + s, t);
+            if (delegate.isInfoEnabled()) {
+                delegate.info(tag + s, t);
+            }
         }
 
         public void warn(String s, Throwable t) {
-            delegate.warn(tag + s, t);
+            if (delegate.isWarnEnabled()) {
+                delegate.warn(tag + s, t);
+            }
         }
 
         public void error(String s, Throwable t) {
-            delegate.error(tag + s, t);
+            if (delegate.isErrorEnabled()) {
+                delegate.error(tag + s, t);
+            }
         }
 
         public void trace(String s, Object... args) {
-            delegate.trace(tag + s, args);
+            if (delegate.isTraceEnabled()) {
+                delegate.trace(tag + s, args);
+            }
         }
 
         public void debug(String s, Object... args) {
-            delegate.debug(tag + s, args);
+            if (delegate.isDebugEnabled()) {
+                delegate.debug(tag + s, args);
+            }
         }
 
         public void info(String s, Object... args) {
-            delegate.info(tag + s, args);
+            if (delegate.isInfoEnabled()) {
+                delegate.info(tag + s, args);
+            }
         }
 
         public void warn(String s, Object... args) {
-            delegate.warn(tag + s, args);
+            if (delegate.isWarnEnabled()) {
+                delegate.warn(tag + s, args);
+            }
         }
 
         public void error(String s, Object... args) {
-            delegate.error(tag + s, args);
+            if (delegate.isErrorEnabled()) {
+                delegate.error(tag + s, args);
+            }
         }
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
@@ -44,8 +45,7 @@ import com.palantir.leader.NotCurrentLeaderException;
 
 public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(AwaitingLeadershipProxy.class);
-    private static final Logger leaderLog = LoggerFactory.getLogger("leadership");
+    private static final AtomicInteger numProxies = new AtomicInteger();
 
     @SuppressWarnings("unchecked")
     public static <T> T newProxyInstance(Class<T> interfaceClass,
@@ -59,6 +59,9 @@ public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
         return (T) Proxy.newProxyInstance(interfaceClass.getClassLoader(), new Class<?>[] {
                 interfaceClass, Closeable.class }, proxy);
     }
+
+    private final TaggedLogger log;
+    private final TaggedLogger leaderLog;
 
     final Supplier<?> delegateSupplier;
     final LeaderElectionService leaderElectionService;
@@ -84,6 +87,10 @@ public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
         this.delegateRef = new AtomicReference<Object>();
         this.interfaceClass = interfaceClass;
         this.isClosed = false;
+
+        String logTag = "Proxy #" + numProxies.getAndIncrement() + " - " + interfaceClass.getSimpleName();
+        log = new TaggedLogger(AwaitingLeadershipProxy.class, logTag);
+        leaderLog = new TaggedLogger("leadership", logTag);
     }
 
     private void tryToGainLeadership() {
@@ -103,6 +110,7 @@ public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
 
     private void gainLeadership() {
         try {
+            leaderLog.info("Quiescing");
             LeadershipToken leadershipToken = leaderElectionService.blockOnBecomingLeader();
             // We are now the leader, we should create a delegate so we can service calls
             Object delegate = null;
@@ -196,7 +204,7 @@ public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
     }
 
     private void markAsNotLeading(final LeadershipToken leadershipToken, @Nullable Throwable cause) {
-        leaderLog.warn("Lost leadership", cause);
+        leaderLog.warn("Noticed that we lost leadership", cause);
         if (leadershipTokenRef.compareAndSet(leadershipToken, null)) {
             try {
                 clearDelegate();
@@ -208,4 +216,61 @@ public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
         throw notCurrentLeaderException("method invoked on a non-leader (leadership lost)", cause);
     }
 
+    /**
+     * Wraps a delegate Logger, prepending the specified string to the start of each log message.
+     */
+    private static class TaggedLogger {
+        private final Logger delegate;
+        private final String tag;
+
+        public TaggedLogger(Class clazz, String tag) {
+            this.delegate = LoggerFactory.getLogger(clazz);
+            this.tag = "[" + tag + "] ";
+        }
+
+        public TaggedLogger(String name, String tag) {
+            this.delegate = LoggerFactory.getLogger(name);
+            this.tag = "[" + tag + "] ";
+        }
+
+        public void trace(String s, Throwable t) {
+            delegate.trace(tag + s, t);
+        }
+
+        public void debug(String s, Throwable t) {
+            delegate.debug(tag + s, t);
+        }
+
+        public void info(String s, Throwable t) {
+            delegate.info(tag + s, t);
+        }
+
+        public void warn(String s, Throwable t) {
+            delegate.warn(tag + s, t);
+        }
+
+        public void error(String s, Throwable t) {
+            delegate.error(tag + s, t);
+        }
+
+        public void trace(String s, Object... args) {
+            delegate.trace(tag + s, args);
+        }
+
+        public void debug(String s, Object... args) {
+            delegate.debug(tag + s, args);
+        }
+
+        public void info(String s, Object... args) {
+            delegate.info(tag + s, args);
+        }
+
+        public void warn(String s, Object... args) {
+            delegate.warn(tag + s, args);
+        }
+
+        public void error(String s, Object... args) {
+            delegate.error(tag + s, args);
+        }
+    }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -110,7 +110,7 @@ public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
 
     private void gainLeadership() {
         try {
-            leaderLog.info("Quiescing");
+            leaderLog.info("Not the leader. Going to sleep.");
             LeadershipToken leadershipToken = leaderElectionService.blockOnBecomingLeader();
             // We are now the leader, we should create a delegate so we can service calls
             Object delegate = null;
@@ -157,6 +157,8 @@ public final class AwaitingLeadershipProxy extends AbstractInvocationHandler {
         }
 
         if (method.getName().equals("close") && args.length == 0) {
+            log.warn("Shutting down now");
+            leaderLog.warn("Shutting down now");
             isClosed = true;
             executor.shutdownNow();
             clearDelegate();

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -90,10 +90,20 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
                     : PaxosAcceptorState.newState(pid);
             if ((oldState == null && state.putIfAbsent(seq, newState) == null)
                     || (oldState != null && state.replace(seq, oldState, newState))) {
-                String lastAcceptedLeader = (oldState.lastAcceptedValue == null) ? null : oldState.lastAcceptedValue.getLeaderUUID();
+                PaxosProposalId lastPromisedId = null;
+                PaxosProposalId lastAcceptedId = null;
+                String lastAcceptedLeader = null;
+
+                if (oldState != null) {
+                    lastPromisedId = oldState.lastPromisedId;
+                    lastAcceptedId = oldState.lastAcceptedId;
+                    lastAcceptedLeader = (oldState.lastAcceptedValue == null) ? null : oldState.lastAcceptedValue.getLeaderUUID();
+                }
+
                 leaderLog.debug("Promised to accept proposal for seq #{} with ID {}; promise is " +
                         "(lastPromisedId={}, lastAcceptedId={}, lastAcceptedValue={})", seq, pid.getNumber(),
-                        oldState.lastPromisedId, oldState.lastAcceptedId, lastAcceptedLeader);
+                        lastPromisedId, lastAcceptedId, lastAcceptedLeader);
+
                 log.writeRound(seq, newState);
                 return new PaxosPromise(
                         newState.lastPromisedId,

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -74,8 +74,9 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
 
             // allow for the same propose to be repeated and return the same result.
             if (oldState != null && pid.compareTo(oldState.lastPromisedId) == 0) {
-                leaderLog.debug("Refused proposal request for seq #" + seq + " with ID " + pid.getNumber() +
-                        " as we've already made a promise with the same pid (" + oldState.lastPromisedId + ")");
+                leaderLog.debug("Accepted proposal request for seq #" + seq + " with ID " + pid.getNumber() +
+                        " as we've already made a promise with the same pid (" + oldState.lastPromisedId + ")" +
+                        " for leader UUID " + oldState.lastAcceptedValue.getLeaderUUID());
                 return new PaxosPromise(
                         oldState.lastPromisedId,
                         oldState.lastAcceptedId,

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -67,16 +67,15 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
 
             // nack
             if (oldState != null && pid.compareTo(oldState.lastPromisedId) < 0) {
-                leaderLog.debug("Refused proposal request for seq #" + seq + " with ID " + pid.getNumber() +
-                        " as we've already made a promise with a greater pid (" + oldState.lastPromisedId + ")");
+                leaderLog.debug("Refused proposal request for seq #{} with ID {} as we've already made a promise with a greater pid ({})",
+                        seq, pid.getNumber(), oldState.lastPromisedId);
                 return new PaxosPromise(oldState.lastPromisedId);
             }
 
             // allow for the same propose to be repeated and return the same result.
             if (oldState != null && pid.compareTo(oldState.lastPromisedId) == 0) {
-                leaderLog.debug("Accepted proposal request for seq #" + seq + " with ID " + pid.getNumber() +
-                        " as we've already made a promise with the same pid (" + oldState.lastPromisedId + ")" +
-                        " for leader UUID " + oldState.lastAcceptedValue.getLeaderUUID());
+                leaderLog.debug("Accepted proposal request for seq #{} with ID {} as we've already made a promise with the same pid ({}) " +
+                        "for leader UUID {}", seq, pid.getNumber(), oldState.lastPromisedId, oldState.lastAcceptedValue.getLeaderUUID());
                 return new PaxosPromise(
                         oldState.lastPromisedId,
                         oldState.lastAcceptedId,
@@ -89,7 +88,7 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
                     : PaxosAcceptorState.newState(pid);
             if ((oldState == null && state.putIfAbsent(seq, newState) == null)
                     || (oldState != null && state.replace(seq, oldState, newState))) {
-                leaderLog.debug("Promised to accept proposal for seq #" + seq + " with ID " + pid.getNumber());
+                leaderLog.debug("Promised to accept proposal for seq #{} with ID {}", seq, pid.getNumber());
                 log.writeRound(seq, newState);
                 return new PaxosPromise(
                         newState.lastPromisedId,
@@ -101,13 +100,13 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
 
     @Override
     public BooleanPaxosResponse accept(long seq, PaxosProposal proposal) {
-        leaderLog.debug("Asked to accept proposal for seq #" + seq + " with ID " + proposal.getId().getNumber() +
-                " from node " + proposal.getId().getProposerUUID());
+        leaderLog.debug("Asked to accept proposal for seq #{} with ID {} from node {}",
+                seq, proposal.getId().getNumber(), proposal.getId().getProposerUUID());
 
         try {
             checkLogIfNeeded(seq);
         } catch (Exception e) {
-            leaderLog.error("log read failed for request: " + seq + " during accept phase; rejecting proposal", e);
+            leaderLog.error("log read failed for request: {} during accept phase; rejecting proposal", seq, e);
             logger.error("log read failed for request: " + seq, e);
             return new BooleanPaxosResponse(false); // nack
         }
@@ -117,8 +116,8 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
 
             // nack
             if (oldState != null && proposal.id.compareTo(oldState.lastPromisedId) < 0) {
-                leaderLog.debug("Rejected proposal for seq #" + seq + " with ID " + proposal.getId().getNumber() +
-                        " as we already promised to accept ID " + oldState.lastPromisedId);
+                leaderLog.debug("Rejected proposal for seq #{} with ID {} as we already promised to accept ID {}",
+                        seq, proposal.getId().getNumber(), oldState.lastPromisedId);
                 return new BooleanPaxosResponse(false);
             }
 
@@ -128,8 +127,8 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
                     : PaxosAcceptorState.newState(proposal.id);
             if ((oldState == null && state.putIfAbsent(seq, newState) == null)
                     || (oldState != null && state.replace(seq, oldState, newState))) {
-                leaderLog.info("Accepted proposal for seq #" + seq + " with ID " + proposal.getId().getNumber() +
-                        "; proposed leader UUID is " + proposal.getValue().getLeaderUUID());
+                leaderLog.info("Accepted proposal for seq #{} with ID {}; proposed leader UUID is {}",
+                        seq, proposal.getId().getNumber(), proposal.getValue().getLeaderUUID());
                 log.writeRound(seq, newState);
                 return new BooleanPaxosResponse(true);
             }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -74,7 +74,7 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
 
             // allow for the same propose to be repeated and return the same result.
             if (oldState != null && pid.compareTo(oldState.lastPromisedId) == 0) {
-                String lastAcceptedLeader = (oldState.lastAcceptedValue == null) ? null : oldState.lastAcceptedValue.getLeaderUUID();
+                String lastAcceptedLeader = (oldState.lastAcceptedValue == null) ? "none" : oldState.lastAcceptedValue.getLeaderUUID();
                 leaderLog.debug("Accepted proposal request for seq #{} with ID {} as we've already made a promise with the same pid ({}): "+
                         "(lastPromisedId={}, lastAcceptedId={}, lastAcceptedValue={})", seq, pid.getNumber(), oldState.lastPromisedId,
                         oldState.lastAcceptedId, lastAcceptedLeader);
@@ -97,7 +97,7 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
                 if (oldState != null) {
                     lastPromisedId = oldState.lastPromisedId;
                     lastAcceptedId = oldState.lastAcceptedId;
-                    lastAcceptedLeader = (oldState.lastAcceptedValue == null) ? null : oldState.lastAcceptedValue.getLeaderUUID();
+                    lastAcceptedLeader = (oldState.lastAcceptedValue == null) ? "(none)" : oldState.lastAcceptedValue.getLeaderUUID();
                 }
 
                 leaderLog.debug("Promised to accept proposal for seq #{} with ID {}; promise is " +

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -58,7 +58,7 @@ public class PaxosLearnerImpl implements PaxosLearner {
 
     @Override
     public void learn(long seq, PaxosValue val) {
-        leaderLog.info("Learned about new leader (seq #" + seq + ") with UUID " + val.getLeaderUUID());
+        leaderLog.info("Learned about new leader (seq #{}) with UUID {}", seq, val.getLeaderUUID());
         state.put(seq, val);
         log.writeRound(seq, val);
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 public class PaxosLearnerImpl implements PaxosLearner {
 
     private static final Logger logger = LoggerFactory.getLogger(PaxosLearnerImpl.class);
+    private static final Logger leaderLog = LoggerFactory.getLogger("leadership");
 
     /**
      * @param logDir string path for directory to place durable logs
@@ -57,6 +58,7 @@ public class PaxosLearnerImpl implements PaxosLearner {
 
     @Override
     public void learn(long seq, PaxosValue val) {
+        leaderLog.info("Learned about new leader (seq #" + seq + ") with UUID " + val.getLeaderUUID());
         state.put(seq, val);
         log.writeRound(seq, val);
     }

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/RateLimitedTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/RateLimitedTimestampService.java
@@ -78,7 +78,7 @@ public class RateLimitedTimestampService implements TimestampService {
             try {
                 batch.awaitPopulation();
             } catch (InterruptedException e) {
-                log.error("Interrupted waiting for timestamp batch to populate. Trying another batch.", e);
+                log.warn("Interrupted waiting for timestamp batch to populate. Trying another batch.", e);
                 throw Throwables.rewrapAndThrowUncheckedException(e);
             }
             if (!batch.isFailed()) {


### PR DESCRIPTION
**Goals (and why)**:

Add more granular leader election logging to facilitate debugging of failed or unexpected leadership transitions.

In diagnosing a customer issue where we suspected there were two simultaneous lock leaders (PDS-50340) I found several points of confusion in the logs:
* Most of the existing logging is in AwaitingLeadershipProxy, so the log lines only get written as a result of a method call kicking the proxy and causing it to notice state change. So things like leadership transition aren't logged at the point they happen.
* If you have multiple AwaitingLeadershipProxy instances (e.g. Lock and Timestamp), they'll both write to the same log file, and it isn't clear that they're two different proxy views onto the same Paxos instance, so it can look as though we're reacting to the same leadership change events multiple times – as opposed to just noticing it in two different proxies.
* In general the existing logging didn't have enough detail to let me build a timetable of how leadership changes were proposed and executed across nodes in the cluster.

I'd like to forward-port this to develop, but for now I'm submitting against 0.4.x so we can deliver this new logging to the customer.

**Implementation Description (bullets)**:

Primarily just new log lines. The only complexity is in AwaitingLeadershipProxy where I added a logger delegate that includes details about the underlying service we're proxying to – so that log lines written by different proxy instances are distinguishable.

**Concerns (what feedback would you like?)**:

* Would you like me to do the `TaggedLogger` differently? Options:
** Use reflection to avoid explicitly writing delegate methods.
** Explicitly implement the `Logger` interface (though this means there are a ton of unneeded methods that need to be implemented)
* Do you think the logging is:
** Sufficient
** Truthful and clear
** Performant

**Where should we start reviewing?**:

AwaitingLeadershipProxy.java

**Priority (whenever / two weeks / yesterday)**:

I was hoping to deliver this to the customer by end of week. At this point that's unrealistic, but if someone could take a look either Friday, or early next week, that would be really great.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1757)
<!-- Reviewable:end -->
