### PR TITLE
(devbreak) disallow use of empty table metadata

### DIFF
--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
@@ -85,8 +85,8 @@ public abstract class NodesDownTestSetup {
         setupDb.put(TEST_TABLE, ImmutableMap.of(CELL_1_2, DEFAULT_CONTENTS), DEFAULT_TIMESTAMP);
         setupDb.put(TEST_TABLE, ImmutableMap.of(CELL_2_1, DEFAULT_CONTENTS), DEFAULT_TIMESTAMP);
 
-        setupDb.createTable(TEST_TABLE_TO_DROP, AtlasDbConstants.EMPTY_TABLE_METADATA);
-        setupDb.createTable(TEST_TABLE_TO_DROP_2, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        setupDb.createTable(TEST_TABLE_TO_DROP, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        setupDb.createTable(TEST_TABLE_TO_DROP_2, AtlasDbConstants.GENERIC_TABLE_METADATA);
 
         setupDb.close();
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.impl;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -50,9 +51,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
  *   - How we apply tricks to avoid work when people make fairly stupid queries
  *     (i.e. call out to the database to read in nothing, etc)
  *   - How we validate query inputs for sanity / correctness
- *   - Not having a ton of boilerplate
- *
- * @author clockfort
+ *   - Not having a ton of boilerplate in each KVS
  */
 public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueService implements KeyValueService {
     private static final Logger log = LoggerFactory.getLogger(ValidatingQueryRewritingKeyValueService.class);
@@ -76,6 +75,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
     @Override
     public void createTable(TableReference tableRef, byte[] tableMetadata) {
         sanityCheckTableName(tableRef);
+        sanityCheckTableMetadata(tableRef, tableMetadata);
         delegate.createTable(tableRef, tableMetadata);
     }
 
@@ -92,6 +92,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
         for (TableReference tableRef : tableRefToTableMetadata.keySet()) {
             sanityCheckTableName(tableRef);
         }
+        tableRefToTableMetadata.entrySet().forEach(entry -> sanityCheckTableMetadata(entry.getKey(), entry.getValue()));
         delegate.createTables(tableRefToTableMetadata);
     }
 
@@ -102,6 +103,15 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
                         || AtlasDbConstants.hiddenTables.contains(tableRef)
                         || tableName.startsWith(AtlasDbConstants.NAMESPACE_PREFIX),
                 "invalid tableName: " + tableName);
+    }
+
+    protected void sanityCheckTableMetadata(TableReference tableRef, byte[] tableMetadata) {
+        if (tableMetadata == null || Arrays.equals(tableMetadata, AtlasDbConstants.EMPTY_TABLE_METADATA)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Passing in empty table metadata for table '%s' does not make sense, and is disallowed.",
+                            tableRef));
+        }
     }
 
     @Override
@@ -197,6 +207,12 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
     }
 
     @Override
+    public void putMetadataForTable(TableReference tableRef, byte[] tableMetadata) {
+        sanityCheckTableMetadata(tableRef, tableMetadata);
+        delegate.putMetadataForTable(tableRef, tableMetadata);
+    }
+
+    @Override
     public void putMetadataForTables(Map<TableReference, byte[]> tableRefToMetadata) {
         if (tableRefToMetadata.isEmpty()) {
             return;
@@ -206,6 +222,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
             putMetadataForTable(entry.getKey(), entry.getValue());
             return;
         }
+        tableRefToMetadata.entrySet().forEach(entry -> sanityCheckTableMetadata(entry.getKey(), entry.getValue()));
         delegate.putMetadataForTables(tableRefToMetadata);
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -89,14 +89,12 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
             createTable(element.getKey(), element.getValue());
             return;
         }
