### PR TITLE
no remote calls in readonly txn

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1191,9 +1191,11 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             checkConstraints();
             commitWrites(transactionService);
             long transactionMillis = TimeUnit.NANOSECONDS.toMillis(transactionTimerContext.stop());
-            perfLogger.debug("Committed transaction {} in {}ms",
-                    getStartTimestamp(),
-                    transactionMillis);
+            if (perfLogger.isDebugEnabled()) {
+                perfLogger.debug("Committed transaction {} in {}ms",
+                        getStartTimestamp(),
+                        transactionMillis);
+            }
             success = true;
         } finally {
             // Once we are in state committing, we need to try/finally to set the state to a terminal state.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1190,8 +1190,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
             checkConstraints();
             commitWrites(transactionService);
-            long transactionMillis = TimeUnit.NANOSECONDS.toMillis(transactionTimerContext.stop());
             if (perfLogger.isDebugEnabled()) {
+                long transactionMillis = TimeUnit.NANOSECONDS.toMillis(transactionTimerContext.stop());
                 perfLogger.debug("Committed transaction {} in {}ms",
                         getStartTimestamp(),
                         transactionMillis);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -19,10 +19,7 @@ package com.palantir.atlasdb.transaction.impl;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
-import java.sql.Timestamp;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -110,8 +107,8 @@ public class TransactionManagerTest extends TransactionTestSetup {
     public void shouldNotMakeRemoteCallsInAReadonlyTransactionIfNoWorkIsDone() {
         TimestampService mockTimestampService = mock(TimestampService.class);
         RemoteLockService mockLockService = mock(RemoteLockService.class);
-        TransactionManager txnManagerWithMocks = new SerializableTransactionManager(getKeyValueService(), mockTimestampService,
-                LockClient.of("foo"), mockLockService, transactionService,
+        TransactionManager txnManagerWithMocks = new SerializableTransactionManager(getKeyValueService(),
+                mockTimestampService, LockClient.of("foo"), mockLockService, transactionService,
                 () -> AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS,
                 conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE);
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,11 @@ develop
            This is no longer permitted, as it leads to many (unsolved) questions about how to deal with such a table.
            If this breaks your tests, you can fix it with making real schema for tests or by switching to AtlasDbConstants.GENERIC_TABLE_METADATA
            (`Pull Request <https://github.com/palantir/1925>`__)
+           
+    *    - |improved|
+         - Read-only transactions will no longer make a remote call to fetch a timestamp, if no work is done on the transaction. 
+           This will benefit services that execute read-only transactions around in-memory cache operations, and frequently never fall through to perform a read.
+           (`Pull Request <https://github.com/palantir/1996>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosQuorumCheckerTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosQuorumCheckerTest.java
@@ -1,7 +1,0 @@
-package com.palantir.paxos;
-
-/**
- * Created by nziebart on 6/5/17.
- */
-public class PaxosQuorumCheckerTest {
-}

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosQuorumCheckerTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosQuorumCheckerTest.java
@@ -1,0 +1,7 @@
+package com.palantir.paxos;
+
+/**
+ * Created by nziebart on 6/5/17.
+ */
+public class PaxosQuorumCheckerTest {
+}


### PR DESCRIPTION
**Goals (and why)**:
Fixes https://github.com/palantir/atlasdb/issues/1986

**Implementation Description (bullets)**:
- only perform the offending debug log if debug logging is enabled

**Concerns (what feedback would you like?)**:
- is this viable as an quick solution? it's a little brittle, but the test should cover us

**Where should we start reviewing?**:
SnapshotTransaction

**Priority (whenever / two weeks / yesterday)**:
today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1996)
<!-- Reviewable:end -->
