### PR TITLE
PaxosTBS: Throw NCLE on the previously infinite-looping case

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,7 +45,7 @@ develop
     *    - |fixed|
          - ``PaxosTimestampBoundStore`` now throws ``NotCurrentLeaderException``, invalidating the timestamp store, if a bound update fails because another timestamp service on the same node proposed a smaller bound for the same sequence number.
            This was added to address a very specific race condition leading to an infinite loop that would saturate the TimeLock cluster with spurious Paxos messages; see `issue 1941<https://github.com/palantir/atlasdb/issues/1941>`__ for more detail.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1942>`__)
 
     *    - |fixed|
          - ``PaxosTimestampBoundStore``, the bound store for Timelock, will now throw ``NotCurrentLeaderException`` instead of ``MultipleRunningTimestampServiceError`` when a bound update fails.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,7 +44,7 @@ develop
 
     *    - |fixed|
          - ``PaxosTimestampBoundStore`` now throws ``NotCurrentLeaderException``, invalidating the timestamp store, if a bound update fails because another timestamp service on the same node proposed a smaller bound for the same sequence number.
-           This was added to address a very specific race condition leading to an infinite loop that would saturate the TimeLock cluster with spurious Paxos messages; see `issue 1941<https://github.com/palantir/atlasdb/issues/1941>`__ for more detail.
+           This was added to address a very specific race condition leading to an infinite loop that would saturate the TimeLock cluster with spurious Paxos messages; see `issue 1941 <https://github.com/palantir/atlasdb/issues/1941>`__ for more detail.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1942>`__)
 
     *    - |fixed|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -47,6 +47,37 @@ develop
            This was added to address a very specific race condition leading to an infinite loop that would saturate the TimeLock cluster with spurious Paxos messages; see `issue 1941 <https://github.com/palantir/atlasdb/issues/1941>`__ for more detail.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1942>`__)
 
+======
+0.42.1
+======
+
+24 May 2017
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |fixed|
+         - ``PaxosTimestampBoundStore`` now throws ``NotCurrentLeaderException``, invalidating the timestamp store, if a bound update fails because another timestamp service on the same node proposed a smaller bound for the same sequence number.
+           This was added to address a very specific race condition leading to an infinite loop that would saturate the TimeLock cluster with spurious Paxos messages; see `issue 1941 <https://github.com/palantir/atlasdb/issues/1941>`__ for more detail.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1942>`__)
+
+======
+0.42.0
+======
+
+23 May 2017
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
     *    - |fixed|
          - ``PaxosTimestampBoundStore``, the bound store for Timelock, will now throw ``NotCurrentLeaderException`` instead of ``MultipleRunningTimestampServiceError`` when a bound update fails.
            The cases where this can happen are explained by a race condition that can occur after leadership change, and it is safe to let requests be retried on another server.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -43,6 +43,11 @@ develop
          - Change
 
     *    - |fixed|
+         - ``PaxosTimestampBoundStore`` now throws ``NotCurrentLeaderException``, invalidating the timestamp store, if a bound update fails because another timestamp service on the same node proposed a smaller bound for the same sequence number.
+           This was added to address a very specific race condition leading to an infinite loop that would saturate the TimeLock cluster with spurious Paxos messages; see `issue 1941<https://github.com/palantir/atlasdb/issues/1941>`__ for more detail.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
+
+    *    - |fixed|
          - ``PaxosTimestampBoundStore``, the bound store for Timelock, will now throw ``NotCurrentLeaderException`` instead of ``MultipleRunningTimestampServiceError`` when a bound update fails.
            The cases where this can happen are explained by a race condition that can occur after leadership change, and it is safe to let requests be retried on another server.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1934>`__)

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -276,6 +276,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
                             newLimit,
                             limit));
                 }
+                return;
             } catch (PaxosRoundFailureException e) {
                 waitForRandomBackoff(e, this::wait);
             }


### PR DESCRIPTION
**Goals (and why)**: Fix the infinite loop that arose in #1941.

**Implementation Description (bullets)**:
* Instead of futilely re-proposing our same higher value on a new sequence number, throw NCLE. Note because of issues discussed on the ticket itself, reproposing at the next sequence number (which seems like the obvious solution) is unsafe.

**Concerns (what feedback would you like?)**:
* Will this impact availability too hard? I don't think so given that previously this case would have triggered an infinite loop and we don't see this that often anyway.
* What should the long term fix for identifying a service as different be?

**Where should we start reviewing?**: `PaxosTimestampBoundStore`, and possibly the ticket #1941. The key issue is the concern I've flagged above, I think.

**Priority (whenever / two weeks / yesterday)**:
Tomorrow, please - I'd like to cut a 0.42.1 soon.

@jamding for SA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1942)
<!-- Reviewable:end -->
