### PR TITLE
Removed explicit setting of compatibility in intellij to java 6

### DIFF
--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -1,10 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-ideaSetModuleLevel(idea, targetCompatibility)
-
 dependencies {
     compile group: 'com.google.code.findbugs', name: 'jsr305'
     compile group: 'com.google.guava', name: 'guava'

--- a/commons-annotations/build.gradle
+++ b/commons-annotations/build.gradle
@@ -1,6 +1,3 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-ideaSetModuleLevel(idea, targetCompatibility)

--- a/commons-api/build.gradle
+++ b/commons-api/build.gradle
@@ -1,10 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-ideaSetModuleLevel(idea, targetCompatibility)
-
 dependencies {
   compile project(':atlasdb-commons')
   compile project(':commons-annotations')

--- a/commons-executors/build.gradle
+++ b/commons-executors/build.gradle
@@ -4,10 +4,6 @@ apply from: "../gradle/shared.gradle"
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-ideaSetModuleLevel(idea, targetCompatibility)
-
 repositories {
     mavenCentral()
 }

--- a/commons-proxy/build.gradle
+++ b/commons-proxy/build.gradle
@@ -1,10 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-ideaSetModuleLevel(idea, targetCompatibility)
-
 dependencies {
   compile group: 'org.slf4j', name: 'slf4j-api'
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,6 +42,10 @@ develop
     *    - Type
          - Change
 
+    *    - |userbreak| |changed|
+         - Projects ``atasdb-commons``, ``commons-annotations``, ``commons-api``, ``commons-executors``, ``commons-proxy``, and ``lock-api`` no longer force Java 6 compatibility. This eliminates the need for a Java 6 compiler to compile AtlasDB, but published artifacts for these projects will depend on Java 8 from now on.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1887>`__)
+
     *    - |improved|
          - Add instrumentation to the thread pool used to run quorum checks during leader elections. This will be useful for
            debugging `PaxosQuorumChecker can leave hanging threads <https://github.com/palantir/atlasdb/issues/1823>`.

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -4,10 +4,6 @@ apply from: "../gradle/shared.gradle"
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-ideaSetModuleLevel(idea, targetCompatibility)
-
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
**Goals (and why)**:
Do not require java 6 to compile AtlasDB. Upgrade to Sierra automatically removes java 6, and there is no obvious reason why we should force compatibility and make people reinstall it.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:
Need to make sure it doesn't break internal products.

**Where should we start reviewing?**:
Anywhere

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1887)
<!-- Reviewable:end -->
