### PR TITLE
Deprecate second transaction manager creation code path

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -15,8 +15,10 @@
  */
 package com.palantir.atlasdb.factory;
 
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLSocketFactory;
 
@@ -31,10 +33,12 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.config.TimeLockClientConfig;
@@ -46,10 +50,12 @@ import com.palantir.atlasdb.keyvalue.impl.ProfilingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.ValidatingQueryRewritingKeyValueService;
+import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 import com.palantir.atlasdb.persistentlock.CheckAndSetExceptionMapper;
 import com.palantir.atlasdb.persistentlock.KvsBackedPersistentLockService;
 import com.palantir.atlasdb.persistentlock.NoOpPersistentLockService;
 import com.palantir.atlasdb.persistentlock.PersistentLockService;
+import com.palantir.atlasdb.schema.AtlasSchema;
 import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
@@ -89,6 +95,24 @@ public final class TransactionManagers {
 
     private TransactionManagers() {
         // Utility class
+    }
+
+    /**
+     * Create a {@link SerializableTransactionManager} backed by an
+     * {@link com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService}.  This should be used for testing
+     * purposes only.
+     */
+    public static SerializableTransactionManager createInMemory(AtlasSchema schema, AtlasSchema... otherSchemas) {
+        return create(ImmutableAtlasDbConfig.builder().keyValueService(new InMemoryAtlasDbConfig()).build(),
+                getSchemaSet(Lists.asList(schema, otherSchemas)),
+                x -> {},
+                false);
+    }
+
+    private static Set<Schema> getSchemaSet(List<AtlasSchema> schemas) {
+        return schemas.stream()
+                .map(AtlasSchema::getLatestSchema)
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -105,7 +105,7 @@ public final class TransactionManagers {
     public static SerializableTransactionManager createInMemory(AtlasSchema schema, AtlasSchema... otherSchemas) {
         return create(ImmutableAtlasDbConfig.builder().keyValueService(new InMemoryAtlasDbConfig()).build(),
                 getSchemaSet(Lists.asList(schema, otherSchemas)),
-                x -> {},
+                x -> { },
                 false);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -86,9 +86,17 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
         return new InMemoryTimestampService();
     }
 
+    /**
+     * @deprecated use {@link TransactionManagers#createInMemory(...)}
+     *
+     * There are some differences in set up between the methods though they are unlikely to cause breaks.
+     * This method has been deprecated as all testing should be conducted on the code path used for
+     * production TransactionManager instantiation (regardless of the backing store).  It will be removed in
+     * future versions.
+     */
+    @Deprecated
     public static SerializableTransactionManager createInMemoryTransactionManager(AtlasSchema schema,
             AtlasSchema... otherSchemas) {
-        AtlasDbVersion.ensureVersionReported();
 
         Set<Schema> schemas = Lists.asList(schema, otherSchemas).stream()
                 .map(AtlasSchema::getLatestSchema)

--- a/atlasdb-service-server/src/test/java/com/palantir/server/TransactionRemotingTest.java
+++ b/atlasdb-service-server/src/test/java/com/palantir/server/TransactionRemotingTest.java
@@ -41,6 +41,7 @@ import com.palantir.atlasdb.api.TableRange;
 import com.palantir.atlasdb.api.TableRowResult;
 import com.palantir.atlasdb.api.TableRowSelection;
 import com.palantir.atlasdb.api.TransactionToken;
+import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.impl.AtlasDbServiceImpl;
 import com.palantir.atlasdb.impl.TableMetadataCache;
 import com.palantir.atlasdb.jackson.AtlasJacksonModule;
@@ -48,7 +49,6 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.memory.InMemoryAtlasDbFactory;
 import com.palantir.atlasdb.schema.AtlasSchema;
 import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.schema.generated.SweepPriorityTable;
@@ -68,7 +68,7 @@ import io.dropwizard.testing.junit.DropwizardClientRule;
 
 public class TransactionRemotingTest {
     public final static AtlasSchema schema = SweepSchema.INSTANCE;
-    public final SerializableTransactionManager txMgr = InMemoryAtlasDbFactory.createInMemoryTransactionManager(schema);
+    public final SerializableTransactionManager txMgr = TransactionManagers.createInMemory(schema);
     public final KeyValueService kvs = txMgr.getKeyValueService();
     public final TableMetadataCache cache = new TableMetadataCache(kvs);
     public final ObjectMapper mapper = new ObjectMapper(); { mapper.registerModule(new AtlasJacksonModule(cache).createModule()); }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
          - Any lock requests that take more than ``100ms`` to receive a response are now logged in the ``SlowLockLogger`` logger.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1769>`__)
 
+    *    - |deprecated|
+         - Deprecated ``InMemoryAtlasDbFactory#createInMemoryTransactionManager``, please instead use the supported ``TransactionManagers.createInMemory(...)`` for your testing.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1784>`__)
+
 =======
 v0.38.0
 =======

--- a/examples/profile-client/build.gradle
+++ b/examples/profile-client/build.gradle
@@ -9,7 +9,7 @@ group = 'com.palantir.atlasdb.examples'
 dependencies {
   compile project(":atlasdb-client")
   compile project(":examples:profile-client-protobufs")
-  testCompile project(":atlasdb-impl-shared")
 
+  testCompile project(":atlasdb-config")
   testCompile group: 'org.hamcrest', name: 'hamcrest-library'
 }

--- a/examples/profile-client/src/test/java/com/palantir/example/profile/ProfileStoreTest.java
+++ b/examples/profile-client/src/test/java/com/palantir/example/profile/ProfileStoreTest.java
@@ -33,7 +33,7 @@ import org.junit.rules.ExpectedException;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closeables;
-import com.palantir.atlasdb.memory.InMemoryAtlasDbFactory;
+import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
@@ -51,8 +51,8 @@ public class ProfileStoreTest {
             .setName("first last")
             .build();
 
-    private final TransactionManager txnMgr = InMemoryAtlasDbFactory
-            .createInMemoryTransactionManager(ProfileSchema.INSTANCE);
+    private final TransactionManager txnMgr =
+            TransactionManagers.createInMemory(ProfileSchema.INSTANCE);
 
     @Rule
     public ExpectedException exception = ExpectedException.none();


### PR DESCRIPTION
**Goals (and why)**: remove secondary (unmaintained) code path for TxManager creation

**Implementation Description (bullets)**:
- deprecated method improperly provided by InMemoryAtlasDbFactory
- added helper method to TransactionsManagers to operate as a drop in replacement
- updated our uses of the new deprecated method

**Concerns (what feedback would you like?)**:
- mostly around the api in TransactionsManagers.createInMemory(), let me know if you would like to do something different

**Where should we start reviewing?**:
- InMemoryAtlasDbFactory / TransactionManagers

**Priority (whenever / two weeks / yesterday)**: whenever