### PR TITLE
Feature/safe logging init use

### DIFF
--- a/atlasdb-api/versions.lock
+++ b/atlasdb-api/versions.lock
@@ -56,6 +56,14 @@
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
@@ -146,6 +154,14 @@
         },
         "com.palantir.remoting:ssl-config": {
             "locked": "0.13.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",

--- a/atlasdb-cassandra-integration-tests/versions.lock
+++ b/atlasdb-cassandra-integration-tests/versions.lock
@@ -12,6 +12,9 @@
             "transitive": [
                 "org.apache.ant:ant"
             ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
@@ -27,6 +30,9 @@
             "transitive": [
                 "org.apache.ant:ant"
             ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/atlasdb-cassandra-integration-tests/versions.lock
+++ b/atlasdb-cassandra-integration-tests/versions.lock
@@ -3,6 +3,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "org.apache.ant:ant": {
             "locked": "1.9.4",
             "requested": "1.9.4"
@@ -12,15 +15,15 @@
             "transitive": [
                 "org.apache.ant:ant"
             ]
-        },
-        "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.1"
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "org.apache.ant:ant": {
             "locked": "1.9.4",
             "requested": "1.9.4"
@@ -30,9 +33,6 @@
             "transitive": [
                 "org.apache.ant:ant"
             ]
-        },
-        "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.1"
         }
     }
 }

