### PR TITLE
Include locking mode in dump and improve memory usage

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -166,6 +166,11 @@ This release contains (almost) exclusively baseline-related changes.
            If you use this method, please replace it with ``ConflictDetectionManagers.create(KeyValueService)``.
            (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/1822>`__) and (`Pull Request 2 <https://github.com/palantir/atlasdb/pull/1850>`__)
 
+    *    - |improved|
+         - Improved memory footprint of lock state dumper and now it will include locking mode as well.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1891>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -139,12 +139,8 @@ import com.palantir.util.JMXUtils;
             this.locks = locks;
         }
 
-        public List<LockDescriptor> getLockDescriptors() {
-            List<LockDescriptor> descriptors = Lists.newArrayListWithCapacity(locks.size());
-            for (ClientAwareReadWriteLock lock : locks) {
-                descriptors.add(lock.getDescriptor());
-            }
-            return descriptors;
+        public T getRealToken() {
+            return realToken;
         }
 
         @Override public String toString() {

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockDescriptorMapper.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockDescriptorMapper.java
@@ -21,15 +21,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Maps;
+import com.palantir.lock.LockDescriptor;
 
+
+/**
+ * Lock descriptors may contain obfuscated sensitive information. We want to make it impossible to get a real descriptor,
+ * from the dump, even using brute force. We enumerate existing lock descriptors inside this class to use just "Lock-ID"
+ * instead the real one. Mapping to original descriptors should be dumped in a separate file
+ * with an explicit warning on the first line.
+ */
 class LockDescriptorMapper {
 
     private static final String LOCK_PREFIX = "Lock-";
 
-    private Map<String, String> mapper = Maps.newConcurrentMap();
+    private Map<LockDescriptor, String> mapper = Maps.newConcurrentMap();
     private AtomicInteger lockCounter = new AtomicInteger();
 
-    String getDescriptorMapping(String descriptor) {
+    String getDescriptorMapping(LockDescriptor descriptor) {
         return mapper.computeIfAbsent(descriptor, k -> LOCK_PREFIX + lockCounter.incrementAndGet());
     }
 
@@ -37,7 +45,7 @@ class LockDescriptorMapper {
      *
      * @return map from mapping to real descriptor.
      */
-    Map<String, String> getReversedMapper() {
+    Map<String, LockDescriptor> getReversedMapper() {
         return mapper.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
     }
 }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -129,7 +129,8 @@ public class LockServiceStateLogger {
         return request.getLocks().stream()
                 .map(lock ->
                         SimpleLockRequest.of(request,
-                                this.lockDescriptorMapper.getDescriptorMapping(lock.getLockDescriptor().getLockIdAsString()),
+                                this.lockDescriptorMapper.getDescriptorMapping(lock.getLockDescriptor()),
+                                lock.getLockMode(),
                                 client.getClientId()))
                 .collect(Collectors.toList());
     }
@@ -137,11 +138,12 @@ public class LockServiceStateLogger {
     private Map<String, Object> getDescriptorToTokenMap(HeldLocksToken heldLocksToken,
             LockServiceImpl.HeldLocks<HeldLocksToken> heldLocks) {
         Map<String, Object> lockToLockInfo = Maps.newHashMap();
-        heldLocks.getLockDescriptors()
-                .forEach(lockDescriptor ->
-                        lockToLockInfo.put(
-                                this.lockDescriptorMapper.getDescriptorMapping(lockDescriptor.getLockIdAsString()),
-                                SimpleTokenInfo.of(heldLocksToken)));
+
+        heldLocks.getRealToken().getLocks().forEach(
+                lock -> lockToLockInfo.put(
+                            this.lockDescriptorMapper.getDescriptorMapping(lock.getLockDescriptor()),
+                            SimpleTokenInfo.of(heldLocksToken, lock.getLockMode()))
+        );
         return lockToLockInfo;
     }
 

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockStateYamlWriter.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockStateYamlWriter.java
@@ -90,6 +90,7 @@ class LockStateYamlWriter implements Closeable {
 
     private static class LockDescriptorAwareRepresenter extends Representer {
         LockDescriptorAwareRepresenter() {
+            super();
             this.representers.put(LockDescriptor.class, data -> representScalar(Tag.STR, data.toString()));
         }
     }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockStateYamlWriter.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockStateYamlWriter.java
@@ -27,6 +27,8 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 
+import com.palantir.lock.LockDescriptor;
+
 /**
  * A simple wrapper for writing lock state as YAML to a file.
  */
@@ -64,10 +66,11 @@ class LockStateYamlWriter implements Closeable {
     }
 
     private static Representer getRepresenter() {
-        Representer representer = new Representer();
+        Representer representer = new LockDescriptorAwareRepresenter();
         representer.addClassTag(ImmutableSimpleTokenInfo.class, Tag.MAP);
         representer.addClassTag(ImmutableSimpleLockRequest.class, Tag.MAP);
         representer.addClassTag(SimpleLockRequestsWithSameDescriptor.class, Tag.MAP);
+        representer.addClassTag(LockDescriptor.class, Tag.MAP);
         return representer;
     }
 
@@ -83,5 +86,11 @@ class LockStateYamlWriter implements Closeable {
     @Override
     public void close() throws IOException {
         writer.close();
+    }
+
+    private static class LockDescriptorAwareRepresenter extends Representer {
+        LockDescriptorAwareRepresenter() {
+            this.representers.put(LockDescriptor.class, data -> representScalar(Tag.STR, data.toString()));
+        }
     }
 }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequest.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequest.java
@@ -19,19 +19,23 @@ import javax.annotation.Nullable;
 
 import org.immutables.value.Value;
 
+import com.palantir.lock.BlockingMode;
+import com.palantir.lock.LockGroupBehavior;
+import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.TimeDuration;
 
 @Value.Immutable
 public abstract class SimpleLockRequest {
 
-    public static SimpleLockRequest of(LockRequest request, String lockDescriptor, String clientId) {
+    public static SimpleLockRequest of(LockRequest request, String lockDescriptor, LockMode lockMode, String clientId) {
         return ImmutableSimpleLockRequest.builder()
                 .lockDescriptor(lockDescriptor)
+                .lockMode(lockMode)
                 .lockCount(request.getLocks().size())
-                .lockTimeout(request.getLockTimeout().getTime())
-                .lockGroupBehavior(request.getLockGroupBehavior().name())
-                .blockingMode(request.getBlockingMode().name())
+                .lockTimeout(request.getLockTimeout().toMillis())
+                .lockGroupBehavior(request.getLockGroupBehavior())
+                .blockingMode(request.getBlockingMode())
                 .blockingDuration(extractBlockingDurationOrNull(request.getBlockingDuration()))
                 .versionId(request.getVersionId())
                 .creatingThread(request.getCreatingThreadName())
@@ -42,16 +46,19 @@ public abstract class SimpleLockRequest {
     public abstract String getLockDescriptor();
 
     @Value.Parameter
+    public abstract LockMode getLockMode();
+
+    @Value.Parameter
     public abstract long getLockCount();
 
     @Value.Parameter
     public abstract long getLockTimeout();
 
     @Value.Parameter
-    public abstract String getLockGroupBehavior();
+    public abstract LockGroupBehavior getLockGroupBehavior();
 
     @Value.Parameter
-    public abstract String getBlockingMode();
+    public abstract BlockingMode getBlockingMode();
 
     @Nullable
     @Value.Parameter
@@ -69,6 +76,6 @@ public abstract class SimpleLockRequest {
 
     @Nullable
     private static Long extractBlockingDurationOrNull(TimeDuration blockingDuration) {
-        return  (blockingDuration != null) ? blockingDuration.getTime() : null;
+        return  (blockingDuration != null) ? blockingDuration.toMillis() : null;
     }
 }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleTokenInfo.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleTokenInfo.java
@@ -21,11 +21,13 @@ import org.immutables.value.Value;
 
 import com.google.common.base.Preconditions;
 import com.palantir.lock.HeldLocksToken;
+import com.palantir.lock.LockMode;
 
 @Value.Immutable
 public abstract class SimpleTokenInfo {
-    public static SimpleTokenInfo of(HeldLocksToken token) {
+    public static SimpleTokenInfo of(HeldLocksToken token, LockMode lockMode) {
         return ImmutableSimpleTokenInfo.builder()
+                .lockMode(lockMode)
                 .expiresIn(token.getExpirationDateMs() - System.currentTimeMillis())
                 .createdAtTs(token.getCreationDateMs())
                 .tokenId(token.getTokenId().toString())
@@ -34,6 +36,9 @@ public abstract class SimpleTokenInfo {
                 .createAt(new Date(token.getCreationDateMs()).toString())
                 .build();
     }
+
+    @Value.Parameter
+    public abstract LockMode getLockMode();
 
     @Value.Parameter
     public abstract long getExpiresIn();


### PR DESCRIPTION
**Goals (and why)**:
Improve lock logging memory usage and include locking mode in YAML

**Implementation Description (bullets)**:

* Use LockDescriptor object instead of String wherever possible. To get a string, we need to serialize byte array which includes extra steps and extra memory usage.
* Include lock mode in dumped Yaml

**Concerns (what feedback would you like?)**:

The most fishy part here seems to be realToken getter in HeldTokens. In our case the token contains blocking mode and seems the only way to get it.

**Where should we start reviewing?**:

LockServiceStateLogger seems to be involved in most useful stuff.

**Priority (whenever / two weeks / yesterday)**:
This week


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1891)
<!-- Reviewable:end -->
