### PR TITLE
Reduce sweep batch size

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -93,7 +93,7 @@ public class AtlasDbConstants {
     public static final boolean DEFAULT_ENABLE_SWEEP = false;
     public static final long DEFAULT_SWEEP_PAUSE_MILLIS = 5 * 1000;
     public static final long DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS = 30_000L;
-    public static final int DEFAULT_SWEEP_BATCH_SIZE = 1000;
+    public static final int DEFAULT_SWEEP_BATCH_SIZE = 100;
     public static final int DEFAULT_SWEEP_CELL_BATCH_SIZE = 10_000;
 
     public static final int DEFAULT_STREAM_IN_MEMORY_THRESHOLD = 4 * 1024 * 1024;

--- a/docs/source/cluster_management/sweep.rst
+++ b/docs/source/cluster_management/sweep.rst
@@ -51,7 +51,7 @@ You may set them as part of your :ref:`AtlasDB configuration <atlas-config>`, or
    :header: "AtlasDB Config", "CLI Option", "Default", "Description"
    :widths: 20, 20, 40, 200
 
-   ``sweepBatchSize``, ``--batch-size``, "1,000", "Maximum number of rows to sweep at once. Decrease this if sweep fails to complete (for example if the sweep job or the underlying KVS runs out of memory). Increasing it may improve sweep performance."
+   ``sweepBatchSize``, ``--batch-size``, "100", "Maximum number of rows to sweep at once. Decrease this if sweep fails to complete (for example if the sweep job or the underlying KVS runs out of memory). Increasing it may improve sweep performance."
    ``sweepCellBatchSize``, ``--cell-batch-size``, "10,000", "Maximum number of cells to sweep at once. Similar to ``sweepBatchSize`` but provides finer control if the row widths vary greatly."
    ``sweepPauseMillis``, ``--sleep``, "5000 ms", "Wait time between row batches. Set this if you want to use less shared DB resources, for example if you run sweep during user-facing hours."
    "``timestampsGetterBatchSize`` (Cassandra KVS only, see :ref:`Cassandra KVS config <cassandra-configuration>`)", "Only specified in config", "Fetch all columns", "Specify a limit on the maximum number of columns to fetch in a single database query. Set this to a number fewer than your number of columns if your Cassandra OOMs when attempting to run sweep with even a small row batch size. This parameter should be used when tuning Sweep for cells with many historical versions."

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,12 @@ develop
          - The ``atlasdb-remoting`` project was removed. We don't believe this was used anywhere, but if you encounter any problems due to the project having being removed, please contact AtlasDB support.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1750>`__)
 
+    *    - |improved|
+         - The default ``sweepBatchSize`` has been changed from 1000 to 100.
+           This has empirically shown to be a better batch size because it puts less stress on the underlying KVS.
+           For a full list of tunable sweep parameters and default settings, see :ref:`sweep tunable options <sweep_tunable_parameters>`.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1763>`__)
+
 =======
 v0.37.0
 =======


### PR DESCRIPTION
**Goals (and why)**: prevent sweep from generating too many tombstones in a single compaction cycle.

**Implementation Description (bullets)**:
1. Sweep fewer rows by default. 100 instead of 1000.

**Concerns (what feedback would you like?)**: na

**Where should we start reviewing?**: AtlasDbConstants.java

**Priority (whenever / two weeks / yesterday)**: anytime.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
