### PR TITLE
deprecate C*KVSConfig.safetyDisabled

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -105,7 +105,7 @@ public class CassandraClientPoolIntegrationTest {
     public void testSanitiseReplicationFactorPassesForTheKeyspace() {
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, CassandraContainer.KVS_CONFIG, false);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, CassandraContainer.KVS_CONFIG);
             } catch (TException e) {
                 fail("currentRf On Keyspace does not Match DesiredRf");
             }
@@ -120,7 +120,7 @@ public class CassandraClientPoolIntegrationTest {
                 CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client,
                         ImmutableCassandraKeyValueServiceConfig.copyOf(
                                 CassandraContainer.KVS_CONFIG).withReplicationFactor(
-                                MODIFIED_REPLICATION_FACTOR), false);
+                                MODIFIED_REPLICATION_FACTOR));
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra config");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);
@@ -134,7 +134,7 @@ public class CassandraClientPoolIntegrationTest {
         changeReplicationFactor(MODIFIED_REPLICATION_FACTOR);
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, CassandraContainer.KVS_CONFIG, false);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, CassandraContainer.KVS_CONFIG);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra keyspace");
             } catch (Exception e) {
                 assertReplicationFactorMismatchError(e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -129,22 +129,8 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         return 5000;
     }
 
-    /**
-     * Ignore all safety checks. Not a good idea,
-     * but occasionally useful to perform some tasks to get a stack
-     * from a known bad configuration back into a good configuration.
-     *
-     * @deprecated Use the more specific "ignoreSpecificTypeOfCheck" relevant to you
-     *             e.g. {@link #ignoreBadNodeTopologyChecks()}
-     */
     @Value.Default
-    @Deprecated
-    public boolean safetyDisabled() {
-        return false;
-    }
-
-    @Value.Default
-    public boolean ignoreBadNodeTopologyChecks() {
+    public boolean ignoreNodeTopologyChecks() {
         return false;
     }
 
@@ -154,7 +140,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
     }
 
     @Value.Default
-    public boolean ignoreBadDatacenterConfigurationChecks() {
+    public boolean ignoreDatacenterConfigurationChecks() {
         return false;
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -129,8 +129,37 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         return 5000;
     }
 
+    /**
+     * Ignore all safety checks. Not a good idea,
+     * but occasionally useful to perform some tasks to get a stack
+     * from a known bad configuration back into a good configuration.
+     *
+     * @deprecated Use the more specific "ignoreSpecificTypeOfCheck" relevant to you
+     *             e.g. {@link #ignoreBadNodeTopologyChecks()}
+     */
     @Value.Default
+    @Deprecated
     public boolean safetyDisabled() {
+        return false;
+    }
+
+    @Value.Default
+    public boolean ignoreBadNodeTopologyChecks() {
+        return false;
+    }
+
+    @Value.Default
+    public boolean ignoreInconsistentRingChecks() {
+        return false;
+    }
+
+    @Value.Default
+    public boolean ignoreBadDatacenterConfigurationChecks() {
+        return false;
+    }
+
+    @Value.Default
+    public boolean ignorePartitionerChecks() {
         return false;
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -746,7 +746,8 @@ public class CassandraClientPool {
                         tokenRangesToHost.get(set2));
             }
 
-            CassandraVerifier.logErrorOrThrow(ex.getMessage(), config.safetyDisabled());
+            CassandraVerifier.logErrorOrThrow(ex.getMessage(),
+                    config.safetyDisabled() || config.ignoreInconsistentRingChecks());
         }
     }
 
@@ -784,7 +785,7 @@ public class CassandraClientPool {
             new FunctionCheckedException<Cassandra.Client, Void, Exception>() {
                 @Override
                 public Void apply(Cassandra.Client client) throws Exception {
-                    CassandraVerifier.validatePartitioner(client, config);
+                    CassandraVerifier.validatePartitioner(client.describe_partitioner(), config);
                     return null;
                 }
             };

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -746,8 +746,7 @@ public class CassandraClientPool {
                         tokenRangesToHost.get(set2));
             }
 
