### PR TITLE
Revert/1524

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -10,13 +10,7 @@ dependencies {
   testCompile project(":atlasdb-docker-test-utils")
   testCompile project(":atlasdb-ete-test-utils")
 
-  testCompile ('org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra) {
-    exclude module: 'junit'
-
-    // override ant to a newer one that is shared with the version in jmock-->cglib
-    exclude module: 'ant'
-    compile 'org.apache.ant:ant:' + libVersions.ant
-  }
+  testCompile 'org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra
   testCompile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
 
   testCompile group: 'org.mockito', name: 'mockito-core'

--- a/atlasdb-cassandra-integration-tests/versions.lock
+++ b/atlasdb-cassandra-integration-tests/versions.lock
@@ -2,31 +2,11 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
-        },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "requested": "1.9.4"
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
-        },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "requested": "1.9.4"
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
         }
     }
 }

--- a/atlasdb-cassandra-multinode-tests/build.gradle
+++ b/atlasdb-cassandra-multinode-tests/build.gradle
@@ -10,13 +10,7 @@ dependencies {
     testCompile project(":atlasdb-docker-test-utils")
     testCompile project(":atlasdb-ete-test-utils")
 
-    testCompile ('org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra) {
-       exclude module: 'junit'
-
-       // override ant to a newer one that is shared with the version in jmock-->cglib
-       exclude module: 'ant'
-       compile 'org.apache.ant:ant:' + libVersions.ant
-    }
+    testCompile 'org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra
     testCompile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
 
     testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'

--- a/atlasdb-cassandra-multinode-tests/versions.lock
+++ b/atlasdb-cassandra-multinode-tests/versions.lock
@@ -2,31 +2,11 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
-        },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "requested": "1.9.4"
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
-        },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "requested": "1.9.4"
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
         }
     }
 }

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -32,8 +32,3 @@ dependencies {
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'
 }
-
-  classifier ''
-  relocate('com.netflix.feign', atlasdb_shaded + 'feign')
-  relocate('org.apache.commons', atlasdb_shaded + 'commons')
-  relocate('org.jboss', atlasdb_shaded + 'jboss')

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -1,6 +1,5 @@
 apply from: "../gradle/publish-jars.gradle"
 apply plugin: 'org.inferred.processors'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 apply from: "../gradle/shared.gradle"
 
@@ -12,10 +11,6 @@ dependencies {
 
   compile ('org.apache.cassandra:cassandra-thrift:' + libVersions.cassandra) {
     exclude module: 'junit'
-
-    // override ant to a newer one that is shared with the version in jmock-->cglib
-    exclude module: 'ant'
-    compile 'org.apache.ant:ant:' + libVersions.ant
   }
   compile 'com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core
   compile group: 'com.google.guava', name: 'guava'
@@ -38,21 +33,7 @@ dependencies {
   processor 'com.google.auto.service:auto-service:1.0-rc2'
 }
 
-shadowJar {
-  mergeServiceFiles()
   classifier ''
-
-  relocate('com.carrotsearch.hppc',  atlasdb_shaded + 'hppc')
   relocate('com.netflix.feign', atlasdb_shaded + 'feign')
-  relocate('jflex', atlasdb_shaded + 'jflex')
   relocate('org.apache.commons', atlasdb_shaded + 'commons')
-  relocate('org.apache.tools.ant', atlasdb_shaded + 'ant')
-  relocate('org.tarturus.snowball', atlasdb_shaded + 'snowball')
-  relocate('org.objectweb.asm', atlasdb_shaded + 'asm')
-  relocate('jnr', atlasdb_shaded + 'jnr')
-  relocate('io.netty', atlasdb_shaded + 'netty')
   relocate('org.jboss', atlasdb_shaded + 'jboss')
-}
-
-jar.dependsOn shadowJar
-jar.onlyIf { false }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -165,15 +165,9 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         return 62 * 1000;
     }
 
-    /*
-        Only allow this many extra enqueued requests above the configured poolsize onto a given node in the pool.
-        Attempts to enqueue more than this will immediately fail and instead fail over to another node as coordinator.
-        A person needing to modify this may have not enough backpressure in their application,
-        or have too much parallelism.
-     */
     @Value.Default
-    public int cqlPoolMaxQueueSize() {
-        return 256;
+    public int cqlPoolTimeoutMillis() {
+        return 20 * 1000;
     }
 
     @Value.Default

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -349,7 +349,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         }
         List<Map<Cell, Value>> perHostResults = runAllTasksCancelOnFailure(tasks);
         Map<Cell, Value> result = Maps.newHashMapWithExpectedSize(Iterables.size(rows));
-        perHostResults.forEach(result::putAll);
+        for (Map<Cell, Value> perHostResult : perHostResults) {
+            result.putAll(perHostResult);
+        }
         return result;
     }
 
