### PR TITLE
Fix/retry behavior

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/FailoverFeignTarget.java
@@ -109,9 +109,9 @@ public class FailoverFeignTarget<T> implements Target<T>, Retryer {
                                 (BACKOFF_BEFORE_ROUND_ROBIN_RETRY_MILLIS * 3) / 2);
 
                 pauseForBackoff(ex, pauseTimeWithJitter);
-            } else {
-                pauseForBackoff(ex);
             }
+        } else {
+            pauseForBackoff(ex);
         }
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,6 +42,10 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - For requests that fail due to to networking or other IOException, `FailOverFeignTarget.continueOrPropagate` now backs off before retrying.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1958>`__)
+
     *    - |userbreak| |improved|
          - The ``acquire-backup-lock`` endpoint of ``PersistentLockService`` now returns a 400 response instead of a 500 response when no reason for acquiring the lock is provided.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1909>`__)


### PR DESCRIPTION
**Goals (and why)**: Backoff on non fast-failover requests (i.e. requests with RETRY_AFTER header).

**Implementation Description (bullets)**: Revert to behavior before #1786.

**Concerns (what feedback would you like?)**: Are the tests exhaustive?

**Where should we start reviewing?**: Just two files.

**Priority (whenever / two weeks / yesterday)**: We probably want this in by the next release.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1958)
<!-- Reviewable:end -->
