### PR TITLE
Backport Log held and outstanding locks in YAML for further processing (#1792)…

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -31,7 +31,7 @@ configurations.matching({ it.name in ['compile', 'runtime'] }).all {
         force 'org.apache.thrift:libthrift:0.9.2'
         force 'org.slf4j:slf4j-api:1.7.6'
         force 'org.xerial.snappy:snappy-java:' + libVersions.snappy
-        force 'org.yaml:snakeyaml:1.12'
+        force 'org.yaml:snakeyaml:' + libVersions.snakeyaml
         force 'commons-codec:commons-codec:1.6'
     }
 }

--- a/atlasdb-exec/src/main/resources/log4j.properties
+++ b/atlasdb-exec/src/main/resources/log4j.properties
@@ -9,8 +9,8 @@ log4j.appender.file.MaxBackupIndex=10
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
  
- # Direct log messages to stdout
- log4j.appender.stdout=org.apache.log4j.ConsoleAppender
- log4j.appender.stdout.Target=System.out
- log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
- log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/atlasdb-server-dropwizard/src/test/java/com/palantir/server/LockRemotingTest.java
+++ b/atlasdb-server-dropwizard/src/test/java/com/palantir/server/LockRemotingTest.java
@@ -32,9 +32,11 @@ import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
+import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.lock.logger.LockServiceLoggerTestUtils;
 
 import feign.Feign;
 import feign.jackson.JacksonDecoder;
@@ -43,7 +45,12 @@ import feign.jaxrs.JAXRSContract;
 import io.dropwizard.testing.junit.DropwizardClientRule;
 
 public class LockRemotingTest {
-    static LockServiceImpl rawLock = LockServiceImpl.create();
+    private static LockServerOptions lockServerOptions = new LockServerOptions() {
+        @Override public String getLockStateLoggerDir() {
+            return LockServiceLoggerTestUtils.TEST_LOG_STATE_DIR;
+        }
+    };
+    private static LockServiceImpl rawLock = LockServiceImpl.create(lockServerOptions);
 
     @ClassRule
     public final static DropwizardClientRule lockService = new DropwizardClientRule(rawLock);
@@ -85,7 +92,11 @@ public class LockRemotingTest {
         Set<LockRefreshToken> refreshed = lock.refreshLockRefreshTokens(ImmutableList.of(token));
         Assert.assertEquals(1, refreshed.size());
         lock.unlock(token);
-        lock.logCurrentState();
+        try {
+            lock.logCurrentState();
+        } finally {
+            LockServiceLoggerTestUtils.cleanUpLogStateDir();
+        }
         lock.currentTimeMillis();
 
         HeldLocksToken token1 = lock.lockAndGetHeldLocks(LockClient.ANONYMOUS.getClientId(), request);

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -17,7 +17,8 @@ ext.libVersions = [
     hamcrest: '1.3',
     commons_codec: '1.6',
     libthrift: '0.9.2',
-    protobuf: '2.6.0'
+    protobuf: '2.6.0',
+    snakeyaml: '1.12'
 ]
 
 configurations.matching({ it.name in ['compile', 'runtime'] }).all {

--- a/lock-api/src/main/java/com/palantir/lock/ExpiringToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/ExpiringToken.java
@@ -47,6 +47,12 @@ public interface ExpiringToken {
     @Nullable LockClient getClient();
 
     /**
+     * Returns the set of locks which were successfully acquired as a map
+     * from descriptor to lock mode.
+     */
+    SortedLockCollection<LockDescriptor> getLockDescriptors();
+
+    /**
      * Returns the amount of time that it takes for these locks to
      * expire.
      */

--- a/lock-api/src/main/java/com/palantir/lock/HeldLocksGrant.java
+++ b/lock-api/src/main/java/com/palantir/lock/HeldLocksGrant.java
@@ -83,6 +83,11 @@ import com.google.common.base.Preconditions;
         return null;
     }
 
+    @Override
+    public SortedLockCollection<LockDescriptor> getLockDescriptors() {
+        return getLocks();
+    }
+
     /**
      * Returns the time (in milliseconds since the epoch) since this token was
      * created.

--- a/lock-api/src/main/java/com/palantir/lock/HeldLocksToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/HeldLocksToken.java
@@ -55,13 +55,14 @@ import com.google.common.collect.Iterables;
     private final SortedLockCollection<LockDescriptor> lockMap;
     private final SimpleTimeDuration lockTimeout;
     @Nullable private final Long versionId;
+    private final String requestingThread;
 
     /**
      * This should only be created by the Lock Service
      */
     public HeldLocksToken(BigInteger tokenId, LockClient client, long creationDateMs,
             long expirationDateMs, SortedLockCollection<LockDescriptor> lockMap,
-            TimeDuration lockTimeout, @Nullable Long versionId) {
+            TimeDuration lockTimeout, @Nullable Long versionId, String requestingThread) {
         this.tokenId = Preconditions.checkNotNull(tokenId);
         this.client = Preconditions.checkNotNull(client);
         this.creationDateMs = creationDateMs;
@@ -69,6 +70,7 @@ import com.google.common.collect.Iterables;
         this.lockMap = lockMap;
         this.lockTimeout = SimpleTimeDuration.of(lockTimeout);
         this.versionId = versionId;
+        this.requestingThread = requestingThread;
         Preconditions.checkArgument(!this.lockMap.isEmpty());
     }
 
@@ -99,6 +101,10 @@ import com.google.common.collect.Iterables;
         return creationDateMs;
     }
 
+    public String getRequestingThread() {
+        return requestingThread;
+    }
+
     /**
      * Returns the time (in milliseconds since the epoch) when this token will
      * expire and become invalid.
@@ -113,6 +119,7 @@ import com.google.common.collect.Iterables;
      * from descriptor to lock mode.
      */
     @JsonIgnore
+    @Override
     public SortedLockCollection<LockDescriptor> getLockDescriptors() {
         return lockMap;
     }
@@ -172,6 +179,7 @@ import com.google.common.collect.Iterables;
                 .add("lockCount", lockMap.size())
                 .add("firstLock", lockMap.entries().iterator().next())
                 .add("versionId", versionId)
+                .add("requestingThread", requestingThread)
                 .toString();
     }
 
@@ -180,7 +188,7 @@ import com.google.common.collect.Iterables;
      */
     public HeldLocksToken refresh(long expirationDateMs) {
         return new HeldLocksToken(tokenId, client, creationDateMs, expirationDateMs, lockMap, lockTimeout,
-                versionId);
+                versionId, requestingThread);
     }
 
     private void readObject(@SuppressWarnings("unused") ObjectInputStream in)
