### PR TITLE
[no release notes] PaxosTimestampBoundStore create/update logging + fix bad log message

### DIFF
--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -208,9 +208,9 @@ public class PaxosTimestampBoundStoreTest {
     @Test
     public void canGetAgreedStateAfterNodeDown() {
         int nodeId = 1;
+        PaxosTimestampBoundStore additionalStore = createPaxosTimestampBoundStore(nodeId);
         failureToggles.get(nodeId).set(true);
         store.storeUpperLimit(TIMESTAMP_1);
-        PaxosTimestampBoundStore additionalStore = createPaxosTimestampBoundStore(nodeId);
         failureToggles.get(nodeId).set(false);
 
         assertThat(additionalStore.getAgreedState(2).getBound()).isEqualTo(TIMESTAMP_1);


### PR DESCRIPTION
**Goals (and why)**:
* Clarify logging to track down #1749 more clearly and address #1886 
* Fix a technically incorrect and potentially confusing point in the MRTSE error message - the UUID being logged for the MRTSE is *not* that of the leader!

**Implementation Description (bullets)**:
* Add log statements to PaxosTimestampBoundStore on creation and when updating the bound.
* Clarify that the UUID is that of our proposer, not the leader.

**Concerns (what feedback would you like?)**:
* Would there be a perf impact?
* Are the log levels reasonable for this?
* Should we use the normal logger rather than `DebugLogger`?
* I've assumed that talking to myself should be very fast. Is this reasonable?

**Where should we start reviewing?**: The one file.

**Priority (whenever / two weeks / yesterday)**: Soon. Ideally before we go on internal party stack

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1890)
<!-- Reviewable:end -->
