### PR TITLE
Removed snapshot version substitution of -g to -r

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,9 +51,7 @@ dependencies {
 apply from: 'gradle/versions.gradle'
 
 group = 'com.palantir.atlasdb'
-// if the version ends with a git hash, replace the 'g' with an 'r'
-// this is to get around maven regexes that considers -g<hash> a snapshot
-version = gitVersion().replaceAll('-g([a-fA-F0-9]+)$', '-r$1')
+version = gitVersion()
 description = 'Transactional distributed database layer'
 
 task printLastVersion {


### PR DESCRIPTION
This workaround is no longer necessary.

**Goals (and why)**:

This was original written as a workaround for publish rules that restricted versions with `-gXXXXXX`. This was done because the default publication location was a mutable snapshot repository with expiration. These properties were undesirable. A new publish location has since been created that lifts the original constraints but is immutable and long-lived.

**Implementation Description (bullets)**:

Remove substitution `version = gitVersion().replaceAll('-g([a-fA-F0-9]+)$', '-r$1')`

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2032)
<!-- Reviewable:end -->
