### PR TITLE
read entire _transactions table during clean transactions range

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/CleanTransactionRange.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/CleanTransactionRange.java
@@ -51,7 +51,6 @@ public class CleanTransactionRange extends AbstractTimestampCommand {
     @Override
     protected int executeTimestampCommand(AtlasDbServices services) {
         KeyValueService kvs = services.getKeyValueService();
-        long backupTimestamp = timestamp;
 
         ClosableIterator<RowResult<Value>> range = kvs.getRange(
                 TransactionConstants.TRANSACTION_TABLE,
@@ -74,7 +73,7 @@ public class CleanTransactionRange extends AbstractTimestampCommand {
             }
 
             long commitTs = TransactionConstants.getTimestampForValue(value.getContents());
-            if (commitTs <= backupTimestamp) {
+            if (commitTs <= timestamp) {
                 continue; // this is a valid transaction
             }
 

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/CleanTransactionRange.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/CleanTransactionRange.java
@@ -31,9 +31,10 @@ import com.palantir.common.base.ClosableIterator;
 
 import io.airlift.airline.Command;
 
-@Command(name = "clean-transactions", description = "Clean a recently restored backup of a _transactions table "
-        + "from an underlying database that lacks PITR backup semantics.  Deletes all transactions with a "
-        + "commit timestamp greater than the backup timestamp provided.")
+@Command(name = "clean-transactions", description = "Clean out the entries in a _transactions table for the "
+        + "purpose of deleting potentially inconsistent transactions from an underlying database that lacks "
+        + "PITR backup semantics.  Deletes all transactions with a commit timestamp greater than the timestamp "
+        + "provided.")
 public class CleanTransactionRange extends AbstractTimestampCommand {
 
     private static final OutputPrinter printer = new OutputPrinter(LoggerFactory.getLogger(CleanTransactionRange.class));

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -114,6 +114,11 @@ v0.37.0
            building up leaked connections, due to a bug in the underlying driver.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1524>`__)
 
+    *    - |fixed|
+         - Correctness issue fixed in the ``clean-transactions-range`` CLI. This CLI is responsible for deleting potentially inconsistent transactions in the KVS upon restore from backup.
+           The CLI was not reading the entire ``_transactions`` table, and as a result was missing deleting transactions whose start timestamp was before the backup timestamp and commit timestamp was after the backup timestamp.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1759>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
**Goals (and why)**: Correctness bug in restore logic

**Implementation Description (bullets)**: The logic is supposed to be: delete all transactions where commit TS > backup TS. Because the _transactions table is keyed on start TS it is possible to have a transaction where: startTs < backupTs < commitTs. When means we need to do a full table scan, and can't just do for row keys (read: startTS) greater than backupTs.

This was an oversight on my part when we changed the correctness logic from backup timestamp relying on immutable timestamp stuff to backup timestamp just being a regular fresh timestamp. That change caused the logic from delete all txns with startTs > backupTs (which is why the range request existed in the first place) to delete all txns with commitTx > backupTs

**Concerns (what feedback would you like?)**: FYSA @rhero @jboreiko @clockfort @ashrayjain @SerialVelocity 

**Where should we start reviewing?**: Only 1 file

**Priority (whenever / two weeks / yesterday)**: P0; restore correctness issue

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
