### PR TITLE
Including down-sampled data.

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
@@ -17,6 +17,12 @@
 
 package com.palantir.atlasdb.performance;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.palantir.atlasdb.performance.backend.DockerizedDatabaseUri;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -30,21 +36,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.DoubleStream;
-import java.util.stream.Stream;
-
 import org.immutables.value.Value;
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.util.Multiset;
 import org.openjdk.jmh.util.Statistics;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.palantir.atlasdb.performance.backend.DockerizedDatabaseUri;
+import org.openjdk.jmh.util.TreeMultiset;
 
 public class PerformanceResults {
     @VisibleForTesting
@@ -65,17 +62,20 @@ public class PerformanceResults {
 
     private static List<ImmutablePerformanceResult> getPerformanceResults(Collection<RunResult> results) {
         long date = System.currentTimeMillis();
-        return results.stream().flatMap(rs -> Stream.of(ImmutablePerformanceResult.builder()
+        return results.stream().map(rs ->  {
+            return ImmutablePerformanceResult.builder()
                 .date(date)
                 .benchmark(getBenchmarkName(rs.getParams()))
                 .samples(rs.getPrimaryResult().getStatistics().getN())
                 .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
                 .mean(rs.getPrimaryResult().getStatistics().getMean())
+                .data(getData(rs))
                 .units(rs.getParams().getTimeUnit())
                 .p50(rs.getPrimaryResult().getStatistics().getPercentile(50.0))
                 .p90(rs.getPrimaryResult().getStatistics().getPercentile(90.0))
                 .p99(rs.getPrimaryResult().getStatistics().getPercentile(99.0))
-                .build())).collect(Collectors.toList());
+                .build();
+        }).collect(Collectors.toList());
     }
 
     @VisibleForTesting
@@ -99,21 +99,49 @@ public class PerformanceResults {
     }
 
     private static List<Double> getData(RunResult result) {
-        return result.getBenchmarkResults().stream()
-                .flatMap(b -> getRawResults(b.getPrimaryResult().getStatistics()).stream())
-                .collect(Collectors.toList());
+        return getRawResults(result.getPrimaryResult().getStatistics());
     }
 
     private static List<Double> getRawResults(Statistics statistics) {
+
         try {
             Field field = statistics.getClass().getDeclaredField("values");
             field.setAccessible(true);
             Multiset<Double> rawResults = (Multiset<Double>) field.get(statistics);
-            return rawResults.entrySet().stream()
-                    .flatMap(e -> DoubleStream.iterate(e.getKey(), d -> d).limit(e.getValue()).boxed())
-                    .collect(Collectors.toList());
+            return downSample(rawResults);
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            return Lists.newArrayList();
+            String msg = new StringBuilder().append("Could not get values from statistics !")
+                    .append("\n\t statistics.class = ").append(statistics.getClass().getName())
+                    .append("\n\t statistics.size = ").append(statistics.getN())
+                    .toString();
+            throw new RuntimeException(msg, e);
+        }
+    }
+
+    private static List<Double> downSample(Multiset<Double> multisetParam) {
+
+        final TreeMultiset<Double> values = asTreeMultiset(multisetParam);
+        final long totalCount = values.size();
+        final int maximumFinalSize = 100;
+        final List<Double> list = Lists.newArrayList();
+
+        int current = 0;
+        for (double d : values.keys()) {
+            current += values.count(d);
+            while( 1.0 * maximumFinalSize * current / totalCount >= (list.size() + 1)) {
+                list.add(d);
+            }
+        }
+        return list;
+    }
+
+    private static TreeMultiset<Double> asTreeMultiset(Multiset<Double> multisetParam) {
+        if (multisetParam instanceof TreeMultiset) {
+            return (TreeMultiset<Double>)multisetParam;
+        } else {
+            TreeMultiset<Double> values = new TreeMultiset<>();
+            multisetParam.keys().forEach(key -> values.add(key, multisetParam.count(key)));
+            return values;
         }
     }
 
@@ -126,6 +154,7 @@ public class PerformanceResults {
         public abstract long samples();
         public abstract double std();
         public abstract double mean();
+        public abstract List<Double> data();
         public abstract TimeUnit units();
         public abstract double p50();
         public abstract double p90();

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
@@ -17,12 +17,6 @@
 
 package com.palantir.atlasdb.performance;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.palantir.atlasdb.performance.backend.DockerizedDatabaseUri;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -42,6 +36,12 @@ import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.util.Multiset;
 import org.openjdk.jmh.util.Statistics;
 import org.openjdk.jmh.util.TreeMultiset;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.palantir.atlasdb.performance.backend.DockerizedDatabaseUri;
 
 public class PerformanceResults {
     @VisibleForTesting
@@ -62,19 +62,19 @@ public class PerformanceResults {
 
     private static List<ImmutablePerformanceResult> getPerformanceResults(Collection<RunResult> results) {
         long date = System.currentTimeMillis();
-        return results.stream().map(rs ->  {
+        return results.stream().map(rs -> {
             return ImmutablePerformanceResult.builder()
-                .date(date)
-                .benchmark(getBenchmarkName(rs.getParams()))
-                .samples(rs.getPrimaryResult().getStatistics().getN())
-                .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
-                .mean(rs.getPrimaryResult().getStatistics().getMean())
-                .data(getData(rs))
-                .units(rs.getParams().getTimeUnit())
-                .p50(rs.getPrimaryResult().getStatistics().getPercentile(50.0))
-                .p90(rs.getPrimaryResult().getStatistics().getPercentile(90.0))
-                .p99(rs.getPrimaryResult().getStatistics().getPercentile(99.0))
-                .build();
+                    .date(date)
+                    .benchmark(getBenchmarkName(rs.getParams()))
+                    .samples(rs.getPrimaryResult().getStatistics().getN())
+                    .std(rs.getPrimaryResult().getStatistics().getStandardDeviation())
+                    .mean(rs.getPrimaryResult().getStatistics().getMean())
+                    .data(getData(rs))
+                    .units(rs.getParams().getTimeUnit())
+                    .p50(rs.getPrimaryResult().getStatistics().getPercentile(50.0))
+                    .p90(rs.getPrimaryResult().getStatistics().getPercentile(90.0))
+                    .p99(rs.getPrimaryResult().getStatistics().getPercentile(99.0))
+                    .build();
         }).collect(Collectors.toList());
     }
 
@@ -128,7 +128,7 @@ public class PerformanceResults {
         int current = 0;
         for (double d : values.keys()) {
             current += values.count(d);
-            while( 1.0 * maximumFinalSize * current / totalCount >= (list.size() + 1)) {
+            while (1.0 * maximumFinalSize * current / totalCount >= (list.size() + 1)) {
                 list.add(d);
             }
         }
@@ -137,7 +137,7 @@ public class PerformanceResults {
 
     private static TreeMultiset<Double> asTreeMultiset(Multiset<Double> multisetParam) {
         if (multisetParam instanceof TreeMultiset) {
-            return (TreeMultiset<Double>)multisetParam;
+            return (TreeMultiset<Double>) multisetParam;
         } else {
             TreeMultiset<Double> values = new TreeMultiset<>();
             multisetParam.keys().forEach(key -> values.add(key, multisetParam.count(key)));

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/PerformanceResults.java
@@ -122,7 +122,7 @@ public class PerformanceResults {
 
         final TreeMultiset<Double> values = asTreeMultiset(multisetParam);
         final long totalCount = values.size();
-        final int maximumFinalSize = 100;
+        final int maximumFinalSize = 500;
         final List<Double> list = Lists.newArrayList();
 
         int current = 0;

--- a/atlasdb-perf/src/test/java/com/palantir/atlasdb/performance/PerformanceResultsTest.java
+++ b/atlasdb-perf/src/test/java/com/palantir/atlasdb/performance/PerformanceResultsTest.java
@@ -17,9 +17,16 @@ package com.palantir.atlasdb.performance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
+import org.assertj.core.util.Lists;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.WorkloadParams;
+import org.openjdk.jmh.util.MultisetStatistics;
 
 import com.palantir.atlasdb.performance.backend.CassandraKeyValueServiceInstrumentation;
 
@@ -38,6 +45,22 @@ public class PerformanceResultsTest {
     private static final String FORMATTED_BENCHMARK_NAME_CASSANDRA
             = FORMATTED_BENCHMARK_NAME + "-" + new CassandraKeyValueServiceInstrumentation().toString();
 
+    private static final RunResult mockRunResult = Mockito.mock(RunResult.class);
+    private static final Result mockResult = Mockito.mock(Result.class);
+    private static final List<Double> SMALL_SAMPLE = Lists.newArrayList();
+    private static final List<Double> LARGE_SAMPLE = Lists.newArrayList();
+
+
+    static {
+        Mockito.when(mockRunResult.getPrimaryResult()).thenReturn(mockResult);
+        for (int i = 0; i < PerformanceResults.DOWNSAMPLE_MAXIMUM_SIZE; ++i) {
+            SMALL_SAMPLE.add(Double.valueOf(i));
+            LARGE_SAMPLE.add(Double.valueOf(3 * i));
+            LARGE_SAMPLE.add(Double.valueOf(3 * i + 1));
+            LARGE_SAMPLE.add(Double.valueOf(3 * i + 2));
+        }
+    }
+
     @Test
     public void canGenerateBenchmarkNameForTestWithoutKeyValueService() {
         BenchmarkParams params = createBenchmarkParams(FULL_BENCHMARK_NAME, "foo", "bar");
@@ -52,6 +75,47 @@ public class PerformanceResultsTest {
                 DOCKERIZED_CASSANDRA_URI);
 
         assertThat(PerformanceResults.getBenchmarkName(params)).isEqualTo(FORMATTED_BENCHMARK_NAME_CASSANDRA);
+    }
+
+    @Test
+    public void doesNotDownsampleSmallSample() {
+        MultisetStatistics stats = new MultisetStatistics();
+        for (double number : SMALL_SAMPLE) {
+            stats.addValue(number, 1);
+        }
+        Mockito.when(mockResult.getStatistics()).thenReturn(stats);
+        assertThat(PerformanceResults.getData(mockRunResult)).containsExactlyElementsOf(SMALL_SAMPLE);
+    }
+
+    @Test
+    public void downSamplesCorrectlyWhenUniform() {
+        MultisetStatistics stats = new MultisetStatistics();
+        for (int i = 0; i < 10; ++i) {
+            for (double number : SMALL_SAMPLE) {
+                stats.addValue(number, 2);
+            }
+        }
+        Mockito.when(mockResult.getStatistics()).thenReturn(stats);
+        assertThat(PerformanceResults.getData(mockRunResult)).containsExactlyElementsOf(SMALL_SAMPLE);
+    }
+
+    @Test
+    public void downSampledDistributionIsRepresentativeForReasonableData() {
+        MultisetStatistics stats = new MultisetStatistics();
+        for (double number : LARGE_SAMPLE) {
+            int elements = (int) (10 * PerformanceResults.DOWNSAMPLE_MAXIMUM_SIZE
+                    / (Math.abs(PerformanceResults.DOWNSAMPLE_MAXIMUM_SIZE - number) + 1));
+            stats.addValue(number,  elements);
+        }
+        Mockito.when(mockResult.getStatistics()).thenReturn(stats);
+        List<Double> downSampledData = PerformanceResults.getData(mockRunResult);
+
+        MultisetStatistics downSampledStats = new MultisetStatistics();
+        for (double number : downSampledData) {
+            downSampledStats.addValue(number, 1);
+        }
+
+        assertThat(stats.compareTo(downSampledStats)).isEqualTo(0);
     }
 
     private static BenchmarkParams createBenchmarkParams(String benchmarkName, String paramKey, String paramValue) {


### PR DESCRIPTION
**Goals (and why)**:

- Align the emitted results JSON with the Benchmarking API so that Atlas benchmarks can be run from Benchmark-Orchestration/develop instead of Benchmark-Orchestration/long-lived/atlasdb

**Implementation Description (bullets)**:

- Down-sample samples to avoid OOMing
- Include "data" in JSON output

**Concerns (what feedback would you like?)**:

- How many samples should we downsample to?

**More Context**:

Corresponding Benchmark-Orchestration change: https://github.palantir.build/gotham/benchmark-orchestration/pull/263

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1973)
<!-- Reviewable:end -->