-            CassandraVerifier.logErrorOrThrow(ex.getMessage(),
-                    config.safetyDisabled() || config.ignoreInconsistentRingChecks());
+            CassandraVerifier.logErrorOrThrow(ex.getMessage(), config.ignoreInconsistentRingChecks());
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -215,12 +215,6 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     }
 
     protected void init() {
-        if (configManager.getConfig().scyllaDb() && !configManager.getConfig().safetyDisabled()) {
-            throw new IllegalArgumentException("Not currently allowing Thrift-based access to ScyllaDB clusters;"
-                    + " there appears to be from our tests"
-                    + " an existing correctness bug with semi-complex column selections");
-        }
-
         boolean supportsCas = !configManager.getConfig().scyllaDb()
                 && clientPool.runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
 
@@ -295,8 +289,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             dcs = clientPool.runWithRetry(client ->
                     CassandraVerifier.sanityCheckDatacenters(
                             client,
-                            config.replicationFactor(),
-                            config.safetyDisabled()));
+                            config));
             KsDef ksDef = clientPool.runWithRetry(client ->
                     client.describe_keyspace(config.keyspace()));
             strategyOptions = Maps.newHashMap(ksDef.getStrategy_options());
@@ -2143,7 +2136,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
     private boolean doesConfigReplicationFactorMatchWithCluster() {
         return clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, configManager.getConfig(), false);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, configManager.getConfig());
                 return true;
             } catch (Exception e) {
                 log.warn("The config and Cassandra cluster do not agree on the replication factor.", e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -130,7 +130,7 @@ public final class CassandraVerifier {
     }
 
     static void validatePartitioner(String partitioner, CassandraKeyValueServiceConfig config) {
-        if (!(config.ignorePartitionerChecks())) {
+        if (!config.ignorePartitionerChecks()) {
             Verify.verify(
                     CassandraConstants.ALLOWED_PARTITIONERS.contains(partitioner),
                     "Invalid partitioner. Allowed: %s, but partitioner is: %s. "

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlKeyValueService.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -281,13 +280,7 @@ public class CqlKeyValueService extends AbstractKeyValueService {
         Metadata metadata = cluster.getMetadata();
 
         final CassandraKeyValueServiceConfig config = configManager.getConfig();
-        String partitioner = metadata.getPartitioner();
-        if (!config.safetyDisabled()) {
-            Validate.isTrue(
-                    CassandraConstants.ALLOWED_PARTITIONERS.contains(partitioner),
-                    "partitioner is: " + partitioner);
-        }
-
+        CassandraVerifier.validatePartitioner(metadata.getPartitioner(), config);
 
         Set<Peer> peers = CqlKeyValueServices.getPeers(session);
 

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -49,7 +49,6 @@ public class CassandraContainer extends Container {
             .mutationBatchCount(10000)
             .mutationBatchSizeBytes(10000000)
             .fetchBatchCount(1000)
-            .safetyDisabled(false)
             .autoRefreshNodes(false)
             .jmx(ImmutableCassandraJmxCompactionConfig.builder()
                     .username(USERNAME)

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -57,7 +57,6 @@ public class ThreeNodeCassandraCluster extends Container {
             .mutationBatchCount(10000)
             .mutationBatchSizeBytes(10000000)
             .fetchBatchCount(1000)
-            .safetyDisabled(false)
             .autoRefreshNodes(false)
             .build();
 

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.cassandra.yml
@@ -24,7 +24,6 @@ atlasdb:
     mutationBatchCount: 10000
     mutationBatchSizeBytes: 10000000
     fetchBatchCount: 1000
-    safetyDisabled: false
     autoRefreshNodes: false
 
   leader:

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.client.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.client.yml
@@ -24,7 +24,6 @@ atlasdb:
     mutationBatchCount: 10000
     mutationBatchSizeBytes: 10000000
     fetchBatchCount: 1000
-    safetyDisabled: false
     autoRefreshNodes: false
 
   leader:

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.yml
@@ -24,5 +24,4 @@ atlasdb:
     mutationBatchCount: 10000
     mutationBatchSizeBytes: 10000000
     fetchBatchCount: 1000
-    safetyDisabled: false
     autoRefreshNodes: false

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.timelock.cassandra.yml
@@ -24,7 +24,6 @@ atlasdb:
     mutationBatchCount: 10000
     mutationBatchSizeBytes: 10000000
     fetchBatchCount: 1000
-    safetyDisabled: false
     autoRefreshNodes: false
 
   timelock:

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/CassandraKeyValueServiceInstrumentation.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/CassandraKeyValueServiceInstrumentation.java
@@ -53,7 +53,6 @@ public class CassandraKeyValueServiceInstrumentation extends KeyValueServiceInst
                 .mutationBatchCount(10000)
                 .mutationBatchSizeBytes(10000000)
                 .fetchBatchCount(1000)
-                .safetyDisabled(false)
                 .autoRefreshNodes(false)
                 .build();
     }

--- a/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
@@ -74,7 +74,6 @@ You must ensure that you have migrated to the Timelock Server before adding a ``
         mutationBatchCount: 10000
         mutationBatchSizeBytes: 10000000
         fetchBatchCount: 1000
-        safetyDisabled: false
         autoRefreshNodes: false
 
       timelock:

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -62,7 +62,6 @@ Example Configuration
         mutationBatchCount: 10000
         mutationBatchSizeBytes: 10000000
         fetchBatchCount: 1000
-        safetyDisabled: false
         autoRefreshNodes: false
 
       leader:

--- a/docs/source/configuration/key_value_service_configs/cassandra_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/cassandra_key_value_service_config.rst
@@ -50,7 +50,6 @@ in the leaders list. If you do not specify a lock creator, the leaders block sho
         mutationBatchCount: 10000
         mutationBatchSizeBytes: 10000000
         fetchBatchCount: 1000
-        safetyDisabled: false
         autoRefreshNodes: false
 
       leader:

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,9 +44,15 @@ develop
     *    - Type
          - Change
 
+
     *    - |fixed|
          - Fixed an issue that could cause AtlasConsole to print unnecessary amounts of input when commands were run.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2130>`__)
+
+   *    - |userbreak|
+         - Remove Cassandra config option 'safetyDisabled';
+           users should instead move to various 'ignoreMoreSpecificCheck' config options; for instance, 'ignoreBadNodeTopologyChecks'
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2024>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,7 +51,8 @@ develop
 
     *    - |userbreak|
          - Remove Cassandra config option 'safetyDisabled';
-           users should instead move to various 'ignoreMoreSpecificCheck' config options; for instance, 'ignoreBadNodeTopologyChecks'
+           users should instead move to a more specific config for their situation, which are:
+	   ignoreNodeTopologyChecks, ignoreInconsistentRingChecks, ignoreDatacenterConfigurationChecks, ignorePartitionerChecks
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2024>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,7 +49,7 @@ develop
          - Fixed an issue that could cause AtlasConsole to print unnecessary amounts of input when commands were run.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2130>`__)
 
-   *    - |userbreak|
+    *    - |userbreak|
          - Remove Cassandra config option 'safetyDisabled';
            users should instead move to various 'ignoreMoreSpecificCheck' config options; for instance, 'ignoreBadNodeTopologyChecks'
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2024>`__)


### PR DESCRIPTION
fixes #2004

**Concerns (what feedback would you like?)**:
Not sure if we really need to go through a round of deprecation; these are very rarely used and we don't even have a really great way outside of release notes to actually tell users they are using deprecated config options. I doubt people will notice until we actually hard-drop any options they're using that are currently deprecated.

**Priority (whenever / two weeks / yesterday)**:
whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2024)
<!-- Reviewable:end -->
