### PR TITLE
Also shade jboss-marshelling package

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 
   compile group: 'com.google.code.findbugs', name: 'annotations'
 
+  compile group: 'org.jboss.marshalling', name: 'jboss-marshalling', version: '1.4.11.Final'
+
   testCompile project(path: ":atlasdb-client", configuration: "testArtifacts")
   testCompile group: 'org.mockito', name: 'mockito-core'
   testCompile group: 'org.assertj', name: 'assertj-core'
@@ -47,6 +49,7 @@ shadowJar {
   relocate('org.objectweb.asm', atlasdb_shaded + 'asm')
   relocate('jnr', atlasdb_shaded + 'jnr')
   relocate('io.netty', atlasdb_shaded + 'netty')
+  relocate('org.jboss', atlasdb_shaded + 'jboss')
 }
 
 jar.dependsOn shadowJar

--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -400,6 +400,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "requested": "1.4.11.Final"
+        },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
             "locked": "1.1.2",
             "transitive": [
@@ -875,6 +879,10 @@
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
+        },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "requested": "1.4.11.Final"
         },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
             "locked": "1.1.2",

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -756,6 +756,12 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.jooq:jooq": {
             "locked": "3.6.4",
             "transitive": [

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -762,6 +762,12 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.jooq:jooq": {
             "locked": "3.6.4",
             "transitive": [

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -2299,6 +2299,12 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.jooq:jooq": {
             "locked": "3.6.4",
             "transitive": [

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -1993,6 +1993,12 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
             "locked": "2.0.6",
             "transitive": [


### PR DESCRIPTION
Netty's marshelling.ChannelBufferByteInput class inherits from a class
in jboss-marshelling. However, this dependency is a Maven "optional"
dependency. If I'm understanding this page:

https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html

Maven optional dependencies simply mean "don't pull this in
transitively".

This raises the disturbing question: how did netty... ever work at all,
unless the classloader just doesn't care that ChannelBufferByteInput is
inheriting from a missing interface?

In any case, let's just shade the jboss dependency as well. That fixes
the problem right and good.

[no release notes]