### PR TITLE
close the lock service

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,8 +42,9 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - Fixed an issue where the lock service was not properly shut down after losing leadership, which could result in threads blocking unnecessarily.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2014>`__)
 
 
 

--- a/lock-api/src/main/java/com/palantir/lock/CloseableRemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/CloseableRemoteLockService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock;
+
+import java.io.Closeable;
+
+public interface CloseableRemoteLockService extends RemoteLockService, Closeable {
+
+}

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -21,7 +21,6 @@ import static com.palantir.lock.LockClient.INTERNAL_LOCK_GRANT_CLIENT;
 import static com.palantir.lock.LockGroupBehavior.LOCK_ALL_OR_NONE;
 import static com.palantir.lock.LockGroupBehavior.LOCK_AS_MANY_AS_POSSIBLE;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Collection;
@@ -75,6 +74,7 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.random.SecureRandomPool;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.lock.BlockingMode;
+import com.palantir.lock.CloseableRemoteLockService;
 import com.palantir.lock.ExpiringToken;
 import com.palantir.lock.HeldLocksGrant;
 import com.palantir.lock.HeldLocksToken;
@@ -105,7 +105,9 @@ import com.palantir.util.JMXUtils;
  *
  * @author jtamer
  */
-@ThreadSafe public final class LockServiceImpl implements LockService, RemoteLockService, LockServiceImplMBean, Closeable {
+@ThreadSafe
+public final class LockServiceImpl
+        implements LockService, CloseableRemoteLockService, RemoteLockService, LockServiceImplMBean {
 
     private static final Logger log = LoggerFactory.getLogger(LockServiceImpl.class);
     private static final Logger requestLogger = LoggerFactory.getLogger("lock.request");

--- a/lock-impl/src/main/java/com/palantir/lock/impl/ThreadPooledLockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/ThreadPooledLockService.java
@@ -15,29 +15,25 @@
  */
 package com.palantir.lock.impl;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 
 import javax.annotation.Nullable;
 
-import com.palantir.lock.ForwardingLockService;
+import com.palantir.lock.CloseableRemoteLockService;
 import com.palantir.lock.HeldLocksToken;
-import com.palantir.lock.LockClient;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
-import com.palantir.lock.LockResponse;
-import com.palantir.lock.LockService;
+import com.palantir.lock.RemoteLockService;
 
-public class ThreadPooledLockService extends ForwardingLockService {
-    private final ThreadPooledWrapper<LockService> wrapper;
+public class ThreadPooledLockService implements CloseableRemoteLockService {
+    private final ThreadPooledWrapper<RemoteLockService> wrapper;
+    private final CloseableRemoteLockService delegate;
 
-    public ThreadPooledLockService(LockService delegate, int localThreadPoolSize, Semaphore sharedThreadPool) {
+    public ThreadPooledLockService(CloseableRemoteLockService delegate, int localThreadPoolSize, Semaphore sharedThreadPool) {
+        this.delegate = delegate;
         wrapper = new ThreadPooledWrapper<>(delegate, localThreadPoolSize, sharedThreadPool);
-    }
-
-    @Override
-    protected LockService delegate() {
-        return wrapper.delegate();
     }
 
     @Nullable
@@ -52,17 +48,33 @@ public class ThreadPooledLockService extends ForwardingLockService {
     }
 
     @Override
-    public LockResponse lockWithFullLockResponse(LockClient client, LockRequest request) throws InterruptedException {
-        return wrapper.applyWithPermit(lockService -> lockService.lockWithFullLockResponse(client, request));
-    }
-
-    @Override
-    public Set<HeldLocksToken> refreshTokens(Iterable<HeldLocksToken> tokens) {
-        return wrapper.applyWithPermit(lockService -> lockService.refreshTokens(tokens));
+    public boolean unlock(LockRefreshToken token) {
+        return delegate.unlock(token);
     }
 
     @Override
     public Set<LockRefreshToken> refreshLockRefreshTokens(Iterable<LockRefreshToken> tokens) {
         return wrapper.applyWithPermit(lockService -> lockService.refreshLockRefreshTokens(tokens));
+    }
+
+    @Nullable
+    @Override
+    public Long getMinLockedInVersionId(String client) {
+        return delegate.getMinLockedInVersionId(client);
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return delegate.currentTimeMillis();
+    }
+
+    @Override
+    public void logCurrentState() {
+        delegate.logCurrentState();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
     }
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -392,7 +392,7 @@ public class PaxosTimeLockServerIntegrationTest {
         // time / lock services
         assertContainsTimer(metrics,
                 "com.palantir.atlasdb.timelock.paxos.ManagedTimestampService.test.getFreshTimestamp");
-        assertContainsTimer(metrics, "com.palantir.lock.LockService.test.currentTimeMillis");
+        assertContainsTimer(metrics, "com.palantir.lock.RemoteLockService.test.currentTimeMillis");
 
         // local leader election classes
         assertContainsTimer(metrics, "com.palantir.paxos.PaxosLearner.learn");

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -21,7 +21,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
-import com.palantir.lock.LockService;
+import com.palantir.lock.RemoteLockService;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 
@@ -34,7 +34,7 @@ public class TimeLockResource {
     }
 
     @Path("/lock")
-    public LockService getLockService(@PathParam("client") String client) {
+    public RemoteLockService getLockService(@PathParam("client") String client) {
         return getTimeLockServicesForClient(client).getLockService();
     }
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServices.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServices.java
@@ -17,7 +17,7 @@ package com.palantir.atlasdb.timelock;
 
 import org.immutables.value.Value;
 
-import com.palantir.lock.LockService;
+import com.palantir.lock.RemoteLockService;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 
@@ -25,7 +25,7 @@ import com.palantir.timestamp.TimestampService;
 public interface TimeLockServices {
     static TimeLockServices create(
             TimestampService timestampService,
-            LockService lockService,
+            RemoteLockService lockService,
             TimestampManagementService timestampManagementService) {
         return ImmutableTimeLockServices.builder()
                 .timestampService(timestampService)
@@ -36,5 +36,5 @@ public interface TimeLockServices {
 
     TimestampManagementService getTimestampManagementService();
     TimestampService getTimestampService();
-    LockService getLockService();
+    RemoteLockService getLockService();
 }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
@@ -52,8 +52,9 @@ import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.PingableLeader;
 import com.palantir.leader.proxy.AwaitingLeadershipProxy;
+import com.palantir.lock.CloseableRemoteLockService;
 import com.palantir.lock.LockServerOptions;
-import com.palantir.lock.LockService;
+import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.lock.impl.ThreadPooledLockService;
 import com.palantir.paxos.PaxosAcceptor;
@@ -173,23 +174,24 @@ public class PaxosTimeLockServer implements TimeLockServer {
                 ManagedTimestampService.class,
                 createPaxosBackedTimestampService(client),
                 client);
-        LockService lockService = instrument(
-                LockService.class,
+        RemoteLockService lockService = instrument(
+                RemoteLockService.class,
                 createLockService(slowLogTriggerMillis),
                 client);
 
         return TimeLockServices.create(timestampService, lockService, timestampService);
     }
 
-    private LockService createLockService(long slowLogTriggerMillis) {
+    private RemoteLockService createLockService(long slowLogTriggerMillis) {
         return AwaitingLeadershipProxy.newProxyInstance(
-                LockService.class,
+                RemoteLockService.class,
                 () -> createThreadPoolingLockService(slowLogTriggerMillis),
                 leaderElectionService);
     }
 
-    private LockService createThreadPoolingLockService(long slowLogTriggerMillis) {
-        LockService lockServiceNotUsingThreadPooling = createTimeLimitedLockService(slowLogTriggerMillis);
+    private CloseableRemoteLockService createThreadPoolingLockService(long slowLogTriggerMillis) {
+        CloseableRemoteLockService lockServiceNotUsingThreadPooling = createTimeLimitedLockService(
+                slowLogTriggerMillis);
 
         if (!timeLockServerConfiguration.useClientRequestLimit()) {
             return lockServiceNotUsingThreadPooling;
@@ -210,7 +212,7 @@ public class PaxosTimeLockServer implements TimeLockServer {
         return new ThreadPooledLockService(lockServiceNotUsingThreadPooling, localThreadPoolSize, sharedThreadPool);
     }
 
-    private LockService createTimeLimitedLockService(long slowLogTriggerMillis) {
+    private CloseableRemoteLockService createTimeLimitedLockService(long slowLogTriggerMillis) {
         LockServerOptions lockServerOptions = new LockServerOptions() {
             @Override
             public long slowLogTriggerMillis() {
@@ -218,7 +220,7 @@ public class PaxosTimeLockServer implements TimeLockServer {
             }
         };
 
-        LockService rawLockService = LockServiceImpl.create(lockServerOptions);
+        LockServiceImpl rawLockService = LockServiceImpl.create(lockServerOptions);
 
         if (timeLockServerConfiguration.timeLimiterConfiguration().enableTimeLimiting()) {
             return BlockingTimeLimitedLockService.create(

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/ThreadPooledLockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/ThreadPooledLockServiceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.lock;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+
+import org.junit.Test;
+
+import com.palantir.lock.CloseableRemoteLockService;
+import com.palantir.lock.impl.ThreadPooledLockService;
+
+public class ThreadPooledLockServiceTest {
+
+    @Test
+    public void closesDelegate() throws IOException {
+        CloseableRemoteLockService delegate = mock(CloseableRemoteLockService.class);
+        ThreadPooledLockService pooledService = new ThreadPooledLockService(delegate, 1, new Semaphore(1));
+
+        pooledService.close();
+
+        verify(delegate).close();
+    }
+
+}


### PR DESCRIPTION
**Goals (and why)**:
At internal piggy deployment, we saw that the lock service was not being closed after losing leadership. This can lead to requests blocking unnecessarily and stuck threads, since it won't be possible to unlock any locks after losing leadership.

**Implementation Description (bullets)**:
- Create a new `CloseableRemoteLockService` interface
- Make our subclasses implement this

**Concerns (what feedback would you like?)**:
- Are the tests sufficient?

**Where should we start reviewing?**:
Only two classes changed

**Priority (whenever / two weeks / yesterday)**:
today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2014)
<!-- Reviewable:end -->
