### PR TITLE
Add support for multiple schemas

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -15,10 +15,14 @@
  */
 package com.palantir.atlasdb.memory;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.google.auto.service.AutoService;
 import com.google.common.base.Optional;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
@@ -82,16 +86,22 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
         return new InMemoryTimestampService();
     }
 
-    public static SerializableTransactionManager createInMemoryTransactionManager(AtlasSchema schema) {
+    public static SerializableTransactionManager createInMemoryTransactionManager(AtlasSchema schema,
+            AtlasSchema... otherSchemas) {
         AtlasDbVersion.ensureVersionReported();
-        return createInMemoryTransactionManagerInternal(schema.getLatestSchema());
+
+        Set<Schema> schemas = Lists.asList(schema, otherSchemas).stream()
+                .map(AtlasSchema::getLatestSchema)
+                .collect(Collectors.toSet());
+
+        return createInMemoryTransactionManagerInternal(schemas);
     }
 
-    private static SerializableTransactionManager createInMemoryTransactionManagerInternal(Schema schema) {
+    private static SerializableTransactionManager createInMemoryTransactionManagerInternal(Set<Schema> schemas) {
         TimestampService ts = new InMemoryTimestampService();
         KeyValueService keyValueService = createTableMappingKv();
 
-        Schemas.createTablesAndIndexes(schema, keyValueService);
+        schemas.forEach(s -> Schemas.createTablesAndIndexes(s, keyValueService));
         TransactionTables.createTables(keyValueService);
 
         TransactionService transactionService = TransactionServices.createTransactionService(keyValueService);
@@ -107,7 +117,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
         ConflictDetectionManager conflictManager = ConflictDetectionManagers.createDefault(keyValueService);
         SweepStrategyManager sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
 
-        CleanupFollower follower = CleanupFollower.create(schema);
+        CleanupFollower follower = CleanupFollower.create(schemas);
         Cleaner cleaner = new DefaultCleanerBuilder(
                 keyValueService,
                 lock,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,6 +58,10 @@ develop
          - Fixed broken batching in getting large sets of rows in Cassandra
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1764>`__)
 
+    *    - |new|
+         - ``InMemoryAtlasDbFactory`` now supports creating an in-memory transaction manager with multiple schemas.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1774>`__)
+
 =======
 v0.37.0
 =======


### PR DESCRIPTION
Addresses #1746
Copied from #1761, with small signature change.

**Goals (and why)**: Support multiple schemas in in-memory transaction manager

**Implementation Description (bullets)**: Add a varargs parameter to `InMemoryAtlasDbFactory.createInMemoryTransactionManager`

**Concerns (what feedback would you like?)**: Does this break binary compatibility? From what I could find, it [doesn't](http://stackoverflow.com/a/3589948).

**Where should we start reviewing?**: One source file

**Priority (whenever / two weeks / yesterday)**: This week

@nziebart for SA.