### PR TITLE
Bumping up background sweep logs priority

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -199,7 +199,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
             } else {
                 SweepBatchConfig lastBatchConfig = getAdjustedBatchConfig();
                 log.warn("The background sweep job failed unexpectedly with batch config {}."
-                        + " Attempting to continue with a lower batch size...",
+                                + " Attempting to continue with a lower batch size...",
                         SafeArg.of("cell batch size", lastBatchConfig),
                         e);
                 // Cut batch size in half, always sweep at least one row (we round down).
@@ -256,7 +256,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
             saveSweepResults(tableToSweep, results);
         } catch (RuntimeException e) {
             // Error logged at a higher log level above.
-            log.warn("Failed to sweep {} with batch config {} starting from row {}",
+            log.debug("Failed to sweep {} with batch config {} starting from row {}",
                     UnsafeArg.of("table name", tableRef),
                     SafeArg.of("cell batch size", batchConfig),
                     UnsafeArg.of("start row hex", startRowToHex(startRow)));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/PersistentLockManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/PersistentLockManager.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.persistentlock.PersistentLockId;
 import com.palantir.atlasdb.persistentlock.PersistentLockService;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.logsafe.SafeArg;
 
 // TODO move to persistentlock package?
 public class PersistentLockManager {
@@ -73,7 +74,7 @@ public class PersistentLockManager {
         while (true) {
             try {
                 lockId = persistentLockService.acquireBackupLock("Sweep");
-                log.info("Successfully acquired persistent lock for sweep: {}", lockId);
+                log.info("Successfully acquired persistent lock for sweep: {}", SafeArg.of("lock id", lockId));
                 return;
             } catch (CheckAndSetException e) {
                 lockFailureMeter.mark();
@@ -95,7 +96,8 @@ public class PersistentLockManager {
             lockId = null;
         } catch (CheckAndSetException e) {
             log.error("Failed to release persistent lock {}. "
-                    + "Either the lock was already released, or communications with the database failed.", lockId, e);
+                    + "Either the lock was already released, or communications with the database failed.",
+                    SafeArg.of("lock id", lockId), e);
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -42,6 +42,7 @@ import com.palantir.atlasdb.sweep.CellsToSweepPartitioningIterator.ExaminedCellL
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.base.ClosableIterator;
+import com.palantir.logsafe.UnsafeArg;
 
 import gnu.trove.TDecorators;
 
@@ -122,7 +123,8 @@ public class SweepTaskRunner {
             return SweepResults.createEmptySweepResult();
         }
         if (keyValueService.getMetadataForTable(tableRef).length == 0) {
-            log.warn("The sweeper tried to sweep table '{}', but the table does not exist. Skipping table.", tableRef);
+            log.warn("The sweeper tried to sweep table '{}', but the table does not exist. Skipping table.",
+                    UnsafeArg.of("table name", tableRef));
             return SweepResults.createEmptySweepResult();
         }
         SweepStrategy sweepStrategy = sweepStrategyManager.get().getOrDefault(tableRef, SweepStrategy.CONSERVATIVE);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,6 +63,10 @@ develop
          - Switched from feign to openfeign and bumped version.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2005>`__)
 
+    *    - |improved|
+         - The priority of logging on background sweep was increased from debug to info or warn.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2031>`__)
+
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**: With the rollout of background sweep, we should bump sweep priority to better perceive the effects of sweeping.

**Implementation Description (bullets)**:
- Bump logs to info and warn accordingly.
- Mark arguments as safe or unsafe accordingly.

**Concerns (what feedback would you like?)**: 
- Am I logging something unsafe?
- Did I forget any important logs?
- Am I logging to much?

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: Since it's small, EOW

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2031)
<!-- Reviewable:end -->
