### PR TITLE
Feature/getrows benchmarks

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsBenchmarks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsBenchmarks.java
@@ -39,7 +39,7 @@ public class KvsGetRowsBenchmarks {
     public Object getManyRowsWithGetRows(ConsecutiveNarrowTable.CleanNarrowTable table) {
         Map<Cell, Value> result = table.getKvs().getRows(
                 table.getTableRef(),
-                table.rows,
+                table.getRowList(),
                 ColumnSelection.all(),
                 Long.MAX_VALUE
         );

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetRowsBenchmarks.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.performance.benchmarks;
+
+import java.util.Map;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.performance.benchmarks.table.ConsecutiveNarrowTable;
+
+@State(Scope.Benchmark)
+public class KvsGetRowsBenchmarks {
+    @Benchmark
+    @Threads(1)
+    @Warmup(time = 5)
+    @Measurement(time = 40)
+    public Object getManyRowsWithGetRows(ConsecutiveNarrowTable.CleanNarrowTable table) {
+        Map<Cell, Value> result = table.getKvs().getRows(
+                table.getTableRef(),
+                table.rows,
+                ColumnSelection.all(),
+                Long.MAX_VALUE
+        );
+        Preconditions.checkState(result.size() == table.getNumRows(),
+                "Should be %s rows, but were: %s", table.getNumRows(), result.size());
+        return result;
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.performance.benchmarks.table;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -72,6 +73,16 @@ public abstract class ConsecutiveNarrowTable {
 
     public int getNumRows() {
         return DEFAULT_NUM_ROWS;
+    }
+
+    public List<byte[]> rows = populateRowNames();
+
+    private List<byte[]> populateRowNames() {
+        List<byte[]> list = new ArrayList<>();
+        for (int j = 0; j < DEFAULT_NUM_ROWS; ++j) {
+            list.add(Ints.toByteArray(j));
+        }
+        return list;
     }
 
     protected abstract void setupData();
@@ -182,7 +193,7 @@ public abstract class ConsecutiveNarrowTable {
         }
         return requests;
     }
-
+    
     private static void storeDataInTable(ConsecutiveNarrowTable table, int numOverwrites) {
         IntStream.range(0, numOverwrites + 1).forEach($ -> {
             table.getTransactionManager().runTaskThrowOnConflict(txn -> {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/ConsecutiveNarrowTable.java
@@ -51,10 +51,19 @@ public abstract class ConsecutiveNarrowTable {
 
     private static final int DEFAULT_NUM_ROWS = 10000;
     private static final int REGENERATING_NUM_ROWS = 500;
+    private static final List<byte[]> ROW_LIST = populateRowNames();
 
     private Random random = new Random(Tables.RANDOM_SEED);
-
     private AtlasDbServicesConnector connector;
+
+    private static List<byte[]> populateRowNames() {
+        List<byte[]> list = new ArrayList<>();
+        for (int j = 0; j < DEFAULT_NUM_ROWS; ++j) {
+            list.add(Ints.toByteArray(j));
+        }
+        return list;
+    }
+
     private AtlasDbServices services;
 
     public Random getRandom() {
@@ -75,14 +84,8 @@ public abstract class ConsecutiveNarrowTable {
         return DEFAULT_NUM_ROWS;
     }
 
-    public List<byte[]> rows = populateRowNames();
-
-    private List<byte[]> populateRowNames() {
-        List<byte[]> list = new ArrayList<>();
-        for (int j = 0; j < DEFAULT_NUM_ROWS; ++j) {
-            list.add(Ints.toByteArray(j));
-        }
-        return list;
+    public List<byte[]> getRowList() {
+        return ROW_LIST;
     }
 
     protected abstract void setupData();
@@ -193,7 +196,7 @@ public abstract class ConsecutiveNarrowTable {
         }
         return requests;
     }
-    
+
     private static void storeDataInTable(ConsecutiveNarrowTable table, int numOverwrites) {
         IntStream.range(0, numOverwrites + 1).forEach($ -> {
             table.getTransactionManager().runTaskThrowOnConflict(txn -> {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,6 +42,10 @@ develop
     *    - Type
          - Change
 
+   *     - |new|
+         - Added a benchmark ``KvsGetRowsBenchmarks`` for benchmarking the KVS ``getRows`` method.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1770>`__)
+
     *    - |fixed|
          - Creating a postgres table with a long name throws if the truncated name (first sixty characters) is the same as that of a different existing table.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1729>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,7 +42,7 @@ develop
     *    - Type
          - Change
 
-   *     - |new|
+    *    - |new|
          - Added a benchmark ``KvsGetRowsBenchmarks`` for benchmarking the KVS ``getRows`` method.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1770>`__)
 


### PR DESCRIPTION
**Goals (and why)**:
Benchmark for KVS `getRows`, to capture the perf improvement by #1764

**Implementation Description (bullets)**:
We reuse the already existing CleanNarrowTable that has 10k rows. 

**Concerns (what feedback would you like?)**:
No concerns, but open to feedback.

**Where should we start reviewing?**:
KvsGetRowsBenchmarks.java

**Priority (whenever / two weeks / yesterday)**:
ASAP, as merging of #1764 is blocking on this.
