### PR TITLE
Fix incorrect release notes concerning additional lock logging

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -278,6 +278,13 @@ This release contains (almost) exclusively baseline-related changes.
            These versions contain a known bug that causes incorrect results to be returned for certain queries.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1820>`__)
 
+    *    - |userbreak| |improved|
+         - The lock server now will dump all held locks and outstanding lock requests in YAML file, when logging state requested, for easy readability and further processing.
+           This will make debuging lock congestions easier. Lock descriptors are changed with places holders and can be decoded using descriptors file,
+           which will be written in the folder. Information like requesting clients, requesting threads and other details can be found in the YAML.
+           Note that this change modifies serialization of lock tokens by adding the name of the requesting thread to the lock token; thus, TimeLock Servers are no longer compatible with AtlasDB clients from preceding versions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1792>`__)
+
     *    - |devbreak| |fixed|
          - Correct ``TransactionManagers.createInMemory(...)`` to conform with the rest of the api by accepting a ``Set<Schema>`` object.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1859>`__)
@@ -357,12 +364,6 @@ v0.39.0
            This manifests as Timelock clients failing over and trying other nodes when receiving a 503 with a ``Retry-After`` header from a remote (e.g. from a TimeLock non-leader).
            Previously, these proxies would immediately retry the connection on the node with a 503 two times (for a total of three attempts) before failing over.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1782>`__)
-
-    *    - |improved|
-         - The lock server now will dump all held locks and outstanding lock requests in YAML file, when logging state requested, for easy readability and further processing.
-           This will make debuging lock congestions easier. Lock descriptors are changed with places holders and can be decoded using descriptors file,
-           which will be written in the folder. Information like requesting clients, requesting threads and other details can be found in the YAML.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1792>`__)
 
     *    - |new|
          - The ``atlasdb-config`` project now shadows the ``error-handling`` and ``jackson-support`` libraries from `http-remoting <https://github.com/palantir/http-remoting>`__.


### PR DESCRIPTION
**Goals (and why)**: PR #1792 modified the serialized form of lock tokens; which is a user break as far as TimeLock Server is concerned (though was not flagged as such at the time). This needs to be flagged. Also the release note was in the wrong place (the change was not merged in time for 0.39.0 despite what the release notes say - [evidence](https://github.com/palantir/atlasdb/compare/0.39.0...0.40.0) - and thus should be in 0.40.0).

**Implementation Description (bullets)**:
* Flag that release note entry as a user break and explain why it's a user break
* Move the entry to 0.40.0

**Concerns (what feedback would you like?)**: None really.

**Where should we start reviewing?**: release-notes.rst

**Priority (whenever / two weeks / yesterday)**: whenever - this is done to avoid future confusion when troubleshooting versioning problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1953)
<!-- Reviewable:end -->
