### PR TITLE
Fix Oracle hint in getRange()

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleGetRange.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleGetRange.java
@@ -248,7 +248,7 @@ public class OracleGetRange implements DbKvsGetRange {
             String direction = reverse ? "DESC" : "ASC";
             String shortTableName = getInternalShortTableName(conns);
             String query = "/* GET_RANGE(" + shortTableName + ") */"
-                    + "  SELECT /*+ USE_NL(sub v) */ sub.row_name, sub.col_name, sub.ts"
+                    + "  SELECT /*+ USE_NL(sub v) LEADING(sub) */ sub.row_name, sub.col_name, sub.ts"
                     +     OracleQueryHelpers.getValueSubselect(haveOverflowValues, "v", true) + " FROM ("
                     + "  SELECT /*+ INDEX_" + direction + "(m " + PrimaryKeyConstraintNames.get(shortTableName) + ")"
                     + "             NO_INDEX_SS(m) */"

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,10 @@ develop
            If this breaks your tests, you can fix it with making real schema for tests or by switching to AtlasDbConstants.GENERIC_TABLE_METADATA
            (`Pull Request <https://github.com/palantir/1925>`__)
 
+    *    - |fixed|
+         - Fixed a severe performance regression in getRange() on Oracle caused by an inadequate query plan being chosen sometimes.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/1989>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 


### PR DESCRIPTION
Sometimes Oracle just picks the wrong join order which causes terrible
perf (as in O(N^2)). I thought that the order of tables in the USE_NL
hint was sufficient, but apparently I also need the LEADING hint. My bad.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1989)
<!-- Reviewable:end -->
