### PR TITLE
Do not restrict refresh requests in ThreadPooledLockService

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,6 +45,11 @@ develop
     *    - |fixed|
          - Fixed an issue where the lock service was not properly shut down after losing leadership, which could result in threads blocking unnecessarily.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2014>`__)
+           
+    *    - |fixed|
+         - Lock refresh requests are no longer restricted by lock service threadpool limiting. 
+           This allows transactions to make progress even when the threadpool is full.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2025>`__)
 
     *    - |devbreak| |improved|
          - Upgraded all usages of http-remoting to remoting2

--- a/lock-impl/src/main/java/com/palantir/lock/impl/ThreadPooledLockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/ThreadPooledLockService.java
@@ -54,7 +54,7 @@ public class ThreadPooledLockService implements CloseableRemoteLockService {
 
     @Override
     public Set<LockRefreshToken> refreshLockRefreshTokens(Iterable<LockRefreshToken> tokens) {
-        return wrapper.applyWithPermit(lockService -> lockService.refreshLockRefreshTokens(tokens));
+        return delegate.refreshLockRefreshTokens(tokens);
     }
 
     @Nullable


### PR DESCRIPTION
**Goals (and why)**:
Currently the `ThreadPooledLockService` restricts lock refresh requests. These requests do not block and thus should be allowed through so transactions can make progress.

**note** this is targeting https://github.com/palantir/atlasdb/pull/2014 to avoid merge conflicts - we should merge this one first

**Implementation Description (bullets)**:
Don't require the semaphore for refreshing

**Concerns (what feedback would you like?)**:
no obvious concerns

**Where should we start reviewing?**:
one file

**Priority (whenever / two weeks / yesterday)**:
today - will make a patch for internal deployment

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2025)
<!-- Reviewable:end -->
