### PR TITLE
Log held and outstanding locks in YAML for further processing (#1792)

### DIFF
--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -771,7 +771,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -656,7 +656,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -1313,7 +1314,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-config/versions.lock
+++ b/atlasdb-config/versions.lock
@@ -487,7 +487,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -979,7 +980,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -777,7 +777,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-console/versions.lock
+++ b/atlasdb-console/versions.lock
@@ -513,7 +513,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -1031,7 +1032,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-dagger/versions.lock
+++ b/atlasdb-dagger/versions.lock
@@ -503,7 +503,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -1011,7 +1012,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -503,6 +503,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
             ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12",
+            "transitive": [
+                "com.palantir.atlasdb:lock-impl"
+            ]
         }
     },
     "runtime": {
@@ -1008,6 +1014,12 @@
             "locked": "1.1.1.7",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12",
+            "transitive": [
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -423,6 +423,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
             ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12",
+            "transitive": [
+                "com.palantir.atlasdb:lock-impl"
+            ]
         }
     },
     "runtime": {
@@ -848,6 +854,12 @@
             "locked": "1.1.1.7",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12",
+            "transitive": [
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -1113,7 +1113,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -2231,7 +2232,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -1173,7 +1173,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -2421,7 +2422,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-exec/src/main/resources/log4j.properties
+++ b/atlasdb-exec/src/main/resources/log4j.properties
@@ -9,8 +9,8 @@ log4j.appender.file.MaxBackupIndex=10
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
  
- # Direct log messages to stdout
- log4j.appender.stdout=org.apache.log4j.ConsoleAppender
- log4j.appender.stdout.Target=System.out
- log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
- log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/atlasdb-impl-shared/versions.lock
+++ b/atlasdb-impl-shared/versions.lock
@@ -309,6 +309,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
             ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12",
+            "transitive": [
+                "com.palantir.atlasdb:lock-impl"
+            ]
         }
     },
     "runtime": {
@@ -620,6 +626,12 @@
             "locked": "1.1.1.7",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12",
+            "transitive": [
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-jepsen-tests/versions.lock
+++ b/atlasdb-jepsen-tests/versions.lock
@@ -495,7 +495,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -995,7 +996,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -823,7 +823,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -1651,7 +1652,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-service-server/src/test/java/com/palantir/server/LockRemotingTest.java
+++ b/atlasdb-service-server/src/test/java/com/palantir/server/LockRemotingTest.java
@@ -32,9 +32,11 @@ import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.lock.logger.LockServiceLoggerTestUtils;
 
 import feign.Feign;
 import feign.jackson.JacksonDecoder;
@@ -43,7 +45,12 @@ import feign.jaxrs.JAXRSContract;
 import io.dropwizard.testing.junit.DropwizardClientRule;
 
 public class LockRemotingTest {
-    static LockServiceImpl rawLock = LockServiceImpl.create();
+    private static LockServerOptions lockServerOptions = new LockServerOptions() {
+        @Override public String getLockStateLoggerDir() {
+            return LockServiceLoggerTestUtils.TEST_LOG_STATE_DIR;
+        }
+    };
+    private static LockServiceImpl rawLock = LockServiceImpl.create(lockServerOptions);
 
     @ClassRule
     public final static DropwizardClientRule lockService = new DropwizardClientRule(rawLock);
@@ -85,7 +92,11 @@ public class LockRemotingTest {
         Set<LockRefreshToken> refreshed = lock.refreshLockRefreshTokens(ImmutableList.of(token));
         Assert.assertEquals(1, refreshed.size());
         lock.unlock(token);
-        lock.logCurrentState();
+        try {
+            lock.logCurrentState();
+        } finally {
+            LockServiceLoggerTestUtils.cleanUpLogStateDir();
+        }
         lock.currentTimeMillis();
 
         HeldLocksToken token1 = lock.lockAndGetHeldLocks(LockClient.ANONYMOUS.getClientId(), request);

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -931,7 +931,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -2008,7 +2009,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-service/versions.lock
+++ b/atlasdb-service/versions.lock
@@ -488,7 +488,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -981,7 +982,8 @@
         "org.yaml:snakeyaml": {
             "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -814,7 +814,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 expirationDateMs,
                 LockCollections.of(builder.build()),
                 lockTimeout,
-                versionId);
+                versionId,
+                "Dummy thread");
     }
 
 

--- a/atlasdb-tests-shared/versions.lock
+++ b/atlasdb-tests-shared/versions.lock
@@ -368,6 +368,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
             ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12",
+            "transitive": [
+                "com.palantir.atlasdb:lock-impl"
+            ]
         }
     },
     "runtime": {
@@ -738,6 +744,12 @@
             "locked": "1.1.1.7",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12",
+            "transitive": [
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -66,10 +66,22 @@ develop
     *    - |improved|
          - Improved performance of getRange() on DbKvs. Range requests are now done with a single round trip to the database.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1805>`__)
+    
+    *    - |improved|
+         - The lock server now will dump all held locks and outstanding lock requests in YAML file, when logging state requested, for easy readability and further processing.
+           This will make debuging lock congestions easier. Lock descriptors are changed with places holders and can be decoded using descriptors file,
+           which will be written in the folder. Information like requesting clients, requesting threads and other details can be found in the YAML.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1792>`__)
+
+    *    - |new|
+         - The ``atlasdb-config`` project now shadows the ``error-handling`` and ``jackson-support`` libraries from `http-remoting <https://github.com/palantir/http-remoting>`__.
+           This will be used to handle exceptions in a future release, and was done in this way to avoid causing dependency issues in upstream products.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1796>`__)
 
     *    - |userbreak|
          - AtlasDB will refuse to start if backed by Postgres 9.5.0 or 9.5.1. These versions contain a known bug that causes incorrect results to be returned for certain queries.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1820>`__)
+
 
 =======
 v0.38.0

--- a/lock-api/src/main/java/com/palantir/lock/ExpiringToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/ExpiringToken.java
@@ -47,6 +47,12 @@ public interface ExpiringToken {
     @Nullable LockClient getClient();
 
     /**
+     * Returns the set of locks which were successfully acquired as a map
+     * from descriptor to lock mode.
+     */
+    SortedLockCollection<LockDescriptor> getLockDescriptors();
+
+    /**
      * Returns the amount of time that it takes for these locks to
      * expire.
      */

--- a/lock-api/src/main/java/com/palantir/lock/HeldLocksGrant.java
+++ b/lock-api/src/main/java/com/palantir/lock/HeldLocksGrant.java
@@ -83,6 +83,11 @@ import com.google.common.base.Preconditions;
         return null;
     }
 
