### PR TITLE
TimeLock instrumentation

### DIFF
--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
@@ -39,12 +39,12 @@ public class AtlasDbMetricsTest {
 
     @Before
     public void before() throws Exception {
-        AtlasDbMetrics.metrics = null;
+        AtlasDbMetrics.metrics.set(null);
     }
 
     @Test
     public void metricsIsDefaultWhenNotSet() {
-        AtlasDbMetrics.metrics = null;
+        AtlasDbMetrics.metrics.set(null);
         assertThat(AtlasDbMetrics.getMetricRegistry(),
                 is(equalTo(SharedMetricRegistries.getOrCreate(AtlasDbMetrics.DEFAULT_REGISTRY_NAME))));
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -66,7 +66,7 @@ public final class Leaders {
     }
 
     public static LeaderElectionService create(Environment env, LeaderConfig config, String userAgent) {
-        LocalPaxosServices localPaxosServices = createLocalServices(config, userAgent);
+        LocalPaxosServices localPaxosServices = createInstrumentedLocalServices(config, userAgent);
 
         env.register(localPaxosServices.ourAcceptor());
         env.register(localPaxosServices.ourLearner());
@@ -76,7 +76,7 @@ public final class Leaders {
         return localPaxosServices.leaderElectionService();
     }
 
-    public static LocalPaxosServices createLocalServices(LeaderConfig config, String userAgent) {
+    public static LocalPaxosServices createInstrumentedLocalServices(LeaderConfig config, String userAgent) {
         Set<String> remoteLeaderUris = Sets.newHashSet(config.leaders());
         remoteLeaderUris.remove(config.localServer());
 
@@ -85,19 +85,15 @@ public final class Leaders {
                 .remoteAcceptorUris(remoteLeaderUris)
                 .remoteLearnerUris(remoteLeaderUris)
                 .build();
-        return createLocalServices(config, remotePaxosServerSpec, userAgent);
+        return createInstrumentedLocalServices(config, remotePaxosServerSpec, userAgent);
     }
 
-    public static LocalPaxosServices createLocalServices(LeaderConfig config, RemotePaxosServerSpec spec) {
-        return createLocalServices(config, spec, UserAgents.DEFAULT_USER_AGENT);
-    }
-
-    public static LocalPaxosServices createLocalServices(
+    public static LocalPaxosServices createInstrumentedLocalServices(
             LeaderConfig config,
             RemotePaxosServerSpec remotePaxosServerSpec,
             String userAgent) {
-        PaxosAcceptor ourAcceptor = PaxosAcceptorImpl.newAcceptor(config.acceptorLogDir().getPath());
-        PaxosLearner ourLearner = PaxosLearnerImpl.newLearner(config.learnerLogDir().getPath());
+        PaxosAcceptor ourAcceptor = AtlasDbMetrics.instrument(PaxosAcceptor.class, PaxosAcceptorImpl.newAcceptor(config.acceptorLogDir().getPath()));
+        PaxosLearner ourLearner = AtlasDbMetrics.instrument(PaxosLearner.class, PaxosLearnerImpl.newLearner(config.learnerLogDir().getPath()));
 
         Optional<SSLSocketFactory> sslSocketFactory =
                 ServiceCreator.createSslSocketFactory(config.sslConfiguration());
@@ -114,14 +110,16 @@ public final class Leaders {
         Map<PingableLeader, HostAndPort> otherLeaders = generatePingables(
                 remotePaxosServerSpec.remoteLeaderUris(), sslSocketFactory, userAgent);
 
-        PaxosProposer proposer = createPaxosProposer(ourLearner, acceptors, learners, config.quorumSize(),
-                new InstrumentedExecutorService(
-                        Executors.newCachedThreadPool(new ThreadFactoryBuilder()
-                                .setNameFormat("atlas-proposer-%d")
-                                .setDaemon(true)
-                                .build()),
-                        AtlasDbMetrics.getMetricRegistry(),
-                        MetricRegistry.name(PaxosProposer.class, "executor")));
+        InstrumentedExecutorService proposerExecutorService = new InstrumentedExecutorService(
+                Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+                        .setNameFormat("atlas-proposer-%d")
+                        .setDaemon(true)
+                        .build()),
+                AtlasDbMetrics.getMetricRegistry(),
+                MetricRegistry.name(PaxosProposer.class, "executor"));
+        PaxosProposer proposer = AtlasDbMetrics.instrument(PaxosProposer.class,
+                createPaxosProposer(ourLearner, acceptors, learners, config.quorumSize(),
+                proposerExecutorService));
 
         InstrumentedExecutorService leaderElectionExecutor = new InstrumentedExecutorService(
                 Executors.newCachedThreadPool(new ThreadFactoryBuilder()
@@ -130,7 +128,7 @@ public final class Leaders {
                         .build()),
                 AtlasDbMetrics.getMetricRegistry(),
                 MetricRegistry.name(PaxosLeaderElectionService.class, "executor"));
-        PaxosLeaderElectionService leader = new PaxosLeaderElectionServiceBuilder()
+        PaxosLeaderElectionService paxosLeaderElectionService = new PaxosLeaderElectionServiceBuilder()
                 .proposer(proposer)
                 .knowledge(ourLearner)
                 .potentialLeadersToHosts(otherLeaders)
@@ -142,11 +140,14 @@ public final class Leaders {
                 .leaderPingResponseWaitMs(config.leaderPingResponseWaitMs())
                 .build();
 
+        LeaderElectionService leaderElectionService = AtlasDbMetrics.instrument(LeaderElectionService.class, paxosLeaderElectionService);
+        PingableLeader pingableLeader = AtlasDbMetrics.instrument(PingableLeader.class, paxosLeaderElectionService);
+
         return ImmutableLocalPaxosServices.builder()
                 .ourAcceptor(ourAcceptor)
                 .ourLearner(ourLearner)
-                .leaderElectionService(leader)
-                .pingableLeader(leader)
+                .leaderElectionService(leaderElectionService)
+                .pingableLeader(pingableLeader)
                 .build();
     }
 
@@ -181,12 +182,6 @@ public final class Leaders {
         return ImmutableList.copyOf(Iterables.concat(
                 AtlasDbHttpClients.createProxies(sslSocketFactory, remoteUris, clazz, userAgent),
                 ImmutableList.of(localObject)));
-    }
-
-    public static Map<PingableLeader, HostAndPort> generatePingables(
-            Collection<String> remoteEndpoints,
-            Optional<SSLSocketFactory> sslSocketFactory) {
-        return generatePingables(remoteEndpoints, sslSocketFactory, UserAgents.DEFAULT_USER_AGENT);
     }
 
     public static Map<PingableLeader, HostAndPort> generatePingables(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -92,8 +92,12 @@ public final class Leaders {
             LeaderConfig config,
             RemotePaxosServerSpec remotePaxosServerSpec,
             String userAgent) {
-        PaxosAcceptor ourAcceptor = AtlasDbMetrics.instrument(PaxosAcceptor.class, PaxosAcceptorImpl.newAcceptor(config.acceptorLogDir().getPath()));
-        PaxosLearner ourLearner = AtlasDbMetrics.instrument(PaxosLearner.class, PaxosLearnerImpl.newLearner(config.learnerLogDir().getPath()));
+        PaxosAcceptor ourAcceptor = AtlasDbMetrics.instrument(
+                PaxosAcceptor.class,
+                PaxosAcceptorImpl.newAcceptor(config.acceptorLogDir().getPath()));
+        PaxosLearner ourLearner = AtlasDbMetrics.instrument(
+                PaxosLearner.class,
+                PaxosLearnerImpl.newLearner(config.learnerLogDir().getPath()));
 
         Optional<SSLSocketFactory> sslSocketFactory =
                 ServiceCreator.createSslSocketFactory(config.sslConfiguration());
@@ -140,8 +144,12 @@ public final class Leaders {
                 .leaderPingResponseWaitMs(config.leaderPingResponseWaitMs())
                 .build();
 
-        LeaderElectionService leaderElectionService = AtlasDbMetrics.instrument(LeaderElectionService.class, paxosLeaderElectionService);
-        PingableLeader pingableLeader = AtlasDbMetrics.instrument(PingableLeader.class, paxosLeaderElectionService);
+        LeaderElectionService leaderElectionService = AtlasDbMetrics.instrument(
+                LeaderElectionService.class,
+                paxosLeaderElectionService);
+        PingableLeader pingableLeader = AtlasDbMetrics.instrument(
+                PingableLeader.class,
+                paxosLeaderElectionService);
 
         return ImmutableLocalPaxosServices.builder()
                 .ourAcceptor(ourAcceptor)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,6 +45,10 @@ develop
     *    - |improved|
          - KVS migration CLI will now clear the checkpoint tables that are required while the migration is in progress but not after the migration is complete.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1927>`__)
+           
+    *    - |improved|
+         - Timelock service now includes user agents for all inter-node requests.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1971>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
          - Timelock service now includes user agents for all inter-node requests.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1971>`__)
 
+    *    - |new|
+         - Timelock now tracks metrics for leadership elections, including leadership gains, losses, and proposals.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1927>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -4,6 +4,7 @@ apply from: "../gradle/shared.gradle"
 dependencies {
   compile project(":leader-election-api")
   compile project(":atlasdb-commons")
+
   compile group: "com.google.protobuf", name: "protobuf-java", version: libVersions.protobuf
   compile group: "commons-lang", name: "commons-lang", version: libVersions.commons_lang
   compile group: "commons-io", name: "commons-io"

--- a/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.paxos.PaxosRoundFailureException;
+import com.palantir.paxos.PaxosValue;
+
+class LeadershipEvents {
+
+    private static final String LEADER_LOG_NAME = "leadership";
+    private static final Logger leaderLog = LoggerFactory.getLogger(LEADER_LOG_NAME);
+
+    private final Meter gainedLeadership;
+    private final Meter lostLeadership;
+    private final Meter noQuorum;
+    private final Meter proposedLeadership;
+    private final Meter proposalFailure;
+
+    public LeadershipEvents(MetricRegistry metrics) {
+        gainedLeadership = metrics.meter("leadership.gained");
+        lostLeadership = metrics.meter("leadership.lost");
+        noQuorum = metrics.meter("leadership.no-quorum");
+        proposedLeadership = metrics.meter("leadership.proposed");
+        proposalFailure = metrics.meter("leadership.proposed.failure");
+    }
+
+    public void proposedLeadershipFor(long round) {
+        leaderLog.info("Proposing leadership", SafeArg.of("round", round));
+        proposedLeadership.mark();
+    }
+
+    public void gainedLeadershipFor(PaxosValue value) {
+        leaderLog.info("Gained leadership", SafeArg.of("value", value));
+        gainedLeadership.mark();
+    }
+
+    public void lostLeadershipFor(PaxosValue value) {
+        leaderLog.info("Lost leadership", SafeArg.of("value", value));
+        lostLeadership.mark();
+    }
+
+    public void noQuorum(PaxosValue value) {
+        leaderLog.warn("The most recent known information says this server is the leader, but there is no quorum right now",
+                SafeArg.of("value", value));
+        noQuorum.mark();
+    }
+
+    public void proposalFailure(PaxosRoundFailureException e) {
+        leaderLog.warn("Leadership was not gained.\n"
+                + "We should recover automatically. If this recurs often, try to \n"
+                + "  (1) ensure that most other nodes are reachable over the network, and \n"
+                + "  (2) increase the randomWaitBeforeProposingLeadershipMs timeout in your configuration.\n"
+                + "See the debug-level leaderLog for more details.");
+        leaderLog.debug("Specifically, leadership was not gained because of the following exception", e);
+        proposalFailure.mark();
+    }
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosKnowledgeEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosKnowledgeEventRecorder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import com.palantir.paxos.PaxosValue;
+
+public interface PaxosKnowledgeEventRecorder {
+
+    void recordRound(PaxosValue round);
+
+    PaxosKnowledgeEventRecorder NO_OP = (round) -> { };
+
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionEventRecorder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import com.palantir.paxos.PaxosRoundFailureException;
+import com.palantir.paxos.PaxosValue;
+
+public interface PaxosLeaderElectionEventRecorder {
+
+    /** Called when a quorum no longer agrees that {@code value} is the latest round, although we are the leader for {@code value}. */
+    void recordNotLeading(PaxosValue value);
+
+    /** Called when we cannot contact a quorum to determine whether {@code value} is the latest round. */
+    void recordNoQuorum(PaxosValue value);
+
+    /** Called when we fail to propose a new value. */
+    void recordProposalFailure(PaxosRoundFailureException e);
+
+    /** Called when we attempt to propose a new value. */
+    void recordProposalAttempt(long round);
+
+    PaxosLeaderElectionEventRecorder NO_OP = new PaxosLeaderElectionEventRecorder() {
+        @Override
+        public void recordNotLeading(PaxosValue value) { }
+
+        @Override
+        public void recordNoQuorum(PaxosValue value) { }
+
+        @Override
+        public void recordProposalFailure(PaxosRoundFailureException e) { }
+
+        @Override
+        public void recordProposalAttempt(long round) { }
+    };
+
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
@@ -35,6 +35,7 @@ public class PaxosLeaderElectionServiceBuilder {
     private long pingRateMs;
     private long randomWaitBeforeProposingLeadershipMs;
     private long leaderPingResponseWaitMs;
+    private PaxosLeaderElectionEventRecorder eventRecorder = PaxosLeaderElectionEventRecorder.NO_OP;
 
     public PaxosLeaderElectionServiceBuilder proposer(PaxosProposer proposer) {
         this.proposer = proposer;
@@ -83,6 +84,11 @@ public class PaxosLeaderElectionServiceBuilder {
         return this;
     }
 
+    public PaxosLeaderElectionServiceBuilder eventRecorder(PaxosLeaderElectionEventRecorder eventRecorder) {
+        this.eventRecorder = eventRecorder;
+        return this;
+    }
+
     public PaxosLeaderElectionService build() {
         return new PaxosLeaderElectionService(
                 proposer,
@@ -93,6 +99,7 @@ public class PaxosLeaderElectionServiceBuilder {
                 executor,
                 pingRateMs,
                 randomWaitBeforeProposingLeadershipMs,
-                leaderPingResponseWaitMs);
+                leaderPingResponseWaitMs,
+                eventRecorder);
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.paxos.PaxosRoundFailureException;
+import com.palantir.paxos.PaxosValue;
+
+public class PaxosLeadershipEventRecorder implements PaxosKnowledgeEventRecorder, PaxosLeaderElectionEventRecorder {
+
+    private final String leaderId;
+    private final LeadershipEvents events;
+
+    @GuardedBy("this") private PaxosValue currentRound = null;
+    @GuardedBy("this") private boolean isLeading = false;
+
+    public static PaxosLeadershipEventRecorder create(MetricRegistry metrics, String leaderUuid) {
+        return new PaxosLeadershipEventRecorder(new LeadershipEvents(metrics), leaderUuid);
+    }
+
+    @VisibleForTesting
+    PaxosLeadershipEventRecorder(LeadershipEvents events, String leaderUuid) {
+        this.events = events;
+        this.leaderId = leaderUuid;
+    }
+
+    @Override
+    public void recordProposalAttempt(long round) {
+        events.proposedLeadershipFor(round);
+    }
+
+    @Override
+    public void recordProposalFailure(PaxosRoundFailureException e) {
+        events.proposalFailure(e);
+    }
+
+    @Override
+    public synchronized void recordRound(PaxosValue round) {
+        if (isNewRound(round)) {
+            recordNewRound(round);
+        }
+    }
+
+    private synchronized void recordNewRound(PaxosValue round) {
+        if (isLeading) {
+            events.lostLeadershipFor(currentRound);
+        }
+
+        if (isLeaderFor(round)) {
+            events.gainedLeadershipFor(round);
+        }
+
+        currentRound = round;
+        isLeading = isLeaderFor(round);
+    }
+
+    @Override
+    public synchronized void recordNotLeading(PaxosValue value) {
+        if (isSameRound(value) && isLeading) {
+            events.lostLeadershipFor(value);
+            isLeading = false;
+        }
+    }
+
+    @Override
+    public synchronized void recordNoQuorum(PaxosValue value) {
+        if (isSameRound(value)) {
+            events.noQuorum(value);
+        }
+    }
+
+    private synchronized boolean isNewRound(PaxosValue value) {
+        return value != null && (currentRound == null || value.getRound() > currentRound.getRound());
+    }
+
+    private synchronized boolean isLeaderFor(PaxosValue round) {
+        return round != null && leaderId.equals(round.getLeaderUUID());
+    }
+
+    private synchronized boolean isSameRound(PaxosValue value) {
+        return currentRound != null && value != null && currentRound.getRound() == value.getRound();
+    }
+
+}

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -46,7 +46,6 @@ import com.palantir.remoting1.tracing.Tracers;
 public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler {
 
     private static final Logger log = LoggerFactory.getLogger(AwaitingLeadershipProxy.class);
-    private static final Logger leaderLog = LoggerFactory.getLogger("leadership");
 
     public static <U> U newProxyInstance(Class<U> interfaceClass,
                                          Supplier<U> delegateSupplier,
@@ -122,7 +121,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                 clearDelegate();
             } else {
                 leadershipTokenRef.set(leadershipToken);
-                leaderLog.info("Gained leadership for {}", SafeArg.of("leadershipToken", leadershipToken));
+                log.info("Gained leadership for {}", SafeArg.of("leadershipToken", leadershipToken));
             }
         } catch (InterruptedException e) {
             log.warn("attempt to gain leadership interrupted", e);
@@ -194,7 +193,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
     }
 
     private void markAsNotLeading(final LeadershipToken leadershipToken, @Nullable Throwable cause) {
-        leaderLog.warn("Lost leadership", cause);
+        log.warn("Lost leadership", cause);
         if (leadershipTokenRef.compareAndSet(leadershipToken, null)) {
             try {
                 clearDelegate();

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
@@ -41,17 +41,39 @@ import com.google.common.collect.ImmutableList;
 public class PaxosProposerImpl implements PaxosProposer {
     private static final Logger log = LoggerFactory.getLogger(PaxosProposerImpl.class);
 
-    public static PaxosProposer newProposer(PaxosLearner localLearner,
-                                            List<PaxosAcceptor> allAcceptors,
-                                            List<PaxosLearner> allLearners,
-                                            int quorumSize,
-                                            ExecutorService executor) {
+    /**
+     * @deprecated use {@link #newProposer(PaxosLearner, List, List, int, UUID, ExecutorService)}
+     */
+    @Deprecated
+    public static PaxosProposer newProposer(
+            PaxosLearner localLearner,
+            List<PaxosAcceptor> allAcceptors,
+            List<PaxosLearner> allLearners,
+            int quorumSize,
+            ExecutorService executor) {
+        return newProposer(
+                localLearner,
+                allAcceptors,
+                allLearners,
+                quorumSize,
+                UUID.randomUUID(),
+                executor
+        );
+    }
+
+    public static PaxosProposer newProposer(
+            PaxosLearner localLearner,
+            List<PaxosAcceptor> allAcceptors,
+            List<PaxosLearner> allLearners,
+            int quorumSize,
+            UUID leaderUUID,
+            ExecutorService executor) {
         return new PaxosProposerImpl(
                 localLearner,
                 allAcceptors,
                 allLearners,
                 quorumSize,
-                UUID.randomUUID().toString(),
+                leaderUUID.toString(),
                 executor);
     }
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.palantir.paxos.PaxosRoundFailureException;
+import com.palantir.paxos.PaxosValue;
+
+public class LeadershipEventRecorderTest {
+
+    private static final String LEADER_ID = "foo";
+
+    private final LeadershipEvents events = mock(LeadershipEvents.class);
+    private final PaxosLeadershipEventRecorder recorder = new PaxosLeadershipEventRecorder(events, LEADER_ID);
+
+    private static final PaxosValue ROUND_1_LEADING = round(1, true);
+    private static final PaxosValue ROUND_2_LEADING = round(2, true);
+    private static final PaxosValue ROUND_3_LEADING = round(3, true);
+    private static final PaxosValue ROUND_1_NOT_LEADING = round(1, false);
+    private static final PaxosValue ROUND_2_NOT_LEADING = round(2, false);
+    private static final PaxosValue ROUND_3_NOT_LEADING = round(3, false);
+
+    @After
+    public void verifyNoMoreEvents() {
+        verifyNoMoreInteractions(events);
+    }
+
+    @Test
+    public void recordsLeadershipGained() {
+        recorder.recordRound(ROUND_1_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+    }
+
+    @Test
+    public void recordsLeadershipLost() {
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordRound(ROUND_2_NOT_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(events).lostLeadershipFor(ROUND_1_LEADING);
+    }
+
+    @Test
+    public void reacordsLeadershipGainedAfterLost() {
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordRound(ROUND_2_NOT_LEADING);
+        recorder.recordRound(ROUND_3_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(events).lostLeadershipFor(ROUND_1_LEADING);
+        verify(events).gainedLeadershipFor(ROUND_3_LEADING);
+    }
+
+    @Test
+    public void recordsLeadershipLostBetweenSequentialLeadershipGained() {
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordRound(ROUND_2_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(events).lostLeadershipFor(ROUND_1_LEADING);
+        verify(events).gainedLeadershipFor(ROUND_2_LEADING);
+    }
+
+    @Test
+    public void doesNotRecordDuplicateLeadershipGained() {
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordRound(ROUND_1_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+    }
+
+    @Test
+    public void doesNotRecordDuplicateLeadershipLost() {
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordRound(ROUND_2_NOT_LEADING);
+        recorder.recordRound(ROUND_2_NOT_LEADING);
+        recorder.recordRound(ROUND_3_NOT_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(events).lostLeadershipFor(ROUND_1_LEADING);
+    }
+
+    @Test
+    public void cannotGainLeadershipAfterLosing() {
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordNotLeading(ROUND_1_LEADING);
+        recorder.recordRound(ROUND_1_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(events).lostLeadershipFor(ROUND_1_LEADING);
+    }
+
+    @Test
+    public void cannotGainLeadershipAfterLosingWithOutOfOrderRounds() {
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordRound(ROUND_3_NOT_LEADING);
+        recorder.recordRound(ROUND_2_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(events).lostLeadershipFor(ROUND_1_LEADING);
+    }
+
+    @Test
+    public void recordsDuplicateNoQuorum() {
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordNoQuorum(ROUND_1_LEADING);
+        recorder.recordNoQuorum(ROUND_1_LEADING);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+        verify(events, times(2)).noQuorum(ROUND_1_LEADING);
+    }
+
+    @Test
+    public void ignoresOtherLeaderIdsForNoQuorum() {
+        recorder.recordNoQuorum(ROUND_1_NOT_LEADING);
+    }
+
+    @Test
+    public void ignoresOtherLeaderIdsForNotLeading() {
+        recorder.recordNotLeading(ROUND_1_NOT_LEADING);
+    }
+
+    @Test
+    public void recordsProposalAttempt() {
+        recorder.recordProposalAttempt(5L);
+
+        verify(events).proposedLeadershipFor(5L);
+    }
+
+    @Test
+    public void recordsProposalFailure() {
+        PaxosRoundFailureException ex = new PaxosRoundFailureException("foo");
+        recorder.recordProposalFailure(ex);
+
+        verify(events).proposalFailure(ex);
+    }
+
+    @Test
+    public void ignoresNullRounds() {
+        recorder.recordRound(null);
+        recorder.recordNotLeading(null);
+        recorder.recordNoQuorum(null);
+        recorder.recordRound(ROUND_1_LEADING);
+        recorder.recordRound(null);
+        recorder.recordNotLeading(null);
+        recorder.recordNoQuorum(null);
+
+        verify(events).gainedLeadershipFor(ROUND_1_LEADING);
+    }
+
+    private static PaxosValue round(long sequence, boolean leading) {
+        return new PaxosValue(leading ? LEADER_ID : "other-leader", sequence, null);
+    }
+}

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -17,6 +17,7 @@ package com.palantir.paxos;
 
 import java.io.File;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -79,6 +80,7 @@ public final class PaxosConsensusTestUtils {
                     ImmutableList.<PaxosAcceptor> copyOf(acceptors),
                     ImmutableList.<PaxosLearner> copyOf(learners),
                     quorumSize,
+                    UUID.randomUUID(),
                     executor);
             PaxosLeaderElectionService leader = new PaxosLeaderElectionServiceBuilder()
                     .proposer(proposer)

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -374,7 +374,6 @@ public class PaxosTimeLockServerIntegrationTest {
         getLockService(CLIENT_1).currentTimeMillis();
 
         JsonNode metrics = getMetricsOutput();
-        System.out.println(new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT).writeValueAsString(metrics));
 
         // time / lock services
         assertContainsTimer(metrics,

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
@@ -45,4 +45,8 @@ public class TimeLockServerHolder extends ExternalResource {
     public int getTimelockPort() {
         return timelockServer.getLocalPort();
     }
+
+    public int getAdminPort() {
+        return timelockServer.getAdminPort();
+    }
 }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResource.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResource.java
@@ -51,19 +51,27 @@ public final class PaxosResource {
     }
 
     public static PaxosResource create(String logDirectory) {
-        return new PaxosResource(logDirectory, Maps.newHashMap(), Maps.newHashMap());
+        return new PaxosResource(logDirectory, Maps.newConcurrentMap(), Maps.newConcurrentMap());
     }
 
     public void addInstrumentedClient(String client) {
         Preconditions.checkState(!paxosLearners.containsKey(client),
                 "Paxos resource already has client '%s' registered", client);
 
-        String learnerLogDir = Paths.get(logDirectory, client, PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH).toString();
-        PaxosLearner learner = instrument(PaxosLearner.class, PaxosLearnerImpl.newLearner(learnerLogDir), client);
+        String learnerLogDir = Paths.get(logDirectory, client, PaxosTimeLockConstants.LEARNER_SUBDIRECTORY_PATH)
+                .toString();
+        PaxosLearner learner = instrument(
+                PaxosLearner.class,
+                PaxosLearnerImpl.newLearner(learnerLogDir),
+                client);
         paxosLearners.put(client, learner);
 
-        String acceptorLogDir = Paths.get(logDirectory, client, PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH).toString();
-        PaxosAcceptor acceptor = instrument(PaxosAcceptor.class, PaxosAcceptorImpl.newAcceptor(acceptorLogDir), client);
+        String acceptorLogDir = Paths.get(logDirectory, client, PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH)
+                .toString();
+        PaxosAcceptor acceptor = instrument(
+                PaxosAcceptor.class,
+                PaxosAcceptorImpl.newAcceptor(acceptorLogDir),
+                client);
         paxosAcceptors.put(client, acceptor);
     }
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
@@ -19,6 +19,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -58,6 +59,7 @@ import com.palantir.lock.impl.ThreadPooledLockService;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosProposer;
+import com.palantir.paxos.PaxosProposerImpl;
 import com.palantir.remoting.ssl.SslSocketFactories;
 import com.palantir.timestamp.PersistentTimestampService;
 import com.palantir.timestamp.TimestampBoundStore;
@@ -254,12 +256,15 @@ public class PaxosTimeLockServer implements TimeLockServer {
                 PaxosLearner.class,
                 "timestamp-bound-store." + client);
 
-        PaxosProposer proposer = instrument(PaxosProposer.class, Leaders.createPaxosProposer(
-                ourLearner,
-                ImmutableList.copyOf(acceptors),
-                ImmutableList.copyOf(learners),
-                getQuorumSize(acceptors),
-                executor), client);
+        PaxosProposer proposer = instrument(PaxosProposer.class,
+                PaxosProposerImpl.newProposer(
+                        ourLearner,
+                        ImmutableList.copyOf(acceptors),
+                        ImmutableList.copyOf(learners),
+                        getQuorumSize(acceptors),
+                        UUID.randomUUID(),
+                        executor),
+                client);
 
         PaxosSynchronizer.synchronizeLearner(ourLearner, learners);
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourceTest.java
@@ -85,7 +85,8 @@ public class PaxosResourceTest {
     @Test
     public void throwsIfTryingToAddClientTwice() {
         paxosResource.addInstrumentedClient(CLIENT_1);
-        assertThatThrownBy(() -> paxosResource.addInstrumentedClient(CLIENT_1)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> paxosResource.addInstrumentedClient(CLIENT_1))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourceTest.java
@@ -59,7 +59,7 @@ public class PaxosResourceTest {
 
     @Test
     public void canAddClients() {
-        paxosResource.addClient(CLIENT_1);
+        paxosResource.addInstrumentedClient(CLIENT_1);
         PaxosLearner learner = paxosResource.getPaxosLearner(CLIENT_1);
         learner.learn(PAXOS_ROUND_ONE, PAXOS_VALUE);
         assertThat(learner.getGreatestLearnedValue()).isNotNull();
@@ -73,7 +73,7 @@ public class PaxosResourceTest {
 
     @Test
     public void addsClientsInSubdirectory() {
-        paxosResource.addClient(CLIENT_1);
+        paxosResource.addInstrumentedClient(CLIENT_1);
         File expectedAcceptorLogDir =
                 Paths.get(logDirectory.getPath(), CLIENT_1, PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH).toFile();
         assertThat(expectedAcceptorLogDir.exists()).isTrue();
@@ -84,13 +84,13 @@ public class PaxosResourceTest {
 
     @Test
     public void throwsIfTryingToAddClientTwice() {
-        paxosResource.addClient(CLIENT_1);
-        assertThatThrownBy(() -> paxosResource.addClient(CLIENT_1)).isInstanceOf(IllegalStateException.class);
+        paxosResource.addInstrumentedClient(CLIENT_1);
+        assertThatThrownBy(() -> paxosResource.addInstrumentedClient(CLIENT_1)).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     public void returnsNullIfClientNotAdded() {
-        paxosResource.addClient(CLIENT_1);
+        paxosResource.addInstrumentedClient(CLIENT_1);
         assertThat(paxosResource.getPaxosLearner(CLIENT_2)).isNull();
         assertThat(paxosResource.getPaxosAcceptor(CLIENT_2)).isNull();
     }

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -291,6 +292,7 @@ public class PaxosTimestampBoundStoreTest {
                 ImmutableList.copyOf(acceptors),
                 ImmutableList.copyOf(learners),
                 NUM_NODES / 2 + 1,
+                UUID.randomUUID(),
                 executor);
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Ensure we have instrumentation on all interesting classes in Timelock.
Since we're pushing for Timelock at more deployments, it's important to have rich metrics in place to track/debug performance and stability.

Will be following up with another PR to ensure we are tracking leadership event metrics

**Implementation Description (bullets)**:
Ensures we have instrumentation for the following classes, and that they are named appropriately (some we already had, but just listing all for completeness):
- Local `PingableLeader`, `PaxosAcceptor`, `PaxosLearner`, `PaxosProposer`
- Remote `PingableLeader`s, `PaxosAcceptor`s, `PaxosLearner`s
- Local TimestampBoundStore `PaxosAcceptor`, `PaxosLeader`, `PaxosProposer`, for each client
- Remote TimestampBoundStore `PaxosAcceptor`, `PaxosLeader`, `PaxosProposer`, for each client
- Local `ManagedTimestampService` and `LockService`, for each client

TODO:
- [x] `PaxosTimestampBoundStore`

**Concerns (what feedback would you like?)**:
Am I missing any classes that should be instrumented?

**Where should we start reviewing?**:
`PaxosTimeLockService` and `Leaders`

**Priority (whenever / two weeks / yesterday)**:
soon - we want metrics at deployments that have timelock

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1971)
<!-- Reviewable:end -->
