### PR TITLE
Only retry DbKvs test set up check if a specific error occurred

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -94,7 +94,11 @@ public final class DbkvsPostgresTestSuite {
                 kvs = ConnectionManagerAwareDbKvs.create(getKvsConfig());
                 return kvs.getConnectionManager().getConnection().isValid(5);
             } catch (Exception e) {
-                return false;
+                if (e.getMessage().contains("The connection attempt failed.")) {
+                    return  false;
+                } else {
+                    throw e;
+                }
             } finally {
                 if (kvs != null) {
                     kvs.close();

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -93,11 +93,11 @@ public final class DbkvsPostgresTestSuite {
             try {
                 kvs = ConnectionManagerAwareDbKvs.create(getKvsConfig());
                 return kvs.getConnectionManager().getConnection().isValid(5);
-            } catch (Exception e) {
-                if (e.getMessage().contains("The connection attempt failed.")) {
+            } catch (Exception ex) {
+                if (ex.getMessage().contains("The connection attempt failed.")) {
                     return false;
                 } else {
-                    throw e;
+                    throw ex;
                 }
             } finally {
                 if (kvs != null) {

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -95,7 +95,7 @@ public final class DbkvsPostgresTestSuite {
                 return kvs.getConnectionManager().getConnection().isValid(5);
             } catch (Exception e) {
                 if (e.getMessage().contains("The connection attempt failed.")) {
-                    return  false;
+                    return false;
                 } else {
                     throw e;
                 }


### PR DESCRIPTION
It doesn't make sense to keep checking if DbKvs is up if we got a
legitimate error.

[no release note]

**Goals (and why)**:
Trying to debug test flakes on CircleCI.
**Implementation Description (bullets)**:
During the DbKvs Postgres test initialization, only retry the check if we got a "white listed" connection error, otherwise crash with a (hopefully) useful message.
**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1903)
<!-- Reviewable:end -->
