### PR TITLE
Register the right exception mapper and modify tests

### DIFF
--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -33,6 +33,7 @@ import com.palantir.atlasdb.todo.SimpleTodoResource;
 import com.palantir.atlasdb.todo.TodoClient;
 import com.palantir.atlasdb.todo.TodoSchema;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.remoting1.servers.jersey.HttpRemotingJerseyFeature;
 import com.palantir.tritium.metrics.MetricRegistries;
 
 import io.dropwizard.Application;
@@ -67,6 +68,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         TransactionManager transactionManager = createTransactionManager(config, environment);
         environment.jersey().register(new SimpleTodoResource(new TodoClient(transactionManager)));
         environment.jersey().register(new SimpleCheckAndSetResource(new CheckAndSetClient(transactionManager)));
+        environment.jersey().register(HttpRemotingJerseyFeature.DEFAULT);
     }
 
     private TransactionManager createTransactionManager(AtlasDbEteConfiguration config, Environment environment)

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -128,9 +128,10 @@ public class TimeLockMigrationEteTest {
 
         // as() is not compatible with assertThatThrownBy - see
         // http://joel-costigliola.github.io/assertj/core/api/org/assertj/core/api/Assertions.html
-        Throwable actual = catchThrowable(timestampClient::getFreshTimestamp);
-        softAssertions.assertThat(actual).as("no longer exposes an embedded timestamp service");
-        softAssertions.assertThat(((AtlasDbRemoteException) actual).getStatus()).isEqualTo(404);
+        softAssertions.assertThat(
+                ((AtlasDbRemoteException) catchThrowable(timestampClient::getFreshTimestamp)).getStatus())
+                .isEqualTo(404)
+                .as("no longer exposes an embedded timestamp service");
     }
 
     private void assertCanNeitherReadNorWrite() {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -32,6 +32,7 @@ import com.google.common.base.Optional;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
+import com.palantir.atlasdb.http.errors.AtlasDbRemoteException;
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
@@ -127,9 +128,9 @@ public class TimeLockMigrationEteTest {
 
         // as() is not compatible with assertThatThrownBy - see
         // http://joel-costigliola.github.io/assertj/core/api/org/assertj/core/api/Assertions.html
-        softAssertions.assertThat(catchThrowable(timestampClient::getFreshTimestamp))
-                .as("no longer exposes an embedded timestamp service")
-                .hasMessageContaining("404");
+        Throwable actual = catchThrowable(timestampClient::getFreshTimestamp);
+        softAssertions.assertThat(actual).as("no longer exposes an embedded timestamp service");
+        softAssertions.assertThat(((AtlasDbRemoteException) actual).getStatus()).isEqualTo(404);
     }
 
     private void assertCanNeitherReadNorWrite() {


### PR DESCRIPTION
#**Goals (and why)**: AtlasDBEteServer should be able to deserialize HTTP exceptions in embedded mode. Fixes #1984.

**Implementation Description (bullets)**:
1. Register the ExceptionMappers from http-remoting.
2. Fix test code

**Concerns (what feedback would you like?)**: every application need to register HttpRemotingJerseyFeature with the dropwizard environment if running in the embedded mode. Most already do! Should we modify docs for this?

**Where should we start reviewing?**: AtlasDbEteServer.java

**Priority (whenever / two weeks / yesterday)**: normal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/1998)
<!-- Reviewable:end -->
