### PR TITLE
multi node timelock test

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -47,6 +47,8 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
 
     private static final Logger log = LoggerFactory.getLogger(AwaitingLeadershipProxy.class);
 
+    private static final long MAX_NO_QUORUM_RETRIES = 10;
+
     public static <U> U newProxyInstance(Class<U> interfaceClass,
                                          Supplier<U> delegateSupplier,
                                          LeaderElectionService leaderElectionService) {
@@ -153,12 +155,18 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         }
 
         Object delegate = delegateRef.get();
-        StillLeadingStatus leading;
-        do {
+        StillLeadingStatus leading = null;
+        for (int i = 0; i < MAX_NO_QUORUM_RETRIES; i++) {
+            // TODO(nziebart): check if leadershipTokenRef has been nulled out between iterations?
             leading = leaderElectionService.isStillLeading(leadershipToken);
-        } while (leading == StillLeadingStatus.NO_QUORUM);
+            if (leading != StillLeadingStatus.NO_QUORUM) {
+                break;
+            }
+        }
 
-        if (leading == StillLeadingStatus.NOT_LEADING) {
+        // treat a repeated NO_QUORUM as NOT_LEADING; likely we've been cut off from the other nodes
+        // and should assume we're not the leader
+        if (leading == StillLeadingStatus.NOT_LEADING || leading == StillLeadingStatus.NO_QUORUM) {
             markAsNotLeading(leadershipToken, null /* cause */);
         }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -39,7 +39,10 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
     private static final String CLIENT = "isolated";
 
     private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
-            "http://localhost", "test","paxosThreeServers.yml");
+            "http://localhost",
+            CLIENT,
+            "paxosThreeServers.yml");
+
     private static final TestableTimelockServer SERVER = CLUSTER.servers().get(0);
 
     @ClassRule
@@ -62,7 +65,6 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
         assertThatThrownBy(() -> SERVER.timestampManagementService().fastForwardTimestamp(1000L))
                 .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
