### PR TITLE
Exclude jersey-server from http-remoting

### DIFF
--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -670,28 +670,18 @@
                 "io.netty:netty-handler"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-service",
-                "io.airlift:airline",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "io.airlift:airline"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -703,10 +693,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -770,99 +757,11 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.jboss.marshalling:jboss-marshalling": {

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -572,29 +572,19 @@
                 "io.netty:netty-handler"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
                 "com.google.dagger:dagger",
                 "com.palantir.atlasdb:atlasdb-service",
-                "io.airlift:airline",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "io.airlift:airline"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -606,10 +596,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -665,99 +652,11 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.jboss.marshalling:jboss-marshalling": {
@@ -1393,28 +1292,18 @@
                 "io.netty:netty-handler"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-service",
-                "io.airlift:airline",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "io.airlift:airline"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -1426,10 +1315,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -1485,99 +1371,11 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.jboss.marshalling:jboss-marshalling": {

--- a/atlasdb-config/versions.lock
+++ b/atlasdb-config/versions.lock
@@ -450,25 +450,10 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -481,10 +466,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting1:error-handling",
-                "com.palantir.remoting2:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting2:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -508,99 +490,11 @@
                 "com.palantir.config.crypto:encrypted-config-value-module"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
@@ -1089,25 +983,10 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -1120,10 +999,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting1:error-handling",
-                "com.palantir.remoting2:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting2:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -1147,99 +1023,11 @@
                 "com.palantir.config.crypto:encrypted-config-value-module"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -659,27 +659,17 @@
                 "io.netty:netty-handler"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-service",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "com.palantir.atlasdb:atlasdb-service"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -691,10 +681,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "jline:jline": {
@@ -776,99 +763,11 @@
                 "com.palantir.atlasdb:atlasdb-console"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.jboss.marshalling:jboss-marshalling": {