+    @Override
+    public SortedLockCollection<LockDescriptor> getLockDescriptors() {
+        return getLocks();
+    }
+
     /**
      * Returns the time (in milliseconds since the epoch) since this token was
      * created.

--- a/lock-api/src/main/java/com/palantir/lock/HeldLocksToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/HeldLocksToken.java
@@ -55,13 +55,14 @@ import com.google.common.collect.Iterables;
     private final SortedLockCollection<LockDescriptor> lockMap;
     private final SimpleTimeDuration lockTimeout;
     @Nullable private final Long versionId;
+    private final String requestingThread;
 
     /**
      * This should only be created by the Lock Service
      */
     public HeldLocksToken(BigInteger tokenId, LockClient client, long creationDateMs,
             long expirationDateMs, SortedLockCollection<LockDescriptor> lockMap,
-            TimeDuration lockTimeout, @Nullable Long versionId) {
+            TimeDuration lockTimeout, @Nullable Long versionId, String requestingThread) {
         this.tokenId = Preconditions.checkNotNull(tokenId);
         this.client = Preconditions.checkNotNull(client);
         this.creationDateMs = creationDateMs;
@@ -69,6 +70,7 @@ import com.google.common.collect.Iterables;
         this.lockMap = lockMap;
         this.lockTimeout = SimpleTimeDuration.of(lockTimeout);
         this.versionId = versionId;
+        this.requestingThread = requestingThread;
         Preconditions.checkArgument(!this.lockMap.isEmpty());
     }
 
@@ -99,6 +101,10 @@ import com.google.common.collect.Iterables;
         return creationDateMs;
     }
 
+    public String getRequestingThread() {
+        return requestingThread;
+    }
+
     /**
      * Returns the time (in milliseconds since the epoch) when this token will
      * expire and become invalid.
@@ -113,6 +119,7 @@ import com.google.common.collect.Iterables;
      * from descriptor to lock mode.
      */
     @JsonIgnore
+    @Override
     public SortedLockCollection<LockDescriptor> getLockDescriptors() {
         return lockMap;
     }
@@ -172,6 +179,7 @@ import com.google.common.collect.Iterables;
                 .add("lockCount", lockMap.size())
                 .add("firstLock", lockMap.entries().iterator().next())
                 .add("versionId", versionId)
+                .add("requestingThread", requestingThread)
                 .toString();
     }
 
@@ -180,7 +188,7 @@ import com.google.common.collect.Iterables;
      */
     public HeldLocksToken refresh(long expirationDateMs) {
         return new HeldLocksToken(tokenId, client, creationDateMs, expirationDateMs, lockMap, lockTimeout,
-                versionId);
+                versionId, requestingThread);
     }
 
     private void readObject(@SuppressWarnings("unused") ObjectInputStream in)
@@ -202,6 +210,7 @@ import com.google.common.collect.Iterables;
         private final SortedLockCollection<LockDescriptor> lockMap;
         private final SimpleTimeDuration lockTimeout;
         @Nullable private final Long versionId;
+        private final String requestingThread;
 
         SerializationProxy(HeldLocksToken heldLocksToken) {
             tokenId = heldLocksToken.tokenId;
@@ -211,16 +220,18 @@ import com.google.common.collect.Iterables;
             lockMap = heldLocksToken.lockMap;
             lockTimeout = heldLocksToken.lockTimeout;
             versionId = heldLocksToken.versionId;
+            requestingThread = heldLocksToken.requestingThread;
         }
 
         @JsonCreator
         public SerializationProxy(@JsonProperty("tokenId") BigInteger tokenId,
-                                  @JsonProperty("client") LockClient client,
-                                  @JsonProperty("creationDateMs") long creationDateMs,
-                                  @JsonProperty("expirationDateMs") long expirationDateMs,
-                                  @JsonProperty("locks") List<LockWithMode> locks,
-                                  @JsonProperty("lockTimeout") TimeDuration lockTimeout,
-                                  @JsonProperty("versionId") Long versionId) {
+                @JsonProperty("client") LockClient client,
+                @JsonProperty("creationDateMs") long creationDateMs,
+                @JsonProperty("expirationDateMs") long expirationDateMs,
+                @JsonProperty("locks") List<LockWithMode> locks,
+                @JsonProperty("lockTimeout") TimeDuration lockTimeout,
+                @JsonProperty("versionId") Long versionId,
+                @JsonProperty("requestingThread") String requestingThread) {
             ImmutableSortedMap.Builder<LockDescriptor, LockMode> localLockMapBuilder = ImmutableSortedMap.naturalOrder();
             for (LockWithMode lock : locks) {
                 localLockMapBuilder.put(lock.getLockDescriptor(), lock.getLockMode());
@@ -232,6 +243,7 @@ import com.google.common.collect.Iterables;
             this.expirationDateMs = expirationDateMs;
             this.lockTimeout = SimpleTimeDuration.of(lockTimeout);
             this.versionId = versionId;
+            this.requestingThread = requestingThread;
             Preconditions.checkArgument(!this.lockMap.isEmpty());
         }
 
@@ -241,7 +253,7 @@ import com.google.common.collect.Iterables;
 
         Object readResolve() {
             return new HeldLocksToken(tokenId, client, creationDateMs, expirationDateMs, lockMap, lockTimeout,
-                    versionId);
+                    versionId, requestingThread);
         }
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -33,7 +33,7 @@ import com.google.common.base.Objects;
  * @author jtamer
  */
 @Immutable public class LockServerOptions implements Serializable {
-    private static final long serialVersionUID = 0xb5fd04db6d65582al;
+    private static final long serialVersionUID = 2930574230723753879L;
 
     /** The default lock server option values. */
     public static final LockServerOptions DEFAULT = new LockServerOptions();
@@ -108,7 +108,8 @@ import com.google.common.base.Objects;
                 && Objects.equal(getMaxAllowedClockDrift(), other.getMaxAllowedClockDrift())
                 && Objects.equal(getMaxAllowedBlockingDuration(), other.getMaxAllowedBlockingDuration())
                 && Objects.equal(getMaxNormalLockAge(), other.getMaxNormalLockAge())
-                && (getRandomBitCount() == other.getRandomBitCount());
+                && (getRandomBitCount() == other.getRandomBitCount()
+                && getLockStateLoggerDir().equals(other.getLockStateLoggerDir()));
     }
 
     @Override public final int hashCode() {
@@ -117,7 +118,8 @@ import com.google.common.base.Objects;
                 getMaxAllowedClockDrift(),
                 getMaxAllowedBlockingDuration(),
                 getMaxNormalLockAge(),
-                getRandomBitCount());
+                getRandomBitCount(),
+                getLockStateLoggerDir());
     }
 
     @Override public final String toString() {
@@ -128,6 +130,7 @@ import com.google.common.base.Objects;
                 .add("maxAllowedBlockingDuration", getMaxAllowedBlockingDuration())
                 .add("maxNormalLockAge", getMaxNormalLockAge())
                 .add("randomBitCount", getRandomBitCount())
+                .add("lockStateLoggerDir", getLockStateLoggerDir())
                 .toString();
     }
 
