### PR TITLE
Fix/mrtse failover

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,6 +42,11 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - ``PaxosTimestampBoundStore``, the bound store for Timelock, will now throw ``NotCurrentLeaderException`` instead of ``MultipleRunningTimestampServiceError`` when a bound update fails.
+           The cases where this can happen are explained by a race condition that can occur after leadership change, and it is safe to let requests be retried on another server.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1934>`__)
+
     *    - |improved|
          - Timelock server can now start with an empty clients list.
            Note that you currently need to restart timelock when adding clients to the configuration.

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -41,6 +41,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
+import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.leader.proxy.ToggleableExceptionProxy;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorImpl;
@@ -50,7 +51,6 @@ import com.palantir.paxos.PaxosProposer;
 import com.palantir.paxos.PaxosProposerImpl;
 import com.palantir.paxos.PaxosRoundFailureException;
 import com.palantir.remoting1.tracing.Tracers;
-import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 
 public class PaxosTimestampBoundStoreTest {
     private static final int NUM_NODES = 5;
@@ -158,7 +158,7 @@ public class PaxosTimestampBoundStoreTest {
         PaxosTimestampBoundStore additionalStore = createPaxosTimestampBoundStore(1);
         additionalStore.storeUpperLimit(TIMESTAMP_1);
         assertThatThrownBy(() -> store.storeUpperLimit(TIMESTAMP_2))
-                .isInstanceOf(MultipleRunningTimestampServiceError.class);
+                .isInstanceOf(NotCurrentLeaderException.class);
     }
 
     @Test

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
@@ -30,7 +30,7 @@ public class AvailableTimestamps {
     private final PersistentUpperLimit upperLimit;
 
     public AvailableTimestamps(LastReturnedTimestamp lastReturnedTimestamp, PersistentUpperLimit upperLimit) {
-        DebugLogger.logger.info("Creating AvailableTimestamps object on thread {}. This should only happen once."
+        DebugLogger.logger.info("Creating AvailableTimestamps object on thread {}."
                         + " If you are running embedded AtlasDB, this should only happen once."
                         + " If you are using Timelock, this should happen once per client per leadership election",
                 Thread.currentThread().getName());

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/AvailableTimestamps.java
@@ -30,7 +30,9 @@ public class AvailableTimestamps {
     private final PersistentUpperLimit upperLimit;
 
     public AvailableTimestamps(LastReturnedTimestamp lastReturnedTimestamp, PersistentUpperLimit upperLimit) {
-        DebugLogger.logger.info("Creating AvailableTimestamps object on thread {}. This should only happen once.",
+        DebugLogger.logger.info("Creating AvailableTimestamps object on thread {}. This should only happen once."
+                        + " If you are running embedded AtlasDB, this should only happen once."
+                        + " If you are using Timelock, this should happen once per client per leadership election",
                 Thread.currentThread().getName());
         this.lastReturnedTimestamp = lastReturnedTimestamp;
         this.upperLimit = upperLimit;

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampService.java
@@ -33,7 +33,9 @@ public class PersistentTimestampService implements TimestampService, TimestampMa
 
     public PersistentTimestampService(AvailableTimestamps availableTimestamps, ExecutorService executor) {
         DebugLogger.logger.info(
-                "Creating PersistentTimestampService object on thread {}. This should only happen once.",
+                "Creating PersistentTimestampService object on thread {}."
+                        + " If you are running embedded AtlasDB, this should only happen once."
+                        + " If you are using Timelock, this should happen once per client per leadership election",
                 Thread.currentThread().getName());
 
         this.availableTimestamps = availableTimestamps;

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
@@ -32,7 +32,9 @@ public class PersistentUpperLimit {
     private volatile long lastIncreasedTime;
 
     public PersistentUpperLimit(TimestampBoundStore tbs, Clock clock, TimestampAllocationFailures allocationFailures) {
-        DebugLogger.logger.info("Creating PersistentUpperLimit object on thread {}. This should only happen once.",
+        DebugLogger.logger.info("Creating PersistentUpperLimit object on thread {}. This should only happen once."
+                        + " If you are running embedded AtlasDB, this should only happen once."
+                        + " If you are using Timelock, this should happen once per client per leadership election",
                 Thread.currentThread().getName());
         this.tbs = tbs;
         this.clock = clock;

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
@@ -32,7 +32,7 @@ public class PersistentUpperLimit {
     private volatile long lastIncreasedTime;
 
     public PersistentUpperLimit(TimestampBoundStore tbs, Clock clock, TimestampAllocationFailures allocationFailures) {
-        DebugLogger.logger.info("Creating PersistentUpperLimit object on thread {}. This should only happen once."
+        DebugLogger.logger.info("Creating PersistentUpperLimit object on thread {}."
                         + " If you are running embedded AtlasDB, this should only happen once."
                         + " If you are using Timelock, this should happen once per client per leadership election",
                 Thread.currentThread().getName());


### PR DESCRIPTION
**Goals (and why)**: Fixes #1749 and #1609. Occurrences of MRTSE on Timelock can be explained by the race condition given in that issue description, and in these cases, it's safe to fail over.

**Implementation Description (bullets)**:
* Throw NotCurrentLeaderException instead of MultipleRunningTimestampServicesError
* Drive-by fixing of a few confusing log lines #1609.

**Concerns (what feedback would you like?)**:
We now have a method that declares `throws MRTSE` when in fact it does no such thing. I should probably explain this with a comment, right?

**Where should we start reviewing?**: Check out the ticket description and comments, and convince yourself that all we need to do is in this changeset.

**Priority (whenever / two weeks / yesterday)**: ASAP, this blocks GA of Timelock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1934)
<!-- Reviewable:end -->
