### PR TITLE
Shade apache-lang-commons

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -44,6 +44,7 @@ shadowJar {
 
   relocate('com.carrotsearch.hppc',  atlasdb_shaded + 'hppc')
   relocate('jflex', atlasdb_shaded + 'jflex')
+  relocate('org.apache.commons', atlasdb_shaded + 'commons')
   relocate('org.apache.tools.ant', atlasdb_shaded + 'ant')
   relocate('org.tarturus.snowball', atlasdb_shaded + 'snowball')
   relocate('org.objectweb.asm', atlasdb_shaded + 'asm')

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -43,6 +43,7 @@ shadowJar {
   classifier ''
 
   relocate('com.carrotsearch.hppc',  atlasdb_shaded + 'hppc')
+  relocate('com.netflix.feign', atlasdb_shaded + 'feign')
   relocate('jflex', atlasdb_shaded + 'jflex')
   relocate('org.apache.commons', atlasdb_shaded + 'commons')
   relocate('org.apache.tools.ant', atlasdb_shaded + 'ant')


### PR DESCRIPTION
This was incorrectly shaded, leading to upstream products pulling in the wrong version of commons-lang3 (and then not compiling, because it used features from lang3 v3.2+).
[no release notes]