### PR TITLE
[no release notes] Disable errorprone compiler

### DIFF
--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStoreTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStoreTest.java
@@ -63,7 +63,7 @@ public class SweepPriorityStoreTest {
     }
 
     @Test
-    public void testStoreAndLoadNew() {
+    public void testStoreAndLoadNew() throws Exception {
         txManager.runTaskWithRetry(tx -> {
             priorityStore.update(
                     tx,
@@ -107,7 +107,7 @@ public class SweepPriorityStoreTest {
     }
 
     @Test
-    public void testDelete() {
+    public void testDelete() throws Exception {
         txManager.runTaskWithRetry(tx -> {
             priorityStore.update(
                     tx,

--- a/gradle/baseline.gradle
+++ b/gradle/baseline.gradle
@@ -20,14 +20,9 @@ List<String> blacklistedBaselineProjects = [
 
 if (!blacklistedBaselineProjects.contains(project.name)) {
     apply plugin: 'com.palantir.baseline-checkstyle'
-    apply plugin: 'org.inferred.processors'  // installs the "processor" configuration needed for baseline-error-prone
-    apply plugin: 'com.palantir.baseline-error-prone'
 
-    configurations.errorprone {
-        resolutionStrategy {
-            force 'com.google.guava:guava:21.0'
-        }
-    }
+    // We are not presently using errorprone because that swaps out the compiler to one based on the beta compiler
+    // for JDK 9, which has a known issue with varargs.
 }
 
 apply plugin: 'com.palantir.baseline-eclipse'


### PR DESCRIPTION
**Goals (and why)**:
* @ashrayjain found some issues with the errorprone compiler concerning varargs - and in general we don't want to be using a compiler that's kind of in beta state as well.

**Implementation Description (bullets)**:
* Remove invocation of the errorprone plugin.
* Leave a comment indicating why we aren't using it.

**Concerns (what feedback would you like?)**:
* Note that we now don't have static analysis at all.

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: ASAP - blocks releasing 0.41.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1914)
<!-- Reviewable:end -->