--- a/atlasdb-console/versions.lock
+++ b/atlasdb-console/versions.lock
@@ -471,27 +471,17 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-service",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "com.palantir.atlasdb:atlasdb-service"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -503,10 +493,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "jline:jline": {
@@ -541,99 +528,11 @@
             "locked": "1.11",
             "requested": "1.11"
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
@@ -1148,27 +1047,17 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-service",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "com.palantir.atlasdb:atlasdb-service"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -1180,10 +1069,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "jline:jline": {
@@ -1218,99 +1104,11 @@
             "locked": "1.11",
             "requested": "1.11"
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {

--- a/atlasdb-dagger/versions.lock
+++ b/atlasdb-dagger/versions.lock
@@ -471,28 +471,18 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
                 "com.google.dagger:dagger",
-                "com.palantir.atlasdb:atlasdb-service",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "com.palantir.atlasdb:atlasdb-service"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -504,10 +494,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -531,99 +518,11 @@
                 "com.palantir.config.crypto:encrypted-config-value-module"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
@@ -1138,28 +1037,18 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
                 "com.google.dagger:dagger",
-                "com.palantir.atlasdb:atlasdb-service",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "com.palantir.atlasdb:atlasdb-service"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -1171,10 +1060,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -1198,99 +1084,11 @@
                 "com.palantir.config.crypto:encrypted-config-value-module"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -423,25 +423,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -452,10 +437,7 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -496,88 +478,6 @@
                 "com.palantir.atlasdb:atlasdb-tests-shared"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
@@ -600,12 +500,6 @@
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mockito:mockito-core": {
@@ -1086,25 +980,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -1115,10 +994,7 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -1159,88 +1035,6 @@
                 "com.palantir.atlasdb:atlasdb-tests-shared"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
@@ -1263,12 +1057,6 @@
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mockito:mockito-core": {

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -383,25 +383,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -412,10 +397,7 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -444,99 +426,11 @@
                 "com.palantir.atlasdb:commons-db"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
@@ -964,25 +858,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -993,10 +872,7 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -1025,99 +901,11 @@
                 "com.palantir.atlasdb:commons-db"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -1049,7 +1049,6 @@
         "org.glassfish.jersey.core:jersey-server": {
             "locked": "2.22.1",
             "transitive": [
-                "com.palantir.remoting1:jersey-servers",
                 "io.dropwizard:dropwizard-jersey",
                 "org.glassfish.jersey.containers:jersey-container-servlet",
                 "org.glassfish.jersey.containers:jersey-container-servlet-core",
@@ -2232,7 +2231,6 @@
         "org.glassfish.jersey.core:jersey-server": {
             "locked": "2.22.1",
             "transitive": [
-                "com.palantir.remoting1:jersey-servers",
                 "io.dropwizard:dropwizard-jersey",
                 "org.glassfish.jersey.containers:jersey-container-servlet",
                 "org.glassfish.jersey.containers:jersey-container-servlet-core",

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -1100,7 +1100,6 @@
         "org.glassfish.jersey.core:jersey-server": {
             "locked": "2.22.1",
             "transitive": [
-                "com.palantir.remoting1:jersey-servers",
                 "io.dropwizard:dropwizard-jersey",
                 "org.glassfish.jersey.containers:jersey-container-servlet",
                 "org.glassfish.jersey.containers:jersey-container-servlet-core",
@@ -2414,7 +2413,6 @@
         "org.glassfish.jersey.core:jersey-server": {
             "locked": "2.22.1",
             "transitive": [
-                "com.palantir.remoting1:jersey-servers",
                 "io.dropwizard:dropwizard-jersey",
                 "org.glassfish.jersey.containers:jersey-container-servlet",
                 "org.glassfish.jersey.containers:jersey-container-servlet-core",

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -22,7 +22,9 @@ dependencies {
 
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
   compile group: 'com.palantir.remoting1', name: 'tracing'
-  compile group: 'com.palantir.remoting1', name: 'jersey-servers'
+  compile (group: 'com.palantir.remoting1', name: 'jersey-servers') {
+    exclude module: 'jersey-server'
+  }
 
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'

--- a/atlasdb-impl-shared/versions.lock
+++ b/atlasdb-impl-shared/versions.lock
@@ -276,25 +276,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -305,10 +290,7 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -329,99 +311,11 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
@@ -733,25 +627,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -762,10 +641,7 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -786,99 +662,11 @@
                 "com.palantir.atlasdb:atlasdb-api"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {

--- a/atlasdb-jepsen-tests/versions.lock
+++ b/atlasdb-jepsen-tests/versions.lock
@@ -458,26 +458,11 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -489,10 +474,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -522,99 +504,11 @@
         "org.clojure:clojure": {
             "locked": "1.8.0"
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
@@ -1116,26 +1010,11 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -1147,10 +1026,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -1180,99 +1056,11 @@
         "org.clojure:clojure": {
             "locked": "1.8.0"
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -672,29 +672,19 @@
                 "io.netty:netty-handler"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
                 "com.google.dagger:dagger",
                 "com.palantir.atlasdb:atlasdb-service",
-                "io.airlift:airline",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "io.airlift:airline"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -706,10 +696,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -793,88 +780,6 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
@@ -899,7 +804,6 @@
         "org.javassist:javassist": {
             "locked": "3.18.2-GA",
             "transitive": [
-                "org.glassfish.hk2:hk2-locator",
                 "org.reflections:reflections"
             ]
         },
@@ -1663,29 +1567,19 @@
                 "io.netty:netty-handler"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
             "transitive": [
                 "com.google.dagger:dagger",
                 "com.palantir.atlasdb:atlasdb-service",
-                "io.airlift:airline",
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
+                "io.airlift:airline"
             ]
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -1697,10 +1591,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -1784,88 +1675,6 @@
                 "org.apache.cassandra:cassandra-thrift"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
@@ -1890,7 +1699,6 @@
         "org.javassist:javassist": {
             "locked": "3.18.2-GA",
             "transitive": [
-                "org.glassfish.hk2:hk2-locator",
                 "org.reflections:reflections"
             ]
         },

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -872,7 +872,6 @@
         "org.glassfish.jersey.core:jersey-server": {
             "locked": "2.22.1",
             "transitive": [
-                "com.palantir.remoting1:jersey-servers",
                 "io.dropwizard:dropwizard-jersey",
                 "org.glassfish.jersey.containers:jersey-container-servlet",
                 "org.glassfish.jersey.containers:jersey-container-servlet-core",
@@ -1996,7 +1995,6 @@
         "org.glassfish.jersey.core:jersey-server": {
             "locked": "2.22.1",
             "transitive": [
-                "com.palantir.remoting1:jersey-servers",
                 "io.dropwizard:dropwizard-jersey",
                 "org.glassfish.jersey.containers:jersey-container-servlet",
                 "org.glassfish.jersey.containers:jersey-container-servlet-core",

--- a/atlasdb-service/versions.lock
+++ b/atlasdb-service/versions.lock
@@ -458,27 +458,15 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
-            "requested": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
+            "requested": "1"
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -490,10 +478,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -517,99 +502,11 @@
                 "com.palantir.config.crypto:encrypted-config-value-module"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {
@@ -1111,27 +1008,15 @@
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "javax.inject:javax.inject": {
             "locked": "1",
-            "requested": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
+            "requested": "1"
         },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-config",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-config"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -1143,10 +1028,7 @@
                 "com.palantir.atlasdb:leader-election-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -1170,99 +1052,11 @@
                 "com.palantir.config.crypto:encrypted-config-value-module"
             ]
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hdrhistogram:HdrHistogram": {
             "locked": "2.1.9",
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mortbay.jetty.alpn:jetty-alpn-agent": {

--- a/atlasdb-tests-shared/versions.lock
+++ b/atlasdb-tests-shared/versions.lock
@@ -308,25 +308,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -337,10 +322,7 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -367,88 +349,6 @@
         "org.assertj:assertj-core": {
             "locked": "3.5.2"
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
@@ -469,12 +369,6 @@
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mockito:mockito-core": {
@@ -828,25 +722,10 @@
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
-        "javax.annotation:javax.annotation-api": {
-            "locked": "1.2",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "javax.inject:javax.inject": {
-            "locked": "1",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-utils"
-            ]
-        },
         "javax.validation:validation-api": {
             "locked": "1.1.0.Final",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
@@ -857,10 +736,7 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.remoting1:error-handling",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server"
+                "com.palantir.remoting1:error-handling"
             ]
         },
         "joda-time:joda-time": {
@@ -887,88 +763,6 @@
         "org.assertj:assertj-core": {
             "locked": "3.5.2"
         },
-        "org.glassfish.hk2.external:aopalliance-repackaged": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2.external:javax.inject": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-api": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator",
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-locator": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.hk2:hk2-utils": {
-            "locked": "2.4.0-b31",
-            "transitive": [
-                "org.glassfish.hk2:hk2-api",
-                "org.glassfish.hk2:hk2-locator"
-            ]
-        },
-        "org.glassfish.hk2:osgi-resource-locator": {
-            "locked": "1.0.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.bundles.repackaged:jersey-guava": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-common"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-client": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-common": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-client",
-                "org.glassfish.jersey.core:jersey-server",
-                "org.glassfish.jersey.media:jersey-media-jaxb"
-            ]
-        },
-        "org.glassfish.jersey.core:jersey-server": {
-            "locked": "2.22.1",
-            "transitive": [
-                "com.palantir.remoting1:jersey-servers"
-            ]
-        },
-        "org.glassfish.jersey.media:jersey-media-jaxb": {
-            "locked": "2.22.1",
-            "transitive": [
-                "org.glassfish.jersey.core:jersey-server"
-            ]
-        },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
@@ -989,12 +783,6 @@
             "transitive": [
                 "com.palantir.tritium:tritium-metrics",
                 "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
-            ]
-        },
-        "org.javassist:javassist": {
-            "locked": "3.18.2-GA",
-            "transitive": [
-                "org.glassfish.hk2:hk2-locator"
             ]
         },
         "org.mockito:mockito-core": {


### PR DESCRIPTION
[no release notes]

**Goals (and why)**: To prevent dependency conflicts in large internal product. The product now builds successfully.

**Implementation Description (bullets)**: exclude `jersey-server` transitive dependency from http-remoting.

**Concerns (what feedback would you like?)**: not really, hope we dont need that version explicitly?

**Where should we start reviewing?**: `atlasdb-impl-shared/build.gradle`. All other files are generated

**Priority (whenever / two weeks / yesterday)**: asap

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1964)
<!-- Reviewable:end -->
