### PR TITLE
[no release notes] Fix incorrect path configuration in Jepsen

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
@@ -19,7 +19,7 @@
         (c/exec :mkdir "/timelock-server")
         (c/exec :tar :xf "/timelock-server.tgz" "-C" "/timelock-server" "--strip-components" "1")
         (c/upload "resources/atlasdb/timelock.yml" "/timelock-server/var/conf")
-        (c/exec :sed :-i (format "s/<HOSTNAME>/%s/" (name node)) "/timelock-server-distribution/var/conf/timelock.yml")
+        (c/exec :sed :-i (format "s/<HOSTNAME>/%s/" (name node)) "/timelock-server/var/conf/timelock.yml")
         (info node "Starting timelock server")
         (c/exec :env "JAVA_HOME=/usr/lib/jvm/java-8-oracle" "/timelock-server/service/bin/init.sh" "start")))
 


### PR DESCRIPTION
**Goals (and why)**: Jepsen tests were failing with exceptions about configuration files not being in the expected place; this fixes that.

**Implementation Description (bullets)**: Update the path, removing `-distribution` (`timelock-server-distribution` still makes a dist called `timelock-server`)

**Concerns (what feedback would you like?)**: nothing really

**Where should we start reviewing?**: this is a +1/-1

**Priority (whenever / two weeks / yesterday)**: ASAP, blocks 0.41 release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1922)
<!-- Reviewable:end -->
