### PR TITLE
TimeLock Server - Gate Lock Service Behind AwaitingLeadershipProxy

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -158,7 +158,7 @@ public final class AtlasDbHttpClients {
     }
 
     @VisibleForTesting
-    static <T> T createProxyWithQuickFailoverForTesting(
+    public static <T> T createProxyWithQuickFailoverForTesting(
             Optional<SSLSocketFactory> sslSocketFactory, Collection<String> endpointUris, Class<T> type) {
         Request.Options options = new Request.Options(QUICK_FEIGN_TIMEOUT_MILLIS, QUICK_FEIGN_TIMEOUT_MILLIS);
         return createProxyWithFailover(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -158,7 +158,7 @@ public final class AtlasDbHttpClients {
     }
 
     @VisibleForTesting
-    public static <T> T createProxyWithQuickFailoverForTesting(
+    static <T> T createProxyWithQuickFailoverForTesting(
             Optional<SSLSocketFactory> sslSocketFactory, Collection<String> endpointUris, Class<T> type) {
         Request.Options options = new Request.Options(QUICK_FEIGN_TIMEOUT_MILLIS, QUICK_FEIGN_TIMEOUT_MILLIS);
         return createProxyWithFailover(

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -91,7 +91,7 @@ develop
 
     *    - |fixed|
          - After `Pull Request <https://github.com/palantir/atlasdb/pull/1808>`__ the TimeLock Server previously did not gate the lock service behind the ``AwaitingLeadershipProxy`` - it now does again.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABC>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1955>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,10 @@ develop
          - Add jitter to backoff on retries to `reduce load <https://www.awsarchitectureblog.com/2015/03/backoff.html>`__ on the server.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1945>`__)
 
+    *    - |fixed|
+         - After `Pull Request <https://github.com/palantir/atlasdb/pull/1808>`__ the TimeLock Server previously did not gate the lock service behind the ``AwaitingLeadershipProxy`` - it now does again.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABC>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -98,14 +99,12 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
     public void canParticipateInPaxosAsAcceptorWithoutQuorum() {
         PaxosAcceptor acceptor = createProxyForInternalNamespacedTestService(PaxosAcceptor.class);
         acceptor.getLatestSequencePreparedOrAccepted();
-        acceptor.prepare(1, new PaxosProposalId(1, "abc"));
     }
 
     @Test
     public void canParticipateInPaxosAsLearnerWithoutQuorum() {
         PaxosLearner learner = createProxyForInternalNamespacedTestService(PaxosLearner.class);
         learner.getGreatestLearnedValue();
-        learner.learn(1, new PaxosValue("abc", 1, null));
     }
 
     private static void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
@@ -126,9 +125,9 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
     }
 
     private static <T> T getProxyForService(String client, Class<T> clazz) {
-        return AtlasDbHttpClients.createProxyWithQuickFailoverForTesting(
+        return AtlasDbHttpClients.createProxy(
                 NO_SSL,
-                ImmutableList.of(getRootUriForClient(client)),
+                getRootUriForClient(client),
                 clazz);
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -24,21 +24,17 @@ import java.io.File;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.leader.PingableLeader;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
-import com.palantir.paxos.PaxosProposalId;
-import com.palantir.paxos.PaxosValue;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 
@@ -47,7 +43,8 @@ import io.dropwizard.testing.ResourceHelpers;
 
 /**
  * This test creates a single TimeLock server that is configured in a three node configuration.
- * Since it has no quorum, all of its operations should fail.
+ * Since it has no quorum, timestamp and lock requests (and fast-forward) should fail.
+ * However it should still be pingable and should be able to participate in Paxos as well.
  */
 public class IsolatedPaxosTimeLockServerIntegrationTest {
     private static final String CLIENT = "test";

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.timestamp.TimestampManagementService;
+import com.palantir.timestamp.TimestampService;
+
+import feign.RetryableException;
+import io.dropwizard.testing.ResourceHelpers;
+
+/**
+ * This test creates a single TimeLock server that is configured in a three node configuration.
+ * Since it has no quorum, all of its operations should fail.
+ */
+public class IsolatedPaxosTimeLockServerIntegrationTest {
+    private static final String CLIENT = "test";
+
+    private static final Optional<SSLSocketFactory> NO_SSL = Optional.absent();
+
+    private static final File TIMELOCK_CONFIG_TEMPLATE =
+            new File(ResourceHelpers.resourceFilePath("paxosThreeServers.yml"));
+
+    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    private static final TemporaryConfigurationHolder TEMPORARY_CONFIG_HOLDER =
+            new TemporaryConfigurationHolder(TEMPORARY_FOLDER, TIMELOCK_CONFIG_TEMPLATE);
+    private static final TimeLockServerHolder TIMELOCK_SERVER_HOLDER =
+            new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation);
+
+    @ClassRule
+    public static final RuleChain ruleChain = RuleChain.outerRule(TEMPORARY_FOLDER)
+            .around(TEMPORARY_CONFIG_HOLDER)
+            .around(TIMELOCK_SERVER_HOLDER);
+
+    @Test
+    public void cannotIssueTimestampsWithoutQuorum() {
+        assertThatThrownBy(() -> getTimestampService(CLIENT).getFreshTimestamp())
+                .satisfies(IsolatedPaxosTimeLockServerIntegrationTest::isRetryableExceptionWhereLeaderCannotBeFound);
+    }
+
+    @Test
+    public void cannotIssueLocksWithoutQuorum() {
+        assertThatThrownBy(() -> getLockService(CLIENT).currentTimeMillis())
+                .satisfies(IsolatedPaxosTimeLockServerIntegrationTest::isRetryableExceptionWhereLeaderCannotBeFound);
+    }
+
+    @Test
+    public void cannotPerformTimestampManagementWithoutQuorum() {
+        assertThatThrownBy(() -> getTimestampManagementService(CLIENT).fastForwardTimestamp(1000L))
+                .satisfies(IsolatedPaxosTimeLockServerIntegrationTest::isRetryableExceptionWhereLeaderCannotBeFound);
+    }
+
+    private static void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
+        assertThat(throwable).isInstanceOf(RetryableException.class)
+                .hasMessageContaining("method invoked on a non-leader");
+    }
+
+    private static RemoteLockService getLockService(String client) {
+        return getProxyForService(client, RemoteLockService.class);
+    }
+
+    private static TimestampService getTimestampService(String client) {
+        return getProxyForService(client, TimestampService.class);
+    }
+
+    private static TimestampManagementService getTimestampManagementService(String client) {
+        return getProxyForService(client, TimestampManagementService.class);
+    }
+
+    private static <T> T getProxyForService(String client, Class<T> clazz) {
+        return AtlasDbHttpClients.createProxyWithQuickFailoverForTesting(
+                NO_SSL,
+                ImmutableList.of(getRootUriForClient(client)),
+                clazz);
+    }
+
+    private static String getRootUriForClient(String client) {
+        return String.format("http://localhost:%d/%s", TIMELOCK_SERVER_HOLDER.getTimelockPort(), client);
+    }
+}

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -47,7 +47,7 @@ import io.dropwizard.testing.ResourceHelpers;
  * However it should still be pingable and should be able to participate in Paxos as well.
  */
 public class IsolatedPaxosTimeLockServerIntegrationTest {
-    private static final String CLIENT = "test";
+    private static final String CLIENT = "isolated";
 
     private static final Optional<SSLSocketFactory> NO_SSL = Optional.absent();
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -68,19 +68,19 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
     @Test
     public void cannotIssueTimestampsWithoutQuorum() {
         assertThatThrownBy(() -> getTimestampService(CLIENT).getFreshTimestamp())
-                .satisfies(IsolatedPaxosTimeLockServerIntegrationTest::isRetryableExceptionWhereLeaderCannotBeFound);
+                .satisfies(this::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void cannotIssueLocksWithoutQuorum() {
         assertThatThrownBy(() -> getLockService(CLIENT).currentTimeMillis())
-                .satisfies(IsolatedPaxosTimeLockServerIntegrationTest::isRetryableExceptionWhereLeaderCannotBeFound);
+                .satisfies(this::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void cannotPerformTimestampManagementWithoutQuorum() {
         assertThatThrownBy(() -> getTimestampManagementService(CLIENT).fastForwardTimestamp(1000L))
-                .satisfies(IsolatedPaxosTimeLockServerIntegrationTest::isRetryableExceptionWhereLeaderCannotBeFound);
+                .satisfies(this::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
         learner.getGreatestLearnedValue();
     }
 
-    private static void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
+    private void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
         assertThat(throwable).isInstanceOf(RetryableException.class)
                 .hasMessageContaining("method invoked on a non-leader");
     }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -33,13 +33,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.net.ssl.SSLSocketFactory;
 
 import org.assertj.core.util.Lists;
 import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -68,6 +67,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
+
 import feign.RetryableException;
 import io.dropwizard.testing.ResourceHelpers;
 

--- a/timelock-server/src/integTest/resources/paxosThreeServers.yml
+++ b/timelock-server/src/integTest/resources/paxosThreeServers.yml
@@ -10,19 +10,4 @@ cluster:
     - localhost:8084
 
 clients:
-  - test
-  - test2
-  - test3
-  - learner
-  - acceptor
-
-useClientRequestLimit: true
-
-server:
-  minThreads: 1
-  maxThreads: 100
-  applicationConnectors:
-    - type: http
-      selectorThreads: 8
-      acceptorThreads: 4
-      idleTimeout: 2s
+  - isolated

--- a/timelock-server/src/integTest/resources/paxosThreeServers.yml
+++ b/timelock-server/src/integTest/resources/paxosThreeServers.yml
@@ -1,0 +1,28 @@
+algorithm:
+  type: paxos
+  paxosDataDir: <TEMP_DATA_DIR>
+
+cluster:
+  localServer: localhost:8080
+  servers:
+    - localhost:8080
+    - localhost:8082
+    - localhost:8084
+
+clients:
+  - test
+  - test2
+  - test3
+  - learner
+  - acceptor
+
+useClientRequestLimit: true
+
+server:
+  minThreads: 1
+  maxThreads: 100
+  applicationConnectors:
+    - type: http
+      selectorThreads: 8
+      acceptorThreads: 4
+      idleTimeout: 2s

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
@@ -173,6 +173,13 @@ public class PaxosTimeLockServer implements TimeLockServer {
     }
 
     private LockService createLockService(long slowLogTriggerMillis) {
+        return AwaitingLeadershipProxy.newProxyInstance(
+                LockService.class,
+                () -> createThreadPoolingLockService(slowLogTriggerMillis),
+                leaderElectionService);
+    }
+
+    private LockService createThreadPoolingLockService(long slowLogTriggerMillis) {
         LockService lockServiceNotUsingThreadPooling = createTimeLimitedLockService(slowLogTriggerMillis);
 
         if (!timeLockServerConfiguration.useClientRequestLimit()) {


### PR DESCRIPTION
**Goals (and why)**: @nziebart found a serious bug in TimeLock, where we did not gate the lock service behind an AwaitingLeadershipProxy after PR #1808 (probably because of bad merge conflict). This change fixes that and adds an integration test that helps prevent this from happening again.

**Implementation Description (bullets)**:
* Put the lock service behind AwaitingLeadershipProxy again
* Add an integration test, that verifies a solo node in a 3-node cluster cannot issue timestamps, locks or perform timestamp management - but can still be pinged and participate in Paxos.

I wanted to do a three node integration test with failover though that's a bit more involved and I think this gives us good signal to begin with.

**Concerns (what feedback would you like?)**:
* How did our Jepsen tests not catch this? (And note that they did run several times)
* Apart from Jepsen, we don't have any multinode integration/smoke tests. This is a start, but I think we should pursue this more aggressively.

**Where should we start reviewing?**: PaxosTimeLockServer, which is basically a one line change. The rest of it is release notes and tests.

**Priority (whenever / two weeks / yesterday)**: Yesterday. Would be P0, but no one actually uses this yet, so I'm filing as P1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1955)
<!-- Reviewable:end -->