@@ -470,7 +472,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             }
 
             SetMultimap<Long, Cell> cellsByTs = Multimaps.invertFrom(
-                    Multimaps.forMap(timestampByCell), HashMultimap.create());
+                    Multimaps.forMap(timestampByCell), HashMultimap.<Long, Cell>create());
             Builder<Cell, Value> builder = ImmutableMap.builder();
             for (long ts : cellsByTs.keySet()) {
                 StartTsResultsCollector collector = new StartTsResultsCollector(ts);
@@ -1079,13 +1081,13 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
             Map<String, List<Mutation>> rowPuts = map.get(rowName);
             if (rowPuts == null) {
-                rowPuts = Maps.newHashMap();
+                rowPuts = Maps.<String, List<Mutation>>newHashMap();
                 map.put(rowName, rowPuts);
             }
 
             List<Mutation> tableMutations = rowPuts.get(internalTableName(tableCellAndValue.tableRef));
             if (tableMutations == null) {
-                tableMutations = Lists.newArrayList();
+                tableMutations = Lists.<Mutation>newArrayList();
                 rowPuts.put(internalTableName(tableCellAndValue.tableRef), tableMutations);
             }
 
@@ -1267,7 +1269,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         int mapIndex = 0;
                         for (long ts : Ordering.natural().immutableSortedCopy(cellVersions.getValue())) {
                             if (!maps.containsKey(mapIndex)) {
-                                maps.put(mapIndex, Maps.newHashMap());
+                                maps.put(mapIndex, Maps.<ByteBuffer, Map<String, List<Mutation>>>newHashMap());
                             }
                             Map<ByteBuffer, Map<String, List<Mutation>>> map = maps.get(mapIndex);
                             ByteBuffer colName = CassandraKeyValueServices.makeCompositeBuffer(
@@ -1282,11 +1284,11 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             mutation.setDeletion(del);
                             ByteBuffer rowName = ByteBuffer.wrap(cellVersions.getKey().getRowName());
                             if (!map.containsKey(rowName)) {
-                                map.put(rowName, Maps.newHashMap());
+                                map.put(rowName, Maps.<String, List<Mutation>>newHashMap());
                             }
                             Map<String, List<Mutation>> rowPuts = map.get(rowName);
                             if (!rowPuts.containsKey(internalTableName(tableRef))) {
-                                rowPuts.put(internalTableName(tableRef), Lists.newArrayList());
+                                rowPuts.put(internalTableName(tableRef), Lists.<Mutation>newArrayList());
                             }
                             rowPuts.get(internalTableName(tableRef)).add(mutation);
                             mapIndex++;
@@ -1565,7 +1567,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         boolean putMetadataWillNeedASchemaChange = !onlyMetadataChangesAreForNewTables;
 
         if (!tablesToActuallyCreate.isEmpty()) {
-            schemaMutationLock.runWithLock(() -> createTablesInternal(tablesToActuallyCreate));
+            schemaMutationLock.runWithLock(() -> {
+                createTablesInternal(tablesToActuallyCreate);
+            });
         }
         internalPutMetadataForTables(tablesToUpdateMetadataFor, putMetadataWillNeedASchemaChange);
     }
@@ -1943,7 +1947,12 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     public void addGarbageCollectionSentinelValues(TableReference tableRef, Set<Cell> cells) {
         try {
             final Value value = Value.create(PtBytes.EMPTY_BYTE_ARRAY, Value.INVALID_VALUE_TIMESTAMP);
-            putInternal(tableRef, Iterables.transform(cells, cell -> Maps.immutableEntry(cell, value)));
+            putInternal(tableRef, Iterables.transform(cells, new Function<Cell, Map.Entry<Cell, Value>>() {
+                @Override
+                public Entry<Cell, Value> apply(Cell cell) {
+                    return Maps.immutableEntry(cell, value);
+                }
+            }));
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         }
@@ -2203,7 +2212,12 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
     private <V> Map<InetSocketAddress, Map<Cell, V>> partitionMapByHost(Iterable<Map.Entry<Cell, V>> cells) {
         Map<InetSocketAddress, List<Map.Entry<Cell, V>>> partitionedByHost =
-                partitionByHost(cells, entry -> entry.getKey().getRowName());
+                partitionByHost(cells, new Function<Map.Entry<Cell, V>, byte[]>() {
+                    @Override
+                    public byte[] apply(Entry<Cell, V> entry) {
+                        return entry.getKey().getRowName();
+                    }
+                });
         Map<InetSocketAddress, Map<Cell, V>> cellsByHost = Maps.newHashMap();
         for (Map.Entry<InetSocketAddress, List<Map.Entry<Cell, V>>> hostAndCells : partitionedByHost.entrySet()) {
             Map<Cell, V> cellsForHost = Maps.newHashMapWithExpectedSize(hostAndCells.getValue().size());

--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -1,14 +1,14 @@
 {
     "compileClasspath": {
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.1.4",
-            "requested": "3.1.4"
+            "locked": "2.2.0-rc3",
+            "requested": "2.2.0-rc3"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
@@ -51,43 +51,6 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.10",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.0",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.0.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.27",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -134,12 +97,6 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -282,48 +239,41 @@
                 "com.palantir.atlasdb:atlasdb-client"
             ]
         },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -349,19 +299,9 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "requested": "1.9.4"
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
-        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.10",
-            "requested": "3.10"
+            "locked": "2.2.8",
+            "requested": "2.2.8"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
@@ -410,40 +350,6 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
@@ -459,6 +365,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -480,15 +387,15 @@
         }
     },
     "runtime": {
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.1.4",
-            "requested": "3.1.4"
+            "locked": "2.2.0-rc3",
+            "requested": "2.2.0-rc3"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
@@ -531,43 +438,6 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.palantir.remoting1:tracing"
-            ]
-        },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.10",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.0",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.0.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.27",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.google.code.findbugs:annotations": {
@@ -614,12 +484,6 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -762,48 +626,41 @@
                 "com.palantir.atlasdb:atlasdb-client"
             ]
         },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -829,19 +686,9 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "requested": "1.9.4"
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
-        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.10",
-            "requested": "3.10"
+            "locked": "2.2.8",
+            "requested": "2.2.8"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
@@ -890,40 +737,6 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
@@ -939,6 +752,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -17,14 +17,15 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.1.4",
+            "locked": "2.2.0-rc3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -111,43 +112,6 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.10",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.0",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.0.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.27",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
@@ -220,12 +184,6 @@
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
                 "com.palantir.atlasdb:leader-election-impl"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -586,12 +544,6 @@
                 "com.palantir.atlasdb:leader-election-impl"
             ]
         },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "io.airlift:airline": {
             "locked": "0.7",
             "transitive": [
@@ -601,9 +553,7 @@
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -621,32 +571,32 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -697,20 +647,8 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
-        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.10",
+            "locked": "2.2.8",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -780,40 +718,6 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
         "org.postgresql:postgresql": {
             "locked": "9.4.1209",
             "transitive": [
@@ -841,6 +745,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-cli/build.gradle
+++ b/atlasdb-cli/build.gradle
@@ -4,7 +4,7 @@ apply from: '../gradle/shared.gradle'
 apply plugin: 'org.inferred.processors'
 
 dependencies {
-    compile project(path: ':atlasdb-cassandra', configuration: 'shadow')
+    compile project(':atlasdb-cassandra')
     compile project(path: ':atlasdb-dagger', configuration: 'shadow')
     compile 'io.airlift:airline:0.7'
 

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -595,6 +595,12 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
             "locked": "2.0.6",
             "transitive": [
@@ -1244,6 +1250,12 @@
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -12,6 +12,18 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -97,6 +109,7 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
@@ -105,6 +118,8 @@
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -112,6 +127,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.tritium:tritium-api",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -131,7 +147,9 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -197,6 +215,7 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-lock-api"
@@ -208,6 +227,7 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
@@ -223,10 +243,12 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:lock-impl"
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-config": {
@@ -260,6 +282,18 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-dagger"
+            ]
+        },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-api"
+            ]
+        },
+        "com.palantir.atlasdb:commons-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-executors": {
@@ -306,7 +340,14 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.atlasdb:timestamp-impl": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -331,16 +372,19 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
-                "com.palantir.atlasdb:lock-impl"
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -391,6 +435,12 @@
                 "com.squareup.okhttp:okhttp"
             ]
         },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.1",
             "transitive": [
@@ -427,6 +477,38 @@
             "locked": "0.9.3",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
             ]
         },
         "javax.inject:javax.inject": {
@@ -467,11 +549,43 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.config.crypto:encrypted-config-value-module"
+                "com.palantir.config.crypto:encrypted-config-value-module",
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.2.5",
+            "transitive": [
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.2.4",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.thrift:libthrift": {
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -493,9 +607,22 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
+        "org.slf4j:jcl-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.slf4j:log4j-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -503,7 +630,11 @@
                 "com.palantir.tritium:tritium-metrics",
                 "com.palantir.tritium:tritium-slf4j",
                 "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard:dropwizard-jackson"
+                "io.dropwizard:dropwizard-jackson",
+                "org.apache.cassandra:cassandra-thrift",
+                "org.apache.thrift:libthrift",
+                "org.slf4j:jcl-over-slf4j",
+                "org.slf4j:log4j-over-slf4j"
             ]
         },
         "org.xerial.snappy:snappy-java": {
@@ -532,6 +663,18 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -617,6 +760,7 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
@@ -625,6 +769,8 @@
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -632,6 +778,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.tritium:tritium-api",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -651,7 +798,9 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -717,6 +866,7 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-lock-api"
@@ -728,6 +878,7 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
@@ -743,10 +894,12 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:lock-impl"
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-config": {
@@ -780,6 +933,18 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-dagger"
+            ]
+        },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-api"
+            ]
+        },
+        "com.palantir.atlasdb:commons-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-executors": {
@@ -826,7 +991,14 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.atlasdb:timestamp-impl": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -851,16 +1023,19 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
-                "com.palantir.atlasdb:lock-impl"
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -911,6 +1086,12 @@
                 "com.squareup.okhttp:okhttp"
             ]
         },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.1",
             "transitive": [
@@ -947,6 +1128,38 @@
             "locked": "0.9.3",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
             ]
         },
         "javax.inject:javax.inject": {
@@ -987,11 +1200,43 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.config.crypto:encrypted-config-value-module"
+                "com.palantir.config.crypto:encrypted-config-value-module",
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.2.5",
+            "transitive": [
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.2.4",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.thrift:libthrift": {
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1013,9 +1258,22 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
+        "org.slf4j:jcl-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.slf4j:log4j-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -1023,7 +1281,11 @@
                 "com.palantir.tritium:tritium-metrics",
                 "com.palantir.tritium:tritium-slf4j",
                 "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard:dropwizard-jackson"
+                "io.dropwizard:dropwizard-jackson",
+                "org.apache.cassandra:cassandra-thrift",
+                "org.apache.thrift:libthrift",
+                "org.slf4j:jcl-over-slf4j",
+                "org.slf4j:log4j-over-slf4j"
             ]
         },
         "org.xerial.snappy:snappy-java": {

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -17,14 +17,15 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.1.4",
+            "locked": "2.2.0-rc3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -111,43 +112,6 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.10",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.0",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.0.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.27",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
@@ -218,12 +182,6 @@
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
                 "com.palantir.atlasdb:leader-election-impl"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -581,18 +539,10 @@
                 "com.palantir.atlasdb:leader-election-impl"
             ]
         },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -610,32 +560,32 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -691,20 +641,8 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
