### PR TITLE
fix file descriptor leak in lock state logging

### DIFF
--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -46,7 +46,7 @@ public class LockServiceStateLogger {
 
     private static final String LOCKSTATE_FILE_PREFIX = "lockstate-";
     private static final String DESCRIPTORS_FILE_PREFIX = "descriptors-";
-    private static final String WARNING_LOCK_DESCRIPTORS = "# WARNING: Lock descriptors may contain sensitive information\n";
+    private static final String WARNING_LOCK_DESCRIPTORS = "WARNING: Lock descriptors may contain sensitive information";
     private static final String FILE_NOT_CREATED_LOG_ERROR = "Destination file [%s] either already exists"
             + "or can't be created. This is a very unlikely scenario."
             + "Retrigger logging or check if process has permitions on the folder";
@@ -169,17 +169,16 @@ public class LockServiceStateLogger {
 
     private void dumpYaml(Map<String, Object> generatedOutstandingRequests, Map<String, Object> generatedHeldLocks,
             File file) throws IOException {
-        YamlWriter writer = YamlWriter.create(file);
-
-        writer.writeToYaml(generatedOutstandingRequests);
-        writer.appendString("\n\n---\n\n");
-        writer.writeToYaml(generatedHeldLocks);
+        try (LockStateYamlWriter writer = LockStateYamlWriter.create(file)) {
+            writer.dumpObject(generatedOutstandingRequests);
+            writer.dumpObject(generatedHeldLocks);
+        }
     }
 
     private void dumpDescriptorsYaml(File descriptorsFile) throws IOException {
-        YamlWriter writer = YamlWriter.create(descriptorsFile);
-
-        writer.appendString(WARNING_LOCK_DESCRIPTORS);
-        writer.writeToYaml(this.lockDescriptorMapper.getReversedMapper());
+        try (LockStateYamlWriter writer = LockStateYamlWriter.create(descriptorsFile)) {
+            writer.appendComment(WARNING_LOCK_DESCRIPTORS);
+            writer.dumpObject(lockDescriptorMapper.getReversedMapper());
+        }
     }
 }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockStateYamlWriter.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockStateYamlWriter.java
@@ -15,10 +15,12 @@
  */
 package com.palantir.lock.logger;
 
+import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -31,24 +33,24 @@ import org.yaml.snakeyaml.representer.Representer;
 class LockStateYamlWriter implements Closeable {
     private static final Yaml yaml = new Yaml(getRepresenter(), getDumperOptions());
 
-    private final FileWriter fileWriter;
+    private final Writer writer;
 
-    LockStateYamlWriter(FileWriter fileWriter) {
-        this.fileWriter = fileWriter;
+    LockStateYamlWriter(Writer fileWriter) {
+        this.writer = fileWriter;
     }
 
     /**
      * Creates a LockStateYamlWriter for the given file in append mode.
      */
     public static LockStateYamlWriter create(File file) throws IOException {
-        return new LockStateYamlWriter(new FileWriter(file, true));
+        return new LockStateYamlWriter(new BufferedWriter(new FileWriter(file, true)));
     }
 
     /**
      * Write an object to the file as YAML.
      */
     public void dumpObject(Object data) {
-        yaml.dump(data, fileWriter);
+        yaml.dump(data, writer);
     }
 
     /**
@@ -56,9 +58,9 @@ class LockStateYamlWriter implements Closeable {
      * The string must be a single line.
      */
     public void appendComment(String string) throws IOException {
-        fileWriter.append("# ");
-        fileWriter.append(string);
-        fileWriter.append("\n");
+        writer.append("# ");
+        writer.append(string);
+        writer.append("\n");
     }
 
     private static Representer getRepresenter() {
@@ -80,6 +82,6 @@ class LockStateYamlWriter implements Closeable {
 
     @Override
     public void close() throws IOException {
-        fileWriter.close();
+        writer.close();
     }
 }


### PR DESCRIPTION
**Goals (and why)**: Fix a file descriptor leak in the YAML lock state logging. Also small refactor and adding some javadocs to improve readability.

**Implementation Description (bullets)**:
* Rename YamlWriter to LockStateYamlWriter as this class is not a general purpose yaml writer, but rather is only meant to be used with specific lock-state related objects.
* Make the writer use append mode in case we want to reuse a file when dumping lock states to yaml.
* Make the writer implement Closeable and use try with resources to make sure we correctly close the writer.
* Use the yaml explicit-start option instead of manually printing "\n---\n"

**Concerns (what feedback would you like?)**: N/A - small change

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: normal -- will need to also put this on 0.39.x branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1882)
<!-- Reviewable:end -->
