### PR TITLE
don't log forever about decommissioned C* nodes

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,10 @@ develop
            Previously, clients would immediately retry the connection on the node with a 503 two times (for a total of three attempts) before failing over.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1782>`__)
 
+    *    - |improved|
+         - No longer fill logs with blacklist messages until Atlas is restarted for Cassandra nodes that have been decommissioned or replaced.
+         - (`Pull Request <https://github.com/palantir/atlasdb/pull/1797>`__)
+
 =======
 v0.38.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
If you live replace a C* node underneath atlas, everything currently works correctly, except we log-spam that we've blacklisted the server forever until Atlas is restarted and it gets a new Atlas KVS config.

**Implementation Description (bullets)**:
Set math. All of the set math.

**Priority (whenever / two weeks / yesterday)**:
Low priority.