@@ -140,8 +143,12 @@ import com.google.common.base.Objects;
         return new SerializationProxy(this);
     }
 
+    public String getLockStateLoggerDir() {
+        return "log/state";
+    }
+
     private static class SerializationProxy implements Serializable {
-        private static final long serialVersionUID = 0xece5944130b16002l;
+        private static final long serialVersionUID = 4043798817916565364L;
 
         private final boolean isStandaloneServer;
         private final SimpleTimeDuration maxAllowedLockTimeout;
@@ -149,6 +156,7 @@ import com.google.common.base.Objects;
         private final SimpleTimeDuration maxAllowedBlockingDuration;
         private final SimpleTimeDuration maxNormalLockAge;
         private final int randomBitCount;
+        private final String lockStateLoggerDir;
 
         SerializationProxy(LockServerOptions lockServerOptions) {
             isStandaloneServer = lockServerOptions.isStandaloneServer();
@@ -161,11 +169,11 @@ import com.google.common.base.Objects;
             maxNormalLockAge = SimpleTimeDuration.of(
                     lockServerOptions.getMaxNormalLockAge());
             randomBitCount = lockServerOptions.getRandomBitCount();
+            lockStateLoggerDir = lockServerOptions.getLockStateLoggerDir();
         }
 
         Object readResolve() {
             return new LockServerOptions() {
-                private static final long serialVersionUID = 0xcc7124dcf06f0803l;
                 @Override public boolean isStandaloneServer() {
                     return isStandaloneServer;
                 }
@@ -183,6 +191,9 @@ import com.google.common.base.Objects;
                 }
                 @Override public int getRandomBitCount() {
                     return randomBitCount;
+                }
+                @Override public String getLockStateLoggerDir() {
+                    return lockStateLoggerDir;
                 }
             };
         }

--- a/lock-api/src/main/java/com/palantir/lock/LockWithMode.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockWithMode.java
@@ -34,4 +34,12 @@ public class LockWithMode {
     public LockMode getLockMode() {
         return lockMode;
     }
+
+    @Override
+    public String toString() {
+        return "LockWithMode{" +
+                "lockDescriptor=" + lockDescriptor +
+                ", lockMode=" + lockMode +
+                '}';
+    }
 }

