### PR TITLE
(0.39.x cherry pick) Refuse to start on Postgres 9.5.0 and 9.5.1 (#1820)

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -230,6 +230,7 @@ public final class DbKvs extends AbstractKeyValueService {
     }
 
     private void init() {
+        checkDatabaseVersion();
         databaseSpecificInitialization();
         createMetadataTable();
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -124,6 +124,12 @@ public class PostgresDdlTable implements DbDdlTable {
                     + " The minimum supported version is {}."
                     + " If you absolutely need to use an older version of postgres,"
                     + " please contact Palantir support for assistance.", version, MIN_POSTGRES_VERSION);
+        } else if (VersionStrings.compareVersions(version, "9.5") >= 0
+                && VersionStrings.compareVersions(version, "9.5.2") < 0) {
+            throw new RuntimeException(
+                      "You are running Postgres " + version + ". Versions 9.5.0 and 9.5.1 contain a known bug "
+                    + "that causes incorrect results to be returned for certain queries. "
+                    + "Please update your Postgres distribution.");
         }
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -67,6 +67,10 @@ develop
          - Improved performance of getRange() on DbKvs. Range requests are now done with a single round trip to the database.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1805>`__)
 
+    *    - |userbreak|
+         - AtlasDB will refuse to start if backed by Postgres 9.5.0 or 9.5.1. These versions contain a known bug that causes incorrect results to be returned for certain queries.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1820>`__)
+
 =======
 v0.38.0
 =======


### PR DESCRIPTION
Refuse to start on Postgres 9.5.0 and 9.5.1

Postgres 9.5 introduced a bug that was fixed in 9.5.2 that causes
incorrect results to be returned for some queries. Here is a simple test
case:

create table foo(a int, b int, primary key (a, b));
insert into foo (a, b) values (1, 1);
select * from foo where (a, b) >= (1, 2); -- returns 0 rows (correct)
select * from foo where (a, b) >= (1, 2) and b = 1; -- returns 1 row (incorrect)

This breaks the new getRange query, so we should refuse to start
on the broken versions.

(cherry picked from commit 9a3f45e7a00691c216e01d0be85eac9ab9437c1a)
