### PR TITLE
parallel dbkvs ddl operations

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DdlConfig.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs;
 
+import java.util.concurrent.TimeUnit;
+
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -55,6 +57,16 @@ public abstract class DdlConfig {
     @Value.Default
     public int mutationBatchSizeBytes() {
         return 2 * 1024 * 1024;
+    }
+
+    @Value.Default
+    public int parallelDdlOperationConcurrency() {
+        return 16;
+    }
+
+    @Value.Default
+    public long ddlOperationTimeoutSeconds() {
+        return TimeUnit.SECONDS.convert(10, TimeUnit.MINUTES);
     }
 
     @Value.Check

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbDdlTable.java
@@ -16,7 +16,7 @@
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
 public interface DbDdlTable {
-    void create(byte[] tableMetadta);
+    void create(byte[] tableMetadata);
     void drop();
     void truncate();
     void checkDatabaseVersion();

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -35,10 +35,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -58,6 +61,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -116,7 +120,6 @@ import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.exception.PalantirSqlException;
 import com.palantir.nexus.db.sql.AgnosticLightResultRow;
-import com.palantir.nexus.db.sql.AgnosticResultRow;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
 import com.palantir.nexus.db.sql.SqlConnection;
 import com.palantir.util.crypto.Sha256Hash;
@@ -139,6 +142,7 @@ public final class DbKvs extends AbstractKeyValueService {
     private final DbTableFactory dbTables;
     private final SqlConnectionSupplier connections;
     private final BatchingTaskRunner batchingQueryRunner;
+    private final ExecutorService ddlExecutor;
     private final OverflowValueLoader overflowValueLoader;
     private final DbKvsGetRange getRangeStrategy;
 
@@ -219,6 +223,9 @@ public final class DbKvs extends AbstractKeyValueService {
         this.config = config;
         this.dbTables = dbTables;
         this.connections = connections;
+        ddlExecutor = Executors.newFixedThreadPool(
+                config.parallelDdlOperationConcurrency(),
+                new NamedThreadFactory("Atlas Relational KVS DDL Runner"));
         this.batchingQueryRunner = batchingQueryRunner;
         this.overflowValueLoader = overflowValueLoader;
         this.getRangeStrategy = getRangeStrategy;
@@ -252,12 +259,9 @@ public final class DbKvs extends AbstractKeyValueService {
     }
 
     private void createMetadataTable() {
-        runInitialization(new Function<DbTableInitializer, Void>() {
-            @Override
-            public Void apply(@Nonnull DbTableInitializer initializer) {
-                initializer.createMetadataTable(config.metadataTable().getQualifiedName());
-                return null;
-            }
+        runInitialization(initializer -> {
+            initializer.createMetadataTable(config.metadataTable().getQualifiedName());
+            return null;
         });
     }
     @Override
@@ -266,6 +270,7 @@ public final class DbKvs extends AbstractKeyValueService {
         dbTables.close();
         connections.close();
         batchingQueryRunner.close();
+        ddlExecutor.shutdown();
     }
 
     @Override
@@ -533,12 +538,9 @@ public final class DbKvs extends AbstractKeyValueService {
 
     @Override
     public void deleteRange(TableReference tableRef, RangeRequest range) {
-        runWriteForceAutocommit(tableRef, new Function<DbWriteTable, Void>() {
-            @Override
-            public Void apply(DbWriteTable table) {
-                table.delete(range);
-                return null;
-            }
+        runWriteForceAutocommit(tableRef, table -> {
+            table.delete(range);
+            return null;
         });
     }
 
@@ -1070,104 +1072,103 @@ public final class DbKvs extends AbstractKeyValueService {
         });
     }
 
+    private void runOnTables(Set<TableReference> tableRefs, Consumer<DbDdlTable> runner) {
+        List<Future> futures = Lists.newArrayListWithCapacity(tableRefs.size());
+        tableRefs.forEach(tableRef -> futures.add(ddlExecutor.submit(() ->
+                runDdl(tableRef, runner))));
+        waitOnDdlOperations(futures);
+    }
+
     @Override
     public void truncateTable(TableReference tableRef) {
-        runDdl(tableRef, new Function<DbDdlTable, Void>() {
-            @Override
-            public Void apply(DbDdlTable table) {
-                table.truncate();
-                return null;
-            }
-        });
+        truncateTables(ImmutableSet.of(tableRef));
+    }
+
+    @Override
+    public void truncateTables(Set<TableReference> tableRefs) {
+        runOnTables(tableRefs, table -> table.truncate());
     }
 
     @Override
     public void dropTable(TableReference tableRef) {
-        runDdl(tableRef, new Function<DbDdlTable, Void>() {
-            @Override
-            public Void apply(DbDdlTable table) {
-                table.drop();
-                return null;
-            }
-        });
+        dropTables(ImmutableSet.of(tableRef));
+    }
+
+    @Override
+    public void dropTables(Set<TableReference> tableRefs) {
+        runOnTables(tableRefs, table -> table.drop());
     }
 
     @Override
     public void createTable(TableReference tableRef, byte[] tableMetadata) {
-        runDdl(tableRef, new Function<DbDdlTable, Void>() {
-            @Override
-            public Void apply(DbDdlTable table) {
-                table.create(tableMetadata);
-                return null;
+        createTables(ImmutableMap.of(tableRef, tableMetadata));
+    }
+
+    @Override
+    public void createTables(Map<TableReference, byte[]> tableRefToTableMetadata) {
+        Set<Entry<TableReference, byte[]>> entries = tableRefToTableMetadata.entrySet();
+        List<Future> futures = Lists.newArrayListWithCapacity(entries.size());
+
+        entries.forEach(entry -> futures.add(ddlExecutor.submit(() ->
+                runDdl(entry.getKey(), table -> {
+                    table.create(entry.getValue());
+                    putMetadataForTable(entry.getKey(), entry.getValue());
+                }))));
+
+        waitOnDdlOperations(futures);
+    }
+
+    private void waitOnDdlOperations(List<Future> futures) {
+        for (Future future : futures) {
+            try {
+                future.get(config.ddlOperationTimeoutSeconds(), TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw Throwables.rewrapAndThrowUncheckedException(e);
             }
-        });
-        // it would be kind of nice if this was in a transaction with the DbDdlTable create,
-        // but the code currently isn't well laid out to accommodate that
-        putMetadataForTable(tableRef, tableMetadata);
+        }
     }
 
     @Override
     public Set<TableReference> getAllTableNames() {
-        return run(new Function<SqlConnection, Set<TableReference>>() {
-            @Override
-            public Set<TableReference> apply(SqlConnection conn) {
-                AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
-                        "SELECT table_name FROM " + config.metadataTable().getQualifiedName());
-                Set<TableReference> ret = Sets.newHashSetWithExpectedSize(results.size());
-                for (AgnosticResultRow row : results.rows()) {
-                    ret.add(TableReference.createUnsafe(row.getString("table_name")));
-                }
-                return ret;
-            }
+        return run(conn -> {
+            AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
+                    "SELECT table_name FROM " + config.metadataTable().getQualifiedName());
+            Set<TableReference> ret = Sets.newHashSetWithExpectedSize(results.size());
+            results.rows().forEach(row -> ret.add(TableReference.createUnsafe(row.getString("table_name"))));
+            return ret;
         });
     }
 
     @Override
     public byte[] getMetadataForTable(TableReference tableRef) {
-        return runMetadata(tableRef, new Function<DbMetadataTable, byte[]>() {
-            @Override
-            public byte[] apply(DbMetadataTable table) {
-                return table.getMetadata();
-            }
-        });
+        return runMetadata(tableRef, table -> table.getMetadata());
     }
 
     @Override
     public void putMetadataForTable(TableReference tableRef, byte[] metadata) {
-        runMetadata(tableRef, new Function<DbMetadataTable, Void>() {
-            @Override
-            public Void apply(DbMetadataTable table) {
-                table.putMetadata(metadata);
-                return null;
-            }
+        runMetadata(tableRef, table -> {
+            table.putMetadata(metadata);
+            return null;
         });
     }
 
     @Override
     public Map<TableReference, byte[]> getMetadataForTables() {
-        return run(new Function<SqlConnection, Map<TableReference, byte[]>>() {
-            @Override
-            @SuppressWarnings("deprecation")
-            public Map<TableReference, byte[]> apply(SqlConnection conn) {
-                AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
-                        "SELECT table_name, value FROM " + config.metadataTable().getQualifiedName());
-                Map<TableReference, byte[]> ret = Maps.newHashMapWithExpectedSize(results.size());
-                for (AgnosticResultRow row : results.rows()) {
-                    ret.put(TableReference.createUnsafe(row.getString("table_name")), row.getBytes("value"));
-                }
-                return ret;
-            }
+        return run(conn -> {
+            AgnosticResultSet results = conn.selectResultSetUnregisteredQuery(
+                    "SELECT table_name, value FROM " + config.metadataTable().getQualifiedName());
+            Map<TableReference, byte[]> ret = Maps.newHashMapWithExpectedSize(results.size());
+            results.rows().forEach(row ->
+                    ret.put(TableReference.createUnsafe(row.getString("table_name")), row.getBytes("value")));
+            return ret;
         });
     }
 
     @Override
     public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
-        runWrite(tableRef, new Function<DbWriteTable, Void>() {
-            @Override
-            public Void apply(DbWriteTable table) {
-                table.putSentinels(cells);
-                return null;
-            }
+        runWrite(tableRef, table -> {
+            table.putSentinels(cells);
+            return null;
         });
     }
 
@@ -1195,13 +1196,7 @@ public final class DbKvs extends AbstractKeyValueService {
 
     @Override
     public void compactInternally(TableReference tableRef) {
-        runDdl(tableRef, new Function<DbDdlTable, Void>() {
-            @Override
-            public Void apply(DbDdlTable table) {
-                table.compactInternally();
-                return null;
-            }
-        });
+        runDdl(tableRef, table -> table.compactInternally());
     }
 
     @Override
@@ -1217,13 +1212,7 @@ public final class DbKvs extends AbstractKeyValueService {
     }
 
     public void checkDatabaseVersion() {
-        runDdl(TableReference.createWithEmptyNamespace(""), new Function<DbDdlTable, Void>() {
-            @Override
-            public Void apply(DbDdlTable table) {
-                table.checkDatabaseVersion();
-                return null;
-            }
-        });
+        runDdl(TableReference.createWithEmptyNamespace(""), table -> table.checkDatabaseVersion());
     }
 
     public String getTablePrefix() {
@@ -1253,11 +1242,11 @@ public final class DbKvs extends AbstractKeyValueService {
         }
     }
 
-    private <T> T runDdl(TableReference tableRef, Function<DbDdlTable, T> runner) {
+    private void runDdl(TableReference tableRef, Consumer<DbDdlTable> runner) {
         ConnectionSupplier conns = new ConnectionSupplier(connections);
         try {
             /* The ddl actions can used both the fully qualified name and the internal name */
-            return runner.apply(dbTables.createDdl(tableRef, conns));
+            runner.accept(dbTables.createDdl(tableRef, conns));
         } finally {
             conns.close();
         }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -162,6 +162,14 @@ develop
          - Added backwards compatibility for the changes introduced in `#2067 <https://github.com/palantir/atlasdb/pull/2067>`__, in particular, for passing row values into AtlasConsole functions.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2080>`__)
 
+    *    - |improved|
+         - DbKVS now parallelizes createTables(), dropTables(), truncateTables() DDL operations
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1788>`__)
+
+    *    - |new|
+         - DbKVS now has a timeout for DDL operations
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1788>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 ======


### PR DESCRIPTION
parallelize dbkvs ddl operations and also add dbkvs ddl timeouts (even for non-parallel version)

**Goals (and why)**:
Two separate issues:
- We have an upgrade task that for some users will drop over 1000 atlas tables.
  Right now Oracle KVS clocks in at about 7 seconds per drop; the upgrade task takes over 2 hours.
  (Really, Oracle KVS is internally doing two table drops (main table, overflow table) w/ purging the segments from the tablespace and two tiny row deletes for table metadata and oracle table name remapper, so to be fair Oracle is clocking in at an extremely reasonable ~3 seconds per actual drop)

- Another customer had an issue where drop table seemed to hang; I suspect maybe because of inability to grab the necessary exclusive locks, but I was not given the requisite information nor access to debug.

**Implementation Description (bullets)**:
- Add configurables for parallelism and timeout
- driveby java8ing of surrounding code

**Concerns**:
- someone with some time on their hands could eventually move all the DBKVS code from Guava Functions to to Java ones; I elected not to rock the boat too too much in this same commit.
- This affects Oracle, Postgres, and H2 KVSs.
- I have not tested the speedup from implementing this; we could merge a benchmark for this first, but the benchmark would add a lot of time to the suite. (>100 ops for good timing numbers, p99 stats would mean doing over ten minutes of wallclock time in the fully serial version). As a result it's probably easier to benchmark myself manually, which I will do and report back.

**Priority (whenever / two weeks / yesterday)**:
whenever, pending sanity check here and some testing I was planning on instead of backporting this just writing parallism higher up into our upgrade task, so no rush on your end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1788)
<!-- Reviewable:end -->
