### PR TITLE
Project "Bankshot" (TimeLock Perf) Stage 1: Jetty Servlets for Common Calls [WIP]

### DIFF
--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
@@ -47,6 +47,8 @@ import com.palantir.atlasdb.timelock.config.PaxosConfiguration;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 import com.palantir.atlasdb.timelock.lock.BlockingTimeLimitedLockService;
 import com.palantir.atlasdb.timelock.lock.BlockingTimeouts;
+import com.palantir.atlasdb.timelock.paxos.servlets.ServletFactory;
+import com.palantir.atlasdb.timelock.paxos.servlets.ServletRegistration;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.PingableLeader;
@@ -121,6 +123,16 @@ public class PaxosTimeLockServer implements TimeLockServer {
                 localPaxosServices.ourLearner()));
         environment.jersey().register(new NotCurrentLeaderExceptionMapper());
         environment.jersey().register(new BlockingTimeoutExceptionMapper());
+
+        ServletRegistration.registerServlet(
+                environment,
+                ServletFactory.leaderPingServlet(localPaxosServices.pingableLeader()),
+                "/leader/ping");
+        ServletRegistration.registerServlet(
+                environment,
+                ServletFactory.getLatestSequencePreparedOrAcceptedServlet(
+                        environment.getObjectMapper(), localPaxosServices.ourAcceptor()),
+                "/.internal/leaderPaxos/acceptor/latest-sequence-prepared-or-accepted");
     }
 
     private void registerHealthCheck(TimeLockServerConfiguration configuration) {
@@ -168,6 +180,10 @@ public class PaxosTimeLockServer implements TimeLockServer {
                 LockService.class,
                 createLockService(slowLogTriggerMillis),
                 client);
+        ServletRegistration.registerServlet(
+                environment,
+                ServletFactory.freshTimestampServlet(environment.getObjectMapper(), timestampService),
+                "/" + client + "/timestamp/fresh-timestamp");
 
         return TimeLockServices.create(timestampService, lockService, timestampService);
     }
