### PR TITLE
Bring back deleted factory method, but deprecated

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
@@ -40,10 +40,25 @@ public final class ConflictDetectionManagers {
                 });
     }
 
+    /**
+     * @deprecated use {@link #create(KeyValueService)} instead. This constructor will be removed in a future release.
+     */
+    @Deprecated
+    public static ConflictDetectionManager createDefault(KeyValueService kvs) {
+        return create(kvs);
+    }
+
+    /**
+     * Creates a ConflictDetectionManager and kicks off an asynchronous thread to warm the cache that is used for
+     * conflict detection.
+     */
     public static ConflictDetectionManager create(KeyValueService kvs) {
         return create(kvs, true);
     }
 
+    /**
+     * Creates a ConflictDetectionManager without warming the cache.
+     */
     public static ConflictDetectionManager createWithoutWarmingCache(KeyValueService kvs) {
         return create(kvs, false);
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -69,6 +69,11 @@ develop
            For more information, see the :ref:`docs <timelock-server-further-config>`.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1785>`__)
 
+    *    - |deprecated|
+         - ``ConflictDetectionManagers.createDefault(KeyValueService)`` has been deprecated.
+           If you use this method, please replace it with ``ConflictDetectionManagers.create(KeyValueService)``.
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/1822>`__) and (`Pull Request 2 <https://github.com/palantir/atlasdb/pull/1850>`__)
+
     *    - |new|
          - Atlas Console tables now have a join() method.  See ``help("join")`` in Atlas Console for more details.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1814>`__)


### PR DESCRIPTION
**Goals (and why)**: Fix downstream compile break caused by #1822.

**Implementation Description (bullets)**: Resurrect ConflictDetectionManagers.createDefault, delegating it to create

**Concerns (what feedback would you like?)**: To save three internal products deleting 7 characters each from their code (such a tragedy!), should we just rename create to createDefault instead (might break anything that @clockfort built on top of it)?

**Where should we start reviewing?**: ASAP

**Priority (whenever / two weeks / yesterday)**: Yesterday

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1850)
<!-- Reviewable:end -->
