### PR TITLE
Shadow HTTP-Remoting2 in AtlasDB-Config

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     // This is added so that AtlasDB clients can specify the javaAgent as a JVM argument to load jars needed for HTTP/2
     // in the boot classpath
-    runtime group: 'org.mortbay.jetty.alpn', name: 'jetty-alpn-agent', version: libVersions.jetty_alpn_agent
+    shadow group: 'org.mortbay.jetty.alpn', name: 'jetty-alpn-agent', version: libVersions.jetty_alpn_agent
 
     processor group: 'org.immutables', name: 'value'
     processor 'com.google.auto.service:auto-service:1.0-rc2'

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -1,28 +1,37 @@
 apply from: "../gradle/publish-jars.gradle"
 apply plugin: 'org.inferred.processors'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 apply from: "../gradle/shared.gradle"
 
-dependencies {
-    compile project(':atlasdb-api')
-    compile project(':atlasdb-impl-shared')
-    compile project(':leader-election-impl')
-    compile project(':lock-impl')
+configurations {
+    explicitShadow
+    compile.extendsFrom(explicitShadow)
+    shadow.extendsFrom(explicitShadow)
+}
 
-    compile group: 'com.netflix.feign', name: 'feign-jackson'
-    compile (group: 'com.netflix.feign', name: 'feign-jaxrs') {
+dependencies {
+    compile group: 'com.palantir.remoting2', name: 'error-handling'
+
+    explicitShadow project(':atlasdb-api')
+    explicitShadow project(':atlasdb-impl-shared')
+    explicitShadow project(':leader-election-impl')
+    explicitShadow project(':lock-impl')
+
+    explicitShadow group: 'com.netflix.feign', name: 'feign-jackson'
+    explicitShadow (group: 'com.netflix.feign', name: 'feign-jaxrs') {
         exclude module: 'jsr311-api'
     }
     // versions below 8.10.0 have a bug where POST requests must have a body
-    compile group: 'com.netflix.feign', name: 'feign-okhttp'
-    compile group: 'javax.validation', name: 'validation-api'
-    compile group: 'com.palantir.config.crypto', name: 'encrypted-config-value-module'
-    compile group: 'com.palantir.tritium', name: 'tritium-lib'
+    explicitShadow group: 'com.netflix.feign', name: 'feign-okhttp'
+    explicitShadow group: 'javax.validation', name: 'validation-api'
+    explicitShadow group: 'com.palantir.config.crypto', name: 'encrypted-config-value-module'
+    explicitShadow group: 'com.palantir.tritium', name: 'tritium-lib'
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml'
-    compile group: 'io.dropwizard', name: 'dropwizard-jackson'
-    compile group: 'com.google.code.findbugs', name: 'annotations'
+    explicitShadow group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    explicitShadow group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml'
+    explicitShadow group: 'io.dropwizard', name: 'dropwizard-jackson'
+    explicitShadow group: 'com.google.code.findbugs', name: 'annotations'
 
     // This is added so that AtlasDB clients can specify the javaAgent as a JVM argument to load jars needed for HTTP/2
     // in the boot classpath
@@ -37,3 +46,17 @@ dependencies {
     testCompile group: 'com.github.tomakehurst', name: 'wiremock'
     testCompile group: 'org.assertj', name: 'assertj-core'
 }
+
+shadowJar {
+    mergeServiceFiles()
+    classifier ''
+
+    relocate('com.palantir.remoting2.errors', 'com.palantir.atlasdb.http.errors')
+    
+    dependencies {
+        include(dependency(group: 'com.palantir.remoting2', name: 'error-handling'))
+    }
+}
+
+jar.dependsOn shadowJar
+jar.onlyIf { false } // Prevents running the jar task directly.

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -51,7 +51,7 @@ shadowJar {
     mergeServiceFiles()
     classifier ''
 
-    relocate('com.palantir.remoting2.errors', 'com.palantir.atlasdb.http.errors')
+    relocate('com.palantir.remoting2.errors', 'com.palantir.atlasdb.shaded.com.palantir.remoting2.errors')
     
     dependencies {
         include(dependency(group: 'com.palantir.remoting2', name: 'error-handling'))

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -12,6 +12,7 @@ configurations {
 
 dependencies {
     compile group: 'com.palantir.remoting2', name: 'error-handling'
+    compile group: 'com.palantir.remoting2', name: 'jackson-support'
 
     explicitShadow project(':atlasdb-api')
     explicitShadow project(':atlasdb-impl-shared')
@@ -52,9 +53,11 @@ shadowJar {
     classifier ''
 
     relocate('com.palantir.remoting2.errors', 'com.palantir.atlasdb.shaded.com.palantir.remoting2.errors')
-    
+    relocate('com.palantir.remoting2.ext.jackson', 'com.palantir.atlasdb.shaded.com.palantir.remoting2.ext.jackson')
+
     dependencies {
         include(dependency(group: 'com.palantir.remoting2', name: 'error-handling'))
+        include(dependency(group: 'com.palantir.remoting2', name: 'jackson-support'))
     }
 }
 

--- a/atlasdb-config/versions.lock
+++ b/atlasdb-config/versions.lock
@@ -33,7 +33,9 @@
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk7",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-joda",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
                 "com.palantir.atlasdb:atlasdb-client",
                 "io.dropwizard:dropwizard-jackson"
@@ -44,7 +46,9 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk7",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-joda",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
                 "com.netflix.feign:feign-jackson",
                 "com.palantir.atlasdb:atlasdb-api",
@@ -54,6 +58,8 @@
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
+                "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting:ssl-config",
                 "io.dropwizard:dropwizard-jackson"
             ]
@@ -69,6 +75,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
+                "com.palantir.remoting2:jackson-support",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -78,16 +86,31 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting2:error-handling",
+                "com.palantir.remoting2:jackson-support"
+            ]
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
             "locked": "2.6.7",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting2:jackson-support"
+            ]
+        },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
             "locked": "2.6.7",
             "transitive": [
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
+                "com.palantir.remoting2:jackson-support",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -119,6 +142,7 @@
             "locked": "1.3.9",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.remoting2:error-handling",
                 "io.dropwizard:dropwizard-util",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -131,6 +155,7 @@
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting:ssl-config",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -295,6 +320,15 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting2:error-handling": {
+            "locked": "2.3.0"
+        },
+        "com.palantir.remoting2:jackson-support": {
+            "locked": "2.3.0",
+            "transitive": [
+                "com.palantir.remoting2:error-handling"
+            ]
+        },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
@@ -393,7 +427,8 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:timestamp-api"
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.remoting2:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -434,6 +469,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -489,7 +525,9 @@
                 "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk7",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-joda",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
                 "com.palantir.atlasdb:atlasdb-client",
                 "io.dropwizard:dropwizard-jackson"
@@ -500,7 +538,9 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk7",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-joda",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
                 "com.netflix.feign:feign-jackson",
                 "com.palantir.atlasdb:atlasdb-api",
@@ -510,6 +550,8 @@
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
+                "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting:ssl-config",
                 "io.dropwizard:dropwizard-jackson"
             ]
@@ -525,6 +567,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
+                "com.palantir.remoting2:jackson-support",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -534,16 +578,31 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting2:error-handling",
+                "com.palantir.remoting2:jackson-support"
+            ]
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
             "locked": "2.6.7",
             "transitive": [
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting2:jackson-support"
+            ]
+        },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
             "locked": "2.6.7",
             "transitive": [
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
+                "com.palantir.remoting2:jackson-support",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -575,6 +634,7 @@
             "locked": "1.3.9",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.remoting2:error-handling",
                 "io.dropwizard:dropwizard-util",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
@@ -587,6 +647,7 @@
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting:ssl-config",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
@@ -751,6 +812,15 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting2:error-handling": {
+            "locked": "2.3.0"
+        },
+        "com.palantir.remoting2:jackson-support": {
+            "locked": "2.3.0",
+            "transitive": [
+                "com.palantir.remoting2:error-handling"
+            ]
+        },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0",
             "transitive": [
@@ -849,7 +919,8 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
-                "com.palantir.atlasdb:timestamp-api"
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.remoting2:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -879,10 +950,6 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "org.mortbay.jetty.alpn:jetty-alpn-agent": {
-            "locked": "2.0.6",
-            "requested": "2.0.6"
-        },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
             "locked": "1.1.2",
             "transitive": [
@@ -894,6 +961,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.remoting2:error-handling",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-dropwizard-bundle/build.gradle
+++ b/atlasdb-dropwizard-bundle/build.gradle
@@ -3,7 +3,7 @@ apply from: "../gradle/shared.gradle"
 
 dependencies {
     compile project(':atlasdb-cli')
-    compile project(':atlasdb-config')
+    compile project(path: ':atlasdb-config', configuration: 'shadow')
     compile project(':atlasdb-console')
 
     compile group: 'io.dropwizard', name: 'dropwizard-core'

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -11,7 +11,7 @@ schemas = [
 dependencies {
     compile project(':lock-impl')
     compile project(':leader-election-impl')
-    compile project(':atlasdb-config')
+    compile project(path: ':atlasdb-config', configuration: 'shadow')
     compile project(':atlasdb-dropwizard-bundle')
     compile project(':atlasdb-hikari')
     compile project(':atlasdb-rocksdb')

--- a/atlasdb-jepsen-tests/build.gradle
+++ b/atlasdb-jepsen-tests/build.gradle
@@ -31,7 +31,7 @@ check.dependsOn integTest
 check.dependsOn runUnitTestsForPrintLogsInChronologicalOrderScript
 
 dependencies {
-    compile project(':atlasdb-config')
+    compile project(path: ':atlasdb-config', configuration: 'shadow')
 
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'

--- a/atlasdb-service-server/build.gradle
+++ b/atlasdb-service-server/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile project(':atlasdb-service')
     compile project(':lock-impl')
     compile project(':leader-election-impl')
-    compile project(':atlasdb-config')
+    compile project(path: ':atlasdb-config', configuration: 'shadow')
     runtime project(':atlasdb-rocksdb')
     runtime project(':atlasdb-cassandra')
 

--- a/atlasdb-service/build.gradle
+++ b/atlasdb-service/build.gradle
@@ -4,7 +4,7 @@ apply from: "../gradle/shared.gradle"
 dependencies {
     compile project(':lock-impl')
     compile project(':leader-election-impl')
-    compile project(':atlasdb-config')
+    compile project(path: ':atlasdb-config', configuration: 'shadow')
     compile 'javax.inject:javax.inject:1'
 
     testCompile group: 'org.mockito', name: 'mockito-core'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -52,6 +52,7 @@ ext.libVersions =
     timelock_dropwizard: '1.0.6',
     timelock_jetty: '9.3.9.v20160517',
     timelock_jersey: '2.23.2',
+    timelock_jackson: '2.7.8',
 
     c3p0: '0.9.5.1',
     log4j: '1.2.17'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -52,7 +52,7 @@ ext.libVersions =
     timelock_dropwizard: '1.0.6',
     timelock_jetty: '9.3.9.v20160517',
     timelock_jersey: '2.23.2',
-    timelock_jackson: '2.7.8',
+    timelock_jackson: '2.6.7',
 
     c3p0: '0.9.5.1',
     log4j: '1.2.17'

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -71,6 +71,7 @@ configurations.all {
                     break
                 case 'com.fasterxml.jackson.core':
                 case 'com.fasterxml.jackson.module':
+                case 'com.fasterxml.jackson.datatype':
                     details.useVersion libVersions.timelock_jackson
                     break
                 case 'org.eclipse.jetty':
@@ -84,9 +85,6 @@ configurations.all {
         forcedModules = [
                 'ch.qos.logback:logback-classic:1.1.7',
                 'com.netflix.feign:feign-core:8.10.1',
-                'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.7.8',
-                'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.7.8',
-                'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.7.8',
                 'io.atomix.catalyst:catalyst-transport:1.1.2',
                 'org.objenesis:objenesis:2.3'
         ]

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -70,7 +70,6 @@ configurations.all {
                     details.useVersion libVersions.timelock_dropwizard
                     break
                 case 'com.fasterxml.jackson.core':
-                case 'com.fasterxml.jackson.module':
                 case 'com.fasterxml.jackson.datatype':
                     details.useVersion libVersions.timelock_jackson
                     break
@@ -84,6 +83,7 @@ configurations.all {
         }
         forcedModules = [
                 'ch.qos.logback:logback-classic:1.1.7',
+                'com.fasterxml.jackson.module:jackson-module-afterburner:2.6.7',
                 'com.netflix.feign:feign-core:8.10.1',
                 'io.atomix.catalyst:catalyst-transport:1.1.2',
                 'org.objenesis:objenesis:2.3'

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile project(":timestamp-impl")
     compile project(":lock-impl")
     compile project(":leader-election-impl")
-    compile project(":atlasdb-config")
+    compile project(path: ":atlasdb-config", configuration: "shadow")
 
     compile group: 'com.github.rholder', name: 'guava-retrying'
     compile group: 'com.palantir.remoting1', name: 'jersey-servers'
@@ -69,6 +69,10 @@ configurations.all {
                 case 'io.dropwizard':
                     details.useVersion libVersions.timelock_dropwizard
                     break
+                case 'com.fasterxml.jackson.core':
+                case 'com.fasterxml.jackson.module':
+                    details.useVersion libVersions.timelock_jackson
+                    break
                 case 'org.eclipse.jetty':
                     details.useVersion libVersions.timelock_jetty
                     break
@@ -79,8 +83,10 @@ configurations.all {
         }
         forcedModules = [
                 'ch.qos.logback:logback-classic:1.1.7',
-                'com.fasterxml.jackson.module:jackson-module-afterburner:2.6.7',
                 'com.netflix.feign:feign-core:8.10.1',
+                'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.7.8',
+                'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.7.8',
+                'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.7.8',
                 'io.atomix.catalyst:catalyst-transport:1.1.2',
                 'org.objenesis:objenesis:2.3'
         ]

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -85,7 +85,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
+            "locked": "2.7.8",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting1:error-handling",
@@ -100,7 +100,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.6.3",
+            "locked": "2.7.8",
             "transitive": [
                 "io.dropwizard.modules:dropwizard-java8"
             ]
@@ -112,7 +112,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.6.3",
+            "locked": "2.7.8",
             "transitive": [
                 "io.dropwizard.modules:dropwizard-java8"
             ]
@@ -130,7 +130,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
+            "locked": "2.7.8",
             "transitive": [
                 "com.palantir.remoting1:error-handling",
                 "com.palantir.remoting1:jersey-servers",
@@ -1282,7 +1282,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.6.7",
+            "locked": "2.7.8",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting1:error-handling",
@@ -1297,7 +1297,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.6.3",
+            "locked": "2.7.8",
             "transitive": [
                 "io.dropwizard.modules:dropwizard-java8"
             ]
@@ -1309,7 +1309,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.6.3",
+            "locked": "2.7.8",
             "transitive": [
                 "io.dropwizard.modules:dropwizard-java8"
             ]
@@ -1327,7 +1327,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.6.7",
+            "locked": "2.7.8",
             "transitive": [
                 "com.palantir.remoting1:error-handling",
                 "com.palantir.remoting1:jersey-servers",

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -27,6 +27,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-joda",
+                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:leader-election-api",
@@ -138,7 +139,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.7.8",
             "transitive": [
                 "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
             ]
@@ -1223,6 +1224,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-joda",
+                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:leader-election-api",
@@ -1334,7 +1336,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.6.7",
+            "locked": "2.7.8",
             "transitive": [
                 "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
             ]

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -27,7 +27,6 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:leader-election-api",
@@ -85,7 +84,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting1:error-handling",
@@ -100,7 +99,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "io.dropwizard.modules:dropwizard-java8"
             ]
@@ -112,7 +111,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "io.dropwizard.modules:dropwizard-java8"
             ]
@@ -130,7 +129,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "com.palantir.remoting1:error-handling",
                 "com.palantir.remoting1:jersey-servers",
@@ -139,7 +138,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
             ]
@@ -1224,7 +1223,6 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-joda",
-                "com.fasterxml.jackson.module:jackson-module-jaxb-annotations",
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:leader-election-api",
@@ -1282,7 +1280,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting1:error-handling",
@@ -1297,7 +1295,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "io.dropwizard.modules:dropwizard-java8"
             ]
@@ -1309,7 +1307,7 @@
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "io.dropwizard.modules:dropwizard-java8"
             ]
@@ -1327,7 +1325,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "com.palantir.remoting1:error-handling",
                 "com.palantir.remoting1:jersey-servers",
@@ -1336,7 +1334,7 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-jaxb-annotations": {
-            "locked": "2.7.8",
+            "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider"
             ]

--- a/versions.props
+++ b/versions.props
@@ -14,6 +14,7 @@ com.palantir.config.crypto:encrypted-config-value-module = 1.0.0
 com.palantir.docker.compose:docker-compose-rule* = 0.31.0
 com.palantir.remoting1:* = 1.0.3
 com.palantir.remoting:* = 0.13.0
+com.palantir.remoting2:* = 2.3.0
 com.palantir.tritium:tritium-lib = 0.6.0-beta
 commons-cli:commons-cli = 1.2
 commons-codec:commons-codec = 1.10


### PR DESCRIPTION
**Goals (and why)**:

* Allow use of the HTTP-remoting error handling library, which has good support for handling serialization/deserialization of exceptions.
* Unblock #1772 in the sense that we can communicate information about what exception occurred on the server, which influences our retry behaviour.
* Introduce shading to atlasdb-config, which subsequently allows us to use/upgrade/not-upgrade dependencies without fear of breaking clients.

**Implementation Description (bullets)**:

* Use the shadow plugin to shadow the http-remoting jar.
* Define an `explicitShadow` configuration to handle large duplication between what would otherwise be `compile` and `shadow` configurations.

**Concerns (what feedback would you like?)**:

* Is this the best way to express what we want in Gradle?
* HTTP Remoting insists that our `ObjectMapper` has several modules, such as the `Jdk8Module` and `GuavaModule` which we didn't previously register. This is as far as I know not breaking (even if we pass exceptions around, the old code made no attempt to deserialize the entity), but would like a sanity check here.

**Where should we start reviewing?**:

`atlasdb-config/build.gradle`

**Priority (whenever / two weeks / yesterday)**:

This week, preferably. I'm proceeding under the assumption this can be done.