--- a/lock-api/src/test/java/com/palantir/lock/HeldLocksTokenTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/HeldLocksTokenTest.java
@@ -35,7 +35,7 @@ public final class HeldLocksTokenTest {
     public void testSerializationDeserialization() throws Exception {
         SortedMap<LockDescriptor, LockMode> lockMap = ImmutableSortedMap.of(StringLockDescriptor.of("foo"), LockMode.READ);
         HeldLocksToken heldLocksToken = new HeldLocksToken(BigInteger.valueOf(0), LockClient.of("foo"), 0, 0,
-                LockCollections.of(lockMap), SimpleTimeDuration.of(1, TimeUnit.SECONDS), 0L);
+                LockCollections.of(lockMap), SimpleTimeDuration.of(1, TimeUnit.SECONDS), 0L, "Dummy Thread");
 
         HeldLocksToken deserializedHeldLocksToken = MAPPER.readValue(MAPPER.writeValueAsString(heldLocksToken), HeldLocksToken.class);
         assertThat(deserializedHeldLocksToken, is(heldLocksToken));

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -1,4 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
+apply plugin: 'org.inferred.processors'
+
 apply from: "../gradle/shared.gradle"
 
 dependencies {
@@ -7,5 +9,9 @@ dependencies {
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
   compile group: 'com.palantir.remoting1', name: 'tracing'
   compile group: 'joda-time', name: 'joda-time'
+  compile group: 'org.yaml', name: 'snakeyaml'
+
+  processor group: 'org.immutables', name: 'value'
+
   testCompile group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
 }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockClientIndices.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockClientIndices.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
@@ -26,7 +27,8 @@ import com.google.common.collect.Maps;
 import com.palantir.lock.LockClient;
 
 @ThreadSafe
-class LockClientIndices {
+@VisibleForTesting
+public class LockClientIndices {
     private final Map<LockClient, Integer> indexByClient = Maps.newConcurrentMap();
     private final Map<Integer, LockClient> clientByIndex = Maps.newConcurrentMap();
 

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -22,13 +22,13 @@ import static com.palantir.lock.LockGroupBehavior.LOCK_ALL_OR_NONE;
 import static com.palantir.lock.LockGroupBehavior.LOCK_AS_MANY_AS_POSSIBLE;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -56,7 +56,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedMap.Builder;
@@ -96,9 +95,9 @@ import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.SortedLockCollection;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.TimeDuration;
+import com.palantir.lock.logger.LockServiceStateLogger;
 import com.palantir.remoting1.tracing.Tracers;
 import com.palantir.util.JMXUtils;
-import com.palantir.util.Pair;
 
 /**
  * Implementation of the Lock Server.
@@ -124,15 +123,13 @@ import com.palantir.util.Pair;
         }
     };
 
-    /**
-     * A set of locks held by the lock server, along with the canonical
-     * {@link HeldLocksToken} or {@link HeldLocksGrant} object for these locks.
-     */
-    @Immutable private static class HeldLocks<T extends ExpiringToken> {
+    @Immutable
+    public static class HeldLocks<T extends ExpiringToken> {
         final T realToken;
         final LockCollection<? extends ClientAwareReadWriteLock> locks;
 
-        static <T extends ExpiringToken> HeldLocks<T> of(T token,
+        @VisibleForTesting
+        public static <T extends ExpiringToken> HeldLocks<T> of(T token,
                 LockCollection<? extends ClientAwareReadWriteLock> locks) {
             return new HeldLocks<T>(token, locks);
         }
@@ -140,6 +137,14 @@ import com.palantir.util.Pair;
         HeldLocks(T token, LockCollection<? extends ClientAwareReadWriteLock> locks) {
             this.realToken = Preconditions.checkNotNull(token);
             this.locks = locks;
+        }
+
+        public List<LockDescriptor> getLockDescriptors() {
+            List<LockDescriptor> descriptors = Lists.newArrayListWithCapacity(locks.size());
+            for (ClientAwareReadWriteLock lock : locks) {
+                descriptors.add(lock.getDescriptor());
+            }
+            return descriptors;
         }
 
         @Override public String toString() {
@@ -163,6 +168,7 @@ import com.palantir.util.Pair;
     private final int randomBitCount;
     private final Runnable callOnClose;
     private volatile boolean isShutDown = false;
+    private final String lockStateLoggerDir;
 
     private final LockClientIndices clientIndices = new LockClientIndices();
 
@@ -212,7 +218,6 @@ import com.palantir.util.Pair;
 
     private static final AtomicInteger instanceCount = new AtomicInteger();
     private static final int MAX_FAILED_LOCKS_TO_LOG = 20;
-    private static final int MAX_LOCKS_TO_LOG = 10000;
 
     /** Creates a new lock server instance with default options. */
     // TODO (jtamer) read lock server options from a prefs file
@@ -244,6 +249,8 @@ import com.palantir.util.Pair;
         maxAllowedBlockingDuration = SimpleTimeDuration.of(options.getMaxAllowedBlockingDuration());
         maxNormalLockAge = SimpleTimeDuration.of(options.getMaxNormalLockAge());
         randomBitCount = options.getRandomBitCount();
+        lockStateLoggerDir = options.getLockStateLoggerDir();
+
         slowLogTriggerMillis = options.slowLogTriggerMillis();
         executor.execute(() -> {
             Thread.currentThread().setName("Held Locks Token Reaper");
@@ -258,12 +265,12 @@ import com.palantir.util.Pair;
     private HeldLocksToken createHeldLocksToken(LockClient client,
             SortedLockCollection<LockDescriptor> lockDescriptorMap,
             LockCollection<? extends ClientAwareReadWriteLock> heldLocksMap, TimeDuration lockTimeout,
-            @Nullable Long versionId) {
+            @Nullable Long versionId, String requestThread) {
         while (true) {
             BigInteger tokenId = new BigInteger(randomBitCount, randomPool.getSecureRandom());
             long expirationDateMs = currentTimeMillis() + lockTimeout.toMillis();
             HeldLocksToken token = new HeldLocksToken(tokenId, client, currentTimeMillis(),
-                    expirationDateMs, lockDescriptorMap, lockTimeout, versionId);
+                    expirationDateMs, lockDescriptorMap, lockTimeout, versionId, requestThread);
             HeldLocks<HeldLocksToken> heldLocks = HeldLocks.of(token, heldLocksMap);
             if (heldLocksTokenMap.putIfAbsent(token, heldLocks) == null) {
                 lockTokenReaperQueue.add(token);
@@ -393,7 +400,7 @@ import com.palantir.util.Pair;
                 versionIdMap.put(client, request.getVersionId());
             }
             HeldLocksToken token = createHeldLocksToken(client, LockCollections.of(lockDescriptorMap.build()), LockCollections.of(locks),
-                    request.getLockTimeout(), request.getVersionId());
+                    request.getLockTimeout(), request.getVersionId(), request.getCreatingThreadName());
             locks.clear();
             if (log.isTraceEnabled()) {
                 log.trace(".lock({}, {}) returns {}", client, request, token);
@@ -536,7 +543,8 @@ import com.palantir.util.Pair;
                 0L,
                 fakeLockSet,
                 maxAllowedLockTimeout,
-                0L));
+                0L,
+                "UnknownThread-unlockSimple"));
     }
 
     @Override
@@ -660,7 +668,8 @@ import com.palantir.util.Pair;
                     0L,
                     fakeLockSet,
                     maxAllowedLockTimeout,
-                    0L));
+                    0L,
+                    "UnknownThread-refreshLockRefreshTokens"));
         }
         return ImmutableSet.copyOf(Iterables.transform(refreshTokens(fakeTokens), HeldLocksTokens.getRefreshTokenFun()));
     }
@@ -791,8 +800,9 @@ import com.palantir.util.Pair;
         }
         HeldLocksGrant realGrant = heldLocks.realToken;
         changeOwner(heldLocks.locks, INTERNAL_LOCK_GRANT_CLIENT, client);
-        HeldLocksToken token = createHeldLocksToken(client, realGrant.getLocks(),
-                heldLocks.locks, realGrant.getLockTimeout(), realGrant.getVersionId());
+        HeldLocksToken token = createHeldLocksToken(client, realGrant.getLockDescriptors(),
+                heldLocks.locks, realGrant.getLockTimeout(), realGrant.getVersionId(),
+                "Converted from Grant, Missing Thread Name");
         if (log.isTraceEnabled()) {
             log.trace(".useGrant({}, {}) returns {}", client, grant, token);
         }
@@ -814,8 +824,9 @@ import com.palantir.util.Pair;
         }
         HeldLocksGrant realGrant = heldLocks.realToken;
         changeOwner(heldLocks.locks, INTERNAL_LOCK_GRANT_CLIENT, client);
-        HeldLocksToken token = createHeldLocksToken(client, realGrant.getLocks(),
-                heldLocks.locks, realGrant.getLockTimeout(), realGrant.getVersionId());
+        HeldLocksToken token = createHeldLocksToken(client, realGrant.getLockDescriptors(),
+                heldLocks.locks, realGrant.getLockTimeout(), realGrant.getVersionId(),
+                "Converted from Grant, Missing Thread Name");
         if (log.isTraceEnabled()) {
             log.trace(".useGrant({}, {}) returns {}", client, grantId.toString(Character.MAX_RADIX), token);
         }
@@ -965,23 +976,32 @@ import com.palantir.util.Pair;
         return options;
     }
 
