### PR TITLE
Use the old version of the docker image

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/resources/docker-compose.yml
+++ b/atlasdb-dbkvs-tests/src/test/resources/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres
+    image: kiasaki/alpine-postgres:9.5
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-ete-tests/docker-compose.dbkvs.yml
+++ b/atlasdb-ete-tests/docker-compose.dbkvs.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres
+    image: kiasaki/alpine-postgres:9.5
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-perf/src/main/resources/postgres-docker-compose.yml
+++ b/atlasdb-perf/src/main/resources/postgres-docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: kiasaki/alpine-postgres
+    image: kiasaki/alpine-postgres:9.5
     container_name: atlas_perf_postgres
     environment:
        POSTGRES_PASSWORD: palantir

--- a/scripts/circle-ci/common-containers.yml
+++ b/scripts/circle-ci/common-containers.yml
@@ -5,7 +5,7 @@ cassandra2:
 #  image: palantirtechnologies/docker-cassandra-atlasdb:3.7
 
 postgres:
-  image: kiasaki/alpine-postgres
+  image: kiasaki/alpine-postgres:9.5
 
 nginx:
   image: 1science/nginx


### PR DESCRIPTION
**Goals (and why)**: fix builds

**Implementation Description (bullets)**: use the earlier postgres version that works for tests

**Concerns (what feedback would you like?)**: will not get docker image updates for tests. I believe we shoudnt have such auto-updates to latest.

**Where should we start reviewing?**: dbkvs/Dockerfile

**Priority (whenever / two weeks / yesterday)**: today

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1897)
<!-- Reviewable:end -->
