### PR TITLE
Fix/all cassandra integ tests

### DIFF
--- a/atlasdb-container-test-utils/build.gradle
+++ b/atlasdb-container-test-utils/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     processor group: 'org.immutables', name: 'value'
 
+    testCompile group: 'com.github.stefanbirkner', name: 'system-rules'
     testCompile group: 'org.assertj', name: 'assertj-core'
     testCompile group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -66,7 +66,7 @@ public class CassandraContainer extends Container {
 
     @Override
     public Map<String, String> getEnvironment() {
-        return CassandraVersion.getEnvironment();
+        return CassandraEnvironment.get();
     }
 
     @Override

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraEnvironment.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraEnvironment.java
@@ -47,6 +47,10 @@ public final class CassandraEnvironment {
                 CASSANDRA_HEAP_NEWSIZE, getOrDefault(CASSANDRA_HEAP_NEWSIZE, DEFAULT_HEAP_NEWSIZE));
     }
 
+    public static String getVersion() {
+        return getOrDefault(CASSANDRA_VERSION, DEFAULT_VERSION);
+    }
+
     private static String getOrDefault(String name, String defaultValue) {
         String version = System.getenv(name);
         if (Strings.isNullOrEmpty(version)) {

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraEnvironment.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraEnvironment.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.containers;
+
+import java.util.Map;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+final class CassandraEnvironment {
+    public static final String CASSANDRA_VERSION = "CASSANDRA_VERSION";
+
+    @VisibleForTesting
+    static final String CASSANDRA_MAX_HEAP_SIZE = "CASSANDRA_MAX_HEAP_SIZE";
+    @VisibleForTesting
+    static final String CASSANDRA_HEAP_NEWSIZE = "CASSANDRA_HEAP_NEWSIZE";
+
+    @VisibleForTesting
+    static final String DEFAULT_VERSION = "2.2.8";
+    @VisibleForTesting
+    static final String DEFAULT_MAX_HEAP_SIZE = "512m";
+    @VisibleForTesting
+    static final String DEFAULT_HEAP_NEWSIZE = "64m";
+
+    private CassandraEnvironment() {
+        // uninstantiable
+    }
+
+    static Map<String, String> get() {
+        return ImmutableMap.of(
+                CASSANDRA_VERSION, getOrDefault(CASSANDRA_VERSION, DEFAULT_VERSION),
+                CASSANDRA_MAX_HEAP_SIZE, getOrDefault(CASSANDRA_MAX_HEAP_SIZE, DEFAULT_MAX_HEAP_SIZE),
+                CASSANDRA_HEAP_NEWSIZE, getOrDefault(CASSANDRA_HEAP_NEWSIZE, DEFAULT_HEAP_NEWSIZE));
+    }
+
+    private static String getOrDefault(String name, String defaultValue) {
+        String version = System.getenv(name);
+        if (Strings.isNullOrEmpty(version)) {
+            version = defaultValue;
+        }
+        return version;
+    }
+}

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraEnvironment.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraEnvironment.java
@@ -21,7 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
-final class CassandraEnvironment {
+public final class CassandraEnvironment {
     public static final String CASSANDRA_VERSION = "CASSANDRA_VERSION";
 
     @VisibleForTesting
@@ -40,7 +40,7 @@ final class CassandraEnvironment {
         // uninstantiable
     }
 
-    static Map<String, String> get() {
+    public static Map<String, String> get() {
         return ImmutableMap.of(
                 CASSANDRA_VERSION, getOrDefault(CASSANDRA_VERSION, DEFAULT_VERSION),
                 CASSANDRA_MAX_HEAP_SIZE, getOrDefault(CASSANDRA_MAX_HEAP_SIZE, DEFAULT_MAX_HEAP_SIZE),

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
@@ -19,14 +19,11 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 
 public interface CassandraVersion {
-    String CASSANDRA_VERSION = "CASSANDRA_VERSION";
-    String DEFAULT_VERSION = "2.2.8";
 
     static CassandraVersion fromEnvironment() {
-        String version = System.getenv(CASSANDRA_VERSION);
+        String version = System.getenv(CassandraEnvironment.CASSANDRA_VERSION);
         return Strings.isNullOrEmpty(version)
                 ? new Cassandra22XVersion()
                 : from(version);
@@ -43,11 +40,7 @@ public interface CassandraVersion {
     }
 
     static Map<String, String> getEnvironment() {
-        String version = System.getenv(CASSANDRA_VERSION);
-        if (Strings.isNullOrEmpty(version)) {
-            version = DEFAULT_VERSION;
-        }
-        return ImmutableMap.of(CASSANDRA_VERSION, version);
+        return CassandraEnvironment.get();
     }
 
     Pattern replicationFactorRegex();

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.containers;
 
-import java.util.Map;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Strings;
@@ -37,10 +36,6 @@ public interface CassandraVersion {
         } else {
             throw new IllegalArgumentException(String.format("Cassandra version %s not supported", version));
         }
-    }
-
-    static Map<String, String> getEnvironment() {
-        return CassandraEnvironment.get();
     }
 
     Pattern replicationFactorRegex();

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraVersion.java
@@ -17,15 +17,11 @@ package com.palantir.atlasdb.containers;
 
 import java.util.regex.Pattern;
 
-import com.google.common.base.Strings;
-
 public interface CassandraVersion {
 
     static CassandraVersion fromEnvironment() {
-        String version = System.getenv(CassandraEnvironment.CASSANDRA_VERSION);
-        return Strings.isNullOrEmpty(version)
-                ? new Cassandra22XVersion()
-                : from(version);
+        String version = CassandraEnvironment.getVersion();
+        return from(version);
     }
 
     static CassandraVersion from(String version) {

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -75,7 +75,7 @@ public class ThreeNodeCassandraCluster extends Container {
 
     @Override
     public Map<String, String> getEnvironment() {
-        return CassandraVersion.getEnvironment();
+        return CassandraEnvironment.get();
     }
 
     @Override

--- a/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraEnvironmentTest.java
+++ b/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraEnvironmentTest.java
@@ -16,17 +16,45 @@
 package com.palantir.atlasdb.containers;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 public class CassandraEnvironmentTest {
+    @Rule
+    public final EnvironmentVariables environment = new EnvironmentVariables();
+
     @Test
     public void testDefaults() {
-        Map<String, String> defaults = CassandraEnvironment.get();
+        assertCassandraEnvironmentContains(
+                CassandraEnvironment.DEFAULT_VERSION,
+                CassandraEnvironment.DEFAULT_MAX_HEAP_SIZE,
+                CassandraEnvironment.DEFAULT_HEAP_NEWSIZE);
+    }
 
-        assertThat(defaults.size(), is(3));
+    @Test
+    public void testNonDefaultsAreRead() {
+        String version = "1.2.19";
+        String maxHeapSize = "1337m";
+        String heapNewsize = "42m";
+
+        environment.set(CassandraEnvironment.CASSANDRA_VERSION, version);
+        environment.set(CassandraEnvironment.CASSANDRA_MAX_HEAP_SIZE, maxHeapSize);
+        environment.set(CassandraEnvironment.CASSANDRA_HEAP_NEWSIZE, heapNewsize);
+
+        assertCassandraEnvironmentContains(version, maxHeapSize, heapNewsize);
+    }
+
+    private void assertCassandraEnvironmentContains(String version, String maxHeapSize, String heapNewsize) {
+        Map<String, String> variables = CassandraEnvironment.get();
+        assertThat(variables.size(), is(3));
+        assertEquals(version, variables.get(CassandraEnvironment.CASSANDRA_VERSION));
+        assertEquals(maxHeapSize, variables.get(CassandraEnvironment.CASSANDRA_MAX_HEAP_SIZE));
+        assertEquals(heapNewsize, variables.get(CassandraEnvironment.CASSANDRA_HEAP_NEWSIZE));
     }
 }

--- a/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraEnvironmentTest.java
+++ b/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraEnvironmentTest.java
@@ -54,6 +54,21 @@ public class CassandraEnvironmentTest {
         assertCassandraEnvironmentContains(version, maxHeapSize, heapNewsize);
     }
 
+    @Test
+    public void testGetVersionWhenEnvironmentSet() {
+        String expectedVersion = "1.2.19";
+        environment.set(CassandraEnvironment.CASSANDRA_VERSION, expectedVersion);
+        String version = CassandraEnvironment.getVersion();
+        assertEquals(expectedVersion, version);
+    }
+
+    @Test
+    public void testGetVersionWhenEnvironmentNotSet() {
+        environment.set(CassandraEnvironment.CASSANDRA_VERSION, null);
+        String version = CassandraEnvironment.getVersion();
+        assertEquals(CassandraEnvironment.DEFAULT_VERSION, version);
+    }
+
     private void assertCassandraEnvironmentContains(String version, String maxHeapSize, String heapNewsize) {
         Map<String, String> variables = CassandraEnvironment.get();
         assertThat(variables.size(), is(3));

--- a/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraEnvironmentTest.java
+++ b/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraEnvironmentTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.containers;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class CassandraEnvironmentTest {
+    @Test
+    public void testDefaults() {
+        Map<String, String> defaults = CassandraEnvironment.get();
+
+        assertThat(defaults.size(), is(3));
+    }
+}

--- a/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraEnvironmentTest.java
+++ b/atlasdb-container-test-utils/src/test/java/com/palantir/atlasdb/containers/CassandraEnvironmentTest.java
@@ -31,6 +31,10 @@ public class CassandraEnvironmentTest {
 
     @Test
     public void testDefaults() {
+        environment.set(CassandraEnvironment.CASSANDRA_VERSION, null);
+        environment.set(CassandraEnvironment.CASSANDRA_MAX_HEAP_SIZE, null);
+        environment.set(CassandraEnvironment.CASSANDRA_HEAP_NEWSIZE, null);
+
         assertCassandraEnvironmentContains(
                 CassandraEnvironment.DEFAULT_VERSION,
                 CassandraEnvironment.DEFAULT_MAX_HEAP_SIZE,

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraMultinodeTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraMultinodeTestSuite.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.containers.CassandraVersion;
+import com.palantir.atlasdb.containers.CassandraEnvironment;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -39,5 +39,5 @@ public class CassandraMultinodeTestSuite extends EteSetup {
             CassandraMultinodeTestSuite.class,
             "docker-compose.cassandra.yml",
             CLIENTS,
-            CassandraVersion.getEnvironment());
+            CassandraEnvironment.get());
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraNoLeaderTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraNoLeaderTestSuite.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.containers.CassandraVersion;
+import com.palantir.atlasdb.containers.CassandraEnvironment;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -39,6 +39,6 @@ public class CassandraNoLeaderTestSuite extends EteSetup {
             CassandraNoLeaderTestSuite.class,
             "docker-compose.no-leader.cassandra.yml",
             CLIENTS,
-            CassandraVersion.getEnvironment());
+            CassandraEnvironment.get());
 
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimeLockTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimeLockTestSuite.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.containers.CassandraVersion;
+import com.palantir.atlasdb.containers.CassandraEnvironment;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -38,5 +38,5 @@ public class CassandraTimeLockTestSuite extends EteSetup {
             CassandraTimeLockTestSuite.class,
             "docker-compose.timelock.cassandra.yml",
             CLIENTS,
-            CassandraVersion.getEnvironment());
+            CassandraEnvironment.get());
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DockerClientOrchestrationRule.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/DockerClientOrchestrationRule.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.containers.CassandraVersion;
+import com.palantir.atlasdb.containers.CassandraEnvironment;
 import com.palantir.atlasdb.testing.DockerProxyRule;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.DockerMachine;
@@ -121,7 +121,7 @@ public class DockerClientOrchestrationRule extends ExternalResource {
 
     private Map<String, String> getEnvironment() {
         return ImmutableMap.<String, String>builder()
-                .putAll(CassandraVersion.getEnvironment())
+                .putAll(CassandraEnvironment.get())
                 .put("CONFIG_FILE_MOUNTPOINT", temporaryFolder.getRoot().getAbsolutePath())
                 .build();
     }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraTestSuite.java
@@ -27,7 +27,7 @@ import org.junit.runners.Suite;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.jayway.awaitility.Awaitility;
-import com.palantir.atlasdb.containers.CassandraVersion;
+import com.palantir.atlasdb.containers.CassandraEnvironment;
 import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.DockerPort;
 
@@ -48,7 +48,7 @@ public class MultiCassandraTestSuite extends EteSetup {
             MultiCassandraTestSuite.class,
             "docker-compose.multiple-cassandra.yml",
             CLIENTS,
-            CassandraVersion.getEnvironment());
+            CassandraEnvironment.get());
 
     public static void killCassandraContainer(String containerName) {
         Container container = EteSetup.getContainer(containerName);

--- a/versions.props
+++ b/versions.props
@@ -2,6 +2,7 @@ ch.qos.logback:* = 1.1.3
 com.codahale.metrics:metrics-core = 3.0.2
 com.fasterxml.jackson.*:* = 2.6.7
 com.github.rholder:guava-retrying = 2.0.0
+com.github.stefanbirkner:system-rules = 1.16.0
 com.github.tomakehurst:wiremock = 1.57
 com.google.code.findbugs:annotations = 2.0.3
 com.google.code.findbugs:jsr305 = 1.3.9


### PR DESCRIPTION
**Goals (and why)**: Enable cassandra integration tests to be run from IDEs without requiring you to set environment variables

**Implementation Description (bullets)**: In CassandraEnvironment, we pass the required variables to docker, either getting them from the System environment, or setting defaults ourselves.

**Concerns (what feedback would you like?)**: No particular concerns, but maybe you want to try it out by checking out the branch?

**Where should we start reviewing?**: CassandraEnvironment and CassandraVersion

**Priority (whenever / two weeks / yesterday)**: whenever