-
 
     @Test
     public void canPingWithoutQuorum() {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/IsolatedPaxosTimeLockServerIntegrationTest.java
@@ -16,29 +16,19 @@
 
 package com.palantir.atlasdb.timelock;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.File;
 import java.util.Optional;
-
-import javax.net.ssl.SSLSocketFactory;
 
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.junit.rules.TemporaryFolder;
 
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
-import com.palantir.leader.PingableLeader;
-import com.palantir.lock.RemoteLockService;
+import com.palantir.atlasdb.timelock.util.ExceptionMatchers;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
-import com.palantir.timestamp.TimestampManagementService;
-import com.palantir.timestamp.TimestampService;
-
-import io.dropwizard.testing.ResourceHelpers;
 
 /**
  * This test creates a single TimeLock server that is configured in a three node configuration.
@@ -48,47 +38,35 @@ import io.dropwizard.testing.ResourceHelpers;
 public class IsolatedPaxosTimeLockServerIntegrationTest {
     private static final String CLIENT = "isolated";
 
-    private static final Optional<SSLSocketFactory> NO_SSL = Optional.empty();
-
-    private static final File TIMELOCK_CONFIG_TEMPLATE =
-            new File(ResourceHelpers.resourceFilePath("paxosThreeServers.yml"));
-
-    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
-    private static final TemporaryConfigurationHolder TEMPORARY_CONFIG_HOLDER =
-            new TemporaryConfigurationHolder(TEMPORARY_FOLDER, TIMELOCK_CONFIG_TEMPLATE);
-    private static final TimeLockServerHolder TIMELOCK_SERVER_HOLDER =
-            new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation);
+    private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
+            "http://localhost", "test","paxosThreeServers.yml");
+    private static final TestableTimelockServer SERVER = CLUSTER.servers().get(0);
 
     @ClassRule
-    public static final RuleChain ruleChain = RuleChain.outerRule(TEMPORARY_FOLDER)
-            .around(TEMPORARY_CONFIG_HOLDER)
-            .around(TIMELOCK_SERVER_HOLDER);
+    public static final RuleChain ruleChain = CLUSTER.getRuleChain();
 
     @Test
     public void cannotIssueTimestampsWithoutQuorum() {
-        assertThatThrownBy(() -> getTimestampService(CLIENT).getFreshTimestamp())
-                .satisfies(this::isRetryableExceptionWhereLeaderCannotBeFound);
+        assertThatThrownBy(() -> SERVER.getFreshTimestamp())
+                .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void cannotIssueLocksWithoutQuorum() {
-        assertThatThrownBy(() -> getLockService(CLIENT).currentTimeMillis())
-                .satisfies(this::isRetryableExceptionWhereLeaderCannotBeFound);
+        assertThatThrownBy(() -> SERVER.lockService().currentTimeMillis())
+                .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
 
     @Test
     public void cannotPerformTimestampManagementWithoutQuorum() {
-        assertThatThrownBy(() -> getTimestampManagementService(CLIENT).fastForwardTimestamp(1000L))
-                .satisfies(this::isRetryableExceptionWhereLeaderCannotBeFound);
+        assertThatThrownBy(() -> SERVER.timestampManagementService().fastForwardTimestamp(1000L))
+                .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
     }
+
 
     @Test
     public void canPingWithoutQuorum() {
-        PingableLeader leader = AtlasDbHttpClients.createProxy(
-                NO_SSL,
-                "http://localhost:" + TIMELOCK_SERVER_HOLDER.getTimelockPort(),
-                PingableLeader.class);
-        leader.ping(); // should succeed
+        SERVER.leaderPing(); // should succeed
     }
 
     @Test
@@ -103,46 +81,15 @@ public class IsolatedPaxosTimeLockServerIntegrationTest {
         learner.getGreatestLearnedValue();
     }
 
-    private void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
-        assertThat(throwable)
-                .hasMessageContaining("method invoked on a non-leader");
-
-        // We shade Feign, so we can't rely on our client's RetryableException exactly matching ours.
-        assertThat(throwable.getClass().getName())
-                .contains("RetryableException");
-    }
-
-    private static RemoteLockService getLockService(String client) {
-        return getProxyForService(client, RemoteLockService.class);
-    }
-
-    private static TimestampService getTimestampService(String client) {
-        return getProxyForService(client, TimestampService.class);
-    }
-
-    private static TimestampManagementService getTimestampManagementService(String client) {
-        return getProxyForService(client, TimestampManagementService.class);
-    }
-
-    private static <T> T getProxyForService(String client, Class<T> clazz) {
-        return AtlasDbHttpClients.createProxy(
-                NO_SSL,
-                getRootUriForClient(client),
-                clazz);
-    }
-
     private static <T> T createProxyForInternalNamespacedTestService(Class<T> clazz) {
         return AtlasDbHttpClients.createProxy(
-                NO_SSL,
+                Optional.empty(),
                 String.format("http://localhost:%d/%s/%s/%s",
-                        TIMELOCK_SERVER_HOLDER.getTimelockPort(),
+                        SERVER.serverHolder().getTimelockPort(),
                         PaxosTimeLockConstants.INTERNAL_NAMESPACE,
                         PaxosTimeLockConstants.CLIENT_PAXOS_NAMESPACE,
                         CLIENT),
                 clazz);
     }
 
-    private static String getRootUriForClient(String client) {
-        return String.format("http://localhost:%d/%s", TIMELOCK_SERVER_HOLDER.getTimelockPort(), client);
-    }
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -84,12 +84,9 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @Test
     public void new_leader_takes_over_if_current_leader_dies() {
-        TestableTimelockServer oldLeader = CLUSTER.currentLeader();
+        CLUSTER.currentLeader().kill();
 
-        oldLeader.kill();
-        CLUSTER.waitUntilLeaderIsElected();
-
-        CLUSTER.currentLeader().getFreshTimestamp();
+        CLUSTER.getFreshTimestamp();
     }
 
     @Test

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.timelock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.StringLockDescriptor;
+
+import feign.RetryableException;
+
+public class MultiNodePaxosTimeLockServerIntegrationTest {
+    private static final String CLIENT_1 = "test";
+
+    private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
+            "http://localhost",
+            CLIENT_1,
+            "paxosMultiServer0.yml",
+            "paxosMultiServer1.yml",
+            "paxosMultiServer2.yml");
+
+    private static final String LOCK_CLIENT = LockClient.ANONYMOUS.getClientId();
+    private static final LockRequest LOCK_REQUEST = LockRequest.builder(
+            ImmutableSortedMap.of(
+                    StringLockDescriptor.of("lock1"),
+                    LockMode.WRITE))
+            .doNotBlock()
+            .build();
+
+    @ClassRule
+    public static final RuleChain ruleChain = CLUSTER.getRuleChain();
+
+    @BeforeClass
+    public static void waitForClusterToStabilize() {
+        CLUSTER.waitUntilLeaderIsElected();
+    }
+
+    @Before
+    public void bringAllNodesOnline() {
+        CLUSTER.waitUntillAllSeversAreOnlineAndLeaderIsElected();
+    }
+
+    @Test
+    public void non_leaders_return_503() {
+        CLUSTER.nonLeaders().forEach(server -> {
+            assertThatThrownBy(() -> server.getFreshTimestamp())
+                    .isInstanceOf(RetryableException.class);
+            assertThatThrownBy(() -> server.lock(LOCK_CLIENT, LOCK_REQUEST))
+                    .isInstanceOf(RetryableException.class);
+        });
+    }
+
+    @Test
+    public void leader_responds_to_requests() throws InterruptedException {
+        CLUSTER.currentLeader().getFreshTimestamp();
+
+        LockRefreshToken token = CLUSTER.currentLeader().lock(LOCK_CLIENT, LOCK_REQUEST);
+        CLUSTER.unlock(token);
+    }
+
+    @Test
+    public void new_leader_takes_over_if_current_leader_dies() {
+        TestableTimelockServer oldLeader = CLUSTER.currentLeader();
+
+        oldLeader.kill();
+        CLUSTER.waitUntilLeaderIsElected();
+
+        CLUSTER.currentLeader().getFreshTimestamp();
+    }
+
+    @Test
+    public void leader_loses_leadership_if_a_quorum_is_not_alive() {
+        TestableTimelockServer leader = CLUSTER.currentLeader();
+        CLUSTER.nonLeaders().forEach(TestableTimelockServer::kill);
+
+        assertThatThrownBy(() -> leader.getFreshTimestamp())
+                .isInstanceOf(RetryableException.class);
+    }
+
+    @Test
+    public void someone_becomes_leader_again_after_quorum_is_restored() {
+        CLUSTER.nonLeaders().forEach(TestableTimelockServer::kill);
+        CLUSTER.nonLeaders().forEach(TestableTimelockServer::start);
+
+        CLUSTER.getFreshTimestamp();
+    }
+
+    @Test
+    public void can_perform_rolling_restart() {
+        for (TestableTimelockServer server : CLUSTER.servers()) {
+            server.kill();
+            CLUSTER.getFreshTimestamp();
+            server.start();
+        }
+    }
+
+    @Test
+    public void timestamps_are_increasing_across_failovers() {
+        long lastTimestamp = CLUSTER.getFreshTimestamp();
+
+        for (int i = 0; i < 3; i++) {
+            CLUSTER.failoverToNewLeader();
+
+            long timestamp = CLUSTER.getFreshTimestamp();
+            assertThat(timestamp).isGreaterThan(lastTimestamp);
+            lastTimestamp = timestamp;
+        }
+    }
+
+    @Test
+    public void locks_are_invalidated_across_failovers() throws InterruptedException {
+        LockRefreshToken token = CLUSTER.lock(LOCK_CLIENT, LOCK_REQUEST);
+
+        for (int i = 0; i < 3; i++) {
+            CLUSTER.failoverToNewLeader();
+
+            assertThat(CLUSTER.unlock(token)).isFalse();
+            token = CLUSTER.lock(LOCK_CLIENT, LOCK_REQUEST);
+        }
+    }
+
+}

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -107,13 +107,11 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @Test
     public void canPerformRollingRestart() {
-        for (int i = 0; i < 20; i++) {
-            bringAllNodesOnline();
-            for (TestableTimelockServer server : CLUSTER.servers()) {
-                server.kill();
-                CLUSTER.getFreshTimestamp();
-                server.start();
-            }
+        bringAllNodesOnline();
+        for (TestableTimelockServer server : CLUSTER.servers()) {
+            server.kill();
+            CLUSTER.getFreshTimestamp();
+            server.start();
         }
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -64,7 +64,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void non_leaders_return_503() {
+    public void nonLeadersReturn503() {
         CLUSTER.nonLeaders().forEach(server -> {
             assertThatThrownBy(() -> server.getFreshTimestamp())
                     .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
@@ -74,7 +74,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void leader_responds_to_requests() throws InterruptedException {
+    public void leaderRespondsToRequests() throws InterruptedException {
         CLUSTER.currentLeader().getFreshTimestamp();
 
         LockRefreshToken token = CLUSTER.currentLeader().lock(LOCK_CLIENT, LOCK_REQUEST);
@@ -82,14 +82,14 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void new_leader_takes_over_if_current_leader_dies() {
+    public void newLeaderTakesOverIfCurrentLeaderDies() {
         CLUSTER.currentLeader().kill();
 
         CLUSTER.getFreshTimestamp();
     }
 
     @Test
-    public void leader_loses_leadership_if_a_quorum_is_not_alive() {
+    public void leaderLosesLeadersipIfQuorumIsNotAlive() {
         TestableTimelockServer leader = CLUSTER.currentLeader();
         CLUSTER.nonLeaders().forEach(TestableTimelockServer::kill);
 
@@ -98,7 +98,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void someone_becomes_leader_again_after_quorum_is_restored() {
+    public void someoneBecomesLeaderAgainAfterQuorumIsRestored() {
         CLUSTER.nonLeaders().forEach(TestableTimelockServer::kill);
         CLUSTER.nonLeaders().forEach(TestableTimelockServer::start);
 
@@ -106,16 +106,19 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void can_perform_rolling_restart() {
-        for (TestableTimelockServer server : CLUSTER.servers()) {
-            server.kill();
-            CLUSTER.getFreshTimestamp();
-            server.start();
+    public void canPerformRollingRestart() {
+        for (int i = 0; i < 20; i++) {
+            bringAllNodesOnline();
+            for (TestableTimelockServer server : CLUSTER.servers()) {
+                server.kill();
+                CLUSTER.getFreshTimestamp();
+                server.start();
+            }
         }
     }
 
     @Test
-    public void timestamps_are_increasing_across_failovers() {
+    public void timestampsAreIncreasingAcrossFailovers() {
         long lastTimestamp = CLUSTER.getFreshTimestamp();
 
         for (int i = 0; i < 3; i++) {
@@ -128,7 +131,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void locks_are_invalidated_across_failovers() throws InterruptedException {
+    public void locksAreInvalidatedAcrossFailures() throws InterruptedException {
         LockRefreshToken token = CLUSTER.lock(LOCK_CLIENT, LOCK_REQUEST);
 
         for (int i = 0; i < 3; i++) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TemporaryConfigurationHolder.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TemporaryConfigurationHolder.java
@@ -41,7 +41,7 @@ public class TemporaryConfigurationHolder extends ExternalResource {
     }
 
     @Override
-    protected void before() throws Exception {
+    public void before() throws Exception {
         temporaryConfigFile = temporaryFolder.newFile();
         temporaryLogDirectory = temporaryFolder.newFolder();
         createTemporaryConfigFile();

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -21,13 +21,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
-import com.jayway.awaitility.Awaitility;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
@@ -60,18 +58,7 @@ public class TestableTimelockCluster {
     }
 
     public void waitUntilLeaderIsElected() {
-        TimestampService timestampService = timestampService();
-        Awaitility.await()
-                .atMost(30, TimeUnit.SECONDS)
-                .pollInterval(500, TimeUnit.MILLISECONDS)
-                .until(() -> {
-                    try {
-                        timestampService.getFreshTimestamp();
-                        return true;
-                    } catch (Throwable t) {
-                        return false;
-                    }
-                });
+        getFreshTimestamp();
     }
 
     public void waitUntillAllSeversAreOnlineAndLeaderIsElected() {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -21,11 +21,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
+import com.jayway.awaitility.Awaitility;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
@@ -58,7 +60,18 @@ public class TestableTimelockCluster {
     }
 
     public void waitUntilLeaderIsElected() {
-        getFreshTimestamp();
+        TimestampService timestampService = timestampService();
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .until(() -> {
+                    try {
+                        timestampService.getFreshTimestamp();
+                        return true;
+                    } catch (Throwable t) {
+                        return false;
+                    }
+                });
     }
 
     public void waitUntillAllSeversAreOnlineAndLeaderIsElected() {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -65,8 +65,12 @@ public class TestableTimelockCluster {
                 .atMost(30, TimeUnit.SECONDS)
                 .pollInterval(500, TimeUnit.MILLISECONDS)
                 .until(() -> {
-                    timestampService.getFreshTimestamp();
-                    return true;
+                    try {
+                        timestampService.getFreshTimestamp();
+                        return true;
+                    } catch (Throwable t) {
+                        return false;
+                    }
                 });
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -38,7 +38,7 @@ import io.dropwizard.testing.ResourceHelpers;
 
 public class TestableTimelockCluster {
 
-    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    private final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private final String defaultClient;
     private final String baseUri;
@@ -136,7 +136,7 @@ public class TestableTimelockCluster {
     }
 
     public RuleChain getRuleChain() {
-        RuleChain ruleChain = RuleChain.outerRule(TEMPORARY_FOLDER);
+        RuleChain ruleChain = RuleChain.outerRule(temporaryFolder);
 
         for (TemporaryConfigurationHolder config : configs) {
             ruleChain = ruleChain.around(config);
@@ -156,7 +156,7 @@ public class TestableTimelockCluster {
     private TemporaryConfigurationHolder getConfigHolder(String configFileName) {
         File configTemplate =
                 new File(ResourceHelpers.resourceFilePath(configFileName));
-        return new TemporaryConfigurationHolder(TEMPORARY_FOLDER, configTemplate);
+        return new TemporaryConfigurationHolder(temporaryFolder, configTemplate);
     }
 
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+import com.jayway.awaitility.Awaitility;
+import com.palantir.atlasdb.timelock.util.TestProxies;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.timestamp.TimestampService;
+
+import io.dropwizard.testing.ResourceHelpers;
+
+public class TestableTimelockCluster {
+
+    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    private final String defaultClient;
+    private final String baseUri;
+    private final List<TemporaryConfigurationHolder> configs;
+    private final List<TestableTimelockServer> servers;
+    private final TestProxies proxies;
+
+    public TestableTimelockCluster(String baseUri, String defaultClient, String... configFileTemplates) {
+        this.defaultClient = defaultClient;
+        this.baseUri = baseUri;
+        this.configs = Arrays.asList(configFileTemplates).stream()
+                .map(this::getConfigHolder)
+                .collect(Collectors.toList());
+        this.servers = configs.stream()
+                .map(this::getServerHolder)
+                .map(holder -> new TestableTimelockServer(baseUri, defaultClient, holder))
+                .collect(Collectors.toList());
+        this.proxies = new TestProxies(baseUri, servers);
+    }
+
+    public void waitUntilLeaderIsElected() {
+        TimestampService timestampService = timestampService();
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .until(() -> {
+                    timestampService.getFreshTimestamp();
+                    return true;
+                });
+    }
+
+    public void waitUntillAllSeversAreOnlineAndLeaderIsElected() {
+        servers.forEach(TestableTimelockServer::start);
+        waitUntilLeaderIsElected();
+    }
+
+    public TestableTimelockServer currentLeader() {
+        for (TestableTimelockServer server : servers) {
+            try {
+                if (server.leaderPing()) {
+                    return server;
+                }
+            } catch (Throwable t) {
+                // continue;
+            }
+        }
+        throw new IllegalStateException("no nodes are currently the leader");
+    }
+
+    public List<TestableTimelockServer> nonLeaders() {
+        TestableTimelockServer leader = currentLeader();
+        return servers.stream()
+                .filter(server -> server != leader)
+                .collect(Collectors.toList());
+    }
+
+    public void failoverToNewLeader() {
+        TestableTimelockServer leader = currentLeader();
+        leader.kill();
+        leader.start();
+
+        waitUntilLeaderIsElected();
+
+        if (servers.size() > 1) {
+            assertThat(currentLeader()).isNotEqualTo(leader);
+        }
+    }
+
+    public List<TestableTimelockServer> servers() {
+        return servers;
+    }
+
+    public long getFreshTimestamp() {
+        return timestampService().getFreshTimestamp();
+    }
+
+    public LockRefreshToken lock(String client, LockRequest lockRequest) throws InterruptedException {
+        return lockService().lock(client, lockRequest);
+    }
+
+    public boolean unlock(LockRefreshToken token) {
+        return lockService().unlock(token);
+    }
+
+    public TimestampService timestampService() {
+        return proxies.failoverForClient(defaultClient, TimestampService.class);
+    }
+
+    public RemoteLockService lockService() {
+        return proxies.failoverForClient(defaultClient, RemoteLockService.class);
+    }
+
+    public RuleChain getRuleChain() {
+        RuleChain ruleChain = RuleChain.outerRule(TEMPORARY_FOLDER);
+
+        for (TemporaryConfigurationHolder config : configs) {
+            ruleChain = ruleChain.around(config);
+        }
+
+        for (TestableTimelockServer server : servers) {
+            ruleChain = ruleChain.around(server.serverHolder());
+        }
+
+        return ruleChain;
+    }
+
+    private TimeLockServerHolder getServerHolder(TemporaryConfigurationHolder configHolder) {
+        return new TimeLockServerHolder(configHolder::getTemporaryConfigFileLocation);
+    }
+
+    private TemporaryConfigurationHolder getConfigHolder(String configFileName) {
+        File configTemplate =
+                new File(ResourceHelpers.resourceFilePath(configFileName));
+        return new TemporaryConfigurationHolder(TEMPORARY_FOLDER, configTemplate);
+    }
+
+}

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -22,6 +22,7 @@ import com.palantir.leader.PingableLeader;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 
 public class TestableTimelockServer {
@@ -68,6 +69,10 @@ public class TestableTimelockServer {
 
     public TimestampService timestampService() {
         return proxies.singleNodeForClient(defaultClient, serverHolder, TimestampService.class);
+    }
+
+    public TimestampManagementService timestampManagementService() {
+        return proxies.singleNodeForClient(defaultClient, serverHolder, TimestampManagementService.class);
     }
 
     public RemoteLockService lockService() {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.timelock.util.TestProxies;
+import com.palantir.leader.PingableLeader;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.timestamp.TimestampService;
+
+public class TestableTimelockServer {
+
+    private final String baseUri;
+    private final TimeLockServerHolder serverHolder;
+    private final String defaultClient;
+    private final TestProxies proxies;
+
+    public TestableTimelockServer(String baseUri, String defaultClient, TimeLockServerHolder serverHolder) {
+        this.baseUri = baseUri;
+        this.defaultClient = defaultClient;
+        this.serverHolder = serverHolder;
+        this.proxies = new TestProxies(baseUri, ImmutableList.of());
+    }
+
+    public TimeLockServerHolder serverHolder() {
+        return serverHolder;
+    }
+
+    public boolean leaderPing() {
+        return pingableLeader().ping();
+    }
+
+    public long getFreshTimestamp() {
+        return timestampService().getFreshTimestamp();
+    }
+
+    public LockRefreshToken lock(String client, LockRequest lockRequest) throws InterruptedException {
+        return lockService().lock(client, lockRequest);
+    }
+
+    public void kill() {
+        serverHolder.kill();
+    }
+
+    public void start() {
+        serverHolder.start();
+    }
+
+    public PingableLeader pingableLeader() {
+        return proxies.singleNode(serverHolder, PingableLeader.class);
+    }
+
+    public TimestampService timestampService() {
+        return proxies.singleNodeForClient(defaultClient, serverHolder, TimestampService.class);
+    }
+
+    public RemoteLockService lockService() {
+        return proxies.singleNodeForClient(defaultClient, serverHolder, RemoteLockService.class);
+    }
+
+}

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TimeLockServerHolder.java
@@ -15,10 +15,14 @@
  */
 package com.palantir.atlasdb.timelock;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 import org.junit.rules.ExternalResource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 
 import io.dropwizard.testing.DropwizardTestSupport;
@@ -26,6 +30,8 @@ import io.dropwizard.testing.DropwizardTestSupport;
 public class TimeLockServerHolder extends ExternalResource {
     private Supplier<String> configFilePathSupplier;
     private DropwizardTestSupport<TimeLockServerConfiguration> timelockServer;
+    private boolean isRunning = false;
+    private int timelockPort;
 
     TimeLockServerHolder(Supplier<String> configFilePathSupplier) {
         this.configFilePathSupplier = configFilePathSupplier;
@@ -33,17 +39,49 @@ public class TimeLockServerHolder extends ExternalResource {
 
     @Override
     protected void before() throws Exception {
+        if (isRunning) {
+            return;
+        }
+
+        timelockPort = readTimelockPort();
+
         timelockServer = new DropwizardTestSupport<>(TimeLockServerLauncher.class, configFilePathSupplier.get());
         timelockServer.before();
+        isRunning = true;
     }
 
     @Override
     protected void after() {
-        timelockServer.after();
+        if (isRunning) {
+            timelockServer.after();
+            isRunning = false;
+        }
     }
 
     public int getTimelockPort() {
-        return timelockServer.getLocalPort();
+        return timelockPort;
+    }
+
+    public synchronized void kill() {
+        after();
+    }
+
+    public synchronized void start() {
+        try {
+            before();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private int readTimelockPort() throws IOException {
+        return new ObjectMapper(new YAMLFactory())
+                .readTree(new File(configFilePathSupplier.get()))
+                .get("server")
+                .get("applicationConnectors")
+                .get(0)
+                .get("port")
+                .intValue();
     }
 
     public int getAdminPort() {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExceptionMatchers {
+
+    private ExceptionMatchers() { }
+
+    public static void isRetryableExceptionWhereLeaderCannotBeFound(Throwable throwable) {
+        assertThat(throwable)
+                .hasMessageContaining("method invoked on a non-leader");
+
+        // We shade Feign, so we can't rely on our client's RetryableException exactly matching ours.
+        assertThat(throwable.getClass().getName())
+                .contains("RetryableException");
+    }
+
+}

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/ExceptionMatchers.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.timelock.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ExceptionMatchers {
+public final class ExceptionMatchers {
 
     private ExceptionMatchers() { }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -17,18 +17,12 @@
 package com.palantir.atlasdb.timelock.util;
 
 import java.util.List;
-<<<<<<< 369acb3402a6ac790bd78bdcc88753547d883063
 import java.util.Optional;
-import java.util.stream.Collectors;
-
-=======
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
->>>>>>> cache proxies
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.timelock.MultiNodePaxosTimeLockServerIntegrationTest;
 import com.palantir.atlasdb.timelock.TestableTimelockServer;
@@ -57,7 +51,7 @@ public class TestProxies {
 
     public <T> T singleNode(Class<T> serviceInterface, String uri) {
         List<Object> key = ImmutableList.of(serviceInterface, uri, "single");
-        return (T)proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxy(
+        return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxy(
                 Optional.empty(),
                 uri,
                 serviceInterface,
@@ -70,7 +64,7 @@ public class TestProxies {
 
     public <T> T failover(Class<T> serviceInterface, List<String> uris) {
         List<Object> key = ImmutableList.of(serviceInterface, uris, "failover");
-        return (T)proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxyWithFailover(
+        return (T) proxies.computeIfAbsent(key, ignored -> AtlasDbHttpClients.createProxyWithFailover(
                 Optional.empty(),
                 uris,
                 serviceInterface,

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.util;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Optional;
+import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.atlasdb.timelock.MultiNodePaxosTimeLockServerIntegrationTest;
+import com.palantir.atlasdb.timelock.TestableTimelockServer;
+import com.palantir.atlasdb.timelock.TimeLockServerHolder;
+
+public class TestProxies {
+
+    private final String baseUri;
+    private final List<TimeLockServerHolder> servers;
+
+    public TestProxies(String baseUri, List<TestableTimelockServer> servers) {
+        this.baseUri = baseUri;
+        this.servers = servers.stream()
+                .map(TestableTimelockServer::serverHolder)
+                .collect(Collectors.toList());
+    }
+
+    public <T> T singleNodeForClient(String client, TimeLockServerHolder server, Class<T> serviceInterface) {
+        return singleNode(serviceInterface, getServerUriForClient(client, server));
+    }
+
+    public <T> T singleNode(TimeLockServerHolder server, Class<T> serviceInterface) {
+        return singleNode(serviceInterface, getServerUri(server));
+    }
+
+    public <T> T singleNode(Class<T> serviceInterface, String uri) {
+        return AtlasDbHttpClients.createProxy(Optional.absent(), uri, serviceInterface,
+                MultiNodePaxosTimeLockServerIntegrationTest.class.toString());
+    }
+
+    public <T> T failoverForClient(String client, Class<T> serviceInterface) {
+        return failover(serviceInterface, getServerUrisForClient(client));
+    }
+
+    public <T> T failover(Class<T> serviceInterface, List<String> uris) {
+        return AtlasDbHttpClients.createProxyWithFailover(
+                com.google.common.base.Optional.absent(),
+                uris,
+                serviceInterface,
+                getClass().toString());
+    }
+
+    public List<String> getServerUris() {
+        return servers.stream()
+                .map(server -> getServerUri(server))
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getServerUrisForClient(String client) {
+        return getServerUris().stream()
+                .map(uri -> uri + "/" + client)
+                .collect(Collectors.toList());
+    }
+
+    private String getServerUri(TimeLockServerHolder server) {
+        return baseUri + ":" + server.getTimelockPort();
+    }
+
+    private String getServerUriForClient(String client, TimeLockServerHolder server) {
+        return getServerUriForClient(client, getServerUri(server));
+    }
+
+    private String getServerUriForClient(String client, String uri) {
+        return uri + "/" + client;
+    }
+
+}

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/TestProxies.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/util/TestProxies.java
@@ -17,9 +17,9 @@
 package com.palantir.atlasdb.timelock.util;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Optional;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.timelock.MultiNodePaxosTimeLockServerIntegrationTest;
 import com.palantir.atlasdb.timelock.TestableTimelockServer;
@@ -46,7 +46,7 @@ public class TestProxies {
     }
 
     public <T> T singleNode(Class<T> serviceInterface, String uri) {
-        return AtlasDbHttpClients.createProxy(Optional.absent(), uri, serviceInterface,
+        return AtlasDbHttpClients.createProxy(Optional.empty(), uri, serviceInterface,
                 MultiNodePaxosTimeLockServerIntegrationTest.class.toString());
     }
 
@@ -56,7 +56,7 @@ public class TestProxies {
 
     public <T> T failover(Class<T> serviceInterface, List<String> uris) {
         return AtlasDbHttpClients.createProxyWithFailover(
-                com.google.common.base.Optional.absent(),
+                Optional.empty(),
                 uris,
                 serviceInterface,
                 getClass().toString());

--- a/timelock-server/src/integTest/resources/paxosMultiServer0.yml
+++ b/timelock-server/src/integTest/resources/paxosMultiServer0.yml
@@ -3,19 +3,21 @@ algorithm:
   paxosDataDir: <TEMP_DATA_DIR>
 
 cluster:
-  localServer: localhost:9060
+  localServer: localhost:9080
   servers:
-    - localhost:9060
-    - localhost:9061
-    - localhost:9062
+    - localhost:9080
+    - localhost:9081
+    - localhost:9082
 
 clients:
-  - isolated
+  - test
+  - test2
+  - test3
 
 server:
   applicationConnectors:
     - type: http
-      port: 9060
+      port: 9080
   adminConnectors:
     - type: http
-      port: 7060
+      port: 7090

--- a/timelock-server/src/integTest/resources/paxosMultiServer1.yml
+++ b/timelock-server/src/integTest/resources/paxosMultiServer1.yml
@@ -3,19 +3,21 @@ algorithm:
   paxosDataDir: <TEMP_DATA_DIR>
 
 cluster:
-  localServer: localhost:9060
+  localServer: localhost:9081
   servers:
-    - localhost:9060
-    - localhost:9061
-    - localhost:9062
+    - localhost:9080
+    - localhost:9081
+    - localhost:9082
 
 clients:
-  - isolated
+  - test
+  - test2
+  - test3
 
 server:
   applicationConnectors:
     - type: http
-      port: 9060
+      port: 9081
   adminConnectors:
     - type: http
-      port: 7060
+      port: 7091

--- a/timelock-server/src/integTest/resources/paxosMultiServer2.yml
+++ b/timelock-server/src/integTest/resources/paxosMultiServer2.yml
@@ -3,19 +3,21 @@ algorithm:
   paxosDataDir: <TEMP_DATA_DIR>
 
 cluster:
-  localServer: localhost:9060
+  localServer: localhost:9082
   servers:
-    - localhost:9060
-    - localhost:9061
-    - localhost:9062
+    - localhost:9080
+    - localhost:9081
+    - localhost:9082
 
 clients:
-  - isolated
+  - test
+  - test2
+  - test3
 
 server:
   applicationConnectors:
     - type: http
-      port: 9060
+      port: 9082
   adminConnectors:
     - type: http
-      port: 7060
+      port: 7082

--- a/timelock-server/src/integTest/resources/paxosSingleServer.yml
+++ b/timelock-server/src/integTest/resources/paxosSingleServer.yml
@@ -3,9 +3,9 @@ algorithm:
   paxosDataDir: <TEMP_DATA_DIR>
 
 cluster:
-  localServer: localhost:8080
+  localServer: localhost:9050
   servers:
-    - localhost:8080
+    - localhost:9050
 
 clients:
   - test
@@ -21,5 +21,9 @@ server:
   maxThreads: 100
   applicationConnectors:
     - type: http
+      port: 9050
       selectorThreads: 8
       acceptorThreads: 4
+  adminConnectors:
+    - type: http
+      port: 7050


### PR DESCRIPTION
**Goals (and why)**:
Add multi-node timelock ete tests, to test failover behavior
addresses https://github.com/palantir/atlasdb/issues/1978

**Implementation Description (bullets)**:
- add multi-node tests
- add some utilities for making them easy to write
- these tests also found a bug (yay): `AwaitingLeadershipProxy` can go into an infinite loop if it gets cut off from other nodes and continually fails to get a quorum (fixed in this PR).

TODO:
- [ ] see if we can make these tests faster
- [x] refactor other tests to use the same utilities

**Concerns (what feedback would you like?)**:
- are there other tests that should be added?
- these tests are super slow (they take 1.5 mins on my laptop). should we have a separate gradle task so they don't run in `check` locally? 

**Where should we start reviewing?**:
`MultiNodePaxosTimeLockServerIntegrationTest`

**Priority (whenever / two weeks / yesterday)**:
this week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1983)
<!-- Reviewable:end -->