-        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.10",
+            "locked": "2.2.8",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -786,40 +724,6 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
         "org.postgresql:postgresql": {
             "locked": "9.4.1209",
             "transitive": [
@@ -847,6 +751,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-container-test-utils/build.gradle
+++ b/atlasdb-container-test-utils/build.gradle
@@ -5,7 +5,7 @@ apply from: "${rootProject.projectDir}/gradle/shared.gradle"
 
 dependencies {
     compile project(':atlasdb-api')
-    compile project(path: ':atlasdb-cassandra', configuration: 'shadow')
+    compile project(':atlasdb-cassandra')
     compile project(':atlasdb-docker-test-utils')
 
     compile group: 'com.google.guava', name: 'guava'

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -446,6 +446,12 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
             "locked": "1.1.2",
             "transitive": [
@@ -940,6 +946,12 @@
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -6,6 +6,18 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -18,14 +30,35 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.6.7",
             "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.netflix.feign:feign-jackson",
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting1:tracing"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-afterburner": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting1:tracing"
             ]
         },
         "com.github.almondtools:conmatch": {
@@ -44,25 +77,63 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-docker-test-utils",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:timestamp-api"
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl",
+                "com.palantir.tritium:tritium-api",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
             ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "1.3.9",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-docker-test-utils",
                 "com.palantir.docker.compose:docker-compose-rule-core",
-                "com.palantir.remoting:ssl-config"
+                "com.palantir.remoting1:tracing",
+                "com.palantir.remoting:ssl-config",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "2.6.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.json-simple:json-simple": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.googlecode.protobuf-java-format:protobuf-java-format": {
+            "locked": "1.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.jayway.awaitility:awaitility": {
@@ -71,20 +142,70 @@
                 "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
+        "com.netflix.feign:feign-core": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.netflix.feign:feign-jackson",
+                "com.netflix.feign:feign-jaxrs"
+            ]
+        },
+        "com.netflix.feign:feign-jackson": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.netflix.feign:feign-jaxrs": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
         "com.palantir.atlasdb:atlasdb-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-cassandra": {
             "project": true
         },
+        "com.palantir.atlasdb:atlasdb-client": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-client-protobufs": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
         "com.palantir.atlasdb:atlasdb-commons": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-docker-test-utils": {
             "project": true
+        },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-api"
+            ]
+        },
+        "com.palantir.atlasdb:commons-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
@@ -95,7 +216,14 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.atlasdb:timestamp-impl": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.docker.compose:docker-compose-rule-core": {
@@ -110,10 +238,60 @@
                 "com.palantir.atlasdb:atlasdb-docker-test-utils"
             ]
         },