--- a/atlasdb-cassandra-multinode-tests/versions.lock
+++ b/atlasdb-cassandra-multinode-tests/versions.lock
@@ -12,6 +12,9 @@
             "transitive": [
                 "org.apache.ant:ant"
             ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
@@ -27,6 +30,9 @@
             "transitive": [
                 "org.apache.ant:ant"
             ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/atlasdb-cassandra-multinode-tests/versions.lock
+++ b/atlasdb-cassandra-multinode-tests/versions.lock
@@ -3,6 +3,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "org.apache.ant:ant": {
             "locked": "1.9.4",
             "requested": "1.9.4"
@@ -12,15 +15,15 @@
             "transitive": [
                 "org.apache.ant:ant"
             ]
-        },
-        "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.1"
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "org.apache.ant:ant": {
             "locked": "1.9.4",
             "requested": "1.9.4"
@@ -30,9 +33,6 @@
             "transitive": [
                 "org.apache.ant:ant"
             ]
-        },
-        "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.1"
         }
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -121,7 +121,6 @@ import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.exception.PalantirRuntimeException;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -121,6 +121,8 @@ import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.exception.PalantirRuntimeException;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -462,7 +464,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     @Override
     public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         if (timestampByCell.isEmpty()) {
-            log.info("Attempted get on '{}' table with empty cells", tableRef);
+            log.info("Attempted get on '{}' table with empty cells", UnsafeArg.of("tableRef", tableRef));
             return ImmutableMap.of();
         }
 
@@ -2272,10 +2274,11 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         tables.remove(tableToKeep.get());
         if (tables.size() > 0) {
             dropTablesInternal(tables);
-            log.info("Dropped tables [{}]", tables.toString());
+            log.info("Dropped tables [{}]", UnsafeArg.of("table names", tables.toString()));
         }
         schemaMutationLock.cleanLockState();
-        log.info("Reset the schema mutation lock in table [{}]", tableToKeep.get().toString());
+        log.info("Reset the schema mutation lock in table [{}]",
+                UnsafeArg.of("table name", tableToKeep.get().toString()));
     }
 
     private <V> Map<InetSocketAddress, Map<Cell, V>> partitionMapByHost(Iterable<Map.Entry<Cell, V>> cells) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -2273,7 +2273,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         tables.remove(tableToKeep.get());
         if (tables.size() > 0) {
             dropTablesInternal(tables);
-            log.info("Dropped tables [{}]", UnsafeArg.of("table names", tables.toString()));
+            log.info("Dropped tables [{}]", UnsafeArg.of("table names", tables));
         }
         schemaMutationLock.cleanLockState();
         log.info("Reset the schema mutation lock in table [{}]",

--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -198,6 +198,20 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -589,6 +603,20 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -2,6 +2,9 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
@@ -483,6 +486,37 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-cli",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -412,6 +412,30 @@
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -1091,6 +1115,30 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-client-protobufs/versions.lock
+++ b/atlasdb-client-protobufs/versions.lock
@@ -6,6 +6,9 @@
         "com.google.protobuf:protobuf-java": {
             "locked": "2.6.0",
             "requested": "2.6.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
@@ -15,6 +18,9 @@
         "com.google.protobuf:protobuf-java": {
             "locked": "2.6.0",
             "requested": "2.6.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/atlasdb-client/versions.lock
+++ b/atlasdb-client/versions.lock
@@ -134,6 +134,16 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -367,6 +377,16 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-commons/versions.lock
+++ b/atlasdb-commons/versions.lock
@@ -18,6 +18,12 @@
         "com.palantir.atlasdb:commons-executors": {
             "project": true
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:commons-executors"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1"
         },
@@ -53,6 +59,12 @@
         },
         "com.palantir.atlasdb:commons-executors": {
             "project": true
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:commons-executors"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1"

--- a/atlasdb-config/versions.lock
+++ b/atlasdb-config/versions.lock
@@ -335,6 +335,25 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -826,6 +845,25 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -2,6 +2,9 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
@@ -472,6 +475,37 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-console",
+                "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-console/versions.lock
+++ b/atlasdb-console/versions.lock
@@ -348,6 +348,26 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -881,6 +901,26 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -257,6 +257,21 @@
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -768,6 +783,21 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-dagger/versions.lock
+++ b/atlasdb-dagger/versions.lock
@@ -351,6 +351,26 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -874,6 +894,26 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-dbkvs-hikari/versions.lock
+++ b/atlasdb-dbkvs-hikari/versions.lock
@@ -114,6 +114,17 @@
                 "com.palantir.atlasdb:commons-db"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy"
+            ]
+        },
         "com.zaxxer:HikariCP": {
             "locked": "2.4.7",
             "transitive": [
@@ -299,6 +310,17 @@
             "locked": "1.0.3",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy"
             ]
         },
         "com.zaxxer:HikariCP": {

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -312,6 +312,30 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-tests-shared",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -822,6 +846,30 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-tests-shared",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -275,6 +275,28 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -705,6 +727,28 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -453,6 +453,32 @@
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-cli",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-console",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -1592,6 +1618,32 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-cli",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-console",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-ete-test-utils/versions.lock
+++ b/atlasdb-ete-test-utils/versions.lock
@@ -3,6 +3,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "commons-io:commons-io": {
             "locked": "2.1"
         },
@@ -22,6 +25,9 @@
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         },
         "commons-io:commons-io": {
             "locked": "2.1"

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -485,6 +485,36 @@
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-cli",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-console",
+                "com.palantir.atlasdb:atlasdb-dropwizard-bundle",
+                "com.palantir.atlasdb:atlasdb-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -1731,6 +1761,40 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-cli",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-console",
+                "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-dropwizard-bundle",
+                "com.palantir.atlasdb:atlasdb-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-hikari/versions.lock
+++ b/atlasdb-hikari/versions.lock
@@ -180,6 +180,19 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -477,6 +490,19 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-impl-shared/versions.lock
+++ b/atlasdb-impl-shared/versions.lock
@@ -196,6 +196,21 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -512,6 +527,21 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-jdbc-tests/versions.lock
+++ b/atlasdb-jdbc-tests/versions.lock
@@ -2,11 +2,17 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/atlasdb-jdbc/versions.lock
+++ b/atlasdb-jdbc/versions.lock
@@ -169,6 +169,18 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -448,6 +460,18 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-jepsen-tests/versions.lock
+++ b/atlasdb-jepsen-tests/versions.lock
@@ -339,6 +339,25 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -849,6 +868,25 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-lock-api/versions.lock
+++ b/atlasdb-lock-api/versions.lock
@@ -78,6 +78,16 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
@@ -196,6 +206,16 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -493,6 +493,35 @@
                 "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dagger",
+                "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -1342,6 +1371,35 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-dagger",
+                "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-db",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-persistent-lock-api/versions.lock
+++ b/atlasdb-persistent-lock-api/versions.lock
@@ -18,6 +18,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",
             "requested": "2.0.1"
@@ -41,6 +44,9 @@
         },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",

--- a/atlasdb-rocksdb-tests/versions.lock
+++ b/atlasdb-rocksdb-tests/versions.lock
@@ -2,11 +2,17 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/atlasdb-rocksdb/versions.lock
+++ b/atlasdb-rocksdb/versions.lock
@@ -169,6 +169,18 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -448,6 +460,18 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -377,6 +377,26 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -1388,6 +1408,31 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-rocksdb",
+                "com.palantir.atlasdb:atlasdb-service",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-service/versions.lock
+++ b/atlasdb-service/versions.lock
@@ -339,6 +339,25 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -847,6 +866,25 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/atlasdb-tests-shared/versions.lock
+++ b/atlasdb-tests-shared/versions.lock
@@ -224,6 +224,22 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -599,6 +615,22 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/cassandra-partitioner/versions.lock
+++ b/cassandra-partitioner/versions.lock
@@ -7,6 +7,9 @@
             "locked": "18.0",
             "requested": "18.0"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "org.apache.cassandra:cassandra-all": {
             "locked": "3.10",
             "requested": "3.10"
@@ -23,6 +26,9 @@
         "com.google.guava:guava": {
             "locked": "18.0",
             "requested": "18.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         },
         "org.apache.cassandra:cassandra-all": {
             "locked": "3.10",

--- a/commons-annotations/versions.lock
+++ b/commons-annotations/versions.lock
@@ -2,11 +2,17 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/commons-api/versions.lock
+++ b/commons-api/versions.lock
@@ -38,6 +38,14 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-executors"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
@@ -101,6 +109,14 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-executors"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {

--- a/commons-db/versions.lock
+++ b/commons-db/versions.lock
@@ -96,6 +96,16 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy"
+            ]
+        },
         "com.zaxxer:HikariCP": {
             "locked": "2.4.7",
             "requested": "2.4.7"
@@ -246,6 +256,16 @@
         },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-proxy"
+            ]
         },
         "com.zaxxer:HikariCP": {
             "locked": "2.4.7",

--- a/commons-executors/versions.lock
+++ b/commons-executors/versions.lock
@@ -2,11 +2,17 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/commons-proxy/versions.lock
+++ b/commons-proxy/versions.lock
@@ -3,6 +3,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5"
         }