@@ -202,6 +210,7 @@ import com.google.common.collect.Iterables;
         private final SortedLockCollection<LockDescriptor> lockMap;
         private final SimpleTimeDuration lockTimeout;
         @Nullable private final Long versionId;
+        private final String requestingThread;
 
         SerializationProxy(HeldLocksToken heldLocksToken) {
             tokenId = heldLocksToken.tokenId;
@@ -211,16 +220,18 @@ import com.google.common.collect.Iterables;
             lockMap = heldLocksToken.lockMap;
             lockTimeout = heldLocksToken.lockTimeout;
             versionId = heldLocksToken.versionId;
+            requestingThread = heldLocksToken.requestingThread;
         }
 
         @JsonCreator
         public SerializationProxy(@JsonProperty("tokenId") BigInteger tokenId,
-                                  @JsonProperty("client") LockClient client,
-                                  @JsonProperty("creationDateMs") long creationDateMs,
-                                  @JsonProperty("expirationDateMs") long expirationDateMs,
-                                  @JsonProperty("locks") List<LockWithMode> locks,
-                                  @JsonProperty("lockTimeout") TimeDuration lockTimeout,
-                                  @JsonProperty("versionId") Long versionId) {
+                @JsonProperty("client") LockClient client,
+                @JsonProperty("creationDateMs") long creationDateMs,
+                @JsonProperty("expirationDateMs") long expirationDateMs,
+                @JsonProperty("locks") List<LockWithMode> locks,
+                @JsonProperty("lockTimeout") TimeDuration lockTimeout,
+                @JsonProperty("versionId") Long versionId,
+                @JsonProperty("requestingThread") String requestingThread) {
             ImmutableSortedMap.Builder<LockDescriptor, LockMode> localLockMapBuilder = ImmutableSortedMap.naturalOrder();
             for (LockWithMode lock : locks) {
                 localLockMapBuilder.put(lock.getLockDescriptor(), lock.getLockMode());
@@ -232,6 +243,7 @@ import com.google.common.collect.Iterables;
             this.expirationDateMs = expirationDateMs;
             this.lockTimeout = SimpleTimeDuration.of(lockTimeout);
             this.versionId = versionId;
+            this.requestingThread = requestingThread;
             Preconditions.checkArgument(!this.lockMap.isEmpty());
         }
 
@@ -241,7 +253,7 @@ import com.google.common.collect.Iterables;
 
         Object readResolve() {
             return new HeldLocksToken(tokenId, client, creationDateMs, expirationDateMs, lockMap, lockTimeout,
-                    versionId);
+                    versionId, requestingThread);
         }
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockServerOptions.java
@@ -33,7 +33,7 @@ import com.google.common.base.Objects;
  * @author jtamer
  */
 @Immutable public class LockServerOptions implements Serializable {
-    private static final long serialVersionUID = 0xb5fd04db6d65582al;
+    private static final long serialVersionUID = 2930574230723753879L;
 
     /** The default lock server option values. */
     public static final LockServerOptions DEFAULT = new LockServerOptions();
@@ -100,7 +100,8 @@ import com.google.common.base.Objects;
                 && Objects.equal(getMaxAllowedClockDrift(), other.getMaxAllowedClockDrift())
                 && Objects.equal(getMaxAllowedBlockingDuration(), other.getMaxAllowedBlockingDuration())
                 && Objects.equal(getMaxNormalLockAge(), other.getMaxNormalLockAge())
-                && (getRandomBitCount() == other.getRandomBitCount());
+                && (getRandomBitCount() == other.getRandomBitCount()
+                && getLockStateLoggerDir().equals(other.getLockStateLoggerDir()));
     }
 
     @Override public final int hashCode() {
@@ -109,7 +110,8 @@ import com.google.common.base.Objects;
                 getMaxAllowedClockDrift(),
                 getMaxAllowedBlockingDuration(),
                 getMaxNormalLockAge(),
-                getRandomBitCount());
+                getRandomBitCount(),
+                getLockStateLoggerDir());
     }
 
     @Override public final String toString() {
@@ -120,6 +122,7 @@ import com.google.common.base.Objects;
                 .add("maxAllowedBlockingDuration", getMaxAllowedBlockingDuration())
                 .add("maxNormalLockAge", getMaxNormalLockAge())
                 .add("randomBitCount", getRandomBitCount())
+                .add("lockStateLoggerDir", getLockStateLoggerDir())
                 .toString();
     }
 