+        "com.palantir.remoting1:tracing": {
+            "locked": "1.0.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.tritium:tritium-api": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
+            ]
+        },
+        "com.palantir.tritium:tritium-core": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
+            ]
+        },
+        "com.palantir.tritium:tritium-lib": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.tritium:tritium-metrics": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-slf4j": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient"
             ]
         },
         "commons-io:commons-io": {
@@ -122,10 +300,50 @@
                 "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
+        "commons-lang:commons-lang": {
+            "locked": "2.6",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.tritium:tritium-metrics",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
             ]
         },
         "javax.validation:validation-api": {
@@ -167,11 +385,43 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.docker.compose:docker-compose-rule-core"
+                "com.palantir.docker.compose:docker-compose-rule-core",
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.2.5",
+            "transitive": [
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.2.4",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.thrift:libthrift": {
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.hamcrest:hamcrest-core": {
@@ -189,18 +439,59 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
+            "locked": "1.1.2",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
         "org.objenesis:objenesis": {
             "locked": "2.2",
             "transitive": [
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "org.slf4j:jcl-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.slf4j:log4j-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.docker.compose:docker-compose-rule-core",
-                "io.dropwizard.metrics:metrics-core"
+                "com.palantir.remoting1:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "io.dropwizard.metrics:metrics-core",
+                "org.apache.cassandra:cassandra-thrift",
+                "org.apache.thrift:libthrift",
+                "org.slf4j:jcl-over-slf4j",
+                "org.slf4j:log4j-over-slf4j"
+            ]
+        },
+        "org.xerial.snappy:snappy-java": {
+            "locked": "1.1.1.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         }
     },
@@ -211,6 +502,18 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -223,14 +526,35 @@
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.6.7",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind"
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.6.7",
             "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.netflix.feign:feign-jackson",
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting1:tracing"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-afterburner": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting1:tracing"
             ]
         },
         "com.github.almondtools:conmatch": {
@@ -249,25 +573,63 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-docker-test-utils",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:timestamp-api"
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl",
+                "com.palantir.tritium:tritium-api",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
             ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "1.3.9",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-docker-test-utils",
                 "com.palantir.docker.compose:docker-compose-rule-core",
-                "com.palantir.remoting:ssl-config"
+                "com.palantir.remoting1:tracing",
+                "com.palantir.remoting:ssl-config",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "2.6.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.json-simple:json-simple": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.googlecode.protobuf-java-format:protobuf-java-format": {
+            "locked": "1.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.jayway.awaitility:awaitility": {
@@ -276,20 +638,70 @@
                 "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
+        "com.netflix.feign:feign-core": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.netflix.feign:feign-jackson",
+                "com.netflix.feign:feign-jaxrs"
+            ]
+        },
+        "com.netflix.feign:feign-jackson": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.netflix.feign:feign-jaxrs": {
+            "locked": "8.6.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
         "com.palantir.atlasdb:atlasdb-api": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-cassandra": {
             "project": true
         },
+        "com.palantir.atlasdb:atlasdb-client": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-client-protobufs": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
         "com.palantir.atlasdb:atlasdb-commons": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-docker-test-utils": {
             "project": true
+        },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-api"
+            ]
+        },
+        "com.palantir.atlasdb:commons-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
@@ -300,7 +712,14 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.atlasdb:timestamp-impl": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.docker.compose:docker-compose-rule-core": {
@@ -315,10 +734,60 @@
                 "com.palantir.atlasdb:atlasdb-docker-test-utils"
             ]
         },
+        "com.palantir.remoting1:tracing": {
+            "locked": "1.0.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.tritium:tritium-api": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
+            ]
+        },
+        "com.palantir.tritium:tritium-core": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
+            ]
+        },
+        "com.palantir.tritium:tritium-lib": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.tritium:tritium-metrics": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-slf4j": {
+            "locked": "0.6.0-beta",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient"
             ]
         },
         "commons-io:commons-io": {
@@ -327,10 +796,50 @@
                 "com.palantir.docker.compose:docker-compose-rule-core"
             ]
         },
