### PR TITLE
Timeout the dropTable operation

### DIFF
--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -1,5 +1,11 @@
 {
     "compileClasspath": {
+        "cglib:cglib-nodep": {
+            "locked": "3.1",
+            "transitive": [
+                "com.jayway.awaitility:awaitility"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -112,6 +118,12 @@
             "locked": "1.2",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.jayway.awaitility:awaitility": {
+            "locked": "1.6.5",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-tests-shared"
             ]
         },
         "com.mchange:c3p0": {
@@ -420,6 +432,7 @@
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "com.palantir.atlasdb:atlasdb-tests-shared",
                 "junit:junit",
                 "org.hamcrest:hamcrest-library",
@@ -429,6 +442,7 @@
         "org.hamcrest:hamcrest-library": {
             "locked": "1.3",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "com.palantir.atlasdb:atlasdb-tests-shared"
             ]
         },
@@ -454,6 +468,7 @@
         "org.objenesis:objenesis": {
             "locked": "2.2",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "org.mockito:mockito-core"
             ]
         },
@@ -485,6 +500,12 @@
         }
     },
     "runtime": {
+        "cglib:cglib-nodep": {
+            "locked": "3.1",
+            "transitive": [
+                "com.jayway.awaitility:awaitility"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -597,6 +618,12 @@
             "locked": "1.2",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.jayway.awaitility:awaitility": {
+            "locked": "1.6.5",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-tests-shared"
             ]
         },
         "com.mchange:c3p0": {
@@ -905,6 +932,7 @@
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "com.palantir.atlasdb:atlasdb-tests-shared",
                 "junit:junit",
                 "org.hamcrest:hamcrest-library",
@@ -914,6 +942,7 @@
         "org.hamcrest:hamcrest-library": {
             "locked": "1.3",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "com.palantir.atlasdb:atlasdb-tests-shared"
             ]
         },
@@ -939,6 +968,7 @@
         "org.objenesis:objenesis": {
             "locked": "2.2",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "org.mockito:mockito-core"
             ]
         },

--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile group: 'org.hamcrest', name: 'hamcrest-library'
   compile group: 'org.assertj', name: 'assertj-core'
   compile group: 'org.mockito', name: 'mockito-core'
+  compile group: "com.jayway.awaitility", name: "awaitility"
 
   testCompile project(path: ":atlasdb-client", configuration: "testArtifacts")
   testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweeperTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweeperTest.java
@@ -40,6 +40,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.Duration;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -127,8 +129,13 @@ public abstract class AbstractSweeperTest {
     }
 
     private static void tearDownTables(KeyValueService kvs) {
-        kvs.getAllTableNames().stream()
-                .forEach(tableRef -> kvs.dropTable(tableRef));
+        Awaitility.await()
+                .timeout(Duration.FIVE_MINUTES)
+                .until(() -> {
+                    kvs.getAllTableNames().stream()
+                            .forEach(tableRef -> kvs.dropTable(tableRef));
+                    return true;
+                });
         TransactionTables.deleteTables(kvs);
         Schemas.deleteTablesAndIndexes(SweepSchema.INSTANCE.getLatestSchema(), kvs);
     }

--- a/atlasdb-tests-shared/versions.lock
+++ b/atlasdb-tests-shared/versions.lock
@@ -1,5 +1,11 @@
 {
     "compileClasspath": {
+        "cglib:cglib-nodep": {
+            "locked": "3.1",
+            "transitive": [
+                "com.jayway.awaitility:awaitility"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -104,6 +110,9 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
             ]
+        },
+        "com.jayway.awaitility:awaitility": {
+            "locked": "1.6.5"
         },
         "com.netflix.feign:feign-core": {
             "locked": "8.6.1",
@@ -307,13 +316,17 @@
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "junit:junit",
                 "org.hamcrest:hamcrest-library",
                 "org.mockito:mockito-core"
             ]
         },
         "org.hamcrest:hamcrest-library": {
-            "locked": "1.3"
+            "locked": "1.3",
+            "transitive": [
+                "com.jayway.awaitility:awaitility"
+            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
@@ -334,6 +347,7 @@
         "org.objenesis:objenesis": {
             "locked": "2.2",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "org.mockito:mockito-core"
             ]
         },
@@ -357,6 +371,12 @@
         }
     },
     "runtime": {
+        "cglib:cglib-nodep": {
+            "locked": "3.1",
+            "transitive": [
+                "com.jayway.awaitility:awaitility"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -461,6 +481,9 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
             ]
+        },
+        "com.jayway.awaitility:awaitility": {
+            "locked": "1.6.5"
         },
         "com.netflix.feign:feign-core": {
             "locked": "8.6.1",
@@ -664,13 +687,17 @@
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "junit:junit",
                 "org.hamcrest:hamcrest-library",
                 "org.mockito:mockito-core"
             ]
         },
         "org.hamcrest:hamcrest-library": {
-            "locked": "1.3"
+            "locked": "1.3",
+            "transitive": [
+                "com.jayway.awaitility:awaitility"
+            ]
         },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
@@ -691,6 +718,7 @@
         "org.objenesis:objenesis": {
             "locked": "2.2",
             "transitive": [
+                "com.jayway.awaitility:awaitility",
                 "org.mockito:mockito-core"
             ]
         },


### PR DESCRIPTION
**Goals (and why)**: Internal build number 2589 failed due to 
```
java.lang.RuntimeException: The current lock holder has failed to update its heartbeat. We suspect that this might be due to a node crashing while holding the schema mutation lock. If this is indeed the case, run the clean-cass-locks-state cli command.
```
after running for over an hour.

**Implementation Description (bullets)**:
1. dropTables waits at most 5 minutes now or just throws.

**Concerns (what feedback would you like?)**: Is the 5 minute time reasonable given the schema mutation lock heartbeats?

**Where should we start reviewing?**: `AbstractSweeperTest.java`

**Priority (whenever / two weeks / yesterday)**: whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
