### PR TITLE
Live reload sweep configs

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -132,7 +132,10 @@ public abstract class AtlasDbConfig {
      * have been overwritten or deleted. This differs from scrubbing
      * because it is an untargeted cleaning process that scans all data
      * looking for cells to delete.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#enableSweep} to make this value
+     * live-reloadable.
      */
+    @Deprecated
     @Value.Default
     public boolean enableSweep() {
         return AtlasDbConstants.DEFAULT_ENABLE_SWEEP;
@@ -141,7 +144,10 @@ public abstract class AtlasDbConfig {
     /**
      * The number of milliseconds to wait between each batch of cells
      * processed by the background sweeper.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepPauseMillis} to make this value
+     * live-reloadable.
      */
+    @Deprecated
     @Value.Default
     public long getSweepPauseMillis() {
         return AtlasDbConstants.DEFAULT_SWEEP_PAUSE_MILLIS;
@@ -158,39 +164,44 @@ public abstract class AtlasDbConfig {
 
     /**
      * The target number of (cell, timestamp) pairs to examine in a single run of the background sweeper.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepReadLimit} to make this value
+     * live-reloadable.
      */
-    // TODO(gbonik): make this Default after we delete the deprecated options. For now, we need to be able to detect
-    // whether the field is present in the configuration file.
+    @Deprecated
     @Nullable
     public abstract Integer getSweepReadLimit();
 
     /**
      * The target number of candidate (cell, timestamp) pairs to load per batch while sweeping.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepCandidateBatchHint} to make this value
+     * live-reloadable.
      */
-    // TODO(gbonik): make this Default after we delete the deprecated options. For now, we need to be able to detect
-    // whether the field is present in the configuration file.
+    @Deprecated
     @Nullable
     public abstract Integer getSweepCandidateBatchHint();
 
     /**
      * The target number of (cell, timestamp) pairs to delete at once while sweeping.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepDeleteBatchHint} to make this value
+     * live-reloadable.
      */
-    // TODO(gbonik): make this Default after we delete the deprecated options. For now, we need to be able to detect
-    // whether the field is present in the configuration file.
+    @Deprecated
     @Nullable
     public abstract Integer getSweepDeleteBatchHint();
 
     /**
-     * @deprecated Use {@link #getSweepReadLimit()}, {@link #getSweepCandidateBatchHint()}
-     * and {@link #getSweepDeleteBatchHint()} instead.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepReadLimit()},
+     * {@link AtlasDbRuntimeConfig#sweepConfig#getSweepCandidateBatchHint()} and
+     * {@link AtlasDbRuntimeConfig#sweepConfig#getSweepDeleteBatchHint()}.
      */
     @Deprecated
     @Nullable
     public abstract Integer getSweepBatchSize();
 
     /**
-     * @deprecated Use {@link #getSweepReadLimit()}, {@link #getSweepCandidateBatchHint()}
-     * and {@link #getSweepDeleteBatchHint()} instead.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepReadLimit()},
+     * {@link AtlasDbRuntimeConfig#sweepConfig#getSweepCandidateBatchHint()} and
+     * {@link AtlasDbRuntimeConfig#sweepConfig#getSweepDeleteBatchHint()}.
      */
     @Deprecated
     @Nullable
@@ -228,16 +239,14 @@ public abstract class AtlasDbConfig {
 
         Preconditions.checkState(lock().isPresent() == timestamp().isPresent(),
                 "Lock and timestamp server blocks must either both be present or both be absent.");
-        if (getSweepBatchSize() != null || getSweepCellBatchSize() != null) {
-            Preconditions.checkState(
-                    getSweepReadLimit() == null
-                            && getSweepCandidateBatchHint() == null
-                            && getSweepDeleteBatchHint() == null,
-                    "Your configuration mixes both the old and the new parameters"
-                            + " for setting sweep batch sizes. Please use 'sweepMaxCellTsPairsToExamine',"
-                            + " 'sweepCandidateBatchSize' and 'sweepDeleteBatchSize' instead of the deprecated"
-                            + " 'sweepBatchSize' and 'sweepCellBatchSize'.");
-        }
+
+        Preconditions.checkState(getSweepBatchSize() == null
+                        && getSweepCellBatchSize() == null
+                        && getSweepReadLimit() == null
+                        && getSweepCandidateBatchHint() == null
+                        && getSweepDeleteBatchHint() == null,
+                "Your configuration specifies sweep parameters on the install config."
+                        + " Please use the runtime config to specify them.");
     }
 
     private boolean areTimeAndLockConfigsAbsent() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -132,7 +132,7 @@ public abstract class AtlasDbConfig {
      * have been overwritten or deleted. This differs from scrubbing
      * because it is an untargeted cleaning process that scans all data
      * looking for cells to delete.
-     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#enableSweep} to make this value
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweep#enableSweep} to make this value
      * live-reloadable.
      */
     @Deprecated
@@ -144,7 +144,7 @@ public abstract class AtlasDbConfig {
     /**
      * The number of milliseconds to wait between each batch of cells
      * processed by the background sweeper.
-     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepPauseMillis} to make this value
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweep#getSweepPauseMillis} to make this value
      * live-reloadable.
      */
     @Deprecated
@@ -164,7 +164,7 @@ public abstract class AtlasDbConfig {
 
     /**
      * The target number of (cell, timestamp) pairs to examine in a single run of the background sweeper.
-     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepReadLimit} to make this value
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweep#getSweepReadLimit} to make this value
      * live-reloadable.
      */
     @Deprecated
@@ -173,7 +173,7 @@ public abstract class AtlasDbConfig {
 
     /**
      * The target number of candidate (cell, timestamp) pairs to load per batch while sweeping.
-     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepCandidateBatchHint} to make this value
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweep#getSweepCandidateBatchHint} to make this value
      * live-reloadable.
      */
     @Deprecated
@@ -182,7 +182,7 @@ public abstract class AtlasDbConfig {
 
     /**
      * The target number of (cell, timestamp) pairs to delete at once while sweeping.
-     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepDeleteBatchHint} to make this value
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweep#getSweepDeleteBatchHint} to make this value
      * live-reloadable.
      */
     @Deprecated
@@ -190,18 +190,18 @@ public abstract class AtlasDbConfig {
     public abstract Integer getSweepDeleteBatchHint();
 
     /**
-     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepReadLimit()},
-     * {@link AtlasDbRuntimeConfig#sweepConfig#getSweepCandidateBatchHint()} and
-     * {@link AtlasDbRuntimeConfig#sweepConfig#getSweepDeleteBatchHint()}.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweep#getSweepReadLimit()},
+     * {@link AtlasDbRuntimeConfig#sweep#getSweepCandidateBatchHint()} and
+     * {@link AtlasDbRuntimeConfig#sweep#getSweepDeleteBatchHint()}.
      */
     @Deprecated
     @Nullable
     public abstract Integer getSweepBatchSize();
 
     /**
-     * @deprecated Use {@link AtlasDbRuntimeConfig#sweepConfig#getSweepReadLimit()},
-     * {@link AtlasDbRuntimeConfig#sweepConfig#getSweepCandidateBatchHint()} and
-     * {@link AtlasDbRuntimeConfig#sweepConfig#getSweepDeleteBatchHint()}.
+     * @deprecated Use {@link AtlasDbRuntimeConfig#sweep#getSweepReadLimit()},
+     * {@link AtlasDbRuntimeConfig#sweep#getSweepCandidateBatchHint()} and
+     * {@link AtlasDbRuntimeConfig#sweep#getSweepDeleteBatchHint()}.
      */
     @Deprecated
     @Nullable

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.config;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonDeserialize(as = ImmutableAtlasDbRuntimeConfig.class)
+@JsonSerialize(as = ImmutableAtlasDbRuntimeConfig.class)
+@Value.Immutable
+public abstract class AtlasDbRuntimeConfig {
+
+    @Value.Default
+    public SweepConfig sweep() {
+        return SweepConfig.defaultSweepConfig();
+    }
+
+    public static ImmutableAtlasDbRuntimeConfig defaultRuntimeConfig() {
+        return ImmutableAtlasDbRuntimeConfig.builder()
+                .sweep(SweepConfig.defaultSweepConfig())
+                .build();
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/SweepConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/SweepConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.config;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.atlasdb.AtlasDbConstants;
+
+@JsonDeserialize(as = ImmutableSweepConfig.class)
+@JsonSerialize(as = ImmutableSweepConfig.class)
+@Value.Immutable
+public class SweepConfig {
+    /**
+     * If true, a background thread will periodically delete cells that
+     * have been overwritten or deleted. This differs from scrubbing
+     * because it is an untargeted cleaning process that scans all data
+     * looking for cells to delete.
+     */
+    @Value.Default
+    public Boolean enabled() {
+        return AtlasDbConstants.DEFAULT_ENABLE_SWEEP;
+    }
+
+    /**
+     * The number of milliseconds to wait between each batch of cells
+     * processed by the background sweeper.
+     */
+    @Value.Default
+    public long pauseMillis() {
+        return AtlasDbConstants.DEFAULT_SWEEP_PAUSE_MILLIS;
+    }
+
+    /**
+     * The target number of (cell, timestamp) pairs to examine in a single run of the background sweeper.
+     */
+    @Value.Default
+    public Integer readLimit() {
+        return AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT;
+    }
+
+    /**
+     * The target number of candidate (cell, timestamp) pairs to load per batch while sweeping.
+     */
+    @Value.Default
+    public Integer candidateBatchHint() {
+        return AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT;
+    }
+
+    /**
+     * The target number of (cell, timestamp) pairs to delete at once while sweeping.
+     */
+    @Value.Default
+    public Integer deleteBatchHint() {
+        return AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT;
+    }
+
+    public static SweepConfig defaultSweepConfig() {
+        return ImmutableSweepConfig.builder()
+                .enabled(AtlasDbConstants.DEFAULT_ENABLE_SWEEP)
+                .pauseMillis(AtlasDbConstants.DEFAULT_SWEEP_PAUSE_MILLIS)
+                .readLimit(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
+                .candidateBatchHint(AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT)
+                .deleteBatchHint(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
+                .build();
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -161,7 +161,8 @@ public class TransactionManagersTest {
                 .keyValueService(new InMemoryAtlasDbConfig())
                 .defaultLockTimeoutSeconds((int) expectedTimeout.getTime())
                 .build();
-        TransactionManagers.create(realConfig, ImmutableSet.of(), environment, false);
+        TransactionManagers.create(realConfig, Optional::empty,
+                ImmutableSet.of(), environment, false);
 
         assertEquals(expectedTimeout, LockRequest.getDefaultLockTimeout());
 

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -21,6 +21,7 @@ import com.palantir.atlasdb.api.AtlasDbService
 import com.palantir.atlasdb.api.TransactionToken
 import com.palantir.atlasdb.config.AtlasDbConfig
 import com.palantir.atlasdb.config.AtlasDbConfigs
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig
 import com.palantir.atlasdb.console.AtlasConsoleModule
 import com.palantir.atlasdb.console.AtlasConsoleService
 import com.palantir.atlasdb.console.AtlasConsoleServiceImpl
@@ -34,6 +35,7 @@ import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager
 import groovy.json.JsonBuilder
 import groovy.json.JsonOutput
 import groovy.transform.CompileStatic
+import java.util.function.Supplier
 
 /**
  * Public methods that clients can call within AtlasConsole.
@@ -164,7 +166,15 @@ class AtlasCoreModule implements AtlasConsoleModule {
     }
 
     private setupConnection(AtlasDbConfig config) {
-        SerializableTransactionManager tm = TransactionManagers.create(config, ImmutableSet.<Schema>of(),
+        SerializableTransactionManager tm = TransactionManagers.create(
+                config,
+                new Supplier<Optional<AtlasDbRuntimeConfig>>() {
+                    @Override
+                    Optional<AtlasDbRuntimeConfig> get() {
+                        return Optional.empty();
+                    }
+                },
+                ImmutableSet.<Schema>of(),
                 new com.palantir.atlasdb.factory.TransactionManagers.Environment() {
                     @Override
                     public void register(Object resource) {

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -80,6 +81,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
             try {
                 return TransactionManagers.create(
                         config.getAtlasDbConfig(),
+                        Optional::empty,
                         ETE_SCHEMAS,
                         environment.jersey()::register,
                         DONT_SHOW_HIDDEN_TABLES);

--- a/atlasdb-service-server/src/main/java/com/palantir/atlasdb/server/AtlasDbServiceServer.java
+++ b/atlasdb-service-server/src/main/java/com/palantir/atlasdb/server/AtlasDbServiceServer.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.server;
 
+import java.util.Optional;
+
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.impl.AtlasDbServiceImpl;
@@ -46,6 +48,7 @@ public class AtlasDbServiceServer extends Application<AtlasDbServiceServerConfig
 
         SerializableTransactionManager tm = TransactionManagers.create(
                 config.getConfig(),
+                Optional::empty,
                 ImmutableSet.of(),
                 environment.jersey()::register,
                 false);

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -28,8 +28,13 @@ In addition to the ``keyValueServiceConfig``, you must specify a configuration f
 If you are using an embedded timestamp and lock service, see the :ref:`Leader Configuration <leader-config>` documentation.
 If you are using the :ref:`external Timelock service <external-timelock-service>`, then see the :ref:`Timelock client configuration <timelock-client-configuration>`.
 
-Other parameters related to :ref:`Sweep <sweep>` can also be specified here. For a full list of the configurations
-available at the ``atlasdb`` root level, see `AtlasDbConfig.java <https://github.com/palantir/atlasdb/blob/develop/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java>`__.
+For a full list of the configurations available at the ``atlasdb`` root level, see
+`AtlasDbConfig.java <https://github.com/palantir/atlasdb/blob/develop/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java>`__.
+
+A second root configuration block, denoted ``atlasdb-runtime``, can be specified for live-reloadable configs.
+Parameters related to :ref:`Sweep <sweep>` can be specified there and will be reloaded in each sweep run.
+For a full list of the configurations available at this block, see
+`AtlasDbRuntimeConfig.java <https://github.com/palantir/atlasdb/blob/develop/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java>`__.
 
 Example Configuration
 =====================
@@ -72,7 +77,7 @@ Example Configuration
         sslConfiguration:
           trustStorePath: var/security/truststore.jks
 
-      enableSweep: false
-      sweepBatchSize: 1000
 
-
+    atlasdb-runtime:
+      sweep:
+        enableSweep: false

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -80,4 +80,4 @@ Example Configuration
 
     atlasdb-runtime:
       sweep:
-        enableSweep: false
+        enabled: false

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,35 +65,37 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2060>`__)
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2060>`__)
 
+    *    - |new|
          - Added support for live-reloading sweep configs.
 
-           There's a new set of `TransactionManagers.create()` methods, which accept a Supplier of the AtlasDbRuntimeConfig. The parameters of the new config are Sweep related:
+           There's a new set of `TransactionManagers.create()` methods, which accept a Supplier of the AtlasDbRuntimeConfig.
+           The AtlasDbRuntimeConfig wraps a SweepConfig block with the options:
 
-             - `enableSweep`
-             - `getSweepPauseMillis`
-             - `getSweepReadLimit`
-             - `getSweepCandidateBatchHint`
-             - `getSweepDeleteBatchHint`
+             - `enabled`
+             - `pauseMillis`
+             - `readLimit`
+             - `candidateBatchHint`
+             - `deleteBatchHint`
 
            The parameters are loaded and used at every sweep run. Please check :ref:`Sweep <sweep>` for information on how to use them.
 
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1976>`__)
 
     *    - |userbreak|
-         - As part of the live-reloading work, were deprecated the sweep options of the AtlasDB config, namely:
+         - As part of the live-reloading work, were deprecated the sweep options of the install config, namely:
 
-           - `enableSweep`
-           - `getSweepPauseMillis`
-           - `getSweepReadLimit`
-           - `getSweepCandidateBatchHint`
-           - `getSweepDeleteBatchHint`
+             - `enableSweep`
+             - `sweepPauseMillis`
+             - `sweepReadLimit`
+             - `sweepCandidateBatchHint`
+             - `sweepDeleteBatchHint`
 
            If any of these options are specified in the install config, **AtlasDB will fail to start**. Please specify them on the runtime config.
 
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1976>`__)
 
     *    - |devbreak|
-         - As part of the live-reloading work, were removed the methods `TransactionManagers.create()` without the AtlasDB runtime config.
+         - As part of the live-reloading work, the methods `TransactionManagers.create()` without the runtime config parameter were removed.
            If needed, the helper method `AtlasDbRuntimeConfig.defaultRuntimeConfig()` can be used to create a runtime config with the default values.
 
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1976>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,6 +65,40 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2060>`__)
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2060>`__)
 
+         - Added support for live-reloading sweep configs.
+
+           There's a new set of `TransactionManagers.create()` methods, which accept a Supplier of the AtlasDbRuntimeConfig. The parameters of the new config are Sweep related:
+
+             - `enableSweep`
+             - `getSweepPauseMillis`
+             - `getSweepReadLimit`
+             - `getSweepCandidateBatchHint`
+             - `getSweepDeleteBatchHint`
+
+           The parameters are loaded and used at every sweep run. Please check :ref:`Sweep <sweep>` for information on how to use them.
+
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1976>`__)
+
+    *    - |userbreak|
+         - As part of the live-reloading work, were deprecated the sweep options of the AtlasDB config, namely:
+
+           - `enableSweep`
+           - `getSweepPauseMillis`
+           - `getSweepReadLimit`
+           - `getSweepCandidateBatchHint`
+           - `getSweepDeleteBatchHint`
+
+           If any of these options are specified in the install config, **AtlasDB will fail to start**. Please specify them on the runtime config.
+
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1976>`__)
+
+    *    - |devbreak|
+         - As part of the live-reloading work, were removed the methods `TransactionManagers.create()` without the AtlasDB runtime config.
+           If needed, the helper method `AtlasDbRuntimeConfig.defaultRuntimeConfig()` can be used to create a runtime config with the default values.
+
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1976>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 ======


### PR DESCRIPTION
**Goals (and why)**: AtlasDB customers should be able to live reload sweep configs, e.g. disabling sweep to reduce load on the Cassandra boxes.

**Implementation Description (bullets)**:
- Create an AtlasDbRuntimeConfig file to host live-reloadable config options.
- Add appropriate endpoints on TransactionManagers.

**Concerns (what feedback would you like?)**:
- Is this the correct approach?
- Are there any tests valuable to be added?

**Where should we start reviewing?**: TransactionManagers.

**Priority (whenever / two weeks / yesterday)**: Soon, since live-reload it's a somewhat high priority feature request.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1976)
<!-- Reviewable:end -->