+        "commons-lang:commons-lang": {
+            "locked": "2.6",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.tritium:tritium-metrics",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
             ]
         },
         "javax.validation:validation-api": {
@@ -372,11 +881,43 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.docker.compose:docker-compose-rule-core"
+                "com.palantir.docker.compose:docker-compose-rule-core",
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.2.5",
+            "transitive": [
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.2.4",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.thrift:libthrift": {
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.hamcrest:hamcrest-core": {
@@ -394,18 +935,59 @@
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
+            "locked": "1.1.2",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
         "org.objenesis:objenesis": {
             "locked": "2.2",
             "transitive": [
                 "com.jayway.awaitility:awaitility"
             ]
         },
+        "org.slf4j:jcl-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.slf4j:log4j-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.docker.compose:docker-compose-rule-core",
-                "io.dropwizard.metrics:metrics-core"
+                "com.palantir.remoting1:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "io.dropwizard.metrics:metrics-core",
+                "org.apache.cassandra:cassandra-thrift",
+                "org.apache.thrift:libthrift",
+                "org.slf4j:jcl-over-slf4j",
+                "org.slf4j:log4j-over-slf4j"
+            ]
+        },
+        "org.xerial.snappy:snappy-java": {
+            "locked": "1.1.1.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         }
     }

--- a/atlasdb-dagger/build.gradle
+++ b/atlasdb-dagger/build.gradle
@@ -23,7 +23,7 @@ shadowJar {
   mergeServiceFiles()
   classifier ''
 
-  relocate('dagger',   atlasdb_shaded + 'dagger')
+  relocate('dagger', 'com.palantir.atlasdb.shaded.dagger')
 
   dependencies {
     include dependency(group: 'com.google.dagger', name: 'dagger')

--- a/atlasdb-dbkvs-hikari/build.gradle
+++ b/atlasdb-dbkvs-hikari/build.gradle
@@ -6,7 +6,7 @@ apply from: '../gradle/shared.gradle'
 dependencies {
   compile project(':commons-db')
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-  compile group: 'io.dropwizard.metrics', name: 'metrics-core'
+  compile group: 'com.codahale.metrics', name: 'metrics-core'
 
   processor group: 'org.immutables', name: 'value'
 }

--- a/atlasdb-dbkvs-hikari/versions.lock
+++ b/atlasdb-dbkvs-hikari/versions.lock
@@ -1,5 +1,8 @@
 {
     "compileClasspath": {
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2"
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -174,6 +177,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
@@ -183,6 +187,9 @@
         }
     },
     "runtime": {
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2"
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -357,6 +364,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -1,5 +1,11 @@
 {
     "compileClasspath": {
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -358,7 +364,6 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -466,6 +471,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
@@ -485,6 +491,12 @@
         }
     },
     "runtime": {
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -843,7 +855,6 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -951,6 +962,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -1,5 +1,11 @@
 {
     "compileClasspath": {
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -332,7 +338,6 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -401,6 +406,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
@@ -420,6 +426,12 @@
         }
     },
     "runtime": {
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -752,7 +764,6 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -821,6 +832,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -1042,6 +1042,12 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
             "locked": "2.0.6",
             "transitive": [
@@ -2152,6 +2158,12 @@
             "locked": "3.1.3.GA",
             "transitive": [
                 "org.hibernate:hibernate-validator"
+            ]
+        },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -15,6 +15,18 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -125,6 +137,7 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-cli",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
@@ -135,6 +148,8 @@
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -142,6 +157,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.tritium:tritium-api",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -161,7 +177,9 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -228,6 +246,7 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-lock-api"
@@ -245,6 +264,7 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
@@ -260,10 +280,12 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:lock-impl"
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-config": {
@@ -304,6 +326,18 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-console",
                 "com.palantir.atlasdb:atlasdb-dagger"
+            ]
+        },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-api"
+            ]
+        },
+        "com.palantir.atlasdb:commons-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-executors": {
@@ -350,7 +384,14 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.atlasdb:timestamp-impl": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -375,16 +416,19 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
-                "com.palantir.atlasdb:lock-impl"
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -439,6 +483,12 @@
             "locked": "1.2",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-console"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient"
             ]
         },
         "commons-io:commons-io": {
@@ -608,6 +658,38 @@
                 "io.dropwizard:dropwizard-metrics"
             ]
         },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
+            ]
+        },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.2",
             "transitive": [
@@ -683,13 +765,45 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "io.dropwizard:dropwizard-configuration",
-                "io.dropwizard:dropwizard-jersey"
+                "io.dropwizard:dropwizard-jersey",
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.2.5",
+            "transitive": [
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.2.4",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.thrift:libthrift": {
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.codehaus.groovy:groovy-all": {
@@ -943,7 +1057,8 @@
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging"
+                "io.dropwizard:dropwizard-logging",
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
@@ -955,12 +1070,14 @@
         "org.slf4j:log4j-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging"
+                "io.dropwizard:dropwizard-logging",
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -974,6 +1091,8 @@
                 "io.dropwizard:dropwizard-logging",
                 "io.dropwizard:dropwizard-metrics",
                 "io.dropwizard:dropwizard-servlets",
+                "org.apache.cassandra:cassandra-thrift",
+                "org.apache.thrift:libthrift",
                 "org.slf4j:jcl-over-slf4j",
                 "org.slf4j:jul-to-slf4j",
                 "org.slf4j:log4j-over-slf4j"
@@ -1008,6 +1127,18 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -1118,6 +1249,7 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-cli",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
@@ -1128,6 +1260,8 @@
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -1135,6 +1269,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.tritium:tritium-api",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -1154,7 +1289,9 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -1221,6 +1358,7 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-lock-api"
@@ -1238,6 +1376,7 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
         },
@@ -1253,10 +1392,12 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:lock-impl"
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-config": {
@@ -1297,6 +1438,18 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-console",
                 "com.palantir.atlasdb:atlasdb-dagger"
+            ]
+        },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-api"
+            ]
+        },
+        "com.palantir.atlasdb:commons-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-executors": {
@@ -1343,7 +1496,14 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.atlasdb:timestamp-impl": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -1368,16 +1528,19 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
-                "com.palantir.atlasdb:lock-impl"
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1432,6 +1595,12 @@
             "locked": "1.2",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-console"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient"
             ]
         },
         "commons-io:commons-io": {
@@ -1601,6 +1770,38 @@
                 "io.dropwizard:dropwizard-metrics"
             ]
         },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
