### PR TITLE
Log TableReferences as Safe

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -121,7 +121,7 @@ import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.exception.PalantirRuntimeException;
-import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -463,7 +463,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     @Override
     public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         if (timestampByCell.isEmpty()) {
-            log.info("Attempted get on '{}' table with empty cells", UnsafeArg.of("tableRef", tableRef));
+            log.info("Attempted get on '{}' table with empty cells", SafeArg.of("tableRef", tableRef));
             return ImmutableMap.of();
         }
 
@@ -2273,11 +2273,11 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
         tables.remove(tableToKeep.get());
         if (tables.size() > 0) {
             dropTablesInternal(tables);
-            log.info("Dropped tables [{}]", UnsafeArg.of("table names", tables));
+            log.info("Dropped tables [{}]", SafeArg.of("table names", tables));
         }
         schemaMutationLock.cleanLockState();
         log.info("Reset the schema mutation lock in table [{}]",
-                UnsafeArg.of("table name", tableToKeep.get().toString()));
+                SafeArg.of("table name", tableToKeep.get()));
     }
 
     private <V> Map<InetSocketAddress, Map<Cell, V>> partitionMapByHost(Iterable<Map.Entry<Cell, V>> cells) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -53,7 +53,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
                 if (!e.canTransactionBeRetried()) {
                     log.warn("[{}] Non-retriable exception while processing transaction.",
                             SafeArg.of("runId", runId),
-                            SafeArg.of("failureCount", failureCount));
+                            e);
                     throw e;
                 }
                 failureCount++;


### PR DESCRIPTION
**Goals (and why)**: Log table names as Safe, fix log message

**Implementation Description (bullets)**:
We've decided that table names are Safe for logging so I've changed this for the log messages we've updated.
Also spotted that we inadvertently changed the arguments to a log message in a recent PR.  This reverts the change. https://github.com/palantir/atlasdb/pull/1931/files

**Concerns (what feedback would you like?)**: I edited this in line in GHE so may things may not compile!  Poor commit message that can't be changed - should I delete branch and push again with better message?  I removed call to toString on the TableReference, is this ok?

**Where should we start reviewing?**: Only 2 files

**Priority (whenever / two weeks / yesterday)**: Before next release (logging will complain about the number of arguments).

[no release notes]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1948)
<!-- Reviewable:end -->