@@ -10,6 +13,9 @@
     "runtime": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5"

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -77,6 +77,13 @@ develop
          - Configuration parameters ``sweepBatchSize`` and ``sweepCellBatchSize`` have been deprecated in favour of ``sweepCandidateBatchHint`` and ``sweepReadLimit`` respectively.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1911>`__)
 
+    *    - |improved|
+         - Some of our log parameters are marked as safe for logging, as part of our internal guidelines.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1931>`__)
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+
 ======
 0.42.1
 ======
@@ -94,6 +101,9 @@ develop
          - ``PaxosTimestampBoundStore`` now throws ``NotCurrentLeaderException``, invalidating the timestamp store, if a bound update fails because another timestamp service on the same node proposed a smaller bound for the same sequence number.
            This was added to address a very specific race condition leading to an infinite loop that would saturate the TimeLock cluster with spurious Paxos messages; see `issue 1941 <https://github.com/palantir/atlasdb/issues/1941>`__ for more detail.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1942>`__)
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
 
 ======
 0.42.0
@@ -135,6 +145,9 @@ develop
     *    - |improved|
          - ``ProfilingKeyValueService`` now has some additional logging mechanisms for logging long-running operations on WARN level, enabled by default.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1801>`__)
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
 
 ======
 0.41.0