@@ -218,6 +234,11 @@ public class PaxosTimeLockServer implements TimeLockServer {
 
     private ManagedTimestampService createPaxosBackedTimestampService(String client) {
         paxosResource.addClient(client);
+        ServletRegistration.registerServlet(
+                environment,
+                ServletFactory.getLatestSequencePreparedOrAcceptedServlet(
+                        environment.getObjectMapper(), paxosResource.getPaxosAcceptor(client)),
+                "/" + client + "/acceptor/latest-sequence-prepared-or-accepted");
 
         ExecutorService executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
                 .setNameFormat("atlas-consensus-" + client + "-%d")

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ApplicationJsonResponseStrategy.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ApplicationJsonResponseStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ApplicationJsonResponseStrategy<V> implements ResponseStrategy<V> {
+    private final ObjectMapper mapper;
+
+    public ApplicationJsonResponseStrategy(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String mediaType() {
+        return MediaType.APPLICATION_JSON;
+    }
+
+    @Override
+    public void writeResponse(V valueToWrite, HttpServletResponse response) throws IOException {
+        response.getWriter().write(mapper.writeValueAsString(valueToWrite));
+    }
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/DelegatingServlet.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/DelegatingServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the BSD-3 License (the "License");

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/DelegatingServlet.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/DelegatingServlet.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.timelock.paxos.servlets;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.remoting1.errors.SerializableError;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.jetty.http.HttpStatus;
+
+public class DelegatingServlet<V> extends HttpServlet {
+    private final Callable<V> function;
+    private final MediaType mediaType;
+    private final ObjectMapper mapper;
+    private final HttpMethod allowedMethod;
+
+    public DelegatingServlet(
+            Callable<V> function, MediaType mediaType, ObjectMapper mapper, HttpMethod allowedMethod) {
+        this.function = function;
+        this.mediaType = mediaType;
+        this.mapper = mapper;
+        this.allowedMethod = allowedMethod;
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        writeResponseIfMethodMatches(response, HttpMethod.GET);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        writeResponseIfMethodMatches(response, HttpMethod.POST);
+    }
+
+    private void writeResponseIfMethodMatches(HttpServletResponse response, String get) throws IOException {
+        if (allowedMethod.value().equals(get)) {
+            writeResponse(response);
+        } else {
+            response.sendError(HttpStatus.METHOD_NOT_ALLOWED_405);
+        }
+    }
+
+    private void writeResponse(HttpServletResponse response) throws IOException {
+        response.addHeader(HttpHeaders.CONTENT_TYPE, mediaType.toString());
+        try {
+            response.getWriter().write(
+                    mapper.writeValueAsString(function.call()));
+        } catch (Exception e) {
+            response.getWriter().write(
+                    mapper.writeValueAsString(SerializableError.of(e.getMessage(), e.getClass())));
+        }
+    }
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ResponseStrategy.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ResponseStrategy.java
@@ -22,7 +22,8 @@ import javax.servlet.http.HttpServletResponse;
 
 public interface ResponseStrategy<V> {
     /**
-     * @return A String representation of the media type this ResponseStrategy is designed to handle
+     * Returns the media type this ResponseStrategy is designed to handle.
+     * @return A String representation of the media type this strategy handles
      */
     String mediaType();
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ResponseStrategy.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ResponseStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+public interface ResponseStrategy<V> {
+    /**
+     * @return A String representation of the media type this ResponseStrategy is designed to handle
+     */
+    String mediaType();
+
+    /**
+     * Writes the provided valueToWrite to the HTTP response response, in a suitable format for the mediaType.
+     * @param valueToWrite the value to include as the payload of the response
+     * @param response the response to write the value to
+     * @throws IOException if there was an I/O error writing to the response
+     */
+    void writeResponse(V valueToWrite, HttpServletResponse response) throws IOException;
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ServletFactory.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ServletFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos.servlets;
+
+import javax.ws.rs.HttpMethod;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.leader.PingableLeader;
+import com.palantir.paxos.PaxosAcceptor;
+import com.palantir.timestamp.TimestampService;
+
+public final class ServletFactory {
+    private ServletFactory() {
+        // factory, so no.
+    }
+
+    public static DelegatingServlet<Boolean> leaderPingServlet(PingableLeader pingable) {
+        return new DelegatingServlet<>(pingable::ping, HttpMethod.GET, new TextPlainResponseStrategy<>());
+    }
+
+    public static DelegatingServlet<Long> getLatestSequencePreparedOrAcceptedServlet(
+            ObjectMapper mapper, PaxosAcceptor acceptor) {
+        return new DelegatingServlet<>(
+                acceptor::getLatestSequencePreparedOrAccepted,
+                HttpMethod.POST,
+                new ApplicationJsonResponseStrategy<>(mapper));
+    }
+
+    public static DelegatingServlet<Long> freshTimestampServlet(
+            ObjectMapper mapper, TimestampService timestampService) {
+        return new DelegatingServlet<>(
+                timestampService::getFreshTimestamp,
+                HttpMethod.POST,
+                new ApplicationJsonResponseStrategy<>(mapper));
+    }
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ServletRegistration.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/ServletRegistration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos.servlets;
+
+import javax.servlet.http.HttpServlet;
+
+import org.eclipse.jetty.servlet.ServletHolder;
+
+import io.dropwizard.setup.Environment;
+
+public final class ServletRegistration {
+    private ServletRegistration() {
+        // no
+    }
+
+    public static void registerServlet(Environment environment, HttpServlet servlet, String path) {
+        environment.getApplicationContext().addServlet(new ServletHolder(servlet), path);
+    }
+}

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/TextPlainResponseStrategy.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/TextPlainResponseStrategy.java
@@ -21,14 +21,14 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 
-public class TextPlainResponseStrategy implements ResponseStrategy<String> {
+public class TextPlainResponseStrategy<V> implements ResponseStrategy<V> {
     @Override
     public String mediaType() {
         return MediaType.TEXT_PLAIN;
     }
 
     @Override
-    public void writeResponse(String valueToWrite, HttpServletResponse response) throws IOException {
-        response.getWriter().write(valueToWrite);
+    public void writeResponse(V valueToWrite, HttpServletResponse response) throws IOException {
+        response.getWriter().write(valueToWrite.toString());
     }
 }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/TextPlainResponseStrategy.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/servlets/TextPlainResponseStrategy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+
+public class TextPlainResponseStrategy implements ResponseStrategy<String> {
+    @Override
+    public String mediaType() {
+        return MediaType.TEXT_PLAIN;
+    }
+
+    @Override
+    public void writeResponse(String valueToWrite, HttpServletResponse response) throws IOException {
+        response.getWriter().write(valueToWrite);
+    }
+}

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServerTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServerTest.java
@@ -44,6 +44,7 @@ import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 import com.palantir.paxos.PaxosAcceptor;
 
 import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.jetty.MutableServletContextHandler;
 import io.dropwizard.setup.Environment;
 
 public class PaxosTimeLockServerTest {
@@ -71,6 +72,7 @@ public class PaxosTimeLockServerTest {
     public void setUp() {
         when(environment.jersey()).thenReturn(mock(JerseyEnvironment.class));
         when(environment.healthChecks()).thenReturn(mock(HealthCheckRegistry.class));
+        when(environment.getApplicationContext()).thenReturn(mock(MutableServletContextHandler.class));
     }
 
     @Test


### PR DESCRIPTION
Throwing this out for initial ideas/review. This is still a WIP though the "core" methodology is likely to be pretty similar to what's here.

**TODO**

- [ ] Some refactoring/reorganisation to ensure this stuff is cleaner
- [ ] Unit tests
- [ ] Benchmark on a remote three node cluster
- [ ] Release notes - perf jumped by foo, from step 2

**Goals (and why)**:
See https://github.com/palantir/atlasdb/issues/1836#issuecomment-297207656 - specifically, this part.

```
-- SSL / HTTP2 -- 
websocket: 110 us

feign + jersey: 310 us
(...)
feign + jetty: 245 us
```

JAX-RS/Jersey dispatch does introduce some overheads. Apparently HTTP/2 overhead over websockets itself isn't too bad; the overhead is largely introduced through Feign and Jersey.

This change switches us to use raw Jetty servlets for the three most common calls on TimeLock:

* leader/ping
* timestamp/fresh-timestamp
* acceptor/getLatestSequencePreparedOrAccepted (for both the leadership and timestamp bound acceptors)

Locally, testing timestamp/fresh-timestamp yielded a 25% improvement (280 --> 210 us), which is not too different from @nziebart's results above. Firing 8 threads which hammered timestamp/fresh-timestamp yielded a much larger improvement (~45%), as well.

Stage 2 could be for us to devise a high performance client to possibly replace the Feign/OkHttp configuration we have in `AtlasDbHttpClients`. That'll probably be a riskier and more invasive change than this one, though it could yield another (probably bigger) perf win.

**Implementation Description (bullets)**:

* Introduce a fair bit of servlet machinery in the timelock-server project, which is a framework for delegating Java functions to servlets.
* Register HTTP servlets for the functions defined above, which take precedence over Jersey resolution.

**Concerns (what feedback would you like?)**:

* Are we handling errors correctly even when this switch is done?
* Is the complexity worth it?

**Where should we start reviewing?**: `DelegatingServlet` is probably the best start point.

**Priority (whenever / two weeks / yesterday)**: for now, whenever; though if/when timelock perf becomes a concern this may subsequently increase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1904)
<!-- Reviewable:end -->
