### PR TITLE
Slow log for lock Service

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,7 +63,11 @@ develop
            This has empirically shown to be a better batch size because it puts less stress on the underlying KVS.
            For a full list of tunable sweep parameters and default settings, see :ref:`sweep tunable options <sweep_tunable_parameters>`.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1763>`__)
-       
+
+    *    - |improved|
+         - Any lock requests that take more than ``100ms`` to receive a response are now logged in the ``SlowLockLogger`` logger.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1769>`__)
+
     *    - |fixed|
          - Fixed broken batching in getting large sets of rows in Cassandra.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1764>`__)

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -91,6 +91,13 @@ import com.google.common.base.Objects;
         return Long.SIZE;
     }
 
+    /**
+     * Info level logging for any lock request that receives a response after 100ms.
+     */
+    public boolean isSlowLogEnabled() {
+        return false;
+    }
+
     @Override public final boolean equals(@Nullable Object obj) {
         if (this == obj) return true;
         if (!(obj instanceof LockServerOptions)) return false;

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -472,13 +472,13 @@ import com.palantir.util.Pair;
     }
 
     private void logAtDebugOrInfo(String lockId, LockClient currentHolder, long duration) {
-        if (log.isDebugEnabled()) {
-            log.debug("Blocked for {} ms to acquire lock {} {}.",
+        if (slowLogEnabled) {
+            SlowLockLogger.logger.info("Blocked for {} ms to acquire lock {} {}.",
                     duration,
                     lockId,
                     currentHolder == null ? "successfully" : "unsuccessfully");
         } else {
-            log.info("Blocked for {} ms to acquire lock {} {}.",
+            log.debug("Blocked for {} ms to acquire lock {} {}.",
                     duration,
                     lockId,
                     currentHolder == null ? "successfully" : "unsuccessfully");

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -152,6 +152,7 @@ import com.palantir.util.Pair;
     private final SecureRandomPool randomPool = new SecureRandomPool(SECURE_RANDOM_ALGORITHM, SECURE_RANDOM_POOL_SIZE);
 
     private final boolean isStandaloneServer;
+    private final boolean slowLogEnabled;
     private final TimeDuration maxAllowedLockTimeout;
     private final TimeDuration maxAllowedClockDrift;
     private final TimeDuration maxAllowedBlockingDuration;
@@ -240,19 +241,14 @@ import com.palantir.util.Pair;
         maxAllowedBlockingDuration = SimpleTimeDuration.of(options.getMaxAllowedBlockingDuration());
         maxNormalLockAge = SimpleTimeDuration.of(options.getMaxNormalLockAge());
         randomBitCount = options.getRandomBitCount();
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                Thread.currentThread().setName("Held Locks Token Reaper");
-                reapLocks(lockTokenReaperQueue, heldLocksTokenMap);
-            }
+        slowLogEnabled = options.isSlowLogEnabled();
+        executor.execute(() -> {
+            Thread.currentThread().setName("Held Locks Token Reaper");
+            reapLocks(lockTokenReaperQueue, heldLocksTokenMap);
         });
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                Thread.currentThread().setName("Held Locks Grant Reaper");
-                reapLocks(lockGrantReaperQueue, heldLocksGrantMap);
-            }
+        executor.execute(() -> {
+            Thread.currentThread().setName("Held Locks Grant Reaper");
+            reapLocks(lockGrantReaperQueue, heldLocksGrantMap);
         });
     }
 
@@ -453,13 +449,10 @@ import com.palantir.util.Pair;
                 long startTime = System.currentTimeMillis();
                 @Nullable LockClient currentHolder = tryLock(lock.get(client, entry.getValue()),
                         blockingMode, deadline);
-                if (log.isDebugEnabled()) {
+                if (log.isDebugEnabled() || slowLogEnabled) {
                     long duration = System.currentTimeMillis() - startTime;
                     if (duration > 100) {
-                        log.debug("Blocked for {} ms to acquire lock {} {}.",
-                                duration,
-                                entry.getKey().getLockIdAsString(),
-                                currentHolder == null ? "successfully" : "unsuccessfully");
+                        logAtDebugOrInfo(entry.getKey().toString(), currentHolder, duration);
                     }
                 }
                 if (currentHolder == null) {
@@ -475,6 +468,20 @@ import com.palantir.util.Pair;
             if (previousThreadName != null) {
                 tryRenameThread(previousThreadName);
             }
+        }
+    }
+
+    private void logAtDebugOrInfo(String lockId, LockClient currentHolder, long duration) {
+        if (log.isDebugEnabled()) {
+            log.debug("Blocked for {} ms to acquire lock {} {}.",
+                    duration,
+                    lockId,
+                    currentHolder == null ? "successfully" : "unsuccessfully");
+        } else {
+            log.info("Blocked for {} ms to acquire lock {} {}.",
+                    duration,
+                    lockId,
+                    currentHolder == null ? "successfully" : "unsuccessfully");
         }
     }
 
@@ -710,23 +717,11 @@ import com.palantir.util.Pair;
     }
 
     private void logIfAbnormallyOld(final HeldLocksGrant grant, final long now) {
-        logIfAbnormallyOld(grant, now,
-                new Supplier<String>() {
-                    @Override
-                    public String get() {
-                        return grant.toString(now);
-                    }
-                });
+        logIfAbnormallyOld(grant, now, () -> grant.toString(now));
     }
 
     private void logIfAbnormallyOld(final HeldLocksToken token, final long now) {
-        logIfAbnormallyOld(token, now,
-                new Supplier<String>() {
-                    @Override
-                    public String get() {
-                        return token.toString(now);
-                    }
-                });
+        logIfAbnormallyOld(token, now, () -> token.toString(now));
     }
 
     private void logIfAbnormallyOld(ExpiringToken token, long now, Supplier<String> description) {

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -452,7 +452,7 @@ import com.palantir.util.Pair;
                 if (log.isDebugEnabled() || slowLogEnabled) {
                     long duration = System.currentTimeMillis() - startTime;
                     if (duration > 100) {
-                        logAtDebugOrInfo(entry.getKey().toString(), currentHolder, duration);
+                        logSlowLockAcquisition(entry.getKey().toString(), currentHolder, duration);
                     }
                 }
                 if (currentHolder == null) {
@@ -471,7 +471,7 @@ import com.palantir.util.Pair;
         }
     }
 
-    private void logAtDebugOrInfo(String lockId, LockClient currentHolder, long duration) {
+    private void logSlowLockAcquisition(String lockId, LockClient currentHolder, long duration) {
         if (slowLogEnabled) {
             SlowLockLogger.logger.info("Blocked for {} ms to acquire lock {} {}.",
                     duration,

--- a/lock-impl/src/main/java/com/palantir/lock/impl/SlowLockLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/SlowLockLogger.java
@@ -22,9 +22,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * This is a logger intended for use tracking down problems arising from
- * https://github.com/palantir/atlasdb/issues/1000.  To activate this logging
- * please follow instructions on
- * http://palantir.github.io/atlasdb/html/configuration/logging.html#debug-logging-for-multiple-timestamp-services-error
+ * PDS-50301 (Product hogs threads on timelock server with HTTP/2 protocol). This is currently logging the locks
+ * requested in a lock request that took more than 100ms to receive a response. This will be auto-enabled
+ * if you migrate to the timelock server.
  */
 @SuppressFBWarnings("SLF4J_LOGGER_SHOULD_BE_PRIVATE")
 public final class SlowLockLogger {

--- a/lock-impl/src/main/java/com/palantir/lock/impl/SlowLockLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/SlowLockLogger.java
@@ -23,7 +23,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * This is a logger intended for use tracking down problems arising from
  * PDS-50301 (Product hogs threads on timelock server with HTTP/2 protocol). This is currently logging the locks
- * requested in a lock request that took more than 100ms to receive a response. This will be auto-enabled
+ * requested in a lock request that took more than 100ms to receive a response. This will be enabled automatically
  * if you migrate to the timelock server.
  */
 @SuppressFBWarnings("SLF4J_LOGGER_SHOULD_BE_PRIVATE")

--- a/lock-impl/src/main/java/com/palantir/lock/impl/SlowLockLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/SlowLockLogger.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * This is a logger intended for use tracking down problems arising from
+ * https://github.com/palantir/atlasdb/issues/1000.  To activate this logging
+ * please follow instructions on
+ * http://palantir.github.io/atlasdb/html/configuration/logging.html#debug-logging-for-multiple-timestamp-services-error
+ */
+@SuppressFBWarnings("SLF4J_LOGGER_SHOULD_BE_PRIVATE")
+public final class SlowLockLogger {
+    public static final Logger logger = LoggerFactory.getLogger(SlowLockLogger.class);
+
+    private SlowLockLogger() {
+        // Logging utility class
+    }
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
@@ -46,6 +46,7 @@ import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.PingableLeader;
 import com.palantir.leader.proxy.AwaitingLeadershipProxy;
+import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.LockService;
 import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.paxos.PaxosAcceptor;
@@ -151,11 +152,17 @@ public class PaxosTimeLockServer implements TimeLockServer {
                 ManagedTimestampService.class,
                 createPaxosBackedTimestampService(client),
                 client);
+        LockServerOptions lockServerOptions = new LockServerOptions() {
+            @Override
+            public boolean isSlowLogEnabled() {
+                return true;
+            }
+        };
         LockService lockService = instrument(
                 LockService.class,
                 AwaitingLeadershipProxy.newProxyInstance(
                         LockService.class,
-                        LockServiceImpl::create,
+                        () -> LockServiceImpl.create(lockServerOptions),
                         leaderElectionService),
                 client);
         return TimeLockServices.create(timestampService, lockService, timestampService);


### PR DESCRIPTION
**Goals (and why)**:
If the lock request is blocked for a very long time, it represents contention on that particular lock. We want to have information for which particular locks have a lot of contention. This is required so that we can flag badness to services using the timelock server.

**Implementation Description (bullets)**:
1. Add `isSlowLogEnabled` to `LockServerOptions`.
2. Log long lock requests at INFO.

**Concerns (what feedback would you like?)**: 
1. Can use some more refactor, but on the cost of readability. Unfortunately, SLF4J Logger doesnt have a generic `log` method.

**Where should we start reviewing?**: LockServerImpl

**Priority (whenever / two weeks / yesterday)**: this week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