@@ -132,8 +135,12 @@ import com.google.common.base.Objects;
         return new SerializationProxy(this);
     }
 
+    public String getLockStateLoggerDir() {
+        return "log/state";
+    }
+
     private static class SerializationProxy implements Serializable {
-        private static final long serialVersionUID = 0xece5944130b16002l;
+        private static final long serialVersionUID = 4043798817916565364L;
 
         private final boolean isStandaloneServer;
         private final SimpleTimeDuration maxAllowedLockTimeout;
@@ -141,6 +148,7 @@ import com.google.common.base.Objects;
         private final SimpleTimeDuration maxAllowedBlockingDuration;
         private final SimpleTimeDuration maxNormalLockAge;
         private final int randomBitCount;
+        private final String lockStateLoggerDir;
 
         SerializationProxy(LockServerOptions lockServerOptions) {
             isStandaloneServer = lockServerOptions.isStandaloneServer();
@@ -153,11 +161,11 @@ import com.google.common.base.Objects;
             maxNormalLockAge = SimpleTimeDuration.of(
                     lockServerOptions.getMaxNormalLockAge());
             randomBitCount = lockServerOptions.getRandomBitCount();
+            lockStateLoggerDir = lockServerOptions.getLockStateLoggerDir();
         }
 
         Object readResolve() {
             return new LockServerOptions() {
-                private static final long serialVersionUID = 0xcc7124dcf06f0803l;
                 @Override public boolean isStandaloneServer() {
                     return isStandaloneServer;
                 }
@@ -175,6 +183,9 @@ import com.google.common.base.Objects;
                 }
                 @Override public int getRandomBitCount() {
                     return randomBitCount;
+                }
+                @Override public String getLockStateLoggerDir() {
+                    return lockStateLoggerDir;
                 }
             };
         }

--- a/lock-api/src/main/java/com/palantir/lock/LockWithMode.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockWithMode.java
@@ -34,4 +34,12 @@ public class LockWithMode {
     public LockMode getLockMode() {
         return lockMode;
     }
+
+    @Override
+    public String toString() {
+        return "LockWithMode{" +
+                "lockDescriptor=" + lockDescriptor +
+                ", lockMode=" + lockMode +
+                '}';
+    }
 }

