### PR TITLE
Remove the distribution plugin in timelock-server

### DIFF
--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.palantir.java-distribution'
 apply plugin: 'org.inferred.processors'
 apply plugin: 'org.unbroken-dome.test-sets'
 


### PR DESCRIPTION
**Goals (and why)**: distTar shouldnt be a timelock-server task. Publications for AtlasDB are failing post #1898.

**Implementation Description (bullets)**: 

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**: one file.

**Priority (whenever / two weeks / yesterday)** : _yesterday_

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1908)
<!-- Reviewable:end -->
