### PR TITLE
Add integration tests to rate limiting

### DIFF
--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -101,8 +101,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     private static final LockRequest REQUEST_LOCK_WITH_LONG_TIMEOUT = LockRequest
             .builder(ImmutableSortedMap.of(StringLockDescriptor.of("lock"), LockMode.WRITE))
-            .timeoutAfter(SimpleTimeDuration.of(10, TimeUnit.SECONDS))
-            .blockForAtMost(SimpleTimeDuration.of(2, TimeUnit.SECONDS))
+            .timeoutAfter(SimpleTimeDuration.of(20, TimeUnit.SECONDS))
+            .blockForAtMost(SimpleTimeDuration.of(4, TimeUnit.SECONDS))
             .build();
 
     private final TimestampService timestampService = getTimestampService(CLIENT_1);
@@ -167,8 +167,8 @@ public class PaxosTimeLockServerIntegrationTest {
         for (RemoteLockService lockService : lockServices) {
             for (int i = 0; i < numRequestsPerClient; i++) {
                 int currentTrial = i;
-                futures.add(executorService.submit(
-                        () -> lockService.lock(CLIENT_2 + String.valueOf(currentTrial), REQUEST_LOCK_WITH_LONG_TIMEOUT)));
+                futures.add(executorService.submit(() -> lockService.lock(
+                                CLIENT_2 + String.valueOf(currentTrial), REQUEST_LOCK_WITH_LONG_TIMEOUT)));
             }
         }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -101,7 +101,7 @@ public class PaxosTimeLockServerIntegrationTest {
 
     private static final LockRequest REQUEST_LOCK_WITH_LONG_TIMEOUT = LockRequest
             .builder(ImmutableSortedMap.of(StringLockDescriptor.of("lock"), LockMode.WRITE))
-            .timeoutAfter(SimpleTimeDuration.of(10, TimeUnit.MINUTES))
+            .timeoutAfter(SimpleTimeDuration.of(10, TimeUnit.SECONDS))
             .blockForAtMost(SimpleTimeDuration.of(2, TimeUnit.SECONDS))
             .build();
 
@@ -131,7 +131,7 @@ public class PaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void throwOnSingleClientRequestingSameLock() throws Exception {
+    public void throwOnSingleClientRequestingSameLockTooManyTimes() throws Exception {
         List<RemoteLockService> lockServiceList = ImmutableList.of(
                 getLockService(CLIENT_1));
         int exceedingRequests = 10;
@@ -142,14 +142,14 @@ public class PaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void throwOnTwoClientsRequestingSameLock() throws Exception {
+    public void throwOnTwoClientsRequestingSameLockTooManyTimes() throws Exception {
         List<RemoteLockService> lockServiceList = ImmutableList.of(
                 getLockService(CLIENT_1), getLockService(CLIENT_2));
-        int requestsPerClient = 80;
-        int maxRequestsForTwoClients = 2 * LOCAL_TC_LIMIT + SHARED_TC_LIMIT;
+        int exceedingRequests = SHARED_TC_LIMIT;
+        int requestsPerClient = LOCAL_TC_LIMIT + SHARED_TC_LIMIT;
 
         assertThat(lockAndUnlockAndCountExceptions(lockServiceList, requestsPerClient))
-                .isEqualTo(2 * requestsPerClient - maxRequestsForTwoClients);
+                .isEqualTo(exceedingRequests);
     }
 
     private int lockAndUnlockAndCountExceptions(List<RemoteLockService> lockServices, int numRequestsPerClient)


### PR DESCRIPTION
**Goals (and why)**: Test rate limiting behavior when client makes too many requests.

**Implementation Description (bullets)**: Add integration tests for rate limiting. The new tests involve creating a TimelockServer, so no mocked behavior is tested.

**Concerns (what feedback would you like?)**: Are the tests readable?

**Where should we start reviewing?**: PaxosTimeLockServerIntegrationTest (single file modified)

**Priority (whenever / two weeks / yesterday)**: whenever.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1878)
<!-- Reviewable:end -->