+            ]
+        },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.2",
             "transitive": [
@@ -1676,13 +1877,45 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "io.dropwizard:dropwizard-configuration",
-                "io.dropwizard:dropwizard-jersey"
+                "io.dropwizard:dropwizard-jersey",
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.2.5",
+            "transitive": [
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.2.4",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.thrift:libthrift": {
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.codehaus.groovy:groovy-all": {
@@ -1936,7 +2169,8 @@
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging"
+                "io.dropwizard:dropwizard-logging",
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
@@ -1948,12 +2182,14 @@
         "org.slf4j:log4j-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging"
+                "io.dropwizard:dropwizard-logging",
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -1967,6 +2203,8 @@
                 "io.dropwizard:dropwizard-logging",
                 "io.dropwizard:dropwizard-metrics",
                 "io.dropwizard:dropwizard-servlets",
+                "org.apache.cassandra:cassandra-thrift",
+                "org.apache.thrift:libthrift",
                 "org.slf4j:jcl-over-slf4j",
                 "org.slf4j:jul-to-slf4j",
                 "org.slf4j:log4j-over-slf4j"

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -15,6 +15,18 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -125,6 +137,7 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-cli",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
@@ -139,6 +152,8 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:atlasdb-rocksdb",
                 "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
@@ -166,7 +181,9 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -233,6 +250,7 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-jdbc",
@@ -255,6 +273,7 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-rocksdb"
@@ -272,6 +291,7 @@
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
@@ -338,6 +358,18 @@
                 "com.palantir.atlasdb:atlasdb-dagger"
             ]
         },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-api"
+            ]
+        },
+        "com.palantir.atlasdb:commons-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.palantir.atlasdb:commons-executors": {
             "project": true,
             "transitive": [
@@ -389,6 +421,7 @@
         "com.palantir.atlasdb:timestamp-impl": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-rocksdb"
             ]
@@ -415,6 +448,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:leader-election-impl",
@@ -425,7 +459,8 @@
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -670,6 +705,38 @@
                 "io.dropwizard:dropwizard-metrics"
             ]
         },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
+            ]
+        },
         "javax.annotation:javax.annotation-api": {
             "locked": "1.2",
             "transitive": [
@@ -745,13 +812,26 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "io.dropwizard:dropwizard-configuration",
-                "io.dropwizard:dropwizard-jersey"
+                "io.dropwizard:dropwizard-jersey",
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "org.apache.httpcomponents:httpclient": {
@@ -768,7 +848,10 @@
             ]
         },
         "org.apache.thrift:libthrift": {
-            "locked": "0.9.2"
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "2.4.4",
@@ -1033,7 +1116,8 @@
         "org.slf4j:jcl-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging"
+                "io.dropwizard:dropwizard-logging",
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
@@ -1045,12 +1129,14 @@
         "org.slf4j:log4j-over-slf4j": {
             "locked": "1.7.5",
             "transitive": [
-                "io.dropwizard:dropwizard-logging"
+                "io.dropwizard:dropwizard-logging",
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -1065,6 +1151,7 @@
                 "io.dropwizard:dropwizard-logging",
                 "io.dropwizard:dropwizard-metrics",
                 "io.dropwizard:dropwizard-servlets",
+                "org.apache.cassandra:cassandra-thrift",
                 "org.apache.thrift:libthrift",
                 "org.slf4j:jcl-over-slf4j",
                 "org.slf4j:jul-to-slf4j",
@@ -1100,14 +1187,15 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.1.4",
+            "locked": "2.2.0-rc3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -1219,43 +1307,6 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.10",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.0",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.0.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.27",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
@@ -1332,12 +1383,6 @@
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
                 "com.palantir.atlasdb:leader-election-impl"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -1731,12 +1776,6 @@
                 "org.apache.httpcomponents:httpclient"
             ]
         },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "io.airlift:airline": {
             "locked": "0.7",
             "transitive": [
@@ -1753,9 +1792,7 @@
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "io.dropwizard.metrics:metrics-jersey2",
                 "io.dropwizard.metrics:metrics-jetty9",
@@ -1896,32 +1933,32 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -2009,20 +2046,8 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
-        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.10",
+            "locked": "2.2.8",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -2323,40 +2348,6 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
         "org.postgresql:postgresql": {
             "locked": "9.4.1209",
             "transitive": [
@@ -2392,6 +2383,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -1089,6 +1089,12 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.jooq:jooq": {
             "locked": "3.6.4",
             "transitive": [

--- a/atlasdb-perf/build.gradle
+++ b/atlasdb-perf/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   compile project(':atlasdb-api')
   compile project(':atlasdb-dagger')
   compile project(':atlasdb-dbkvs')
-  compile project(path: ':atlasdb-cassandra', configuration: 'shadow')
+  compile project(':atlasdb-cassandra')
 
   compile group: 'io.airlift', name: 'airline', version: '0.7'
   compile group: 'org.reflections', name: 'reflections', version: '0.9.10'

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -18,6 +18,19 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -110,6 +123,7 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
@@ -159,7 +173,9 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -245,6 +261,7 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
@@ -257,6 +274,7 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
@@ -333,6 +351,7 @@
         "com.palantir.atlasdb:commons-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -401,6 +420,7 @@
         "com.palantir.atlasdb:timestamp-impl": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs"
             ]
         },
@@ -435,6 +455,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:commons-db",
@@ -446,7 +467,8 @@
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -503,6 +525,12 @@
                 "com.palantir.atlasdb:commons-db"
             ]
         },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient"
+            ]
+        },
         "commons-dbutils:commons-dbutils": {
             "locked": "1.3",
             "transitive": [
@@ -533,7 +561,6 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -548,6 +575,38 @@
             "locked": "0.9.3",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
             ]
         },
         "javax.inject:javax.inject": {
@@ -609,19 +668,51 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:commons-db",
                 "com.palantir.config.crypto:encrypted-config-value-module",
-                "com.palantir.docker.compose:docker-compose-rule-core"
+                "com.palantir.docker.compose:docker-compose-rule-core",
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.apache.commons:commons-math3": {
             "locked": "3.2",
             "transitive": [
                 "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.2.5",
+            "transitive": [
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.2.4",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.thrift:libthrift": {
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.hamcrest:hamcrest-core": {
@@ -683,10 +774,23 @@
             "locked": "0.9.10",
             "requested": "0.9.10"
         },
+        "org.slf4j:jcl-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.slf4j:log4j-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
                 "ch.qos.logback:logback-classic",
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.docker.compose:docker-compose-rule-core",
@@ -697,7 +801,11 @@
                 "com.palantir.tritium:tritium-slf4j",
                 "com.zaxxer:HikariCP",
                 "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard:dropwizard-jackson"
+                "io.dropwizard:dropwizard-jackson",
+                "org.apache.cassandra:cassandra-thrift",
+                "org.apache.thrift:libthrift",
+                "org.slf4j:jcl-over-slf4j",
+                "org.slf4j:log4j-over-slf4j"
             ]
         },
         "org.xerial.snappy:snappy-java": {
@@ -732,6 +840,19 @@
                 "ch.qos.logback:logback-classic"
             ]
         },
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari"
+            ]
+        },
+        "com.datastax.cassandra:cassandra-driver-core": {
+            "locked": "2.2.0-rc3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.6.7",
             "transitive": [
@@ -824,6 +945,7 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
@@ -873,7 +995,9 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
@@ -959,6 +1083,7 @@
         "com.palantir.atlasdb:atlasdb-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
@@ -971,6 +1096,7 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared"
             ]
@@ -1047,6 +1173,7 @@
         "com.palantir.atlasdb:commons-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -1115,6 +1242,7 @@
         "com.palantir.atlasdb:timestamp-impl": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs"
             ]
         },