--- a/lock-api/src/test/java/com/palantir/lock/HeldLocksTokenTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/HeldLocksTokenTest.java
@@ -35,7 +35,7 @@ public final class HeldLocksTokenTest {
     public void testSerializationDeserialization() throws Exception {
         SortedMap<LockDescriptor, LockMode> lockMap = ImmutableSortedMap.of(StringLockDescriptor.of("foo"), LockMode.READ);
         HeldLocksToken heldLocksToken = new HeldLocksToken(BigInteger.valueOf(0), LockClient.of("foo"), 0, 0,
-                LockCollections.of(lockMap), SimpleTimeDuration.of(1, TimeUnit.SECONDS), 0L);
+                LockCollections.of(lockMap), SimpleTimeDuration.of(1, TimeUnit.SECONDS), 0L, "Dummy Thread");
 
         HeldLocksToken deserializedHeldLocksToken = MAPPER.readValue(MAPPER.writeValueAsString(heldLocksToken), HeldLocksToken.class);
         assertThat(deserializedHeldLocksToken, is(heldLocksToken));

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -1,8 +1,13 @@
+apply plugin: 'org.inferred.processors'
+
 apply from: "../gradle/shared.gradle"
 
 dependencies {
   compile(project(":lock-api"))
   compile(project(":atlasdb-commons"))
   compile 'com.palantir.patches.sourceforge:trove3:3.0.3-p5'
-  compile 'joda-time:joda-time:' + libVersions.joda_time
+  compile group: 'joda-time', name: 'joda-time', version: libVersions.joda_time
+  compile group: 'org.yaml', name: 'snakeyaml', version: libVersions.snakeyaml
+  
+  processor 'org.immutables:value:2.0.21'
 }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockClientIndices.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockClientIndices.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
@@ -26,7 +27,8 @@ import com.google.common.collect.Maps;
 import com.palantir.lock.LockClient;
 
 @ThreadSafe
-class LockClientIndices {
+@VisibleForTesting
+public class LockClientIndices {
     private final Map<LockClient, Integer> indexByClient = Maps.newConcurrentMap();
     private final Map<Integer, LockClient> clientByIndex = Maps.newConcurrentMap();
 

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockDescriptorMapper.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockDescriptorMapper.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Maps;
+
+class LockDescriptorMapper {
+
+    private static final String LOCK_PREFIX = "Lock-";
+
+    private Map<String, String> mapper = Maps.newConcurrentMap();
+    private AtomicInteger lockCounter = new AtomicInteger();
+
+    String getDescriptorMapping(String descriptor) {
+        return mapper.computeIfAbsent(descriptor, k -> LOCK_PREFIX + lockCounter.incrementAndGet());
+    }
+
+    /**
+     *
+     * @return map from mapping to real descriptor.
+     */
+    Map<String, String> getReversedMapper() {
+        return mapper.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceLoggerTestUtils.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceLoggerTestUtils.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.io.File;
+import java.io.IOException;
+
+public class LockServiceLoggerTestUtils {
+    public static final String TEST_LOG_STATE_DIR = "log-state";
+
+    public static void cleanUpLogStateDir() throws IOException {
+        File rootDir = new File(TEST_LOG_STATE_DIR);
+        if (rootDir.isDirectory()) {
+            for (File file : rootDir.listFiles()) {
+                file.delete();
+            }
+        }
+        rootDir.delete();
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -46,7 +46,7 @@ public class LockServiceStateLogger {
 
     private static final String LOCKSTATE_FILE_PREFIX = "lockstate-";
     private static final String DESCRIPTORS_FILE_PREFIX = "descriptors-";
-    private static final String WARNING_LOCK_DESCRIPTORS = "# WARNING: Lock descriptors may contain sensitive information\n";
+    private static final String WARNING_LOCK_DESCRIPTORS = "WARNING: Lock descriptors may contain sensitive information";
     private static final String FILE_NOT_CREATED_LOG_ERROR = "Destination file [%s] either already exists"
             + "or can't be created. This is a very unlikely scenario."
             + "Retrigger logging or check if process has permitions on the folder";
@@ -169,17 +169,16 @@ public class LockServiceStateLogger {
 
     private void dumpYaml(Map<String, Object> generatedOutstandingRequests, Map<String, Object> generatedHeldLocks,
             File file) throws IOException {
-        YamlWriter writer = YamlWriter.create(file);
-
-        writer.writeToYaml(generatedOutstandingRequests);
-        writer.appendString("\n\n---\n\n");
-        writer.writeToYaml(generatedHeldLocks);
+        try (LockStateYamlWriter writer = LockStateYamlWriter.create(file)) {
+            writer.dumpObject(generatedOutstandingRequests);
+            writer.dumpObject(generatedHeldLocks);
+        }
     }
 
     private void dumpDescriptorsYaml(File descriptorsFile) throws IOException {
-        YamlWriter writer = YamlWriter.create(descriptorsFile);
-
-        writer.appendString(WARNING_LOCK_DESCRIPTORS);
-        writer.writeToYaml(this.lockDescriptorMapper.getReversedMapper());
+        try (LockStateYamlWriter writer = LockStateYamlWriter.create(descriptorsFile)) {
+            writer.appendComment(WARNING_LOCK_DESCRIPTORS);
+            writer.dumpObject(lockDescriptorMapper.getReversedMapper());
+        }
     }
 }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+import com.palantir.lock.HeldLocksToken;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.impl.LockServiceImpl;
+
+public class LockServiceStateLogger {
+    private static Logger log = LoggerFactory.getLogger(LockServiceStateLogger.class);
+
+    private static final String LOCKSTATE_FILE_PREFIX = "lockstate-";
+    private static final String DESCRIPTORS_FILE_PREFIX = "descriptors-";
+    private static final String WARNING_LOCK_DESCRIPTORS = "# WARNING: Lock descriptors may contain sensitive information\n";
+    private static final String FILE_NOT_CREATED_LOG_ERROR = "Destination file [%s] either already exists"
+            + "or can't be created. This is a very unlikely scenario."
+            + "Retrigger logging or check if process has permitions on the folder";
+
+
+    private static final String OUTSTANDING_LOCK_REQUESTS_TITLE = "OutstandingLockRequests";
+    private static final String HELD_LOCKS_TITLE = "HeldLocks";
+
+    private final LockDescriptorMapper lockDescriptorMapper = new LockDescriptorMapper();
+    private final long startTimestamp = System.currentTimeMillis();
+
+    private final ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocks;
+    private final Map<LockClient, Set<LockRequest>> outstandingLockRequests;
+    private String outputDir;
+
+
+    public LockServiceStateLogger(ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap,
+            SetMultimap<LockClient, LockRequest> outstandingLockRequestMultimap, String outputDir) {
+        this.heldLocks = heldLocksTokenMap;
+        this.outstandingLockRequests = Multimaps.asMap(outstandingLockRequestMultimap);
+        this.outputDir = outputDir;
+    }
+
+    public void logLocks() throws IOException {
+        Map<String, Object> generatedOutstandingRequests = generateOutstandingLocksYaml(outstandingLockRequests);
+        Map<String, Object> generatedHeldLocks = generateHeldLocks(heldLocks);
+
+        Path outputDirPath = Paths.get(outputDir);
+        Files.createDirectories(outputDirPath);
+
+        dumpYamlsInNewFiles(generatedOutstandingRequests, generatedHeldLocks);
+    }
+
+    private Map<String, Object> generateOutstandingLocksYaml(Map<LockClient, Set<LockRequest>> outstandingLockRequestsMap) {
+        Map<String, SimpleLockRequestsWithSameDescriptor> outstandingRequestMap = Maps.newHashMap();
+
+        outstandingLockRequestsMap.forEach((client, requestSet) -> {
+            if (requestSet != null) {
+                ImmutableSet<LockRequest> lockRequests = ImmutableSet.copyOf(requestSet);
+                lockRequests.forEach(lockRequest -> {
+                    List<SimpleLockRequest> requestList = getDescriptorSimpleRequestMap(client, lockRequest);
+                    requestList.forEach(request -> {
+                        outstandingRequestMap.putIfAbsent(request.getLockDescriptor(),
+                                new SimpleLockRequestsWithSameDescriptor(request.getLockDescriptor()));
+                        outstandingRequestMap.get(request.getLockDescriptor()).addLockRequest(request);
+                    });
+                });
+            }
+        });
+
+        List<SimpleLockRequestsWithSameDescriptor> sortedOutstandingRequests = sortOutstandingRequests(outstandingRequestMap.values());
+
+        return nameObjectForYamlConvertion(OUTSTANDING_LOCK_REQUESTS_TITLE, sortedOutstandingRequests);
+    }
+
+    private List<SimpleLockRequestsWithSameDescriptor> sortOutstandingRequests(
+            Collection<SimpleLockRequestsWithSameDescriptor> outstandingRequestsByDescriptor) {
+
+        List<SimpleLockRequestsWithSameDescriptor> sortedEntries = Lists.newArrayList(outstandingRequestsByDescriptor);
+        sortedEntries.sort(
+                (o1, o2) -> Integer.compare(o2.getLockRequestsCount(),
+                        o1.getLockRequestsCount()));
+        return sortedEntries;
+    }
+
+    private Map<String, Object> generateHeldLocks(ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap) {
+        Map<String, Object> mappedLocksToToken = Maps.newHashMap();
+        heldLocksTokenMap.forEach((token, locks) -> {
+            mappedLocksToToken.putAll(getDescriptorToTokenMap(token, locks));
+        });
+
+        return nameObjectForYamlConvertion(HELD_LOCKS_TITLE, mappedLocksToToken);
+    }
+
+    private Map<String, Object> nameObjectForYamlConvertion(String name, Object objectToName) {
+        return ImmutableMap.of(name, objectToName);
+    }
+
+    private List<SimpleLockRequest> getDescriptorSimpleRequestMap(LockClient client, LockRequest request) {
+        return request.getLocks().stream()
+                .map(lock ->
+                        SimpleLockRequest.of(request,
+                                this.lockDescriptorMapper.getDescriptorMapping(lock.getLockDescriptor().getLockIdAsString()),
+                                client.getClientId()))
+                .collect(Collectors.toList());
+    }
+
+    private Map<String, Object> getDescriptorToTokenMap(HeldLocksToken heldLocksToken,
+            LockServiceImpl.HeldLocks<HeldLocksToken> heldLocks) {
+        Map<String, Object> lockToLockInfo = Maps.newHashMap();
+        heldLocks.getLockDescriptors()
+                .forEach(lockDescriptor ->
+                        lockToLockInfo.put(
+                                this.lockDescriptorMapper.getDescriptorMapping(lockDescriptor.getLockIdAsString()),
+                                SimpleTokenInfo.of(heldLocksToken)));
+        return lockToLockInfo;
+    }
+
+    private void dumpYamlsInNewFiles(Map<String, Object> generatedOutstandingRequests,
+            Map<String, Object> generatedHeldLocks) throws IOException {
+        File lockStateFile = createNewFile(LOCKSTATE_FILE_PREFIX);
+        File descriptorsFile = createNewFile(DESCRIPTORS_FILE_PREFIX);
+
+        dumpYaml(generatedOutstandingRequests, generatedHeldLocks, lockStateFile);
+        dumpDescriptorsYaml(descriptorsFile);
+    }
+
+    private File createNewFile(String fileNamePrefix) throws IOException {
+        String fileName = fileNamePrefix + this.startTimestamp + ".yaml";
+        File file = new File(outputDir, fileName);
+
+        if (!file.createNewFile()) {
+            String fileCreationError = String.format(FILE_NOT_CREATED_LOG_ERROR, file.getAbsolutePath());
+            log.error(fileCreationError);
+            throw new IllegalStateException(fileCreationError);
+        }
+
+        return file;
+    }
+
+    private void dumpYaml(Map<String, Object> generatedOutstandingRequests, Map<String, Object> generatedHeldLocks,
+            File file) throws IOException {
+        YamlWriter writer = YamlWriter.create(file);
+
+        writer.writeToYaml(generatedOutstandingRequests);
+        writer.appendString("\n\n---\n\n");
+        writer.writeToYaml(generatedHeldLocks);
+    }
+
+    private void dumpDescriptorsYaml(File descriptorsFile) throws IOException {
+        YamlWriter writer = YamlWriter.create(descriptorsFile);
+
+        writer.appendString(WARNING_LOCK_DESCRIPTORS);
+        writer.writeToYaml(this.lockDescriptorMapper.getReversedMapper());
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequest.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value;
+
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.TimeDuration;
+
+@Value.Immutable
+public abstract class SimpleLockRequest {
+
+    public static SimpleLockRequest of(LockRequest request, String lockDescriptor, String clientId) {
+        return ImmutableSimpleLockRequest.builder()
+                .lockDescriptor(lockDescriptor)
+                .lockCount(request.getLocks().size())
+                .lockTimeout(request.getLockTimeout().getTime())
+                .lockGroupBehavior(request.getLockGroupBehavior().name())
+                .blockingMode(request.getBlockingMode().name())
+                .blockingDuration(extractBlockingDurationOrNull(request.getBlockingDuration()))
+                .versionId(request.getVersionId())
+                .creatingThread(request.getCreatingThreadName())
+                .clientId(clientId).build();
+    }
+
+    @Value.Parameter
+    public abstract String getLockDescriptor();
+
+    @Value.Parameter
+    public abstract long getLockCount();
+
+    @Value.Parameter
+    public abstract long getLockTimeout();
+
+    @Value.Parameter
+    public abstract String getLockGroupBehavior();
+
+    @Value.Parameter
+    public abstract String getBlockingMode();
+
+    @Nullable
+    @Value.Parameter
+    public abstract Long getBlockingDuration();
+
+    @Nullable
+    @Value.Parameter
+    public abstract Long getVersionId();
+
+    @Value.Parameter
+    public abstract String getClientId();
+
+    @Value.Parameter
+    public abstract String getCreatingThread();
+
+    @Nullable
+    private static Long extractBlockingDurationOrNull(TimeDuration blockingDuration) {
+        return  (blockingDuration != null) ? blockingDuration.getTime() : null;
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequestsWithSameDescriptor.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleLockRequestsWithSameDescriptor.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimpleLockRequestsWithSameDescriptor {
+    private final String lockDescriptor;
+    private List<SimpleLockRequest> lockRequests = new ArrayList<>();
+
+    SimpleLockRequestsWithSameDescriptor(String lockDescriptor) {
+        this.lockDescriptor = lockDescriptor;
+    }
+
+    void addLockRequest(SimpleLockRequest lockRequest) {
+        lockRequests.add(lockRequest);
+    }
+
+    public String getLockDescriptor() {
+        return lockDescriptor;
+    }
+
+    public List<SimpleLockRequest> getLockRequests() {
+        return lockRequests;
+    }
+
+    public int getLockRequestsCount() {
+        return lockRequests.size();
+    }
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleTokenInfo.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleTokenInfo.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.util.Date;
+
+import org.immutables.value.Value;
+
+import com.google.common.base.Preconditions;
+import com.palantir.lock.HeldLocksToken;
+
+@Value.Immutable
+public abstract class SimpleTokenInfo {
+    public static SimpleTokenInfo of(HeldLocksToken token) {
+        return ImmutableSimpleTokenInfo.builder()
+                .expiresIn(token.getExpirationDateMs() - System.currentTimeMillis())
+                .createdAtTs(token.getCreationDateMs())
+                .tokenId(token.getTokenId().toString())
+                .clientId(Preconditions.checkNotNull(token.getClient()).getClientId())
+                .requestThread(token.getRequestingThread())
+                .createAt(new Date(token.getCreationDateMs()).toString())
+                .build();
+    }
+
+    @Value.Parameter
+    public abstract long getExpiresIn();
+
+    @Value.Parameter
+    public abstract long getCreatedAtTs();
+
+    @Value.Parameter
+    public abstract String getTokenId();
+
+    @Value.Parameter
+    public abstract String getClientId();
+
+    @Value.Parameter
+    public abstract String getRequestThread();
+
+    @Value.Parameter
+    public abstract String getCreateAt();
+}

--- a/lock-impl/src/main/java/com/palantir/lock/logger/YamlWriter.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/YamlWriter.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+/**
+ * Created by davidt on 4/20/17.
+ */
+class YamlWriter {
+    private static final Yaml yaml = new Yaml(getRepresenter(), getDumperOptions());
+
+    private final FileWriter fileWriter;
+
+    YamlWriter(FileWriter fileWriter) {
+        this.fileWriter = fileWriter;
+    }
+
+    public static YamlWriter create(File file) throws IOException {
+        return new YamlWriter(new FileWriter(file));
+    }
+
+    public void writeToYaml(Object data) {
+        yaml.dump(data, fileWriter);
+    }
+
+    public void appendString(String string) throws IOException {
+        fileWriter.append(string);
+    }
+
+    private static Representer getRepresenter() {
+        Representer representer = new Representer();
+        representer.addClassTag(ImmutableSimpleTokenInfo.class, Tag.MAP);
+        representer.addClassTag(ImmutableSimpleLockRequest.class, Tag.MAP);
+        representer.addClassTag(SimpleLockRequestsWithSameDescriptor.class, Tag.MAP);
+        return representer;
+    }
+
+    private static DumperOptions getDumperOptions() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setIndent(4);
+        options.setAllowReadOnlyProperties(true);
+        return options;
+    }
+}

--- a/lock-impl/src/test/java/com/palantir/lock/AllLockTests.java
+++ b/lock-impl/src/test/java/com/palantir/lock/AllLockTests.java
@@ -21,6 +21,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.palantir.lock.client.LockRefreshingLockServiceTest;
 import com.palantir.lock.impl.ClientAwareLockTest;
+import com.palantir.lock.logger.LockServiceStateLoggerTest;
 
 /**
  * Runs all lock server tests.
@@ -30,6 +31,7 @@ import com.palantir.lock.impl.ClientAwareLockTest;
 @SuiteClasses(value = {
         ClientAwareLockTest.class,
         LockServiceImplTest.class,
+        LockServiceStateLoggerTest.class,
         LockRefreshingLockServiceTest.class
 }) @RunWith(value = Suite.class) public final class AllLockTests {
     /* Empty; the annotations above take care of everything. */

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceImplTest.java
@@ -41,6 +41,7 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.proxy.SerializingProxy;
 import com.palantir.common.proxy.SimulatingServerProxy;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.lock.logger.LockServiceLoggerTestUtils;
 import com.palantir.util.Mutable;
 import com.palantir.util.Mutables;
 
@@ -463,6 +464,8 @@ public final class LockServiceImplTest {
         } catch (TimeoutException e) {
             // If we exceed the timeout, the call is hung and it's a failure
             Assert.fail();
+        } finally {
+            LockServiceLoggerTestUtils.cleanUpLogStateDir();
         }
     }
 

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.lock.logger;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.MapMaker;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+import com.palantir.lock.HeldLocksToken;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockCollections;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.impl.ClientAwareReadWriteLock;
+import com.palantir.lock.impl.LockClientIndices;
+import com.palantir.lock.impl.LockServerLock;
+import com.palantir.lock.impl.LockServiceImpl;
+
+public class LockServiceStateLoggerTest {
+
+    private final ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap =
+            new MapMaker().makeMap();
+
+    private final SetMultimap<LockClient, LockRequest> outstandingLockRequestMultimap =
+            Multimaps.synchronizedSetMultimap(HashMultimap.<LockClient, LockRequest>create());
+
+    @Before
+    public void setUp() throws Exception {
+        LockClient clientA = LockClient.of("Client A");
+        LockClient clientB = LockClient.of("Client B");
+
+        LockDescriptor descriptor1 = StringLockDescriptor.of("logger-lock");
+        LockDescriptor descriptor2 = StringLockDescriptor.of("logger-BBB");
+
+        LockRequest request1 = LockRequest.builder(LockCollections.of(ImmutableSortedMap.of(descriptor1, LockMode.WRITE)))
+                .blockForAtMost(SimpleTimeDuration.of(1000, TimeUnit.MILLISECONDS))
+                .build();
+        LockRequest request2 = LockRequest.builder(LockCollections.of(ImmutableSortedMap.of(descriptor2, LockMode.WRITE)))
+                .blockForAtMost(SimpleTimeDuration.of(1000, TimeUnit.MILLISECONDS))
+                .build();
+
+        outstandingLockRequestMultimap.put(clientA, request1);
+        outstandingLockRequestMultimap.put(clientB, request2);
+        outstandingLockRequestMultimap.put(clientA, request2);
+
+        HeldLocksToken token = getFakeHeldLocksToken("client A", "Fake thread", new BigInteger("1"));
+        HeldLocksToken token2 = getFakeHeldLocksToken("client B", "Fake thread 2", new BigInteger("2"));
+
+        Map<ClientAwareReadWriteLock, LockMode> locks = Maps.newLinkedHashMap();
+        locks.put(new LockServerLock(StringLockDescriptor.of("logger-lock-2"), new LockClientIndices()), LockMode.WRITE);
+        locks.put(new LockServerLock(StringLockDescriptor.of("logger-lock"), new LockClientIndices()), LockMode.READ);
+
+        heldLocksTokenMap.putIfAbsent(token, LockServiceImpl.HeldLocks.of(token, LockCollections.of(locks)));
+
+        Map<ClientAwareReadWriteLock, LockMode> locks2 = Maps.newLinkedHashMap();
+        locks2.put(new LockServerLock(StringLockDescriptor.of("logger-lock-3"), new LockClientIndices()), LockMode.WRITE);
+        locks2.put(new LockServerLock(StringLockDescriptor.of("logger-lock-4"), new LockClientIndices()), LockMode.READ);
+        heldLocksTokenMap.putIfAbsent(token2, LockServiceImpl.HeldLocks.of(token2, LockCollections.of(locks2)));
+    }
+
+    private HeldLocksToken getFakeHeldLocksToken(String clientName, String requestingThread, BigInteger tokenId) {
+        LockDescriptor descriptor1 = StringLockDescriptor.of("123");
+        ImmutableSortedMap.Builder<LockDescriptor, LockMode> builder =
+                ImmutableSortedMap.naturalOrder();
+        builder.put(descriptor1, LockMode.WRITE);
+
+        return new HeldLocksToken(tokenId, LockClient.of(clientName),
+                System.currentTimeMillis(), System.currentTimeMillis(),
+                LockCollections.of(builder.build()),
+                LockRequest.DEFAULT_LOCK_TIMEOUT, 0L, requestingThread);
+    }
+
+    @Test
+    public void testLocksLogging() throws Exception {
+        LockServiceStateLogger logger = new LockServiceStateLogger(
+                heldLocksTokenMap,
+                outstandingLockRequestMultimap,
+                LockServiceLoggerTestUtils.TEST_LOG_STATE_DIR);
+        logger.logLocks();
+    }
+
+    @After
+    public void after() throws IOException {
+        LockServiceLoggerTestUtils.cleanUpLogStateDir();
+    }
+}


### PR DESCRIPTION
… (#1824)

Backport from 0.39.3 to 0.4.x
(cherry picked from commit 4299035c358e69b5ccc038debcc0920ba9a59ad9)

**Goals (and why)**:
Would like to have this available for the large internal product, which is currently running on this version of OSS Atlas.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
Ideally by the end of the week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1913)
<!-- Reviewable:end -->
