### PR TITLE
Improve leader election logging (#1757)

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
@@ -44,8 +45,7 @@ import com.palantir.remoting1.tracing.Tracers;
 
 public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(AwaitingLeadershipProxy.class);
-    private static final Logger leaderLog = LoggerFactory.getLogger("leadership");
+    private static final AtomicInteger numProxies = new AtomicInteger();
 
     public static <U> U newProxyInstance(Class<U> interfaceClass,
                                          Supplier<U> delegateSupplier,
@@ -61,6 +61,9 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                 new Class<?>[] { interfaceClass, Closeable.class },
                 proxy);
     }
+
+    private final TaggedLogger log;
+    private final TaggedLogger leaderLog;
 
     final Supplier<T> delegateSupplier;
     final LeaderElectionService leaderElectionService;
@@ -86,6 +89,10 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         this.delegateRef = new AtomicReference<>();
         this.interfaceClass = interfaceClass;
         this.isClosed = false;
+
+        String logTag = "Proxy #" + numProxies.getAndIncrement() + " - " + interfaceClass.getSimpleName();
+        log = new TaggedLogger(AwaitingLeadershipProxy.class, logTag);
+        leaderLog = new TaggedLogger("leadership", logTag);
     }
 
     private void tryToGainLeadership() {
@@ -100,6 +107,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
 
     private void gainLeadership() {
         try {
+            leaderLog.info("Not the leader. Going to sleep.");
             LeadershipToken leadershipToken = leaderElectionService.blockOnBecomingLeader();
             // We are now the leader, we should create a delegate so we can service calls
             T delegate = null;
@@ -146,6 +154,8 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         }
 
         if (method.getName().equals("close") && args.length == 0) {
+            log.warn("Shutting down now");
+            leaderLog.warn("Shutting down now");
             isClosed = true;
             executor.shutdownNow();
             clearDelegate();
@@ -193,7 +203,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
     }
 
     private void markAsNotLeading(final LeadershipToken leadershipToken, @Nullable Throwable cause) {
-        leaderLog.warn("Lost leadership", cause);
+        leaderLog.warn("Noticed that we lost leadership", cause);
         if (leadershipTokenRef.compareAndSet(leadershipToken, null)) {
             try {
                 clearDelegate();
@@ -205,4 +215,81 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         throw notCurrentLeaderException("method invoked on a non-leader (leadership lost)", cause);
     }
 
+    /**
+     * Wraps a delegate Logger, prepending the specified string to the start of each log message.
+     */
+    private static class TaggedLogger {
+        private final Logger delegate;
+        private final String tag;
+
+        public TaggedLogger(Class clazz, String tag) {
+            this.delegate = LoggerFactory.getLogger(clazz);
+            this.tag = "[" + tag + "] ";
+        }
+
+        public TaggedLogger(String name, String tag) {
+            this.delegate = LoggerFactory.getLogger(name);
+            this.tag = "[" + tag + "] ";
+        }
+
+        public void trace(String s, Throwable t) {
+            if (delegate.isTraceEnabled()) {
+                delegate.trace(tag + s, t);
+            }
+        }
+
+        public void debug(String s, Throwable t) {
+            if (delegate.isDebugEnabled()) {
+                delegate.debug(tag + s, t);
+            }
+        }
+
+        public void info(String s, Throwable t) {
+            if (delegate.isInfoEnabled()) {
+                delegate.info(tag + s, t);
+            }
+        }
+
+        public void warn(String s, Throwable t) {
+            if (delegate.isWarnEnabled()) {
+                delegate.warn(tag + s, t);
+            }
+        }
+
+        public void error(String s, Throwable t) {
+            if (delegate.isErrorEnabled()) {
+                delegate.error(tag + s, t);
+            }
+        }
+
+        public void trace(String s, Object... args) {
+            if (delegate.isTraceEnabled()) {
+                delegate.trace(tag + s, args);
+            }
+        }
+
+        public void debug(String s, Object... args) {
+            if (delegate.isDebugEnabled()) {
+                delegate.debug(tag + s, args);
+            }
+        }
+
+        public void info(String s, Object... args) {
+            if (delegate.isInfoEnabled()) {
+                delegate.info(tag + s, args);
+            }
+        }
+
+        public void warn(String s, Object... args) {
+            if (delegate.isWarnEnabled()) {
+                delegate.warn(tag + s, args);
+            }
+        }
+
+        public void error(String s, Object... args) {
+            if (delegate.isErrorEnabled()) {
+                delegate.error(tag + s, args);
+            }
+        }
+    }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 public class PaxosLearnerImpl implements PaxosLearner {
 
     private static final Logger logger = LoggerFactory.getLogger(PaxosLearnerImpl.class);
+    private static final Logger leaderLog = LoggerFactory.getLogger("leadership");
 
     /**
      * @param logDir string path for directory to place durable logs
@@ -57,6 +58,7 @@ public class PaxosLearnerImpl implements PaxosLearner {
 
     @Override
     public void learn(long seq, PaxosValue val) {
+        leaderLog.info("Learned about new leader (seq #{}) with UUID {}", seq, val.getLeaderUUID());
         state.put(seq, val);
         log.writeRound(seq, val);
     }


### PR DESCRIPTION
(Cherry-pick of https://github.com/palantir/atlasdb/pull/1757 to develop)

As per the original commit this adds more granular logging to the leader election code to make it easier to debug issues leader election and handoff. 

Feedback I'm looking for is:
 * Mistakes in merge conflict resolution (PaxosLeaderElectionService.java, AwaitingLeadershipProxy.java, PaxosAcceptorImpl.java)
 * Anything you think needs neatening up for develop.
 * Incompatibilities with changes made since 0.4.x.

Cheers!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1905)
<!-- Reviewable:end -->