@@ -1149,6 +1277,7 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:commons-db",
@@ -1160,7 +1289,8 @@
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1217,6 +1347,12 @@
                 "com.palantir.atlasdb:commons-db"
             ]
         },
+        "commons-codec:commons-codec": {
+            "locked": "1.10",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient"
+            ]
+        },
         "commons-dbutils:commons-dbutils": {
             "locked": "1.3",
             "transitive": [
@@ -1247,7 +1383,6 @@
             "locked": "3.1.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -1262,6 +1397,38 @@
             "locked": "0.9.3",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-handler"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-buffer"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "com.datastax.cassandra:cassandra-driver-core"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.0.27.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-handler"
             ]
         },
         "javax.inject:javax.inject": {
@@ -1323,19 +1490,51 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
+        "org.apache.cassandra:cassandra-thrift": {
+            "locked": "2.2.8",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:commons-db",
                 "com.palantir.config.crypto:encrypted-config-value-module",
-                "com.palantir.docker.compose:docker-compose-rule-core"
+                "com.palantir.docker.compose:docker-compose-rule-core",
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.apache.commons:commons-math3": {
             "locked": "3.2",
             "transitive": [
                 "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-pool2": {
+            "locked": "2.4.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.2.5",
+            "transitive": [
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.2.4",
+            "transitive": [
+                "org.apache.httpcomponents:httpclient",
+                "org.apache.thrift:libthrift"
+            ]
+        },
+        "org.apache.thrift:libthrift": {
+            "locked": "0.9.2",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "org.hamcrest:hamcrest-core": {
@@ -1397,10 +1596,23 @@
             "locked": "0.9.10",
             "requested": "0.9.10"
         },
+        "org.slf4j:jcl-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
+        "org.slf4j:log4j-over-slf4j": {
+            "locked": "1.7.5",
+            "transitive": [
+                "org.apache.cassandra:cassandra-thrift"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
                 "ch.qos.logback:logback-classic",
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.docker.compose:docker-compose-rule-core",
@@ -1411,7 +1623,11 @@
                 "com.palantir.tritium:tritium-slf4j",
                 "com.zaxxer:HikariCP",
                 "io.dropwizard.metrics:metrics-core",
-                "io.dropwizard:dropwizard-jackson"
+                "io.dropwizard:dropwizard-jackson",
+                "org.apache.cassandra:cassandra-thrift",
+                "org.apache.thrift:libthrift",
+                "org.slf4j:jcl-over-slf4j",
+                "org.slf4j:log4j-over-slf4j"
             ]
         },
         "org.xerial.snappy:snappy-java": {

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -742,6 +742,12 @@
                 "org.reflections:reflections"
             ]
         },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
             "locked": "2.0.6",
             "transitive": [
@@ -1562,6 +1568,12 @@
             "locked": "3.18.2-GA",
             "transitive": [
                 "org.reflections:reflections"
+            ]
+        },
+        "org.jboss.marshalling:jboss-marshalling": {
+            "locked": "1.4.11.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -951,14 +951,14 @@
                 "io.dropwizard:dropwizard-logging"
             ]
         },
-        "com.carrotsearch:hppc": {
-            "locked": "0.5.4",
+        "com.codahale.metrics:metrics-core": {
+            "locked": "3.0.2",
             "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
+                "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "com.datastax.cassandra:cassandra-driver-core": {
-            "locked": "3.1.4",
+            "locked": "2.2.0-rc3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -1069,43 +1069,6 @@
                 "org.hibernate:hibernate-validator"
             ]
         },
-        "com.github.jnr:jffi": {
-            "locked": "1.2.10",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.jnr:jnr-constants": {
-            "locked": "0.9.0",
-            "transitive": [
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-ffi": {
-            "locked": "2.0.7",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
-                "com.github.jnr:jnr-posix"
-            ]
-        },
-        "com.github.jnr:jnr-posix": {
-            "locked": "3.0.27",
-            "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core"
-            ]
-        },
-        "com.github.jnr:jnr-x86asm": {
-            "locked": "1.0.2",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "com.github.rholder:snowball-stemmer": {
-            "locked": "1.3.0.581.1",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
@@ -1171,12 +1134,6 @@
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:leader-election-api-protobufs",
                 "com.palantir.atlasdb:leader-election-impl"
-            ]
-        },
-        "com.googlecode.concurrent-trees:concurrent-trees": {
-            "locked": "2.4.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
             ]
         },
         "com.googlecode.json-simple:json-simple": {
@@ -1462,12 +1419,6 @@
                 "com.palantir.atlasdb:leader-election-impl"
             ]
         },