-        for (TableReference tableRef : tableRefToTableMetadata.keySet()) {
-            sanityCheckTableName(tableRef);
-        }
+        tableRefToTableMetadata.keySet().forEach(ValidatingQueryRewritingKeyValueService::sanityCheckTableName);
         tableRefToTableMetadata.entrySet().forEach(entry -> sanityCheckTableMetadata(entry.getKey(), entry.getValue()));
         delegate.createTables(tableRefToTableMetadata);
     }
 
-    protected void sanityCheckTableName(TableReference tableRef) {
+    protected static void sanityCheckTableName(TableReference tableRef) {
         String tableName = tableRef.getQualifiedName();
         Validate.isTrue(
                 (!tableName.startsWith("_") && tableName.contains("."))
@@ -105,11 +103,13 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
                 "invalid tableName: " + tableName);
     }
 
-    protected void sanityCheckTableMetadata(TableReference tableRef, byte[] tableMetadata) {
+    protected static void sanityCheckTableMetadata(TableReference tableRef, byte[] tableMetadata) {
         if (tableMetadata == null || Arrays.equals(tableMetadata, AtlasDbConstants.EMPTY_TABLE_METADATA)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "Passing in empty table metadata for table '%s' does not make sense, and is disallowed.",
+                            "Passing in empty table metadata for table '%s' is disallowed,"
+                                    + " as reasoning about such tables is hard. Consider using"
+                                    + " AtlasDbConstants.GENERIC_TABLE_METADATA instead.",
                             tableRef));
         }
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -46,6 +46,12 @@ develop
          - KVS migration CLI will now clear the checkpoint tables that are required while the migration is in progress but not after the migration is complete.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1927>`__)
 
+   *     - |devbreak|
+         - Some downstream projects were using empty table metadata for dev-laziness reasons in their tests.
+           This is no longer permitted, as it leads to many (unsolved) questions about how to deal with such a table.
+           If this breaks your tests, you can fix it with making real schema for tests or switch to AtlasDbConstants.GENERIC_TABLE_METADATA
+           (`Pull Request <https://github.com/palantir/1925>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -46,10 +46,10 @@ develop
          - KVS migration CLI will now clear the checkpoint tables that are required while the migration is in progress but not after the migration is complete.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1927>`__)
 
-   *     - |devbreak|
+    *    - |devbreak|
          - Some downstream projects were using empty table metadata for dev-laziness reasons in their tests.
            This is no longer permitted, as it leads to many (unsolved) questions about how to deal with such a table.
-           If this breaks your tests, you can fix it with making real schema for tests or switch to AtlasDbConstants.GENERIC_TABLE_METADATA
+           If this breaks your tests, you can fix it with making real schema for tests or by switching to AtlasDbConstants.GENERIC_TABLE_METADATA
            (`Pull Request <https://github.com/palantir/1925>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>


### PR DESCRIPTION
**Goals (and why)**:
We have some weird error output in $DOWNSTREAM_PROJECT after I merged #1822 that would indicate that despite me playing whack-a-mole and thinking I found all the places that tests downstream that used empty table metadata, it looks like some ETE tests do something more insidious that I didn't catch. (the new #1822 code doesn't actually fail, but the cache warming fails because KVS.getMetadataForTables() returns some empty byte arrays which it can't deserialize, which Should Never Happen™)

Adding this guarantee/throw should hopefully let me catch the offending tests at metadata table insert time, and we should make this guarantee anyways, for our own sanity's sake, as tables with empty metadata leave too many questions for us with how to deal with them. (what conflict handling should they have? etc)

** Concerns **:
I'm expecting (hoping!) this breaks some of $BIG_DOWNSTREAM_PROJECT's tests; it may also break some of our other downstream projects' tests if they were the same variety of lazy when writing tests.
I'm okay with that, and they should switch to the real table builder or use AtlasDbConstants.GENERIC_TABLE_METADATA if they want to continue being lazy.

**Priority (whenever / two weeks / yesterday)**:
two weeks; it's a test only problem and it's not actually breaking any tests, just cluttering the error output and confusing people looking for other issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1925)
<!-- Reviewable:end -->
