### PR TITLE
Configurable lock timeout

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -101,4 +101,6 @@ public class AtlasDbConstants {
 
     public static final int MAX_TABLE_PREFIX_LENGTH = 7;
     public static final int MAX_OVERFLOW_TABLE_PREFIX_LENGTH = 6;
+
+    public static final int DEFAULT_LOCK_TIMEOUT_SECONDS = 120;
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -204,7 +204,7 @@ public abstract class AtlasDbConfig {
     }
 
     /**
-     * The default lock expiration time for locks used by the transaction protocol.
+     * The default lock expiration time for requests to the lock service.
      */
     @Value.Default
     public int getDefaultLockTimeoutSeconds() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -203,6 +203,14 @@ public abstract class AtlasDbConfig {
         return 1000;
     }
 
+    /**
+     * The default lock expiration time for locks used by the transaction protocol.
+     */
+    @Value.Default
+    public int getDefaultLockTimeoutSeconds() {
+        return AtlasDbConstants.DEFAULT_LOCK_TIMEOUT_SECONDS;
+    }
+
     @Value.Check
     protected final void check() {
         if (leader().isPresent()) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -86,7 +86,6 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.SimpleTimeDuration;
-import com.palantir.lock.TimeDuration;
 import com.palantir.lock.client.LockRefreshingRemoteLockService;
 import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.timestamp.TimestampService;
@@ -183,7 +182,8 @@ public final class TransactionManagers {
 
         KeyValueService rawKvs = atlasFactory.getKeyValueService();
 
-        LockRequest.setDefaultLockTimeout(SimpleTimeDuration.of(config.getDefaultLockTimeoutSeconds(), TimeUnit.SECONDS));
+        LockRequest.setDefaultLockTimeout(
+                SimpleTimeDuration.of(config.getDefaultLockTimeoutSeconds(), TimeUnit.SECONDS));
         LockAndTimestampServices lockAndTimestampServices = createLockAndTimestampServices(
                 config,
                 env,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.factory;
 
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSocketFactory;
@@ -81,8 +82,11 @@ import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.proxy.AwaitingLeadershipProxy;
 import com.palantir.lock.LockClient;
+import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.TimeDuration;
 import com.palantir.lock.client.LockRefreshingRemoteLockService;
 import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.timestamp.TimestampService;
@@ -179,6 +183,7 @@ public final class TransactionManagers {
 
         KeyValueService rawKvs = atlasFactory.getKeyValueService();
 
+        LockRequest.setDefaultLockTimeout(SimpleTimeDuration.of(config.getDefaultLockTimeoutSeconds(), TimeUnit.SECONDS));
         LockAndTimestampServices lockAndTimestampServices = createLockAndTimestampServices(
                 config,
                 env,

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -160,7 +160,6 @@ public class TransactionManagersTest {
                 .keyValueService(new InMemoryAtlasDbConfig())
                 .defaultLockTimeoutSeconds((int) expectedTimeout.getTime())
                 .build();
-
         TransactionManagers.create(realConfig, ImmutableSet.of(), environment, false);
 
         assertEquals(expectedTimeout, LockRequest.getDefaultLockTimeout());

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.factory;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -43,12 +45,21 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
 import com.palantir.atlasdb.config.ImmutableLeaderConfig;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.config.ImmutableTimeLockClientConfig;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.config.TimeLockClientConfig;
+import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.TimeDuration;
 import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.timestamp.InMemoryTimestampService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
@@ -100,6 +111,7 @@ public class TransactionManagersTest {
         when(config.timestamp()).thenReturn(Optional.absent());
         when(config.lock()).thenReturn(Optional.absent());
         when(config.timelock()).thenReturn(Optional.absent());
+        when(config.keyValueService()).thenReturn(new InMemoryAtlasDbConfig());
 
         environment = mock(TransactionManagers.Environment.class);
 
@@ -139,6 +151,24 @@ public class TransactionManagersTest {
                 .build()));
 
         verifyUserAgentOnRawTimestampAndLockRequests();
+    }
+
+    @Test
+    public void setsGlobalDefaultLockTimeout() {
+        TimeDuration expectedTimeout = SimpleTimeDuration.of(47, TimeUnit.SECONDS);
+        AtlasDbConfig realConfig = ImmutableAtlasDbConfig.builder()
+                .keyValueService(new InMemoryAtlasDbConfig())
+                .defaultLockTimeoutSeconds((int) expectedTimeout.getTime())
+                .build();
+
+        TransactionManagers.create(realConfig, ImmutableSet.of(), environment, false);
+
+        assertEquals(expectedTimeout, LockRequest.getDefaultLockTimeout());
+
+        LockRequest lockRequest = LockRequest
+                .builder(ImmutableSortedMap.of(StringLockDescriptor.of("foo"),
+                        LockMode.WRITE)).build();
+        assertEquals(expectedTimeout, lockRequest.getLockTimeout());
     }
 
     private void verifyUserAgentOnRawTimestampAndLockRequests() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,6 +58,11 @@ develop
     *    - |devbreak| |improved|
          - Upgraded all usages of http-remoting to remoting2
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1999>`__)
+           
+    *    - |new|
+         - The default lock timeout is now configurable. 
+           Currently, the default lock timeout is 2 minutes. This can cause a large delay if a lock requester's connection has died at the time it receives the lock. Since TransactionManagers#create provides an auto-refreshing lock service, it is safe to lower the default timeout to reduce the delay that happens in this case.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2025>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/lock-api/src/main/java/com/palantir/lock/LockRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockRequest.java
@@ -50,9 +50,8 @@ import com.google.common.collect.Iterables;
 @Immutable public final class LockRequest implements Serializable {
     private static final long serialVersionUID = 0xf6c12b970b44af68L;
 
-    private static final TimeDuration DEFAULT_LOCK_TIMEOUT = SimpleTimeDuration.of(120, TimeUnit.SECONDS);
-
-    private static final AtomicReference<TimeDuration> defaultLockTimeout = new AtomicReference<>(DEFAULT_LOCK_TIMEOUT);
+    private static final AtomicReference<TimeDuration> defaultLockTimeout = new AtomicReference<>(
+            SimpleTimeDuration.of(120, TimeUnit.SECONDS));
 
     /** The default amount of time that it takes a lock (lease) to expire. */
     public static TimeDuration getDefaultLockTimeout() {
@@ -377,7 +376,7 @@ import com.google.common.collect.Iterables;
                 serverName = " (on server " + localServerName + ")";
             }
             LockRequest request = new LockRequest(lockMap,
-                    MoreObjects.firstNonNull(lockTimeout, DEFAULT_LOCK_TIMEOUT),
+                    MoreObjects.firstNonNull(lockTimeout, getDefaultLockTimeout()),
                     MoreObjects.firstNonNull(lockGroupBehavior, LockGroupBehavior.LOCK_ALL_OR_NONE),
                     MoreObjects.firstNonNull(blockingMode, BlockingMode.BLOCK_INDEFINITELY),
                     blockingDuration, versionId,

--- a/lock-api/src/main/java/com/palantir/lock/LockRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockRequest.java
@@ -58,10 +58,13 @@ import com.google.common.collect.Iterables;
         return DEFAULT_LOCK_TIMEOUT.get();
     }
 
-    /** Sets the default lock timeout for all lock requests that do not specify an explicit timeout. See {@link Builder#timeoutAfter}. */
+    /**
+     * Sets the default lock timeout for all lock requests that do not specify an explicit timeout. See {@link
+     * Builder#timeoutAfter}.
+     */
     public static void setDefaultLockTimeout(TimeDuration timeout) {
-        Preconditions.checkNotNull(timeout);
-        Preconditions.checkArgument(timeout.getTime() > 0);
+        Preconditions.checkNotNull(timeout, "timeout cannot be null");
+        Preconditions.checkArgument(timeout.getTime() > 0, "timeout must be > 0");
 
         DEFAULT_LOCK_TIMEOUT.set(timeout);
     }

--- a/lock-api/src/main/java/com/palantir/lock/LockRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockRequest.java
@@ -50,16 +50,16 @@ import com.google.common.collect.Iterables;
 @Immutable public final class LockRequest implements Serializable {
     private static final long serialVersionUID = 0xf6c12b970b44af68L;
 
-    private static final AtomicReference<TimeDuration> defaultLockTimeout = new AtomicReference<>(
+    private static final AtomicReference<TimeDuration> DEFAULT_LOCK_TIMEOUT = new AtomicReference<>(
             SimpleTimeDuration.of(120, TimeUnit.SECONDS));
 
     /** The default amount of time that it takes a lock (lease) to expire. */
     public static TimeDuration getDefaultLockTimeout() {
-        return defaultLockTimeout.get();
+        return DEFAULT_LOCK_TIMEOUT.get();
     }
 
     public static void setDefaultLockTimeout(TimeDuration timeout) {
-        defaultLockTimeout.set(timeout);
+        DEFAULT_LOCK_TIMEOUT.set(timeout);
     }
 
     private static final Function<Map.Entry<LockDescriptor, LockMode>, LockWithMode> TO_LOCK_WITH_MODE_FUNCTION =

--- a/lock-api/src/main/java/com/palantir/lock/LockRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockRequest.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -48,8 +50,18 @@ import com.google.common.collect.Iterables;
 @Immutable public final class LockRequest implements Serializable {
     private static final long serialVersionUID = 0xf6c12b970b44af68L;
 
+    private static final TimeDuration DEFAULT_LOCK_TIMEOUT = SimpleTimeDuration.of(120, TimeUnit.SECONDS);
+
+    private static final AtomicReference<TimeDuration> defaultLockTimeout = new AtomicReference<>(DEFAULT_LOCK_TIMEOUT);
+
     /** The default amount of time that it takes a lock (lease) to expire. */
-    public static final TimeDuration DEFAULT_LOCK_TIMEOUT = SimpleTimeDuration.of(120, TimeUnit.SECONDS);
+    public static TimeDuration getDefaultLockTimeout() {
+        return defaultLockTimeout.get();
+    }
+
+    public static void setDefaultLockTimeout(TimeDuration timeout) {
+        defaultLockTimeout.set(timeout);
+    }
 
     private static final Function<Map.Entry<LockDescriptor, LockMode>, LockWithMode> TO_LOCK_WITH_MODE_FUNCTION =
             new Function<Map.Entry<LockDescriptor, LockMode>, LockWithMode>() {

--- a/lock-api/src/main/java/com/palantir/lock/LockRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockRequest.java
@@ -58,7 +58,11 @@ import com.google.common.collect.Iterables;
         return DEFAULT_LOCK_TIMEOUT.get();
     }
 
+    /** Sets the default lock timeout for all lock requests that do not specify an explicit timeout. See {@link Builder#timeoutAfter}. */
     public static void setDefaultLockTimeout(TimeDuration timeout) {
+        Preconditions.checkNotNull(timeout);
+        Preconditions.checkArgument(timeout.getTime() > 0);
+
         DEFAULT_LOCK_TIMEOUT.set(timeout);
     }
 
@@ -252,11 +256,10 @@ import com.google.common.collect.Iterables;
 
         /**
          * Instructs the lock server to release these locks if a refresh request
-         * has not been received for the period of time represented by
-         * the <code>lockTimeout</code> parameter. By default, the lock server
-         * will release locks
-         * which have not been refreshed in the past 120 seconds. You may not
-         * call this method multiple times.
+         * has not been received for the period of time represented by the
+         * <code>lockTimeout</code> parameter. The default value is controlled
+         * by {@link #LockRequest#getDefaultLockTimeout()}.
+         * You may not call this method multiple times.
          */
         public Builder timeoutAfter(TimeDuration newLockTimeout) {
             Preconditions.checkArgument(newLockTimeout.toMillis() > 0);

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -57,7 +57,7 @@ public class LockRefreshingLockService extends ForwardingLockService {
                 } finally {
                     long elapsed = System.currentTimeMillis() - startTime;
 
-                    if (elapsed > LockRequest.DEFAULT_LOCK_TIMEOUT.toMillis() / 2) {
+                    if (elapsed > LockRequest.getDefaultLockTimeout().toMillis() / 2) {
                         log.error("Refreshing locks took {} milliseconds"
                                 + " for tokens: {}", elapsed, ret.toRefresh);
                     } else if (elapsed > ret.refreshFrequencyMillis) {

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingRemoteLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingRemoteLockService.java
@@ -54,7 +54,7 @@ public class LockRefreshingRemoteLockService extends ForwardingRemoteLockService
                 } finally {
                     long elapsed = System.currentTimeMillis() - startTime;
 
-                    if (elapsed > LockRequest.DEFAULT_LOCK_TIMEOUT.toMillis() / 2) {
+                    if (elapsed > LockRequest.getDefaultLockTimeout().toMillis() / 2) {
                         log.error("Refreshing locks took {} milliseconds"
                                 + " for tokens: {}", elapsed,  ret.toRefresh);
                     } else if (elapsed > ret.refreshFrequencyMillis) {

--- a/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/LockServiceTest.java
@@ -92,7 +92,7 @@ public abstract class LockServiceTest {
 
     /** Tests using doNotBlock() in the lock request. */
     @Test public void testDoNotBlock() throws InterruptedException {
-        long lockTimeoutMs = LockRequest.DEFAULT_LOCK_TIMEOUT.toMillis();
+        long lockTimeoutMs = LockRequest.getDefaultLockTimeout().toMillis();
         LockRequest request = LockRequest.builder(ImmutableSortedMap.of(
                 lock1, LockMode.READ, lock2, LockMode.WRITE))
                 .withLockedInVersionId(10).doNotBlock().build();
@@ -151,7 +151,7 @@ public abstract class LockServiceTest {
 
     /** Tests using blockForAtMost() in the lock request. */
     @Test public void testBlockForAtMost() throws Exception {
-        long lockTimeoutMs = LockRequest.DEFAULT_LOCK_TIMEOUT.toMillis();
+        long lockTimeoutMs = LockRequest.getDefaultLockTimeout().toMillis();
         LockRequest request = LockRequest.builder(ImmutableSortedMap.of(
                 lock1, LockMode.READ, lock2, LockMode.WRITE))
                 .withLockedInVersionId(10)
@@ -248,7 +248,7 @@ public abstract class LockServiceTest {
 
     /** Tests using block indefinitely mode */
     @Test public void testBlockIndefinitely() throws Exception {
-        long lockTimeoutMs = LockRequest.DEFAULT_LOCK_TIMEOUT.toMillis();
+        long lockTimeoutMs = LockRequest.getDefaultLockTimeout().toMillis();
         LockRequest request = LockRequest.builder(ImmutableSortedMap.of(
                 lock1, LockMode.READ, lock2, LockMode.WRITE)).withLockedInVersionId(10).build();
         long currentTimeMs = System.currentTimeMillis();
@@ -425,7 +425,7 @@ public abstract class LockServiceTest {
 
     /** Tests against LockService.logCurrentState() long-block bug (QA-87074) */
     @Test public void testLogCurrentState() throws Exception {
-        long lockTimeoutMs = LockRequest.DEFAULT_LOCK_TIMEOUT.toMillis();
+        long lockTimeoutMs = LockRequest.getDefaultLockTimeout().toMillis();
         // Timeout in private LockServiceImpl.LOG_STATE_DEBUG_LOCK_WAIT_TIME_IN_MILLIS; test value is double that
         long logCurrentStateCallTimeoutMs = 2 * 5000L;
 

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
@@ -84,7 +84,7 @@ public class LockServiceStateLoggerTest {
         return new HeldLocksToken(tokenId, LockClient.of(clientName),
                 System.currentTimeMillis(), System.currentTimeMillis(),
                 LockCollections.of(builder.build()),
-                LockRequest.DEFAULT_LOCK_TIMEOUT, 0L, requestingThread);
+                LockRequest.getDefaultLockTimeout(), 0L, requestingThread);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Allow configuration of the default lock timeout used by the transaction protocol

We've seen in the field that lock requests can succeed despite the client connection being closed. This results in the lock being effectively stuck for 2 minutes, until it expires.

The real solution here is to make lock requests idempotent and/or detect when the connection has been closed - however this is a good workaround in the meantime.

**Implementation Description (bullets)**:

- Allow configuration of the default lock timeout (this gets used by the transaction protocol, because none of the requests it makes specify an explicit timeout)
- Remove the static constant `DEFAULT_LOCK_TIMEOUT` variable

**Concerns (what feedback would you like?)**:
- Is there a cleaner way to do this?
- This is going to break the large internal product which references the above removed constant, though the fix is very easy

**Where should we start reviewing?**:
LockRequest.java

**Priority (whenever / two weeks / yesterday)**:
soon - would be nice to include this in patch to internal deployment, but not critical

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2026)
<!-- Reviewable:end -->