-        "de.jflex:jflex": {
-            "locked": "1.6.0",
-            "transitive": [
-                "org.apache.cassandra:cassandra-thrift"
-            ]
-        },
         "io.dropwizard.metrics:metrics-annotation": {
             "locked": "3.1.1",
             "transitive": [
@@ -1478,7 +1429,6 @@
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
-                "com.datastax.cassandra:cassandra-driver-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.tritium:tritium-metrics",
                 "io.dropwizard.metrics:metrics-jersey2",
@@ -1617,32 +1567,32 @@
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-handler"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-buffer"
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "com.datastax.cassandra:cassandra-driver-core"
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.0.37.Final",
+            "locked": "4.0.27.Final",
             "transitive": [
                 "io.netty:netty-codec",
                 "io.netty:netty-handler"
@@ -1716,20 +1666,8 @@
                 "io.dropwizard:dropwizard-core"
             ]
         },
-        "org.apache.ant:ant": {
-            "locked": "1.9.4",
-            "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
-            ]
-        },
-        "org.apache.ant:ant-launcher": {
-            "locked": "1.9.4",
-            "transitive": [
-                "org.apache.ant:ant"
-            ]
-        },
         "org.apache.cassandra:cassandra-thrift": {
-            "locked": "3.10",
+            "locked": "2.2.8",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
@@ -2011,40 +1949,6 @@
                 "com.palantir.tritium:tritium-metrics"
             ]
         },
-        "org.ow2.asm:asm": {
-            "locked": "5.0.4",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-tree"
-            ]
-        },
-        "org.ow2.asm:asm-analysis": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-commons": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
-        "org.ow2.asm:asm-tree": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi",
-                "org.ow2.asm:asm-analysis",
-                "org.ow2.asm:asm-commons",
-                "org.ow2.asm:asm-util"
-            ]
-        },
-        "org.ow2.asm:asm-util": {
-            "locked": "5.0.3",
-            "transitive": [
-                "com.github.jnr:jnr-ffi"
-            ]
-        },
         "org.rocksdb:rocksdbjni": {
             "locked": "4.1.0",
             "transitive": [
@@ -2074,6 +1978,7 @@
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
+                "com.codahale.metrics:metrics-core",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.tritium:tritium-core",

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.4'
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
     id 'com.palantir.configuration-resolver' version '0.1.0'
     id 'com.palantir.git-version' version '0.5.2'
     id 'org.inferred.processors' version '1.2.4-rc2'

--- a/cassandra-partitioner/versions.lock
+++ b/cassandra-partitioner/versions.lock
@@ -8,8 +8,8 @@
             "requested": "18.0"
         },
         "org.apache.cassandra:cassandra-all": {
-            "locked": "3.10",
-            "requested": "3.10"
+            "locked": "2.2.8",
+            "requested": "2.2.8"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",
@@ -25,8 +25,8 @@
             "requested": "18.0"
         },
         "org.apache.cassandra:cassandra-all": {
-            "locked": "3.10",
-            "requested": "3.10"
+            "locked": "2.2.8",
+            "requested": "2.2.8"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.1",

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -126,13 +126,11 @@ v0.37.0
            This should fix a bug (`#1654 <https://github.com/palantir/atlasdb/issues/1654>`__) that caused
            AtlasDB probing downed Cassandra nodes every few minutes to see if they were up and working yet to eventually take out the entire cluster by steadily
            building up leaked connections, due to a bug in the underlying driver.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1524>`__)
 
     *    - |fixed|
          - Correctness issue fixed in the ``clean-transactions-range`` CLI. This CLI is responsible for deleting potentially inconsistent transactions in the KVS upon restore from backup.
            The CLI was not reading the entire ``_transactions`` table, and as a result was missing deleting transactions whose start timestamp was before the backup timestamp and commit timestamp was after the backup timestamp.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1759>`__)
-
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -124,5 +124,3 @@ task verifyDependencyLocksAreCurrent << {
 }
 
 check.dependsOn generateLock, verifyDependencyLocksAreCurrent
-
-ext.atlasdb_shaded = 'com.palantir.atlasdb.shaded'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -27,8 +27,8 @@ ext.libVersions =
     jackson_annotation: '2.5.0',
     jacoco: '0.7.7.201606060606',
     snakeyaml: '1.12',
-    cassandra: '3.10',
-    cassandra_driver_core: '3.1.4',
+    cassandra: '2.2.8',
+    cassandra_driver_core: '2.2.0-rc3',
     groovy: '2.4.4',
     hamcrest: '1.3',
     libthrift: '0.9.2',
@@ -37,7 +37,6 @@ ext.libVersions =
     hikariCP: '2.4.7',
     checkstyle: '6.18',
     findbugsAnnotations: '2.0.3',
-    ant: '1.9.4',
 
     // Danger, Will Robinson!
     //

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,5 @@
 ch.qos.logback:* = 1.1.3
+com.codahale.metrics:metrics-core = 3.0.2
 com.fasterxml.jackson.*:* = 2.6.7
 com.github.rholder:guava-retrying = 2.0.0
 com.github.tomakehurst:wiremock = 1.57


### PR DESCRIPTION
**Goals (and why)**: Revert #1524. The shading introduced in this PR was breaking several upstream products, meaning nobody could take 0.37.0.

**Implementation Description (bullets)**: git revert, fix conflicts, update dependency lock

**Concerns**: This might make things _worse_ for our large internal product.

**Priority (whenever / two weeks / yesterday)**: ASAP

@clockfort for SA.