### PR TITLE
Backoff after querying all the servers on fast failover

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -43,6 +43,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
     private static final Logger log = LoggerFactory.getLogger(FailoverFeignTarget.class);
 
     public static final int DEFAULT_MAX_BACKOFF_MILLIS = 3000;
+    public static final long BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS = 500L;
 
     private static final double GOLDEN_RATIO = (Math.sqrt(5) + 1.0) / 2.0;
 
@@ -98,7 +99,7 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
         checkAndHandleFailure(ex);
         if (retryBehaviour.shouldBackoffAndTryOtherNodes()) {
             if (failoverCount.get() % servers.size() == 0) {
-                pauseForBackoff(ex, 1000L);
+                pauseForBackoff(ex, BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS);
             } else {
                 pauseForBackoff(ex);
             }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -98,7 +98,8 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
 
         checkAndHandleFailure(ex);
         if (retryBehaviour.shouldBackoffAndTryOtherNodes()) {
-            if (failoverCount.get() % servers.size() == 0) {
+            int numFailovers = failoverCount.get();
+            if (numFailovers > 0 && numFailovers % servers.size() == 0) {
                 pauseForBackoff(ex, BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS);
             } else {
                 pauseForBackoff(ex);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -28,6 +28,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.apache.http.HttpStatus;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -164,11 +166,7 @@ public class FailoverFeignTargetTest {
         verify(spiedTarget, times(CLUSTER_SIZE)).pauseForBackoff(any(), argument.capture());
 
         List<Long> arguments = argument.getAllValues();
-        assertThat(arguments.size()).isEqualTo(CLUSTER_SIZE);
-        for (int i = 0; i < CLUSTER_SIZE - 1; i++) {
-            assertThat(arguments.get(i)).isEqualTo(1L);
-        }
-        assertThat(arguments.get(CLUSTER_SIZE - 1)).isEqualTo(1000L);
+        MatcherAssert.assertThat(arguments, Matchers.contains(1L, 1L, 500L));
     }
 
     private void simulateRequest() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,11 +56,10 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1726>`__)
 
     *    - |fixed|
-         - A 1s timeout has been added to the client when the client has queried all the servers of a cluster and received a NotCurrentLeaderException.
-
-           When the cluster is electing a leader, a ``getFreshTimestamp()`` call receives a NotCurrentLeaderException (status 503) response.
-           This answer would make the client trigger the same request with a 1ms backoff to all the nodes in the cluster, slowing down the election and making the cluster unable to proceed.
-           This behavior has been fixed by adding a 1s backoff when the client has received a NotCurrentLeaderException from all the nodes in the cluster before retrying.
+         - A 500 ms backoff has been added to the our retry logic when the client has queried all the servers of a cluster and received a ``NotCurrentLeaderException``.
+           Previously in this case, our retry logic would dictate infinitely many retries with a 1 ms backoff.
+           The new backoff should reduce contention during leadership elections, when all nodes throw ``NotCurrentLeaderException``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1939>`__)
 
 ======
 0.41.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,13 @@ develop
            There is no issue with having tables with different values for ``gc_grace_seconds``, and this can be updated at any time.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1726>`__)
 
+    *    - |fixed|
+         - A 1s timeout has been added to the client when the client has queried all the servers of a cluster and received a NotCurrentLeaderException.
+
+           When the cluster is electing a leader, a ``getFreshTimestamp()`` call receives a NotCurrentLeaderException (status 503) response.
+           This answer would make the client trigger the same request with a 1ms backoff to all the nodes in the cluster, slowing down the election and making the cluster unable to proceed.
+           This behavior has been fixed by adding a 1s backoff when the client has received a NotCurrentLeaderException from all the nodes in the cluster before retrying.
+
 ======
 0.41.0
 ======


### PR DESCRIPTION
**Goals (and why)**: Implement the fix proposed on #1799.

**Implementation Description (bullets)**: When an exception triggers fast failover, check if we’ve queried all the nodes in the cluster. If so, sleep for 1s and then re-query the nodes.

**Concerns (what feedback would you like?)**: I tried making the minimal change. Did I change any behavior that should not be changed?

**Where should we start reviewing?**: FailoverFeignTarget.

**Priority (whenever / two weeks / yesterday)**: Whenever, but soon, to fix the test flakiness.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1939)
<!-- Reviewable:end -->
