### PR TITLE
Add environment variables to JUnit defaults

### DIFF
--- a/idea.gradle
+++ b/idea.gradle
@@ -32,6 +32,16 @@ class Xml {
     void set(Map<String, String> attr) {
         node.attributes().putAll(attr)
     }
+
+    Xml removeAllChildren() {
+        node.value = ""
+        new Xml(node: node)
+    }
+
+    Xml addChild(String tag, Map<String, String> attr) {
+        node.appendNode(tag, attr)
+        new Xml(node: node)
+    }
 }
 
 // This is intended to match the value in gradlew and/or gradle.properties
@@ -56,6 +66,13 @@ if (project == rootProject) {
                     .get('component', name: 'PropertiesComponent')
                     .get('property', name: 'show.inlinked.gradle.project.popup')
                     .set(value: 'false')
+            Xml.from(provider)
+                    .get('component', name: 'RunManager')
+                    .get('configuration', factoryName: 'JUnit')
+                    .get('envs')
+                    .removeAllChildren()
+                    .addChild('env', [name: 'CASSANDRA_MAX_HEAP_SIZE', value:'512m'])
+                    .addChild('env', [name: 'CASSANDRA_HEAP_NEWSIZE', value:'64m'])
         }
     }
 


### PR DESCRIPTION
This works for clean checkouts of AtlasDB.
If you already have `atlasdb.iws`, you can:
a) add the variables manually to the default JUnit configuration
or, b) delete `atlasdb.iws` and run `./gradlew idea`

**Goals (and why)**: Enable running of Cassandra integration tests directly from Intellij

**Implementation Description (bullets)**: Groovy code to find the JUnit defaults, and add two environment variables.

**Concerns (what feedback would you like?)**: Is the workaround acceptable?

**Where should we start reviewing?**:  idea.gradle

**Priority (whenever / two weeks / yesterday)**: Shortly before you want to run Cassandra integration tests =)