### PR TITLE
fix getRange with column selection in console

### DIFF
--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/AtlasJacksonModule.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/AtlasJacksonModule.java
@@ -42,7 +42,7 @@ public class AtlasJacksonModule {
         module.addSerializer(new TableCellSerializer(cache));
         module.addSerializer(new TableCellValSerializer(cache));
         module.addSerializer(new TableMetadataSerializer());
-        module.addSerializer(new TableRangeSerializer());
+        module.addSerializer(new TableRangeSerializer(cache));
         module.addSerializer(new TableRowResultSerializer(cache));
         module.addSerializer(new TableRowSelectionSerializer(cache));
         module.addDeserializer(RangeToken.class, new RangeTokenDeserializer());

--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/AtlasSerializers.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/AtlasSerializers.java
@@ -83,21 +83,20 @@ public final class AtlasSerializers {
         serializeVal(jgen, description.getValue(), val);
     }
 
-    public static ColumnValueDescription serializeCol(JsonGenerator jgen,
+    public static void serializeCol(JsonGenerator jgen,
             ColumnMetadataDescription colDescription,
             byte[] col) throws IOException {
         if (colDescription.hasDynamicColumns()) {
             DynamicColumnDescription dynMetadata = colDescription.getDynamicColumn();
             NameMetadataDescription description = dynMetadata.getColumnNameDesc();
             jgen.writeRawValue(description.renderToJson(col));
-            return dynMetadata.getValue();
         } else {
-            jgen.writeString(PtBytes.toString(col));
             Set<NamedColumnDescription> namedColumns = colDescription.getNamedColumns();
             for (NamedColumnDescription description : namedColumns) {
                 if (UnsignedBytes.lexicographicalComparator().compare(col,
                         PtBytes.toCachedBytes(description.getShortName())) == 0) {
-                    return description.getValue();
+                    jgen.writeString(description.getLongName());
+                    return;
                 }
             }
             throw new IllegalArgumentException(

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -71,6 +71,10 @@ develop
          - Relax the signature of KeyValueService.addGarbageCollectionSentinelValues() to take an Iterable instead of a Set.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1843>`__)
 
+    *    - |fixed|
+         - Fixed a bug that would cause console to error on any range request that used a column selection and had more than one batch of results.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1876>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 


### PR DESCRIPTION
**Goals (and why)**:

Console had a bug where a getRange with a column selection would fail
as soon as it tried to get the second batch. This was due to an
asymmetry in serialize/deserialize for TableRanges. This asymmetry
caused the second batch to incorrectly send the request using the short
column names when the API expects it to send the long column names.

The TableRangeDeserializer converts long column names into short names,
and now (after this change) the TableRangeSerializer converts short
column names back into the long names.

**Implementation Description (bullets)**:
* Fix the TableRangeSerializer to correctly mirror the Deserializer

**Concerns (what feedback would you like?)**: N/A

**Where should we start reviewing?**: N/A - small change

**Priority (whenever / two weeks / yesterday)**: low - current workaround for console is to never use column selection even though this is slower.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1876)
<!-- Reviewable:end -->