-    private <T> List<T> queueToOrderedList(Queue<T> queue) {
-        List<T> list = Lists.newLinkedList();
-        while (!queue.isEmpty()) {
-            list.add(queue.poll());
-        }
-        for (T element : list) {
-            queue.add(element);
-        }
-        return list;
-    }
-
     /**
      * Prints the current state of the lock server to the logs. Useful for
      * debugging.
      */
     @Override
     public void logCurrentState() {
+        StringBuilder logString = getGeneralLockStats();
+        log.info("Current State: {}", logString.toString());
+
+        try {
+            logAllHeldAndOutstandingLocks();
+        } catch (IOException e) {
+            log.error("Can't dump state to Yaml: [{}]", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void logAllHeldAndOutstandingLocks() throws IOException {
+        LockServiceStateLogger lockServiceStateLogger = new LockServiceStateLogger(
+                heldLocksTokenMap,
+                outstandingLockRequestMultimap,
+                lockStateLoggerDir);
+        lockServiceStateLogger.logLocks();
+    }
+
+    private StringBuilder getGeneralLockStats() {
         StringBuilder logString = new StringBuilder();
         logString.append("Logging current state. Time = ").append(currentTimeMillis()).append("\n");
         logString.append("isStandaloneServer = ").append(isStandaloneServer).append("\n");
@@ -989,28 +1009,19 @@ import com.palantir.util.Pair;
         logString.append("maxAllowedClockDrift = ").append(maxAllowedClockDrift).append("\n");
         logString.append("maxAllowedBlockingDuration = ").append(maxAllowedBlockingDuration).append("\n");
         logString.append("randomBitCount = ").append(randomBitCount).append("\n");
-        for (Pair<String, ? extends Collection<?>> nameValuePair : ImmutableList.of(
-                Pair.create("descriptorToLockMap", descriptorToLockMap.asMap().entrySet()),
-                Pair.create("outstandingLockRequestMultimap", outstandingLockRequestMultimap.asMap().entrySet()),
-                Pair.create("heldLocksTokenMap", heldLocksTokenMap.entrySet()),
-                Pair.create("heldLocksGrantMap", heldLocksGrantMap.entrySet()),
-                Pair.create("lockTokenReaperQueue", queueToOrderedList(lockTokenReaperQueue)),
-                Pair.create("lockGrantReaperQueue", queueToOrderedList(lockGrantReaperQueue)),
-                Pair.create("lockClientMultimap", lockClientMultimap.asMap().entrySet()),
-                Pair.create("versionIdMap", versionIdMap.asMap().entrySet()))) {
-            Collection<?> elements = nameValuePair.getRhSide();
-            logString.append(nameValuePair.getLhSide()).append(".size() = ").append(elements.size()).append("\n");
-            if (elements.size() > MAX_LOCKS_TO_LOG) {
-                logString.append("WARNING: Only logging the first ").append(MAX_LOCKS_TO_LOG).append(" locks, ");
-                logString.append("logging more is likely to OOM or slow down lock server to the point of failure");
-            }
-            for (Object element : Iterables.limit(elements, MAX_LOCKS_TO_LOG)) {
-                logString.append(element).append("\n");
-            }
-        }
-        logString.append("Finished logging current state. Time = ").append(currentTimeMillis());
-        log.error("Current State: {}", logString.toString());
+
+        logString.append("descriptorToLockMap.size = ").append(descriptorToLockMap.size()).append("\n");
+        logString.append("outstandingLockRequestMultimap.size = ").append(descriptorToLockMap.size()).append("\n");
+        logString.append("heldLocksTokenMap.size = ").append(heldLocksTokenMap.size()).append("\n");
+        logString.append("heldLocksGrantMap.size = ").append(heldLocksGrantMap.size()).append("\n");
+        logString.append("lockTokenReaperQueue.size = ").append(lockTokenReaperQueue.size()).append("\n");
+        logString.append("lockGrantReaperQueue.size = ").append(lockGrantReaperQueue.size()).append("\n");
+        logString.append("lockClientMultimap.size = ").append(lockClientMultimap.size()).append("\n");
+        logString.append("lockClientMultimap.size = ").append(lockClientMultimap.size()).append("\n");
+
+        return logString;
     }
+
 
     @Override
     public void close() {

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockDescriptorMapper.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockDescriptorMapper.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Maps;
+
+class LockDescriptorMapper {
+
+    private static final String LOCK_PREFIX = "Lock-";
+
+    private Map<String, String> mapper = Maps.newConcurrentMap();
+    private AtomicInteger lockCounter = new AtomicInteger();
+
+    String getDescriptorMapping(String descriptor) {
+        return mapper.computeIfAbsent(descriptor, k -> LOCK_PREFIX + lockCounter.incrementAndGet());
+    }
+
+    /**
+     *
+     * @return map from mapping to real descriptor.
+     */
+    Map<String, String> getReversedMapper() {
+        return mapper.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceLoggerTestUtils.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceLoggerTestUtils.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.io.File;
+import java.io.IOException;
+
+public class LockServiceLoggerTestUtils {
+    public static final String TEST_LOG_STATE_DIR = "log-state";
+
+    public static void cleanUpLogStateDir() throws IOException {
+        File rootDir = new File(TEST_LOG_STATE_DIR);
+        if (rootDir.isDirectory()) {
+            for (File file : rootDir.listFiles()) {
+                file.delete();
+            }
+        }
+        rootDir.delete();
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+import com.palantir.lock.HeldLocksToken;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.impl.LockServiceImpl;
+
+public class LockServiceStateLogger {
+    private static Logger log = LoggerFactory.getLogger(LockServiceStateLogger.class);
+
+    private static final String LOCKSTATE_FILE_PREFIX = "lockstate-";
+    private static final String DESCRIPTORS_FILE_PREFIX = "descriptors-";
+    private static final String WARNING_LOCK_DESCRIPTORS = "# WARNING: Lock descriptors may contain sensitive information\n";
+    private static final String FILE_NOT_CREATED_LOG_ERROR = "Destination file [%s] either already exists"
+            + "or can't be created. This is a very unlikely scenario."
+            + "Retrigger logging or check if process has permitions on the folder";
+
+
+    private static final String OUTSTANDING_LOCK_REQUESTS_TITLE = "OutstandingLockRequests";
+    private static final String HELD_LOCKS_TITLE = "HeldLocks";
+
+    private final LockDescriptorMapper lockDescriptorMapper = new LockDescriptorMapper();
+    private final long startTimestamp = System.currentTimeMillis();
+
+    private final ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocks;
+    private final Map<LockClient, Set<LockRequest>> outstandingLockRequests;
+    private String outputDir;
+
+
+    public LockServiceStateLogger(ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap,
+            SetMultimap<LockClient, LockRequest> outstandingLockRequestMultimap, String outputDir) {
+        this.heldLocks = heldLocksTokenMap;
+        this.outstandingLockRequests = Multimaps.asMap(outstandingLockRequestMultimap);
+        this.outputDir = outputDir;
+    }
+
+    public void logLocks() throws IOException {
+        Map<String, Object> generatedOutstandingRequests = generateOutstandingLocksYaml(outstandingLockRequests);
+        Map<String, Object> generatedHeldLocks = generateHeldLocks(heldLocks);
+
+        Path outputDirPath = Paths.get(outputDir);
+        Files.createDirectories(outputDirPath);
+
+        dumpYamlsInNewFiles(generatedOutstandingRequests, generatedHeldLocks);
+    }
+
+    private Map<String, Object> generateOutstandingLocksYaml(Map<LockClient, Set<LockRequest>> outstandingLockRequestsMap) {
+        Map<String, SimpleLockRequestsWithSameDescriptor> outstandingRequestMap = Maps.newHashMap();
+
+        outstandingLockRequestsMap.forEach((client, requestSet) -> {
+            if (requestSet != null) {
+                ImmutableSet<LockRequest> lockRequests = ImmutableSet.copyOf(requestSet);
+                lockRequests.forEach(lockRequest -> {
+                    List<SimpleLockRequest> requestList = getDescriptorSimpleRequestMap(client, lockRequest);
+                    requestList.forEach(request -> {
+                        outstandingRequestMap.putIfAbsent(request.getLockDescriptor(),
+                                new SimpleLockRequestsWithSameDescriptor(request.getLockDescriptor()));
+                        outstandingRequestMap.get(request.getLockDescriptor()).addLockRequest(request);
+                    });
+                });
+            }
+        });
+
+        List<SimpleLockRequestsWithSameDescriptor> sortedOutstandingRequests = sortOutstandingRequests(outstandingRequestMap.values());
+
+        return nameObjectForYamlConvertion(OUTSTANDING_LOCK_REQUESTS_TITLE, sortedOutstandingRequests);
+    }
+
+    private List<SimpleLockRequestsWithSameDescriptor> sortOutstandingRequests(
+            Collection<SimpleLockRequestsWithSameDescriptor> outstandingRequestsByDescriptor) {
+
+        List<SimpleLockRequestsWithSameDescriptor> sortedEntries = Lists.newArrayList(outstandingRequestsByDescriptor);
+        sortedEntries.sort(
+                (o1, o2) -> Integer.compare(o2.getLockRequestsCount(),
+                        o1.getLockRequestsCount()));
+        return sortedEntries;
+    }
+
+    private Map<String, Object> generateHeldLocks(ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap) {
+        Map<String, Object> mappedLocksToToken = Maps.newHashMap();
+        heldLocksTokenMap.forEach((token, locks) -> {
+            mappedLocksToToken.putAll(getDescriptorToTokenMap(token, locks));
+        });
+
+        return nameObjectForYamlConvertion(HELD_LOCKS_TITLE, mappedLocksToToken);
+    }
+
+    private Map<String, Object> nameObjectForYamlConvertion(String name, Object objectToName) {
+        return ImmutableMap.of(name, objectToName);
+    }
+
+    private List<SimpleLockRequest> getDescriptorSimpleRequestMap(LockClient client, LockRequest request) {
+        return request.getLocks().stream()
+                .map(lock ->
+                        SimpleLockRequest.of(request,
+                                this.lockDescriptorMapper.getDescriptorMapping(lock.getLockDescriptor().getLockIdAsString()),
+                                client.getClientId()))
+                .collect(Collectors.toList());
+    }
+
+    private Map<String, Object> getDescriptorToTokenMap(HeldLocksToken heldLocksToken,
+            LockServiceImpl.HeldLocks<HeldLocksToken> heldLocks) {
+        Map<String, Object> lockToLockInfo = Maps.newHashMap();
+        heldLocks.getLockDescriptors()
+                .forEach(lockDescriptor ->
+                        lockToLockInfo.put(
+                                this.lockDescriptorMapper.getDescriptorMapping(lockDescriptor.getLockIdAsString()),
+                                SimpleTokenInfo.of(heldLocksToken)));
+        return lockToLockInfo;
+    }
+
+    private void dumpYamlsInNewFiles(Map<String, Object> generatedOutstandingRequests,
+            Map<String, Object> generatedHeldLocks) throws IOException {
+        File lockStateFile = createNewFile(LOCKSTATE_FILE_PREFIX);
+        File descriptorsFile = createNewFile(DESCRIPTORS_FILE_PREFIX);
+
+        dumpYaml(generatedOutstandingRequests, generatedHeldLocks, lockStateFile);
+        dumpDescriptorsYaml(descriptorsFile);
+    }
+
+    private File createNewFile(String fileNamePrefix) throws IOException {
+        String fileName = fileNamePrefix + this.startTimestamp + ".yaml";
+        File file = new File(outputDir, fileName);
+
+        if (!file.createNewFile()) {
+            String fileCreationError = String.format(FILE_NOT_CREATED_LOG_ERROR, file.getAbsolutePath());
+            log.error(fileCreationError);
+            throw new IllegalStateException(fileCreationError);
+        }
+
+        return file;
+    }
+
+    private void dumpYaml(Map<String, Object> generatedOutstandingRequests, Map<String, Object> generatedHeldLocks,
+            File file) throws IOException {
+        YamlWriter writer = YamlWriter.create(file);
+
+        writer.writeToYaml(generatedOutstandingRequests);
+        writer.appendString("\n\n---\n\n");
+        writer.writeToYaml(generatedHeldLocks);
+    }
+
+    private void dumpDescriptorsYaml(File descriptorsFile) throws IOException {
+        YamlWriter writer = YamlWriter.create(descriptorsFile);
+
+        writer.appendString(WARNING_LOCK_DESCRIPTORS);
+        writer.writeToYaml(this.lockDescriptorMapper.getReversedMapper());
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequest.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value;
+
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.TimeDuration;
+
+@Value.Immutable
+public abstract class SimpleLockRequest {
+
+    public static SimpleLockRequest of(LockRequest request, String lockDescriptor, String clientId) {
+        return ImmutableSimpleLockRequest.builder()
+                .lockDescriptor(lockDescriptor)
+                .lockCount(request.getLocks().size())
+                .lockTimeout(request.getLockTimeout().getTime())
+                .lockGroupBehavior(request.getLockGroupBehavior().name())
+                .blockingMode(request.getBlockingMode().name())
+                .blockingDuration(extractBlockingDurationOrNull(request.getBlockingDuration()))
+                .versionId(request.getVersionId())
+                .creatingThread(request.getCreatingThreadName())
+                .clientId(clientId).build();
+    }
+
+    @Value.Parameter
+    public abstract String getLockDescriptor();
+
+    @Value.Parameter
+    public abstract long getLockCount();
+
+    @Value.Parameter
+    public abstract long getLockTimeout();
+
+    @Value.Parameter
+    public abstract String getLockGroupBehavior();
+
+    @Value.Parameter
+    public abstract String getBlockingMode();
+
+    @Nullable
+    @Value.Parameter
+    public abstract Long getBlockingDuration();
+
+    @Nullable
+    @Value.Parameter
+    public abstract Long getVersionId();
+
+    @Value.Parameter
+    public abstract String getClientId();
+
+    @Value.Parameter
+    public abstract String getCreatingThread();
+
+    @Nullable
+    private static Long extractBlockingDurationOrNull(TimeDuration blockingDuration) {
+        return  (blockingDuration != null) ? blockingDuration.getTime() : null;
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequestsWithSameDescriptor.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequestsWithSameDescriptor.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimpleLockRequestsWithSameDescriptor {
+    private final String lockDescriptor;
+    private List<SimpleLockRequest> lockRequests = new ArrayList<>();
+
+    SimpleLockRequestsWithSameDescriptor(String lockDescriptor) {
+        this.lockDescriptor = lockDescriptor;
+    }
+
+    void addLockRequest(SimpleLockRequest lockRequest) {
+        lockRequests.add(lockRequest);
+    }
+
+    public String getLockDescriptor() {
+        return lockDescriptor;
+    }
+
+    public List<SimpleLockRequest> getLockRequests() {
+        return lockRequests;
+    }
+
+    public int getLockRequestsCount() {
+        return lockRequests.size();
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleTokenInfo.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleTokenInfo.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.util.Date;
+
+import org.immutables.value.Value;
+
+import com.google.common.base.Preconditions;
+import com.palantir.lock.HeldLocksToken;
+
+@Value.Immutable
+public abstract class SimpleTokenInfo {
+    public static SimpleTokenInfo of(HeldLocksToken token) {
+        return ImmutableSimpleTokenInfo.builder()
+                .expiresIn(token.getExpirationDateMs() - System.currentTimeMillis())
+                .createdAtTs(token.getCreationDateMs())
+                .tokenId(token.getTokenId().toString())
+                .clientId(Preconditions.checkNotNull(token.getClient()).getClientId())
+                .requestThread(token.getRequestingThread())
+                .createAt(new Date(token.getCreationDateMs()).toString())
+                .build();
+    }
+
+    @Value.Parameter
+    public abstract long getExpiresIn();
+
+    @Value.Parameter
+    public abstract long getCreatedAtTs();
+
+    @Value.Parameter
+    public abstract String getTokenId();
+
+    @Value.Parameter
+    public abstract String getClientId();
+
+    @Value.Parameter
+    public abstract String getRequestThread();
+
+    @Value.Parameter
+    public abstract String getCreateAt();
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/YamlWriter.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/YamlWriter.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+/**
+ * Created by davidt on 4/20/17.
+ */
+class YamlWriter {
+    private static final Yaml yaml = new Yaml(getRepresenter(), getDumperOptions());
+
+    private final FileWriter fileWriter;
+
+    YamlWriter(FileWriter fileWriter) {
+        this.fileWriter = fileWriter;
+    }
+
+    public static YamlWriter create(File file) throws IOException {
+        return new YamlWriter(new FileWriter(file));
+    }
+
+    public void writeToYaml(Object data) {
+        yaml.dump(data, fileWriter);
+    }
+
+    public void appendString(String string) throws IOException {
+        fileWriter.append(string);
+    }
+
+    private static Representer getRepresenter() {
+        Representer representer = new Representer();
+        representer.addClassTag(ImmutableSimpleTokenInfo.class, Tag.MAP);
+        representer.addClassTag(ImmutableSimpleLockRequest.class, Tag.MAP);
+        representer.addClassTag(SimpleLockRequestsWithSameDescriptor.class, Tag.MAP);
+        return representer;
+    }
+
+    private static DumperOptions getDumperOptions() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setIndent(4);
+        options.setAllowReadOnlyProperties(true);
+        return options;
+    }
+}

--- a/lock-impl/src/test/java/com/palantir/lock/AllLockTests.java
+++ b/lock-impl/src/test/java/com/palantir/lock/AllLockTests.java
@@ -21,6 +21,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.palantir.lock.client.LockRefreshingLockServiceTest;
 import com.palantir.lock.impl.ClientAwareLockTest;
+import com.palantir.lock.logger.LockServiceStateLoggerTest;
 
 /**
  * Runs all lock server tests.
@@ -29,6 +30,7 @@ import com.palantir.lock.impl.ClientAwareLockTest;
  */
 @SuiteClasses(value = {
         ClientAwareLockTest.class,
+        LockServiceStateLoggerTest.class,
         LockServiceIntegrationTest.class,
         LockRefreshingLockServiceTest.class
 }) @RunWith(value = Suite.class) public final class AllLockTests {

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceIntegrationTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceIntegrationTest.java
@@ -17,6 +17,7 @@ package com.palantir.lock;
 
 import com.palantir.common.proxy.SerializingProxy;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.lock.logger.LockServiceLoggerTestUtils;
 
 public final class LockServiceIntegrationTest extends LockServiceTest {
     @Override
@@ -26,6 +27,9 @@ public final class LockServiceIntegrationTest extends LockServiceTest {
                     private static final long serialVersionUID = 1L;
                     @Override public boolean isStandaloneServer() {
                         return false;
+                    }
+                    @Override public String getLockStateLoggerDir() {
+                        return LockServiceLoggerTestUtils.TEST_LOG_STATE_DIR;
                     }
                 }));
     }

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
@@ -40,6 +40,7 @@ import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.proxy.SimulatingServerProxy;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.lock.logger.LockServiceLoggerTestUtils;
 import com.palantir.remoting1.tracing.Tracers;
 import com.palantir.util.Mutable;
 import com.palantir.util.Mutables;
@@ -478,6 +479,8 @@ public abstract class LockServiceTest {
         } catch (TimeoutException e) {
             // If we exceed the timeout, the call is hung and it's a failure
             Assert.fail();
+        } finally {
+            LockServiceLoggerTestUtils.cleanUpLogStateDir();
         }
     }
 

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.MapMaker;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+import com.palantir.lock.HeldLocksToken;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockCollections;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.impl.ClientAwareReadWriteLock;
+import com.palantir.lock.impl.LockClientIndices;
+import com.palantir.lock.impl.LockServerLock;
+import com.palantir.lock.impl.LockServiceImpl;
+
+public class LockServiceStateLoggerTest {
+
+    private final ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap =
+            new MapMaker().makeMap();
+
+    private final SetMultimap<LockClient, LockRequest> outstandingLockRequestMultimap =
+            Multimaps.synchronizedSetMultimap(HashMultimap.<LockClient, LockRequest>create());
+
+    @Before
+    public void setUp() throws Exception {
+        LockClient clientA = LockClient.of("Client A");
+        LockClient clientB = LockClient.of("Client B");
+
+        LockDescriptor descriptor1 = StringLockDescriptor.of("logger-lock");
+        LockDescriptor descriptor2 = StringLockDescriptor.of("logger-BBB");
+
+        LockRequest request1 = LockRequest.builder(LockCollections.of(ImmutableSortedMap.of(descriptor1, LockMode.WRITE)))
+                .blockForAtMost(SimpleTimeDuration.of(1000, TimeUnit.MILLISECONDS))
+                .build();
+        LockRequest request2 = LockRequest.builder(LockCollections.of(ImmutableSortedMap.of(descriptor2, LockMode.WRITE)))
+                .blockForAtMost(SimpleTimeDuration.of(1000, TimeUnit.MILLISECONDS))
+                .build();
+
+        outstandingLockRequestMultimap.put(clientA, request1);
+        outstandingLockRequestMultimap.put(clientB, request2);
+        outstandingLockRequestMultimap.put(clientA, request2);
+
+        HeldLocksToken token = getFakeHeldLocksToken("client A", "Fake thread", new BigInteger("1"));
+        HeldLocksToken token2 = getFakeHeldLocksToken("client B", "Fake thread 2", new BigInteger("2"));
+
+        Map<ClientAwareReadWriteLock, LockMode> locks = Maps.newLinkedHashMap();
+        locks.put(new LockServerLock(StringLockDescriptor.of("logger-lock-2"), new LockClientIndices()), LockMode.WRITE);
+        locks.put(new LockServerLock(StringLockDescriptor.of("logger-lock"), new LockClientIndices()), LockMode.READ);
+
+        heldLocksTokenMap.putIfAbsent(token, LockServiceImpl.HeldLocks.of(token, LockCollections.of(locks)));
+
+        Map<ClientAwareReadWriteLock, LockMode> locks2 = Maps.newLinkedHashMap();
+        locks2.put(new LockServerLock(StringLockDescriptor.of("logger-lock-3"), new LockClientIndices()), LockMode.WRITE);
+        locks2.put(new LockServerLock(StringLockDescriptor.of("logger-lock-4"), new LockClientIndices()), LockMode.READ);
+        heldLocksTokenMap.putIfAbsent(token2, LockServiceImpl.HeldLocks.of(token2, LockCollections.of(locks2)));
+    }
+
+    private HeldLocksToken getFakeHeldLocksToken(String clientName, String requestingThread, BigInteger tokenId) {
+        LockDescriptor descriptor1 = StringLockDescriptor.of("123");
+        ImmutableSortedMap.Builder<LockDescriptor, LockMode> builder =
+                ImmutableSortedMap.naturalOrder();
+        builder.put(descriptor1, LockMode.WRITE);
+
+        return new HeldLocksToken(tokenId, LockClient.of(clientName),
+                System.currentTimeMillis(), System.currentTimeMillis(),
+                LockCollections.of(builder.build()),
+                LockRequest.DEFAULT_LOCK_TIMEOUT, 0L, requestingThread);
+    }
+
+    @Test
+    public void testLocksLogging() throws Exception {
+        LockServiceStateLogger logger = new LockServiceStateLogger(
+                heldLocksTokenMap,
+                outstandingLockRequestMultimap,
+                LockServiceLoggerTestUtils.TEST_LOG_STATE_DIR);
+        logger.logLocks();
+    }
+
+    @After
+    public void after() throws IOException {
+        LockServiceLoggerTestUtils.cleanUpLogStateDir();
+    }
+}

--- a/lock-impl/versions.lock
+++ b/lock-impl/versions.lock
@@ -110,6 +110,9 @@
                 "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12"
         }
     },
     "runtime": {
@@ -223,6 +226,9 @@
                 "com.palantir.remoting1:tracing",
                 "io.dropwizard.metrics:metrics-core"
             ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "1.12"
         }
     }
 }

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -1190,9 +1190,10 @@
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "1.15",
+            "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     },
@@ -2388,9 +2389,10 @@
             ]
         },
         "org.yaml:snakeyaml": {
-            "locked": "1.15",
+            "locked": "1.12",
             "transitive": [
-                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+                "com.palantir.atlasdb:lock-impl"
             ]
         }
     }


### PR DESCRIPTION
* Log held and outstanding locks in YAML for further processing

* Change info to warn as by default we shouldn't log anything. It can be very noisy

* Add JsonPoperty to requestingThread

* Use Immutables to generate immutable classes. Remove logging configs and move HeldLocks back in LockServiceImpl

* Change the way outstanging lock requests are logged

* Add lock descriptor encryption

* Dump state in a separate Yaml file with a key for descriptors

* Clean up logging directory after tests

* Clean up logged folder for all tests calling logCurrentState

* Remove descriptor encrypting and add mapping

* Add release notes for log locking change

* Remove old state dumping, which was not full and using ERROR level logging

* Make lock descriptors in logger tests more descriptive

* Add map sizes in logging + make unknown thread names better

* Clean up LockServiceStateLogger

* Push more logic into YamlWriter class

* Further clean up and deduplicaiton of logic

**Goals (and why)**:

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
