### PR TITLE
Enable error-prone pt. 2

### DIFF
--- a/commons-db/src/main/java/com/palantir/nexus/db/ThreadConfinedProxy.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/ThreadConfinedProxy.java
@@ -178,7 +178,7 @@ public class ThreadConfinedProxy extends AbstractInvocationHandler implements De
         threadName = newThread.getName();
     }
 
-    private void checkThreadChange(Thread oldThread, Thread newThread) {
+    private synchronized void checkThreadChange(Thread oldThread, Thread newThread) {
         if (oldThread.getId() != threadId) {
             String message = String.format(
                     "Thread confinement violation: tried to change threads from thread %s (ID %s) to thread %s (ID %s), but we expected thread %s (ID %s)",

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SQLString.java
@@ -164,6 +164,7 @@ public class SQLString extends BasicSQLString {
      * @param dbType Look for queries registered with this override first
      * @return a SQLString object representing the stored query
      */
+    @SuppressWarnings("GuardedByChecker")
     static FinalSQLString getByKey(final String key, DBType dbType) {
         assert isValidKey(key) : "Keys only consist of word characters"; //$NON-NLS-1$
         assert registeredValues.containsKey(key) || registeredValuesOverride.containsKey(key) :
@@ -207,6 +208,7 @@ public class SQLString extends BasicSQLString {
      * @param sql The string to be used in a query
      * @return a SQLString object representing the given SQL
      */
+    @SuppressWarnings("GuardedByChecker")
     static FinalSQLString getUnregisteredQuery(String sql) {
         assert !isValidKey(sql) : "Unregistered Queries should not look like keys"; //$NON-NLS-1$
         FinalSQLString cached = cachedUnregistered.get(canonicalizeStringAndRemoveWhitespaceEntirely(sql));
@@ -406,6 +408,7 @@ public class SQLString extends BasicSQLString {
         return new RegisteredSQLString(key.delegate);
     }
 
+    @SuppressWarnings("GuardedByChecker")
     protected static ImmutableMap<String, FinalSQLString> getCachedUnregistered() {
         return cachedUnregistered;
     }
@@ -416,6 +419,7 @@ public class SQLString extends BasicSQLString {
         }
     }
 
+    @SuppressWarnings("GuardedByChecker")
     protected static ImmutableMap<String, FinalSQLString> getCachedKeyed() {
         return cachedKeyed;
     }

--- a/gradle/baseline.gradle
+++ b/gradle/baseline.gradle
@@ -18,14 +18,6 @@ List<String> blacklistedBaselineProjects = [
         'timestamp-impl']
 
 List<String> blacklistedErrorProneProjects = [
-        'atlasdb-console',
-        'atlasdb-dbkvs-hikari',
-        'atlasdb-jdbc',
-        'atlasdb-jdbc-tests',
-        'atlasdb-rocksdb',
-        'atlasdb-rocksdb-tests',
-        'atlasdb-service-server',
-        'cassandra-partitioner',
         'commons-db',
         'commons-executors',
         'leader-election-impl',

--- a/gradle/baseline.gradle
+++ b/gradle/baseline.gradle
@@ -18,7 +18,6 @@ List<String> blacklistedBaselineProjects = [
         'timestamp-impl']
 
 List<String> blacklistedErrorProneProjects = [
-        'commons-db',
         'commons-executors',
         'leader-election-impl',
         'lock-impl',

--- a/gradle/baseline.gradle
+++ b/gradle/baseline.gradle
@@ -19,7 +19,6 @@ List<String> blacklistedBaselineProjects = [
 
 List<String> blacklistedErrorProneProjects = [
         'lock-impl',
-        'profile-client-protobufs',
         'timestamp-impl']
 
 if (!blacklistedBaselineProjects.contains(project.name)) {

--- a/gradle/baseline.gradle
+++ b/gradle/baseline.gradle
@@ -18,8 +18,6 @@ List<String> blacklistedBaselineProjects = [
         'timestamp-impl']
 
 List<String> blacklistedErrorProneProjects = [
-        'commons-executors',
-        'leader-election-impl',
         'lock-impl',
         'profile-client-protobufs',
         'timestamp-impl']

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -30,6 +30,7 @@ import com.palantir.leader.LeaderElectionService;
 public class AwaitingLeadershipProxyTest {
 
     @Test
+    @SuppressWarnings("SelfEquals")
     public void shouldAllowObjectMethodsWhenLeading() throws Exception {
         Runnable mockRunnable = mock(Runnable.class);
         Supplier<Runnable> delegateSupplier = Suppliers.ofInstance(mockRunnable);
@@ -48,6 +49,7 @@ public class AwaitingLeadershipProxyTest {
     }
 
     @Test
+    @SuppressWarnings("SelfEquals")
     public void shouldAllowObjectMethodsWhenNotLeading() throws Exception {
         Runnable mockRunnable = mock(Runnable.class);
         Supplier<Runnable> delegateSupplier = Suppliers.ofInstance(mockRunnable);

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -30,7 +30,7 @@ import com.palantir.leader.LeaderElectionService;
 public class AwaitingLeadershipProxyTest {
 
     @Test
-    @SuppressWarnings("SelfEquals")
+    @SuppressWarnings("SelfEquals") // We're asserting that calling .equals on a proxy does not redirect the .equals call to the instance its being proxied.
     public void shouldAllowObjectMethodsWhenLeading() throws Exception {
         Runnable mockRunnable = mock(Runnable.class);
         Supplier<Runnable> delegateSupplier = Suppliers.ofInstance(mockRunnable);
@@ -49,7 +49,7 @@ public class AwaitingLeadershipProxyTest {
     }
 
     @Test
-    @SuppressWarnings("SelfEquals")
+    @SuppressWarnings("SelfEquals") // We're asserting that calling .equals on a proxy does not redirect the .equals call to the instance its being proxied.
     public void shouldAllowObjectMethodsWhenNotLeading() throws Exception {
         Runnable mockRunnable = mock(Runnable.class);
         Supplier<Runnable> delegateSupplier = Suppliers.ofInstance(mockRunnable);


### PR DESCRIPTION
**Goals (and why)**: Continue to enable error-prone on several projects.

**Implementation Description (bullets)**: Enable error-prone on following modules:

- atlasdb-console
- atlasdb-dbkvs-hikari
- atlasdb-jdbc
- atlasdb-jdbc-tests
- atlasdb-rocksdb
- atlasdb-rocksdb-tests
- atlasdb-service-server
- cassandra-partitioner
- commons-db
- commons-executors
- leader-election-impl

**Concerns (what feedback would you like?)**: Did I change the behavior of anything that shouldn't be changed?

**Where should we start reviewing?**: Review it after #1889.

**Priority (whenever / two weeks / yesterday)**: EOW.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1901)
<!-- Reviewable:end -->
