### PR TITLE
Add jitter to backoffs

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -102,8 +102,8 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
             int numFailovers = failoverCount.get();
             if (numFailovers > 0 && numFailovers % servers.size() == 0) {
 
-                // We use the Equal Jitter (https://www.awsarchitectureblog.com/2015/03/backoff.html).
-                // We prioritize a low server load over completion time, while having a base.
+                // We implement some randomness around the expected value of BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS.
+                // Even though this is not exponential backoff, should be enough to avoid a thundering herd problem.
                 long pauseTimeWithJitter = ThreadLocalRandom.current()
                         .nextLong(BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS / 2,
                                 (BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS * 3) / 2);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -166,7 +166,7 @@ public class FailoverFeignTargetTest {
         verify(spiedTarget, times(CLUSTER_SIZE)).pauseForBackoff(any(), argument.capture());
 
         List<Long> arguments = argument.getAllValues();
-        MatcherAssert.assertThat(arguments, Matchers.contains(1L, 1L, 500L));
+        MatcherAssert.assertThat(arguments, Matchers.contains(0L, 0L, 500L));
     }
 
     @Test
@@ -182,7 +182,7 @@ public class FailoverFeignTargetTest {
         verify(spiedTarget, times(3 * CLUSTER_SIZE)).pauseForBackoff(any(), argument.capture());
 
         List<Long> arguments = argument.getAllValues();
-        MatcherAssert.assertThat(arguments, Matchers.contains(1L, 1L, 500L, 1L, 1L, 500L, 1L, 1L, 500L));
+        MatcherAssert.assertThat(arguments, Matchers.contains(0L, 0L, 500L, 0L, 0L, 500L, 0L, 0L, 500L));
     }
 
     private void simulateRequest() {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/FailoverFeignTargetTest.java
@@ -17,6 +17,10 @@ package com.palantir.atlasdb.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -28,6 +32,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.apache.http.HttpStatus;
+import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -154,6 +159,7 @@ public class FailoverFeignTargetTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void blockingTimeout() {
         final FailoverFeignTarget spiedTarget = Mockito.spy(new FailoverFeignTarget<>(
                 SERVERS, 1, Object.class));
@@ -166,10 +172,15 @@ public class FailoverFeignTargetTest {
         verify(spiedTarget, times(CLUSTER_SIZE)).pauseForBackoff(any(), argument.capture());
 
         List<Long> arguments = argument.getAllValues();
-        MatcherAssert.assertThat(arguments, Matchers.contains(0L, 0L, 500L));
+
+        long bottom = FailoverFeignTarget.BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS / 2;
+        long cap = (FailoverFeignTarget.BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS * 3) / 2;
+        MatcherAssert.assertThat(arguments, Matchers.contains(
+                is(0L), is(0L), is(both(greaterThanOrEqualTo(bottom)).and(lessThan(cap)))));
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void blockingTimeoutManyTimes() {
         final FailoverFeignTarget spiedTarget = Mockito.spy(new FailoverFeignTarget<>(
                 SERVERS, 1, Object.class));
@@ -182,7 +193,14 @@ public class FailoverFeignTargetTest {
         verify(spiedTarget, times(3 * CLUSTER_SIZE)).pauseForBackoff(any(), argument.capture());
 
         List<Long> arguments = argument.getAllValues();
-        MatcherAssert.assertThat(arguments, Matchers.contains(0L, 0L, 500L, 0L, 0L, 500L, 0L, 0L, 500L));
+
+        long bottom = FailoverFeignTarget.BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS / 2;
+        long cap = (FailoverFeignTarget.BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS * 3) / 2;
+        Matcher jitteredBackoffMatcher = is(both(greaterThanOrEqualTo(bottom)).and(lessThan(cap)));
+        MatcherAssert.assertThat(arguments, Matchers.contains(
+                is(0L), is(0L), jitteredBackoffMatcher,
+                is(0L), is(0L), jitteredBackoffMatcher,
+                is(0L), is(0L), jitteredBackoffMatcher));
     }
 
     private void simulateRequest() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -82,7 +82,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1931>`__)
 
     *    - |improved|
-         - Add jitter to backoff on retries to `reduce load <https://www.awsarchitectureblog.com/2015/03/backoff.html>`__ in the server.
+         - Add jitter to backoff on retries to `reduce load <https://www.awsarchitectureblog.com/2015/03/backoff.html>`__ on the server.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1945>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -81,6 +81,10 @@ develop
          - Some of our log parameters are marked as safe for logging, as part of our internal guidelines.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1931>`__)
 
+    *    - |improved|
+         - Add jitter to backoff on retries to `reduce load <https://www.awsarchitectureblog.com/2015/03/backoff.html>`__ in the server.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1945>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 


### PR DESCRIPTION
**Goals (and why)**: As per the experiments on https://www.awsarchitectureblog.com/2015/03/backoff.html, jitter reduces loads on the server and makes request complete sooner.

We’ve chosen the ‘full jitter’ approach, to prioritize load on the server over overall latency time.

**Implementation Description (bullets)**: Make the backoff pause time a random number from 0 to a _x_, where _x_ is exponentially increasing with the number of tries.

**Concerns (what feedback would you like?)**: Did I choose the best implementation of the ones described on the article?

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: EOW

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1945)
<!-- Reviewable:end -->
