### PR TITLE
(0.39.x) Cap the page size in PostgresGetRange

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresGetRange.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresGetRange.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterators;
+import com.palantir.atlasdb.AtlasDbPerformanceConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
@@ -138,7 +139,8 @@ public class PostgresGetRange implements DbKvsGetRange {
                                                long timestamp) {
         int maxRowsPerPage = RangeHelpers.getMaxRowsPerPage(rangeRequest);
         int cellsPerRowEstimate = getCellsPerRowEstimate(tableRef, rangeRequest);
-        int maxCellsPerPage = maxRowsPerPage * cellsPerRowEstimate + 1;
+        int maxCellsPerPage = Math.min(
+                AtlasDbPerformanceConstants.MAX_BATCH_SIZE, maxRowsPerPage * cellsPerRowEstimate) + 1;
         String tableName = DbKvs.internalTableName(tableRef);
         Iterator<Iterator<RowResult<Value>>> pageIterator = new PageIterator(
                 rangeRequest.getStartInclusive(),


### PR DESCRIPTION
If the caller passes 10_000 as the batchHint and the table has dynamic
columns, we probably don't want to load 1_000_000 SQL rows at once.

See PDS-53298

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2002)
<!-- Reviewable:end -->
