### PR TITLE
[WIP] add getRanges method with explicit control over parallism

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.RequestLimitedExecutorService;
 
 /**
  * Provides the methods for a transaction with the key-value store.
@@ -81,6 +82,17 @@ public interface Transaction {
     Iterable<BatchingVisitable<RowResult<byte[]>>> getRanges(
             TableReference tableRef,
             Iterable<RangeRequest> rangeRequests);
+
+    /**
+     * Same logic as {@link Transaction#getRanges(TableReference, Iterable)} but provides explicit control
+     * of parallelism. This should be favored over the former method to avoid unexpected concurrent calls
+     * hidden in the implementation.
+     */
+    @Idempotent
+    Iterable<BatchingVisitable<RowResult<byte[]>>> getRanges(
+            final TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            RequestLimitedExecutorService executor);
 
     /**
      * Puts values into the key-value store. If you put a null or the empty byte array, then

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.RequestLimitedExecutorService;
 
 public class ReadTransaction extends ForwardingTransaction {
 
@@ -71,6 +72,15 @@ public class ReadTransaction extends ForwardingTransaction {
                                                                     Iterable<RangeRequest> rangeRequests) {
         checkTableName(tableRef);
         return delegate().getRanges(tableRef, rangeRequests);
+    }
+
+    @Override
+    public Iterable<BatchingVisitable<RowResult<byte[]>>> getRanges(
+            final TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            RequestLimitedExecutorService executor) {
+        checkTableName(tableRef);
+        return delegate().getRanges(tableRef, rangeRequests, executor);
     }
 
     @Override

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Parallelism.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Parallelism.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.base;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+
+public class Parallelism {
+
+    private Parallelism() {}
+
+    public static <T> List<T> getAll(List<Callable<T>> callables, RequestLimitedExecutorService executor) {
+        List<Future<T>> futures = Lists.newArrayListWithCapacity(callables.size());
+        callables.forEach(callable -> futures.add(executor.submit(callable)));
+        return futures.stream().map(f -> {
+            try {
+                return f.get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }).collect(Collectors.toList());
+    }
+
+    public static <T> List<T> concat(List<Callable<List<T>>> callables, RequestLimitedExecutorService executor) {
+        return getAll(callables, executor).stream().flatMap(Collection::stream).collect(Collectors.toList());
+    }
+
+}

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/RequestLimitedExecutorService.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/RequestLimitedExecutorService.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.base;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class RequestLimitedExecutorService implements ExecutorService {
+
+    private final ExecutorService delegate;
+    private final Semaphore semaphore;
+    private final long blockingTimeoutMillis;
+
+    private RequestLimitedExecutorService(ExecutorService delegate, int maxConcurrency, Duration blockingTimeout) {
+        this.delegate = delegate;
+        this.semaphore = new Semaphore(maxConcurrency);
+        this.blockingTimeoutMillis = blockingTimeout.toMillis();
+    }
+
+    public static RequestLimitedExecutorService fromDelegate(
+            ExecutorService delegate, int maxConcurrency, Duration blockingTimeout) {
+        return new RequestLimitedExecutorService(delegate, maxConcurrency, blockingTimeout);
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return runBlockingOnSemaphore(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return runBlockingOnSemaphore(() -> {
+            task.run();
+            return result;
+        });
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return runBlockingOnSemaphore(() -> {
+            task.run();
+            return null;
+        });
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        submit(command);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        throw new UnsupportedOperationException("Not Implemented");
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        throw new UnsupportedOperationException("Not Implemented");
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        throw new UnsupportedOperationException("Not Implemented");
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        throw new UnsupportedOperationException("Not Implemented");
+    }
+
+    private <T> Future<T> runBlockingOnSemaphore(Callable<T> callable) {
+        try {
+            boolean acquired = semaphore.tryAcquire(blockingTimeoutMillis, TimeUnit.MILLISECONDS);
+            if (!acquired) {
+                throw new RuntimeException(String.format(
+                        "Timed out after %s seconds waiting to run operation", blockingTimeoutMillis));
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        return delegate.submit(() -> {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                semaphore.release();
+            }
+        });
+    }
+}


### PR DESCRIPTION
@schlosna @tpetracca @jboreiko for thoughts on high-level idea. Basically want to push the parallelism toward the user and just provide some utilities to help them do so.
```
        RequestLimitedExecutorService executor = RequestLimitedExecutorService.fromDelegate(
                someSharedExecutor, 8, Duration.ofSeconds(10));

        Iterable<BatchingVisitable<RowResult<byte[]>>> visitables = t.getRanges(tableRef, ranges, executor);

        // To be added as a utility
        List<List<RowResult<byte[]>>> results = Parallelism.getAll(StreamSupport.stream(visitables.spliterator(), false)
                .map(visitable -> () -> BatchingVisitableView.of(visitable).immutableCopy())
                .collect(Collectors.toList()), executor);

        // To be added as a utility
        List<RowResult<byte[]>> results = Parallelism.concat(StreamSupport.stream(visitables.spliterator(), false)
                .map(visitable -> () -> BatchingVisitableView.of(visitable).immutableCopy())
                .collect(Collectors.toList()), executor);
```
This would help ensure (1) we're not accidentally running much more parallel than we think (e.g. 64 threads) and (2) that the initial page runs with same concurrency than subsequent batches. Also allows the concurrency to be KVS-agnostic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1935)
<!-- Reviewable:end -->
