### PR TITLE
Add generateMapToFullTableNames in TableMappingService

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/TableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/TableMappingService.java
@@ -26,5 +26,5 @@ public interface TableMappingService {
     void removeTable(TableReference tableRef);
     TableReference getMappedTableName(TableReference tableRef);
     <T> Map<TableReference, T> mapToShortTableNames(Map<TableReference, T> tableMap);
-    Set<TableReference> mapToFullTableNames(Set<TableReference> tableNames);
+    Map<TableReference, TableReference> generateMapToFullTableNames(Set<TableReference> tableNames);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractTableMappingService.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang.Validate;
 
 import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.keyvalue.TableMappingService;
@@ -88,31 +89,31 @@ public abstract class AbstractTableMappingService implements TableMappingService
     private final ConcurrentHashMap<TableReference, Boolean> unmappedTables = new ConcurrentHashMap<TableReference, Boolean>();
 
     @Override
-    public Set<TableReference> mapToFullTableNames(Set<TableReference> tableRefs) {
-        Set<TableReference> newSet = Sets.newHashSet();
+    public Map<TableReference, TableReference> generateMapToFullTableNames(Set<TableReference> tableRefs) {
+        ImmutableMap.Builder<TableReference, TableReference> shortNameToFullTableName = ImmutableMap.builder();
         Set<TableReference> tablesToReload = Sets.newHashSet();
-        for (TableReference name : tableRefs) {
-            if (name.isFullyQualifiedName()) {
-                newSet.add(name);
-            } else if (tableMap.get().containsValue(name)) {
-                newSet.add(getFullTableName(name));
-            } else if (unmappedTables.containsKey(name)) {
-                newSet.add(name);
+        for (TableReference inputName : tableRefs) {
+            if (inputName.isFullyQualifiedName()) {
+                shortNameToFullTableName.put(inputName, inputName);
+            } else if (tableMap.get().containsValue(inputName)) {
+                shortNameToFullTableName.put(inputName, getFullTableName(inputName));
+            } else if (unmappedTables.containsKey(inputName)) {
+                shortNameToFullTableName.put(inputName, inputName);
             } else {
-                tablesToReload.add(name);
+                tablesToReload.add(inputName);
             }
         }
         if (!tablesToReload.isEmpty()) {
             updateTableMap();
             for (TableReference tableRef : Sets.difference(tablesToReload, tableMap.get().values())) {
                 unmappedTables.put(tableRef, true);
-                newSet.add(tableRef);
+                shortNameToFullTableName.put(tableRef, tableRef);
             }
             for (TableReference tableRef : Sets.intersection(tablesToReload, tableMap.get().values())) {
-                newSet.add(getFullTableName(tableRef));
+                shortNameToFullTableName.put(tableRef, getFullTableName(tableRef));
             }
         }
-        return newSet;
+        return shortNameToFullTableName.build();
     }
 
 }


### PR DESCRIPTION
**Goals (and why)**:
This is a cherry pick of #1568 that was missed several months ago.

This should fix issue #1485, which was causing
excessive reads from the DB during initialization
of the SweepStrategyManager.

(cherry picked from commit 7f586015f1b4bbe9a35d9c6fa9f5755277c061f1)

Use ImmutableMap.Builder in AbstractTableMappingService.generateMapToFullTableNames()

(cherry picked from commit 7594ccd5c4a53020156cb42dcc05fcb890aee214)

**Implementation Description (bullets)**:
Adds a new method on the TableMappingService so that we can make one call to get full table mapping from short name to full name.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
This is a cherry pick of #1568 that was missed several months ago.

**Priority (whenever / two weeks / yesterday)**:
Hoping for end of the week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1912)
<!-- Reviewable:end -->
