### PR TITLE
Fix/deprecation

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Functions;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Maps;
@@ -35,7 +34,6 @@ import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cli.output.OutputPrinter;
-import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -72,12 +70,18 @@ public class SweepCommand extends SingleBackendCommand {
             description = "Sweep all tables")
     boolean sweepAllTables;
 
+    /**
+     * @deprecated Use --candidate-batch-hint instead.
+     */
     @Deprecated
     @Option(name = {"--batch-size"},
             description = "Sweeper row batch size. This option has been deprecated deprecated "
                     + "in favor of --candidate-batch-hint")
     Integer batchSize;
 
+    /**
+     * @deprecated Use --read-limit instead.
+     */
     @Deprecated
     @Option(name = {"--cell-batch-size"},
             description = "Sweeper cell batch size. This option has been deprecated deprecated "

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -96,7 +96,7 @@ public class SweepCommand extends SingleBackendCommand {
     @Option(name = {"--candidate-batch-hint"},
             description = "Approximate number of candidate (cell, timestamp) pairs to load at once (default: "
                     + AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT + ")")
-    Integer candidateBatchHint = AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT;
+    Integer candidateBatchHint;
 
     @Option(name = {"--read-limit"},
             description = "Target number of (cell, timestamp) pairs to examine (default: "

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -75,7 +75,7 @@ public class SweepCommand extends SingleBackendCommand {
      */
     @Deprecated
     @Option(name = {"--batch-size"},
-            description = "Sweeper row batch size. This option has been deprecated deprecated "
+            description = "Sweeper row batch size. This option has been deprecated "
                     + "in favor of --candidate-batch-hint")
     Integer batchSize;
 
@@ -84,7 +84,7 @@ public class SweepCommand extends SingleBackendCommand {
      */
     @Deprecated
     @Option(name = {"--cell-batch-size"},
-            description = "Sweeper cell batch size. This option has been deprecated deprecated "
+            description = "Sweeper cell batch size. This option has been deprecated "
                     + "in favor of --read-limit")
     Integer cellBatchSize;
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -76,10 +76,10 @@ develop
          - :ref:`Sweep metrics <dropwizard-metrics>` now record counts of cell-timestamp pairs examined rather than the count of entire cells examined. This provides more accurate insight on the work done by the sweeper.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1911>`__)
 
-    *    - |userbreak|
-         - The Sweep CLI configuration parameters ``--batch-size`` and ``--cell-batch-size`` have been removed, as we now batch on cell-timestamp pairs rather than by rows and cells.
+    *    - |deprecated|
+         - The Sweep CLI configuration parameters ``--batch-size`` and ``--cell-batch-size`` have been deprecated, as we now batch on cell-timestamp pairs rather than by rows and cells.
            Please use the ``--candidate-batch-hint`` parameter instead of ``--batch-hint``, and ``--read-limit`` instead of ``--cell-batch-size`` (:ref:`docs <sweep_tunable_parameters>`).
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/1911>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1962>`__)
 
     *    - |deprecated|
          - Configuration parameters ``sweepBatchSize`` and ``sweepCellBatchSize`` have been deprecated in favour of ``sweepCandidateBatchHint`` and ``sweepReadLimit`` respectively.


### PR DESCRIPTION
**Goals (and why)**:
Deprecate `--batch-size` and `--cell-batch-size` from the sweep CLI instead of deleting them.

**Implementation Description (bullets)**:
Used same logic as `TransactionManagers.java`

**Concerns (what feedback would you like?)**:
No tests yet. Do we have time to write tests?

**Where should we start reviewing?**:
Anywhere

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1962)
<!-- Reviewable:end -->
