### PR TITLE
Adds a max size to the cache inside CachingTransaction

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
@@ -42,21 +42,21 @@ import com.palantir.atlasdb.keyvalue.impl.Cells;
 import com.palantir.atlasdb.transaction.api.Transaction;
 
 public class CachingTransaction extends ForwardingTransaction {
-
     private static final Logger log = LoggerFactory.getLogger(CachingTransaction.class);
-    private static final int defaultMaxCacheSize = 100_000;
+
+    private static final int DEFAULT_MAX_CACHE_SIZE = 100_000;
 
     final Transaction delegate;
 
     private final LoadingCache<String, ConcurrentMap<Cell, byte[]>> columnTableCache = CacheBuilder.newBuilder()
             .softValues()
-            .maximumSize(defaultMaxCacheSize)
+            .maximumSize(DEFAULT_MAX_CACHE_SIZE)
             .build(new CacheLoader<String, ConcurrentMap<Cell, byte[]>>() {
-        @Override
-        public ConcurrentMap<Cell, byte[]> load(String key) throws Exception {
-            return Maps.newConcurrentMap();
-        }
-    });
+                @Override
+                public ConcurrentMap<Cell, byte[]> load(String key) throws Exception {
+                    return Maps.newConcurrentMap();
+                }
+            });
 
     public CachingTransaction(Transaction delegate) {
         this.delegate = delegate;
@@ -162,7 +162,7 @@ public class CachingTransaction extends ForwardingTransaction {
     }
 
     @Override
-    final public void delete(TableReference tableRef, Set<Cell> cells) {
+    public final void delete(TableReference tableRef, Set<Cell> cells) {
         super.delete(tableRef, cells);
         addToColCache(tableRef, Cells.constantValueMap(cells, PtBytes.EMPTY_BYTE_ARRAY));
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/CachingTransaction.java
@@ -44,11 +44,13 @@ import com.palantir.atlasdb.transaction.api.Transaction;
 public class CachingTransaction extends ForwardingTransaction {
 
     private static final Logger log = LoggerFactory.getLogger(CachingTransaction.class);
+    private static final int defaultMaxCacheSize = 100_000;
 
     final Transaction delegate;
 
     private final LoadingCache<String, ConcurrentMap<Cell, byte[]>> columnTableCache = CacheBuilder.newBuilder()
             .softValues()
+            .maximumSize(defaultMaxCacheSize)
             .build(new CacheLoader<String, ConcurrentMap<Cell, byte[]>>() {
         @Override
         public ConcurrentMap<Cell, byte[]> load(String key) throws Exception {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,9 @@ develop
            Previously, clients would immediately retry the connection on the node with a 503 two times (for a total of three attempts) before failing over.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1782>`__)
 
+    *    - |improved|
+         - Set a maximum cache size on ``CachingTransaction`` to avoid GC spirals on very large transactions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1798>`__)
 =======
 v0.38.0
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,6 +63,7 @@ develop
     *    - |improved|
          - Set a maximum cache size on ``CachingTransaction`` to avoid GC spirals on very large transactions.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1798>`__)
+
 =======
 v0.38.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
- We were seeing an issue internally (happy to point Palantir people to the right internal tickets) where a large transaction was caching 20GB of stuff and causing a GC death spiral as the soft keys were evicted.
- Goal: Not having that happen.

**Implementation Description (bullets)**:
- Setting a max size on the cache

**Concerns (what feedback would you like?)**:
- No concerns explicitly

**Where should we start reviewing?**:
- It's a 2 line change

**Priority (whenever / two weeks / yesterday)**:
- Ideally getting this in ASAP

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
