### PR TITLE
use partition of rows in getRowsForSingleHost rather than full list

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -376,7 +376,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                 SlicePredicate pred = new SlicePredicate();
                                 pred.setSlice_range(slice);
 
-                                List<ByteBuffer> rowNames = wrap(rows);
+                                List<ByteBuffer> rowNames = wrap(batch);
 
                                 ColumnParent colFam = new ColumnParent(internalTableName(tableRef));
                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -386,7 +386,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                         colFam,
                                         pred,
                                         readConsistency);
-                                Map<Cell, Value> ret = Maps.newHashMap();
+                                Map<Cell, Value> ret = Maps.newHashMapWithExpectedSize(batch.size());
                                 new ValueExtractor(ret).extractResults(results, startTs, ColumnSelection.all());
                                 return ret;
                             }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
          - The ``atlasdb-remoting`` project was removed. We don't believe this was used anywhere, but if you encounter any problems due to the project having being removed, please contact AtlasDB support.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1750>`__)
 
+    *    - |improved|
+         - Fixed broken batching in getting large sets of rows in Cassandra
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1764>`__)
+
 =======
 v0.37.0
 =======


### PR DESCRIPTION
Correct me if I'm misunderstanding this, but I think https://github.com/palantir/atlasdb/pull/582 accidentally removed the batching from the `getRowsForSingleHost` call. So if we had cells `n > fetchBatchCount` cells, rather than doing `n / fetchBatchCount` calls of size `fetchBatchCount`, we seem do be doing  `n / fetchBatchCount` calls of size `n`.