### PR TITLE
Ensure tables with different gc grace seconds mismatch and hence will be updated

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -1635,8 +1635,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
                 CassandraVerifier.sanityCheckTableName(table);
 
-                TableReference tableRefLowerCased = TableReference
-                        .createLowerCased(table);
+                TableReference tableRefLowerCased = TableReference.createLowerCased(table);
                 if (!existingTablesLowerCased.contains(tableRefLowerCased)) {
                     filteredTables.put(table, metadata);
                 } else {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitionsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitionsTest.java
@@ -46,7 +46,7 @@ public class ColumnFamilyDefinitionsTest {
 
 
     @Test
-    public void ifCfDefsHaveDifferentGcGraceSecondsIsMatchingCfReturnsFalse() {
+    public void cfDefWithOldAndNewDefaultValuesShouldNotMatch() {
         CfDef clientSideTable = ColumnFamilyDefinitions.getCfDef(
                 "test_keyspace",
                 TableReference.fromString("test_table"),

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitionsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitionsTest.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 public class ColumnFamilyDefinitionsTest {
-    private static final int ONE_DAY = 4 * 24 * 60 * 60;
+    private static final int FOUR_DAYS_IN_SECONDS = 4 * 24 * 60 * 60;
 
     @Test
     public void compactionStrategiesShouldMatchWithOrWithoutPackageName() {
@@ -46,7 +46,7 @@ public class ColumnFamilyDefinitionsTest {
 
 
     @Test
-    public void cfDefWithOldAndNewDefaultValuesShouldNotMatch() {
+    public void cfDefWithDifferingGcGraceSecondsValuesShouldNotMatch() {
         CfDef clientSideTable = ColumnFamilyDefinitions.getCfDef(
                 "test_keyspace",
                 TableReference.fromString("test_table"),
@@ -54,7 +54,7 @@ public class ColumnFamilyDefinitionsTest {
         CfDef clusterSideTable = ColumnFamilyDefinitions.getCfDef(
                 "test_keyspace",
                 TableReference.fromString("test_table"),
-                AtlasDbConstants.GENERIC_TABLE_METADATA).setGc_grace_seconds(ONE_DAY);
+                AtlasDbConstants.GENERIC_TABLE_METADATA).setGc_grace_seconds(FOUR_DAYS_IN_SECONDS);
 
         assertFalse("ColumnDefinitions with different gc_grace_seconds should not match",
                 ColumnFamilyDefinitions.isMatchingCf(clientSideTable, clusterSideTable));


### PR DESCRIPTION

**Goals (and why)**: Unit test for CfDef mismatch when tables have different GC grace seconds. liked to #1929.

**Implementation Description (bullets)**: test

**Concerns (what feedback would you like?)**: na

**Where should we start reviewing?**: small PR

**Priority (whenever / two weeks / yesterday)**: whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2017)
<!-- Reviewable:end -->
