### PR TITLE
Fix DbKvs.getRangeOfTimestamps() only returning the first page

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -702,7 +702,7 @@ public final class DbKvs extends AbstractKeyValueService {
             Token token) {
         try (ClosableIterator<AgnosticLightResultRow> iterator = table
                 .getAllRows(rows, columns, timestamp, false, DbReadTable.Order.fromBoolean(isReverse))) {
-            return TimestampsByCellResultWithToken.create(iterator, token, batchSize);
+            return TimestampsByCellResultWithToken.create(iterator, token, batchSize, isReverse);
         }
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1082,17 +1082,17 @@ public abstract class AbstractKeyValueServiceTest {
     public void testGetRangeOfTimestampsReturnsAllRows() {
         keyValueService.put(TEST_TABLE,
             ImmutableMap.of(
-                Cell.create(row0, column0), value0_t0,
-                Cell.create(row1, column0), value0_t0,
-                Cell.create(row2, column0), value0_t0),
+                    Cell.create(row0, column0), value0_t0,
+                    Cell.create(row1, column0), value0_t0,
+                    Cell.create(row2, column0), value0_t0),
             TEST_TIMESTAMP);
         RangeRequest range = RangeRequest.all().withBatchHint(1);
         List<RowResult<Set<Long>>> results = ImmutableList.copyOf(
                 keyValueService.getRangeOfTimestamps(TEST_TABLE, range, TEST_TIMESTAMP + 1));
         assertEquals(3, results.size());
-        assertTrue(Arrays.equals(row0, results.get(0).getRowName()));
-        assertTrue(Arrays.equals(row1, results.get(1).getRowName()));
-        assertTrue(Arrays.equals(row2, results.get(2).getRowName()));
+        assertArrayEquals(row0, results.get(0).getRowName());
+        assertArrayEquals(row1, results.get(1).getRowName());
+        assertArrayEquals(row2, results.get(2).getRowName());
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1079,6 +1079,23 @@ public abstract class AbstractKeyValueServiceTest {
     }
 
     @Test
+    public void testGetRangeOfTimestampsReturnsAllRows() {
+        keyValueService.put(TEST_TABLE,
+            ImmutableMap.of(
+                Cell.create(row0, column0), value0_t0,
+                Cell.create(row1, column0), value0_t0,
+                Cell.create(row2, column0), value0_t0),
+            TEST_TIMESTAMP);
+        RangeRequest range = RangeRequest.all().withBatchHint(1);
+        List<RowResult<Set<Long>>> results = ImmutableList.copyOf(
+                keyValueService.getRangeOfTimestamps(TEST_TABLE, range, TEST_TIMESTAMP + 1));
+        assertEquals(3, results.size());
+        assertTrue(Arrays.equals(row0, results.get(0).getRowName()));
+        assertTrue(Arrays.equals(row1, results.get(1).getRowName()));
+        assertTrue(Arrays.equals(row2, results.get(2).getRowName()));
+    }
+
+    @Test
     public void testKeyAlreadyExists() {
         // Test that it does not throw some random exceptions
         putTestDataForSingleTimestamp();

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1081,11 +1081,11 @@ public abstract class AbstractKeyValueServiceTest {
     @Test
     public void testGetRangeOfTimestampsReturnsAllRows() {
         keyValueService.put(TEST_TABLE,
-            ImmutableMap.of(
+                ImmutableMap.of(
                     Cell.create(row0, column0), value0_t0,
                     Cell.create(row1, column0), value0_t0,
                     Cell.create(row2, column0), value0_t0),
-            TEST_TIMESTAMP);
+                TEST_TIMESTAMP);
         RangeRequest range = RangeRequest.all().withBatchHint(1);
         List<RowResult<Set<Long>>> results = ImmutableList.copyOf(
                 keyValueService.getRangeOfTimestamps(TEST_TABLE, range, TEST_TIMESTAMP + 1));

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -71,6 +71,10 @@ develop
          - Relax the signature of KeyValueService.addGarbageCollectionSentinelValues() to take an Iterable instead of a Set.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1843>`__)
 
+    *    - |fixed|
+         - Fixed DbKvs.getRangeOfTimestamps() only returning the first page of results rather than paging through the whole range.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1872>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 


### PR DESCRIPTION
The expectation is to return all results that fall into the range
regardless of the page size. This is how all other KVSs work
at least, and also consistent with getRange().

I'm planning to delete all of this code soon, and just need it to "work" in order
to execute the intermediate steps of my big sweep refactor/rewrite.

**Goals (and why)**:
Fix broken stuff that is blocking my work
**Implementation Description (bullets)**:
Load an extra row. Add a test.
**Concerns (what feedback would you like?)**:
It's still wrong, but that's okay (read above)
**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1872)
<!-- Reviewable:end -->
