### PR TITLE
Use available http ports instead of hardcoded ones

### DIFF
--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/startup/TimeLockMigratorTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/startup/TimeLockMigratorTest.java
@@ -40,11 +40,9 @@ import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.config.ImmutableTimeLockClientConfig;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.config.TimeLockClientConfig;
-import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 
 public class TimeLockMigratorTest {
-    private static final int PORT = 8082; // needs to be different from port in AtlasDbHttpClientsTest to avoid flakes
     private static final long BACKUP_TIMESTAMP = 42;
     private static final String TEST_ENDPOINT = "/testClient/timestamp-management/fast-forward?currentTimestamp="
             + BACKUP_TIMESTAMP;
@@ -52,20 +50,15 @@ public class TimeLockMigratorTest {
     private static final MappingBuilder TEST_MAPPING = post(urlEqualTo(TEST_ENDPOINT));
     private static final MappingBuilder PING_MAPPING = get(urlEqualTo(PING_ENDPOINT));
 
-    private static final KeyValueServiceConfig KVS_CONFIG = mock(KeyValueServiceConfig.class);
-    private static final ServerListConfig DEFAULT_SERVER_LIST = ImmutableServerListConfig.builder()
-            .addServers("http://" + WireMockConfiguration.DEFAULT_BIND_ADDRESS + ":" + PORT)
-            .build();
-    private static final TimeLockClientConfig TIMELOCK_CONFIG = ImmutableTimeLockClientConfig.builder()
-            .client("testClient")
-            .serversList(DEFAULT_SERVER_LIST)
-            .build();
     private static final String USER_AGENT = "user-agent (123456789)";
+
+    private ServerListConfig defaultServerListConfig;
+    private TimeLockClientConfig timelockConfig;
 
     private final TimestampStoreInvalidator invalidator = mock(TimestampStoreInvalidator.class);
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(PORT);
+    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort());
 
     @Before
     public void setUp() {
@@ -74,13 +67,22 @@ public class TimeLockMigratorTest {
                 .withStatus(200)
                 .withBody("pong")
                 .withHeader("Content-Type", "text/plain")));
+
+        String serverUri = String.format("http://%s:%s",
+                WireMockConfiguration.DEFAULT_BIND_ADDRESS,
+                wireMockRule.port());
+        defaultServerListConfig = ImmutableServerListConfig.builder().addServers(serverUri).build();
+        timelockConfig = ImmutableTimeLockClientConfig.builder()
+                .client("testClient")
+                .serversList(defaultServerListConfig)
+                .build();
     }
 
     @Test
     public void propagatesBackupTimestampToFastForwardOnRemoteService() {
         wireMockRule.stubFor(TEST_MAPPING.willReturn(aResponse().withStatus(204)));
 
-        TimeLockMigrator migrator = TimeLockMigrator.create(TIMELOCK_CONFIG, invalidator, USER_AGENT);
+        TimeLockMigrator migrator = TimeLockMigrator.create(timelockConfig, invalidator, USER_AGENT);
         migrator.migrate();
 
         wireMockRule.verify(getRequestedFor(urlEqualTo(PING_ENDPOINT)));
@@ -92,7 +94,7 @@ public class TimeLockMigratorTest {
     public void invalidationDoesNotProceedIfTimelockPingUnsuccessful() {
         wireMockRule.stubFor(PING_MAPPING.willReturn(aResponse().withStatus(500)));
 
-        TimeLockMigrator migrator = TimeLockMigrator.create(TIMELOCK_CONFIG, invalidator, USER_AGENT);
+        TimeLockMigrator migrator = TimeLockMigrator.create(timelockConfig, invalidator, USER_AGENT);
         assertThatThrownBy(migrator::migrate).isInstanceOf(IllegalStateException.class);
         verify(invalidator, never()).backupAndInvalidate();
     }
@@ -101,7 +103,7 @@ public class TimeLockMigratorTest {
     public void migrationDoesNotProceedIfInvalidationFails() {
         when(invalidator.backupAndInvalidate()).thenThrow(new IllegalStateException());
 
-        TimeLockMigrator migrator = TimeLockMigrator.create(TIMELOCK_CONFIG, invalidator, USER_AGENT);
+        TimeLockMigrator migrator = TimeLockMigrator.create(timelockConfig, invalidator, USER_AGENT);
         assertThatThrownBy(migrator::migrate).isInstanceOf(IllegalStateException.class);
         wireMockRule.verify(0, postRequestedFor(urlEqualTo(TEST_ENDPOINT)));
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -47,17 +47,17 @@ public class AtlasDbHttpClientsTest {
     private static final Optional<SSLSocketFactory> NO_SSL = Optional.absent();
     private static final String TEST_ENDPOINT = "/number";
     private static final MappingBuilder ENDPOINT_MAPPING = get(urlEqualTo(TEST_ENDPOINT));
-    private static final int UNAVAILABLE_PORT = 8081;
     private static final int TEST_NUMBER = 12;
 
     private int availablePort;
+    private int unavailablePort;
     private Set<String> bothUris;
 
     @Rule
     public WireMockRule availableServer = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort());
 
     @Rule
-    public WireMockRule unavailableServer = new WireMockRule(UNAVAILABLE_PORT);
+    public WireMockRule unavailableServer = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort());
 
     public interface TestResource {
         @GET
@@ -72,8 +72,9 @@ public class AtlasDbHttpClientsTest {
         availableServer.stubFor(ENDPOINT_MAPPING.willReturn(aResponse().withStatus(200).withBody(testNumberAsString)));
 
         availablePort = availableServer.port();
+        unavailablePort = unavailableServer.port();
         bothUris = ImmutableSet.of(
-                getUriForPort(UNAVAILABLE_PORT),
+                getUriForPort(unavailablePort),
                 getUriForPort(availablePort));
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -47,15 +47,14 @@ public class AtlasDbHttpClientsTest {
     private static final Optional<SSLSocketFactory> NO_SSL = Optional.absent();
     private static final String TEST_ENDPOINT = "/number";
     private static final MappingBuilder ENDPOINT_MAPPING = get(urlEqualTo(TEST_ENDPOINT));
-    private static final int AVAILABLE_PORT = 8080;
     private static final int UNAVAILABLE_PORT = 8081;
     private static final int TEST_NUMBER = 12;
-    private static final Set<String> BOTH_URIS = ImmutableSet.of(
-            getUriForPort(UNAVAILABLE_PORT),
-            getUriForPort(AVAILABLE_PORT));
+
+    private int availablePort;
+    private Set<String> bothUris;
 
     @Rule
-    public WireMockRule availableServer = new WireMockRule(AVAILABLE_PORT);
+    public WireMockRule availableServer = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort());
 
     @Rule
     public WireMockRule unavailableServer = new WireMockRule(UNAVAILABLE_PORT);
@@ -71,13 +70,18 @@ public class AtlasDbHttpClientsTest {
     public void setup() {
         String testNumberAsString = Integer.toString(TEST_NUMBER);
         availableServer.stubFor(ENDPOINT_MAPPING.willReturn(aResponse().withStatus(200).withBody(testNumberAsString)));
+
+        availablePort = availableServer.port();
+        bothUris = ImmutableSet.of(
+                getUriForPort(UNAVAILABLE_PORT),
+                getUriForPort(availablePort));
     }
 
     @Test
     public void ifOneServerResponds503WithNoRetryHeaderTheRequestIsRerouted() {
         unavailableServer.stubFor(ENDPOINT_MAPPING.willReturn(aResponse().withStatus(503)));
 
-        TestResource client = AtlasDbHttpClients.createProxyWithFailover(NO_SSL, BOTH_URIS, TestResource.class);
+        TestResource client = AtlasDbHttpClients.createProxyWithFailover(NO_SSL, bothUris, TestResource.class);
         int response = client.getTestNumber();
 
         assertThat(response, equalTo(TEST_NUMBER));
@@ -87,7 +91,7 @@ public class AtlasDbHttpClientsTest {
     @Test
     public void userAgentIsPresentOnClientRequests() {
         TestResource client =
-                AtlasDbHttpClients.createProxy(NO_SSL, getUriForPort(AVAILABLE_PORT), TestResource.class);
+                AtlasDbHttpClients.createProxy(NO_SSL, getUriForPort(availablePort), TestResource.class);
         client.getTestNumber();
 
         String defaultUserAgent = UserAgents.fromStrings(UserAgents.DEFAULT_VALUE, UserAgents.DEFAULT_VALUE);


### PR DESCRIPTION
**Goals (and why)**:
Fix #1830, which was causing builds to be flaky.

**Implementation Description (bullets)**:
Use wiremock's feature of finding open ports on test, to avoid port collision of tests running in parallel.

**Concerns (what feedback would you like?)**:
Having changed some of the tests logic unintentionally (some variables are not static anymore, so were initialized on methods with the `@Before` annotation).

**Where should we start reviewing?**:
Any test class.

**Priority (whenever / two weeks / yesterday)**:
Soon, to avoid having more flakiness.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
