### PR TITLE
Blocking Timeout Retry Infrastructure

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/ExceptionRetryBehaviour.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/ExceptionRetryBehaviour.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/ExceptionRetryBehaviour.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/ExceptionRetryBehaviour.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import com.palantir.lock.remoting.BlockingTimeoutException;
+
+import feign.RetryableException;
+
+public enum ExceptionRetryBehaviour {
+    RETRY_ON_OTHER_NODE(true, true),
+    RETRY_INDEFINITELY_ON_SAME_NODE(true, false),
+    RETRY_ON_SAME_NODE(false, false);
+
+    private final boolean shouldRetryInfinitelyManyTimes;
+    private final boolean shouldBackoffAndTryOtherNodes;
+
+    ExceptionRetryBehaviour(boolean shouldRetryInfinitelyManyTimes, boolean shouldBackoffAndTryOtherNodes) {
+        this.shouldRetryInfinitelyManyTimes = shouldRetryInfinitelyManyTimes;
+        this.shouldBackoffAndTryOtherNodes = shouldBackoffAndTryOtherNodes;
+    }
+
+    public static ExceptionRetryBehaviour getRetryBehaviourForException(RetryableException retryableException) {
+        if (retryableException.getCause() instanceof BlockingTimeoutException) {
+            // This is the case where we have a network request that failed because it blocked too long on a lock.
+            // Since it is still the leader, we want to try again on the same node.
+            return RETRY_INDEFINITELY_ON_SAME_NODE;
+        }
+
+        if (retryableException.retryAfter() == null) {
+            // This is the case where we have failed due to networking or other IOException.
+            return RETRY_ON_SAME_NODE;
+        }
+
+        // This is the case where the server has returned a 503.
+        // This is done when we want to do fast failover because we aren't the leader or we are shutting down.
+        return RETRY_ON_OTHER_NODE;
+    }
+
+    public boolean shouldRetryInfinitelyManyTimes() {
+        return shouldRetryInfinitelyManyTimes;
+    }
+
+    public boolean shouldBackoffAndTryOtherNodes() {
+        return shouldBackoffAndTryOtherNodes;
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -48,7 +49,8 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     private final ImmutableList<String> servers;
     private final Class<T> type;
     private final AtomicInteger failoverCount = new AtomicInteger();
-    private final int failuresBeforeSwitching = 3;
+    @VisibleForTesting
+    final int failuresBeforeSwitching = 3;
     private final int numServersToTryBeforeFailing = 14;
     private final int fastFailoverTimeoutMillis = 10000;
     private final int maxBackoffMillis;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -102,8 +102,8 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     }
 
     private boolean shouldSwitchNode(ExceptionRetryBehaviour retryBehaviour, long failures) {
-        return retryBehaviour.shouldBackoffAndTryOtherNodes() ||
-                (!retryBehaviour.shouldRetryInfinitelyManyTimes() && failures >= failuresBeforeSwitching);
+        return retryBehaviour.shouldBackoffAndTryOtherNodes()
+                || (!retryBehaviour.shouldRetryInfinitelyManyTimes() && failures >= failuresBeforeSwitching);
     }
 
     private void failoverToNextNode(ExceptionRetryBehaviour retryBehaviour) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/ExceptionRetryBehaviourTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/ExceptionRetryBehaviourTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/ExceptionRetryBehaviourTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/ExceptionRetryBehaviourTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Date;
+
+import org.junit.Test;
+
+import com.palantir.common.remoting.ServiceNotAvailableException;
+import com.palantir.lock.remoting.BlockingTimeoutException;
+
+import feign.RetryableException;
+
+@SuppressWarnings("ThrowableResultOfMethodCallIgnored") // We need to create exceptions for testing.
+public class ExceptionRetryBehaviourTest {
+    private static final ServiceNotAvailableException SERVICE_NOT_AVAILABLE_EXCEPTION
+            = new ServiceNotAvailableException("foo");
+    private static final BlockingTimeoutException BLOCKING_TIMEOUT_EXCEPTION = new BlockingTimeoutException("foo");
+    private static final Date DATE = Date.from(Instant.EPOCH);
+
+    @Test
+    public void retryOnOtherNodesShouldRetryInfinitelyManyTimes() {
+        ExceptionRetryBehaviour behaviour = ExceptionRetryBehaviour.RETRY_ON_OTHER_NODE;
+        assertThat(behaviour.shouldRetryInfinitelyManyTimes()).isTrue();
+    }
+
+    @Test
+    public void retryOnOtherNodesShouldRetryOnOtherNodes() {
+        ExceptionRetryBehaviour behaviour = ExceptionRetryBehaviour.RETRY_ON_OTHER_NODE;
+        assertThat(behaviour.shouldBackoffAndTryOtherNodes()).isTrue();
+    }
+
+    @Test
+    public void retryIndefinitelyOnSameNodeShouldRetryInfinitelyManyTimes() {
+        ExceptionRetryBehaviour behaviour = ExceptionRetryBehaviour.RETRY_INDEFINITELY_ON_SAME_NODE;
+        assertThat(behaviour.shouldRetryInfinitelyManyTimes()).isTrue();
+    }
+
+    @Test
+    public void retryIndefinitelyOnSameNodeShouldRetryOnSameNode() {
+        ExceptionRetryBehaviour behaviour = ExceptionRetryBehaviour.RETRY_INDEFINITELY_ON_SAME_NODE;
+        assertThat(behaviour.shouldBackoffAndTryOtherNodes()).isFalse();
+    }
+
+    @Test
+    public void retryOnSameNodeShouldRetryFinitelyManyTimes() {
+        ExceptionRetryBehaviour behaviour = ExceptionRetryBehaviour.RETRY_ON_SAME_NODE;
+        assertThat(behaviour.shouldRetryInfinitelyManyTimes()).isFalse();
+    }
+
+    @Test
+    public void retryOnSameNodeShouldRetryOnSameNode() {
+        ExceptionRetryBehaviour behaviour = ExceptionRetryBehaviour.RETRY_ON_SAME_NODE;
+        assertThat(behaviour.shouldBackoffAndTryOtherNodes()).isFalse();
+    }
+
+    @Test
+    public void shouldRetryIndefinitelyOnSameNodeOnBlockingTimeoutExceptionWithoutRetryAfter() {
+        RetryableException exception = createRetryableExceptionWithGenericMessage(
+                BLOCKING_TIMEOUT_EXCEPTION, null);
+        assertThat(ExceptionRetryBehaviour.getRetryBehaviourForException(exception))
+                .isEqualTo(ExceptionRetryBehaviour.RETRY_INDEFINITELY_ON_SAME_NODE);
+    }
+
+    @Test
+    public void shouldRetryIndefinitelyOnSameNodeOnBlockingTimeoutExceptionWithRetryAfter() {
+        RetryableException exception = createRetryableExceptionWithGenericMessage(
+                BLOCKING_TIMEOUT_EXCEPTION, DATE);
+        assertThat(ExceptionRetryBehaviour.getRetryBehaviourForException(exception))
+                .isEqualTo(ExceptionRetryBehaviour.RETRY_INDEFINITELY_ON_SAME_NODE);
+    }
+
+    @Test
+    public void shouldRetryOnSameNodeOnUnknownCauseRetryableExceptionWithoutRetryAfter() {
+        RetryableException exception = createRetryableExceptionWithGenericMessage(
+                null, null);
+        assertThat(ExceptionRetryBehaviour.getRetryBehaviourForException(exception))
+                .isEqualTo(ExceptionRetryBehaviour.RETRY_ON_SAME_NODE);
+    }
+
+    @Test
+    public void shouldRetryOnOtherNodesOnUnknownCauseRetryableExceptionWithRetryAfter() {
+        RetryableException exception = createRetryableExceptionWithGenericMessage(
+                null, DATE);
+        assertThat(ExceptionRetryBehaviour.getRetryBehaviourForException(exception))
+                .isEqualTo(ExceptionRetryBehaviour.RETRY_ON_OTHER_NODE);
+    }
+
+    @Test
+    public void shouldRetryOnSameNodeOnServiceNotAvailableExceptionWithoutRetryAfter() {
+        RetryableException exception = createRetryableExceptionWithGenericMessage(
+                SERVICE_NOT_AVAILABLE_EXCEPTION, null);
+        assertThat(ExceptionRetryBehaviour.getRetryBehaviourForException(exception))
+                .isEqualTo(ExceptionRetryBehaviour.RETRY_ON_SAME_NODE);
+    }
+
+    @Test
+    public void shouldRetryOnOtherNodesOnServiceNotAvailableExceptionWithRetryAfter() {
+        RetryableException exception = createRetryableExceptionWithGenericMessage(
+                SERVICE_NOT_AVAILABLE_EXCEPTION, DATE);
+        assertThat(ExceptionRetryBehaviour.getRetryBehaviourForException(exception))
+                .isEqualTo(ExceptionRetryBehaviour.RETRY_ON_OTHER_NODE);
+    }
+
+    private static RetryableException createRetryableExceptionWithGenericMessage(Exception cause, Date retryAfter) {
+        return new RetryableException("Timeout", cause, retryAfter);
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.lock.remoting.BlockingTimeoutException;
+
+import feign.RetryableException;
+
+public class FailoverFeignTargetTest {
+    private static final int FAILOVERS = 1000;
+    private static final int CLUSTER_SIZE = 3;
+
+    private static final String SERVER_1 = "server1";
+    private static final String SERVER_2 = "server2";
+    private static final String SERVER_3 = "server3";
+    private static final List<String> SERVERS = ImmutableList.of(SERVER_1, SERVER_2, SERVER_3);
+
+    private static final RetryableException EXCEPTION_WITH_RETRY_AFTER = mock(RetryableException.class);
+    private static final RetryableException EXCEPTION_WITHOUT_RETRY_AFTER = mock(RetryableException.class);
+    private static final RetryableException BLOCKING_TIMEOUT_EXCEPTION = mock(RetryableException.class);
+
+    private final FailoverFeignTarget<Object> target = new FailoverFeignTarget<>(
+            SERVERS, 1, Object.class);
+
+    static {
+        when(EXCEPTION_WITH_RETRY_AFTER.retryAfter()).thenReturn(Date.valueOf(LocalDate.MAX));
+        when(EXCEPTION_WITHOUT_RETRY_AFTER.retryAfter()).thenReturn(null);
+        when(BLOCKING_TIMEOUT_EXCEPTION.getCause()).thenReturn(new BlockingTimeoutException(new Exception()));
+    }
+
+    @Test
+    public void failsOverOnExceptionWithRetryAfter() {
+        String initialUrl = target.url();
+        target.continueOrPropagate(EXCEPTION_WITH_RETRY_AFTER);
+        assertThat(target.url()).isNotEqualTo(initialUrl);
+    }
+
+    @Test
+    public void failsOverMultipleTimesOnExceptionsWithRetryAfter() {
+        String previousUrl;
+        for (int i = 0; i < FAILOVERS; i++) {
+            previousUrl = target.url();
+            target.continueOrPropagate(EXCEPTION_WITH_RETRY_AFTER);
+            assertThat(target.url()).isNotEqualTo(previousUrl);
+        }
+    }
+
+    @Test
+    public void doesNotImmediatelyFailOverOnExceptionWithoutRetryAfter() {
+        String initialUrl = target.url();
+        target.continueOrPropagate(EXCEPTION_WITHOUT_RETRY_AFTER);
+        assertThat(target.url()).isEqualTo(initialUrl);
+    }
+
+    @Test
+    public void rethrowsExceptionWithoutRetryAfterWhenLimitExceeded() {
+        assertThatThrownBy(() -> {
+            for (int i = 0; i < FAILOVERS; i++) {
+                target.url();
+                target.continueOrPropagate(EXCEPTION_WITHOUT_RETRY_AFTER);
+            }
+        }).isEqualTo(EXCEPTION_WITHOUT_RETRY_AFTER);
+    }
+
+    @Test
+    public void doesNotFailOverOnBlockingTimeoutException() {
+        String initialUrl = target.url();
+        target.continueOrPropagate(BLOCKING_TIMEOUT_EXCEPTION);
+        assertThat(target.url()).isEqualTo(initialUrl);
+    }
+
+    @Test
+    public void doesNotFailOverOnMultipleBlockingTimeoutExceptions() {
+        String initialUrl = target.url();
+        for (int i = 0; i < FAILOVERS; i++) {
+            target.continueOrPropagate(BLOCKING_TIMEOUT_EXCEPTION);
+            assertThat(target.url()).isEqualTo(initialUrl);
+        }
+    }
+
+    @Test
+    public void failsOverMultipleTimesWithFailingLeader() {
+        for (int i = 0; i < FAILOVERS; i++) {
+            target.continueOrPropagate(
+                    i % CLUSTER_SIZE == 0 ? EXCEPTION_WITHOUT_RETRY_AFTER : EXCEPTION_WITH_RETRY_AFTER);
+        }
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/remoting/BlockingTimeoutException.java
+++ b/lock-api/src/main/java/com/palantir/lock/remoting/BlockingTimeoutException.java
@@ -28,8 +28,4 @@ public class BlockingTimeoutException extends RuntimeException {
     public BlockingTimeoutException(Throwable cause) {
         super(cause);
     }
-
-    public BlockingTimeoutException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/remoting/BlockingTimeoutException.java
+++ b/lock-api/src/main/java/com/palantir/lock/remoting/BlockingTimeoutException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.remoting;
+
+/**
+ * A BlockingTimeoutException indicates that a lock request has blocked for too long, and that the server
+ * will no longer service the request. The request may be retried; it is the responsibility of servers to
+ * clean up their resources when throwing this exception.
+ */
+public class BlockingTimeoutException extends RuntimeException {
+    public BlockingTimeoutException(String message) {
+        super(message);
+    }
+
+    public BlockingTimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    public BlockingTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:

* Part of #1772. We need clients to be able to sensibly handle retries.

**Implementation Description (bullets)**:

* Split exceptions into three classes. We previously define an exception to be a _fast failover exception_ if it is a 503 with a `Retry-After` header. Upon receiving one of these exceptions, we would retry on other nodes. This PR introduces _exception retry behaviours_, which depend on the properties of a `RetryableException`:
  - `RETRY_ON_OTHER_NODE` which is the previous fast failover exception; 
  - `RETRY_ON_SAME_NODE` which is the previous non fast failover exception;
  - `RETRY_INDEFINITELY_ON_SAME_NODE` which handles `BlockingTimeoutException`.
* Modify the retry logic in `FailoverFeignTarget` to use the behaviour enum defined above
* Unit tests for the retry behaviour enum, and `FailoverFeignTarget` which previously lacked unit tests (shudder)

From here, the path forward looks like:

* Serialize exceptions differently, so that we are able to identify a `BlockingTimeoutException` as one.
* Implement a time-limited lock service on the server that throws `BlockingTimeoutException` in a suitable way.

**Concerns (what feedback would you like?)**:

* I found the original retry semantics rather unintuitive. I _think_ it's easier to understand now, but it might still be confusing.
* Would it be more appropriate to have a separate retryer for lock clients that actually needs to worry about the `RETRY_INDEFINITELY_ON_SAME_NODE` behaviour?
* Is the perf of `getRetryBehaviourForException()` suboptimal in terms of the order of testing the cases? Does it matter?

**Where should we start reviewing?**:

* Start with `ExceptionRetryBehaviour`, and then `FailoverFeignTarget`.

**Priority (whenever / two weeks / yesterday)**:

Early next week please! We are probably going to patch internal party stack with a fix to #1772 that incorporates #1782, this one and changes to be made in at least one subsequent PR, but I'd rather not have that diverge too much from develop.