--- a/examples/profile-client-protobufs/versions.lock
+++ b/examples/profile-client-protobufs/versions.lock
@@ -6,6 +6,9 @@
         "com.google.protobuf:protobuf-java": {
             "locked": "2.6.0",
             "requested": "2.6.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
@@ -15,6 +18,9 @@
         "com.google.protobuf:protobuf-java": {
             "locked": "2.6.0",
             "requested": "2.6.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/examples/profile-client/versions.lock
+++ b/examples/profile-client/versions.lock
@@ -167,6 +167,18 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb.examples:profile-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -440,6 +452,18 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb.examples:profile-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -44,6 +44,7 @@ jar {
 libsDirName = file('build/artifacts')
 
 dependencies {
+    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile group: 'com.google.code.findbugs', name: 'annotations'
     checkstyle group: 'com.puppycrawl.tools', name: 'checkstyle', version: libVersions.checkstyle
     testCompile group: 'junit', name: 'junit'

--- a/leader-election-api-protobufs/versions.lock
+++ b/leader-election-api-protobufs/versions.lock
@@ -6,6 +6,9 @@
         "com.google.protobuf:protobuf-java": {
             "locked": "2.6.0",
             "requested": "2.6.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
@@ -15,6 +18,9 @@
         "com.google.protobuf:protobuf-java": {
             "locked": "2.6.0",
             "requested": "2.6.0"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     }
 }

--- a/leader-election-api/versions.lock
+++ b/leader-election-api/versions.lock
@@ -44,6 +44,14 @@
         "com.palantir.atlasdb:leader-election-api-protobufs": {
             "project": true
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api-protobufs"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
@@ -118,6 +126,14 @@
         },
         "com.palantir.atlasdb:leader-election-api-protobufs": {
             "project": true
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api-protobufs"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -40,6 +40,7 @@ import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.LeaderElectionService.LeadershipToken;
 import com.palantir.leader.LeaderElectionService.StillLeadingStatus;
 import com.palantir.leader.NotCurrentLeaderException;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.remoting1.tracing.Tracers;
 
 public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler {
@@ -121,7 +122,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                 clearDelegate();
             } else {
                 leadershipTokenRef.set(leadershipToken);
-                leaderLog.info("Gained leadership for {}", leadershipToken);
+                leaderLog.info("Gained leadership for {}", SafeArg.of("leadershipToken", leadershipToken));
             }
         } catch (InterruptedException e) {
             log.warn("attempt to gain leadership interrupted", e);

--- a/leader-election-impl/versions.lock
+++ b/leader-election-impl/versions.lock
@@ -90,6 +90,15 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs"
+            ]
+        },
         "commons-io:commons-io": {
             "locked": "2.1"
         },
@@ -221,6 +230,15 @@
         },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs"
+            ]
         },
         "commons-io:commons-io": {
             "locked": "2.1"

--- a/lock-api/src/main/java/com/palantir/lock/RemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/RemoteLockService.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.annotation.NonIdempotent;
+import com.palantir.logsafe.Safe;
 
 @Path("/lock")
 public interface RemoteLockService {
@@ -39,7 +40,7 @@ public interface RemoteLockService {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Nullable
-    LockRefreshToken lock(@PathParam("client") String client, LockRequest request) throws InterruptedException;
+    LockRefreshToken lock(@Safe @PathParam("client") String client, LockRequest request) throws InterruptedException;
 
     /**
      * This is the same as {@link #lock(String, LockRequest)} but will return as many locks as can be acquired.
@@ -49,7 +50,7 @@ public interface RemoteLockService {
     @Path("try-lock/{client: .*}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    HeldLocksToken lockAndGetHeldLocks(@PathParam("client") String client, LockRequest request)
+    HeldLocksToken lockAndGetHeldLocks(@Safe @PathParam("client") String client, LockRequest request)
             throws InterruptedException;
 
     /**
@@ -90,7 +91,7 @@ public interface RemoteLockService {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Idempotent
-    @Nullable Long getMinLockedInVersionId(@PathParam("client") String client);
+    @Nullable Long getMinLockedInVersionId(@Safe @PathParam("client") String client);
 
     /** Returns the current time in milliseconds on the server. */
     @POST

--- a/lock-api/versions.lock
+++ b/lock-api/versions.lock
@@ -44,6 +44,13 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
@@ -114,6 +121,13 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {

--- a/lock-impl/versions.lock
+++ b/lock-impl/versions.lock
@@ -81,6 +81,14 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:lock-api"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
@@ -196,6 +204,14 @@
         },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:lock-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",

--- a/timelock-server-distribution/versions.lock
+++ b/timelock-server-distribution/versions.lock
@@ -2,6 +2,9 @@
     "compileClasspath": {
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         }
     },
     "runtime": {
@@ -436,6 +439,27 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timelock-server",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -411,6 +411,26 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
             "transitive": [
@@ -1608,6 +1628,26 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:atlasdb-lock-api",
+                "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:leader-election-api",
+                "com.palantir.atlasdb:leader-election-api-protobufs",
+                "com.palantir.atlasdb:leader-election-impl",
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/timestamp-api/versions.lock
+++ b/timestamp-api/versions.lock
@@ -6,6 +6,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
+        },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",
             "requested": "2.0.1"
@@ -17,6 +20,9 @@
         },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1"
         },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",

--- a/timestamp-impl/versions.lock
+++ b/timestamp-impl/versions.lock
@@ -73,6 +73,14 @@
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",
             "transitive": [
@@ -174,6 +182,14 @@
         },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.1",

--- a/versions.props
+++ b/versions.props
@@ -17,6 +17,7 @@ com.palantir.docker.proxy:docker-proxy-rule = 0.3.0
 com.palantir.remoting1:* = 1.0.3
 com.palantir.remoting:* = 0.13.0
 com.palantir.remoting2:* = 2.3.0
+com.palantir.safe-logging:* = 0.1.1
 com.palantir.tritium:tritium-lib = 0.6.0
 commons-cli:commons-cli = 1.2
 commons-codec:commons-codec = 1.10


### PR DESCRIPTION
**Goals (and why)**: Test our use of the annotations in safe-logging is legit

**Implementation Description (bullets)**:
1. Add dependency on safe logging and annotations
2. We should look at these log lines in the internal logging product.

**Concerns (what feedback would you like?)**: The UnsafeArg logs dont seem to be on common code paths. This will make testing log collection difficult, Not sure if we have some?

**Where should we start reviewing?**: N/A

**Priority (whenever / two weeks / yesterday)**: one week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1931)
<!-- Reviewable:end -->
