### PR TITLE
Add joins to AtlasConsole

### DIFF
--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/AtlasConsoleJoins.java
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/AtlasConsoleJoins.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.console;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+
+/**
+ * Created by dcohen on 4/17/17.
+ */
+public class AtlasConsoleJoins {
+
+    public enum JoinComponent {
+        JOIN_KEY, INPUT_VALUE, OUTPUT_VALUE
+    }
+
+    public static Iterable<Map<String, Object>> join(Iterable<Map<?, ?>> input, int batchSize,
+            Function<List<?>, List<Map<String, ?>>> getRowsFunction) {
+        Iterable<Map.Entry<?, ?>> entries = Iterables.concat(Iterables.transform(input, java.util.Map::entrySet));
+        return FluentIterable.from(Iterables.partition(entries, batchSize)).transformAndConcat(
+                batch -> {
+                    Map<?, ?> batchMap = batch.stream().collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+                    List<?> keys = batch.stream().map(Map.Entry::getKey).collect(Collectors.toList());
+                    List<Map<String, ?>> batchResult = getRowsFunction.apply(keys);
+
+                    return batchResult.stream().map(result -> {
+                        Map<String, Object> map = Maps.newHashMap();
+                        Object row = result.get("row");
+                        map.put(JoinComponent.JOIN_KEY.toString(), row);
+                        map.put(JoinComponent.OUTPUT_VALUE.toString(), result);
+                        map.put(JoinComponent.INPUT_VALUE.toString(), batchMap.get(row));
+                        return map;
+                    }).collect(Collectors.toList());
+                }
+        );
+    }
+}

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/AtlasConsoleJoins.java
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/AtlasConsoleJoins.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.console;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -25,7 +26,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
 /**
- * Created by dcohen on 4/17/17.
+ * Utility for joins.
  */
 public class AtlasConsoleJoins {
 
@@ -35,11 +36,11 @@ public class AtlasConsoleJoins {
 
     public static Iterable<Map<String, Object>> join(Iterable<Map<?, ?>> input, int batchSize,
             Function<List<?>, List<Map<String, ?>>> getRowsFunction) {
-        Iterable<Map.Entry<?, ?>> entries = Iterables.concat(Iterables.transform(input, java.util.Map::entrySet));
+        Iterable<Entry<?, ?>> entries = Iterables.concat(Iterables.transform(input, Map::entrySet));
         return FluentIterable.from(Iterables.partition(entries, batchSize)).transformAndConcat(
                 batch -> {
-                    Map<?, ?> batchMap = batch.stream().collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
-                    List<?> keys = batch.stream().map(Map.Entry::getKey).collect(Collectors.toList());
+                    Map<?, ?> batchMap = batch.stream().collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+                    List<?> keys = batch.stream().map(Entry::getKey).collect(Collectors.toList());
                     List<Map<String, ?>> batchResult = getRowsFunction.apply(keys);
 
                     return batchResult.stream().map(result -> {

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/AtlasConsoleMain.java
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/AtlasConsoleMain.java
@@ -107,7 +107,7 @@ public class AtlasConsoleMain {
                 setupScript += "\n" + Joiner.on('\n').join(cli.getOptionValues(EVAL_FLAG_SHORT));
             }
 
-            setupScript += "\n//AtlasConsole started!";
+            setupScript += "\n//AtlasConsole started, type help() for more info!";
             List<String> args = new ArrayList<String>(Arrays.asList(cli.getArgs()));
             args.add(setupScript);
             if(cli.hasOption(CLASSPATH_FLAG_SHORT)) {

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/AtlasConsoleServiceImpl.java
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/AtlasConsoleServiceImpl.java
@@ -116,4 +116,6 @@ public class AtlasConsoleServiceImpl implements AtlasConsoleService {
     private <T> T fromJson(String data, Class<T> type) throws IOException {
         return mapper.getFactory().createParser(data).readValueAs(type);
     }
+
+
 }

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -79,7 +79,19 @@ class AtlasCoreModule implements AtlasConsoleModule {
                          <TABLE>.join([[ <ROW-VALUE-1> : <EXTRA-DATA-1>], [ <ROW-VALUE-2> : <EXTRA-DATA-2]])
                          Returns:
                          [["JOIN_KEY" : <ROW-VALUE-1>, "INPUT_VALUE" : <EXTRA-DATA-1>, "OUTPUT_VALUE" : <TABLE-ROW-1>], 
-                         ["JOIN_KEY" : <ROW-VALUE-2>, "INPUT_VALUE" : <EXTRA-DATA-2>, "OUTPUT_VALUE" : <TABLE-ROW-2>]] 
+                         ["JOIN_KEY" : <ROW-VALUE-2>, "INPUT_VALUE" : <EXTRA-DATA-2>, "OUTPUT_VALUE" : <TABLE-ROW-2>]]
+
+                         The join() method partitions the input iterable into batches, default 10000.
+                         Use join(iterable, cols, batchSize) to override.
+
+                         For an easy way to lazily transform a table range into the appropriate format for joining,
+                         consider Guava (since Groovy's Iterable#collect is not lazy).  For example, if two tables have
+                         the same structure in their row keys, a full join looks like this:
+
+                         FluentIterable = com.google.common.collect.FluentIterable
+                         input = FluentIterable.from(table("myTable").getRange()).transform{ [(it.row): it}
+                         output = table("myOtherTable").join(input)
+                         output.each { println it}
                          '''.stripIndent(),
 
             'getCells': '''\

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -15,10 +15,6 @@
  */
 package com.palantir.atlasdb.console.module
 
-import groovy.json.JsonBuilder
-import groovy.json.JsonOutput
-import groovy.transform.CompileStatic
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.collect.ImmutableSet
 import com.palantir.atlasdb.api.AtlasDbService
@@ -35,6 +31,9 @@ import com.palantir.atlasdb.impl.TableMetadataCache
 import com.palantir.atlasdb.jackson.AtlasJacksonModule
 import com.palantir.atlasdb.table.description.Schema
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager
+import groovy.json.JsonBuilder
+import groovy.json.JsonOutput
+import groovy.transform.CompileStatic
 
 /**
  * Public methods that clients can call within AtlasConsole.
@@ -74,6 +73,15 @@ class AtlasCoreModule implements AtlasConsoleModule {
             'getRows': '''\
                          Retrieve one or more rows from a table. Ex:
                          <TABLE>.getRows([ <ROW-VALUE>, <ROW-VALUE> ])'''.stripIndent(),
+            'join': '''\
+                         Retreive one or more rows from a table and match them up by row-key
+                         with corresponding values.  Ex:
+                         <TABLE>.join([[ <ROW-VALUE-1> : <EXTRA-DATA-1>], [ <ROW-VALUE-2> : <EXTRA-DATA-2]])
+                         Returns:
+                         [["JOIN_KEY" : <ROW-VALUE-1>, "INPUT_VALUE" : <EXTRA-DATA-1>, "OUTPUT_VALUE" : <TABLE-ROW-1>], 
+                         ["JOIN_KEY" : <ROW-VALUE-2>, "INPUT_VALUE" : <EXTRA-DATA-2>, "OUTPUT_VALUE" : <TABLE-ROW-2>]] 
+                         '''.stripIndent(),
+
             'getCells': '''\
                          Retrieve one or more cells from a table, specified by row and
                          column.

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.console.module
 
 import com.palantir.atlasdb.api.TransactionToken
+import com.palantir.atlasdb.console.AtlasConsoleJoins
 import com.palantir.atlasdb.console.AtlasConsoleServiceWrapper
 import groovy.transform.CompileStatic
 
@@ -24,6 +25,8 @@ class Table {
     String name
     def desc = null
     AtlasConsoleServiceWrapper service
+
+    private static int DEFAULT_JOIN_BATCH_SIZE = 10000;
 
     Table(String name, AtlasConsoleServiceWrapper service) {
         this.name = name
@@ -36,7 +39,7 @@ class Table {
     }
 
     def getDescription() {
-        if(desc == null) {
+        if (desc == null) {
             desc = service.getMetadata(name)
         }
         return desc
@@ -51,7 +54,7 @@ class Table {
             println("columnNames cannot be called on a table with dynamic columns")
             return []
         }
-        getDescription()['columns'].collect { it['long_name'] }
+        getDescription()['columns'].collect {it['long_name']}
     }
 
 
@@ -174,6 +177,39 @@ class Table {
         }
         return new Range(service, service.getRange(query, token) as Map, token)
     }
+
+    /**
+     * Lazily joins against an Iterable of key/value pairs.
+     *
+     *
+     *
+     * Tip: Since it is hard to lazily transform Iterables in Groovy, use Guava.
+     *
+     * Example:
+     * <pre>
+     * FluentIterable = com.google.common.collect.FluentIterable
+     * input = FluentIterable.from(table("myTable").getRange()).transform{ [(it.row): it}
+     * output = table("myOtherTable").join(input)
+     * </pre>
+     * @param input Iterable of Map<joinKey, inputValue> where JOIN_KEY is the row key of this table.
+     * @param cols columns to select from this table.
+     * @param batchSize size of getRows calls against this table, default 1000.
+     * @param token.
+     * @return Iterable of Maps with size 3, structured as
+     * <pre>
+     * { JOIN_KEY: joinKey, INPUT_VALUE: inputValue, OUTPUT_VALUE: outputValue}
+     * </pre>
+     * where joinKey and inputValue map to the inputs, and outputValue is the corresponding row in this table.
+     */
+    public Iterable<Map<String, Object>> join(
+            Iterable<Map<?, ?>> input,
+            cols = null,
+            int batchSize = 10000,
+            TransactionToken token = service.getTransactionToken()) {
+
+        return AtlasConsoleJoins.join(input, batchSize, { keys -> getRows(keys, cols, token)});
+    }
+
 
     void put(entries, TransactionToken token = service.getTransactionToken()) {
         def query = [table:name as Object]

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
@@ -204,7 +204,7 @@ class Table {
     public Iterable<Map<String, Object>> join(
             Iterable<Map<?, ?>> input,
             cols = null,
-            int batchSize = 10000,
+            int batchSize = DEFAULT_JOIN_BATCH_SIZE,
             TransactionToken token = service.getTransactionToken()) {
 
         return AtlasConsoleJoins.join(input, batchSize, { keys -> getRows(keys, cols, token)});

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CommandLineEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CommandLineEteTest.java
@@ -43,7 +43,7 @@ public class CommandLineEteTest {
     public void consoleShouldLoadAndConnectToDb() throws IOException, InterruptedException {
         String output = EteSetup.runCliCommand("echo | service/bin/atlasdb-ete atlasdb console var/conf/atlasdb-ete.yml");
 
-        assertThat(output).contains("//AtlasConsole started!");
+        assertThat(output).contains("//AtlasConsole started");
     }
 
     private int fetchTimestamp() throws IOException, InterruptedException {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -66,6 +66,7 @@ develop
    *    - |new|
         - Atlas Console tables now have a join() method.  See ``help("join")`` in Atlas Console for more details.
 
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -64,7 +64,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1785>`__)
 
    *    - |new|
-         - Atlas Console tables now have a join() method.  See ``help("join")`` in Atlas Console for more details.
+        - Atlas Console tables now have a join() method.  See ``help("join")`` in Atlas Console for more details.
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,9 +63,9 @@ develop
            For more information, see the :ref:`docs <timelock-server-further-config>`.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1785>`__)
 
-   *    - |new|
-        - Atlas Console tables now have a join() method.  See ``help("join")`` in Atlas Console for more details.
-
+    *    - |new|
+         - Atlas Console tables now have a join() method.  See ``help("join")`` in Atlas Console for more details.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1814>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,6 +63,9 @@ develop
            For more information, see the :ref:`docs <timelock-server-further-config>`.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1785>`__)
 
+   *    - |new|
+         - Atlas Console tables now have a join() method.  See ``help("join")`` in Atlas Console for more details.
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
**Goals (and why)**:

Doing joins by hand in Atlas Console is painful.  One of the main reasons is that the logic for batching up requests and comparing the results of the get against the input data is a lot of code, especially when you are hoping to do something quickly.

In the long run we might move away from Console, but in the meantime I'd like to do small things to make it more useful.

Here's an example of what I did the hard way recently:

```groovy
Iterables=com.google.common.collect.Iterables
mapped = Iterables.transform(table('obj_cur_version').getRange([start: [2,0]])) { 
   frag = it['current_version']['snapshot']; 
   [true_realm: it['row'][0], object_id: it['row'][1], lookup_realm: frag['realm_id'], 
     version: frag['fragment_version_id']]}
partitioned = Iterables.partition(mapped, 2)
keysToMaps = Iterables.transform(partitioned) { r -> retVal = [:]; 
   r.each { key = [it['object_id'], it['lookup_realm'], it['version']]; retVal[key] = it;}; 
   retVal}
joined = Iterables.transform(keysToMaps) 
   {table('obj_fragment').getRows(it.keySet().asList()).collect { r -> [left: it[r.row], right: r]}}
flattened = Iterables.concat(joined)
realms_to_types = Iterables.transform(flattened) { [it.left.true_realm, it.right.base_object.type] }
hist = [:].withDefault {[:].withDefault{0}}
realms_to_types.each { hist[it[0]][it[1]] = hist[it[0]][it[1]] + 1}
pp hist
```

**Implementation Description (bullets)**:

Input is an Iterable of Map<joinKey, inputData>
Output is an Iterable of Map<String, ?> where each map looks like:
{ JOIN_KEY: joinKey, INPUT_VALUE: inputData, OUTPUT_VALUE: rowFromThisTable}
joinKey should be the rowname in the target table.

**Concerns (what feedback would you like?)**:

API is not amazing, I'm interested in other's thoughts.  Worth trying to do something like the above.  In my version, it would look more like this:

```groovy
Iterables=com.google.common.collect.Iterables
input = Iterables.transform(table('obj_cur_version').getRange([start: [2,0]])) { 
   frag = it['current_version']['snapshot']; 
   key = [it['row'][1], frag['realm_id'], frag['fragment_version_id']]
   [(key): it['row'][0]]
}
joined = table('obj_fragment').join(input)
realms_to_types = Iterables.transform(joined) { 
   [it.INPUT_VALUE, it.OUTPUT_VALUE.base_object.type] }
hist = [:].withDefault {[:].withDefault{0}}
realms_to_types.each { hist[it[0]][it[1]] = hist[it[0]][it[1]] + 1}
pp hist
```
**Where should we start reviewing?**:

Start with Table.groovy

**Priority (whenever / two weeks / yesterday)**:

Soon but I wouldn't hold the upcoming PG release for it