### PR TITLE
Refuse to start on Postgres 9.5.0 and 9.5.1

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -230,6 +230,7 @@ public final class DbKvs extends AbstractKeyValueService {
     }
 
     private void init() {
+        checkDatabaseVersion();
         databaseSpecificInitialization();
         createMetadataTable();
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -124,6 +124,11 @@ public class PostgresDdlTable implements DbDdlTable {
                     + " The minimum supported version is {}."
                     + " If you absolutely need to use an older version of postgres,"
                     + " please contact Palantir support for assistance.", version, MIN_POSTGRES_VERSION);
+        } else if (VersionStrings.compareVersions(version, "9.5") >= 0 && VersionStrings.compareVersions(version, "9.5.2") < 0) {
+            throw new RuntimeException(
+                      "You are running Postgres " + version + ". Versions 9.5.0 and 9.5.1 contain a known bug "
+                    + "that causes incorrect results to be returned for certain queries. "
+                    + "Please update your Postgres distribution.");
         }
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -124,7 +124,8 @@ public class PostgresDdlTable implements DbDdlTable {
                     + " The minimum supported version is {}."
                     + " If you absolutely need to use an older version of postgres,"
                     + " please contact Palantir support for assistance.", version, MIN_POSTGRES_VERSION);
-        } else if (VersionStrings.compareVersions(version, "9.5") >= 0 && VersionStrings.compareVersions(version, "9.5.2") < 0) {
+        } else if (VersionStrings.compareVersions(version, "9.5") >= 0
+                && VersionStrings.compareVersions(version, "9.5.2") < 0) {
             throw new RuntimeException(
                       "You are running Postgres " + version + ". Versions 9.5.0 and 9.5.1 contain a known bug "
                     + "that causes incorrect results to be returned for certain queries. "

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,6 +53,11 @@ develop
            If you do encounter breaks due to this addition, please contact the AtlasDB team for support.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1810>`__)
 
+    *    - |userbreak|
+         - AtlasDB will refuse to start if backed by Postgres 9.5.0 or 9.5.1. These versions contain a known bug that causes incorrect results to be returned for certain queries.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1820>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Postgres 9.5 introduced a bug that was fixed in 9.5.2 that causes incorrect results to be returned for some queries. Here is a simple test case:
```
create table foo(a int, b int, primary key (a, b));
insert into foo (a, b) values (1, 1);
select * from foo where (a, b) >= (1, 2); -- returns 0 rows (correct)
select * from foo where (a, b) >= (1, 2) and b = 1; -- returns 1 row (incorrect)
```
We should simply refuse to start if we are running against an affected database version.
