### PR TITLE
Fix race condition in Jepsen lock client

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -75,21 +75,22 @@
           (let [lock-name (:value op)
                 token-store-key (str client-name lock-name)
                 current-store-version (version-bump! token-store)]
-            (case (:f op)
-              :lock
-              (let [response (LockClient/lock lock-service client-name lock-name)]
-                (do (replace-token! token-store token-store-key response current-store-version)
-                  (assoc-ok-value op response [client-name lock-name])))
-              :unlock
-              (let [token (@token-store token-store-key)
-                    response (LockClient/unlock lock-service token)]
-                (do (replace-token! token-store token-store-key nil current-store-version)
-                  (assoc-ok-value op response token)))
-              :refresh
-              (let [token (@token-store token-store-key)
-                    response (LockClient/refresh lock-service token)]
-                (do (replace-token! token-store token-store-key token current-store-version)
-                  (assoc-ok-value op response token)))))
+            (if ((complement nil?) current-store-version)
+              (case (:f op)
+                :lock
+                (let [response (LockClient/lock lock-service client-name lock-name)]
+                  (do (replace-token! token-store token-store-key response current-store-version)
+                    (assoc-ok-value op response [client-name lock-name])))
+                :unlock
+                (let [token (@token-store token-store-key)
+                      response (LockClient/unlock lock-service token)]
+                  (do (replace-token! token-store token-store-key nil current-store-version)
+                    (assoc-ok-value op response token)))
+                :refresh
+                (let [token (@token-store token-store-key)
+                      response (LockClient/refresh lock-service token)]
+                  (do (replace-token! token-store token-store-key token current-store-version)
+                    (assoc-ok-value op response token))))))
           (catch Exception e
             (assoc op :type :fail :error (.toString e))))))
 

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -83,12 +83,12 @@
               :unlock
               (let [token (@token-store token-store-key)
                     response (LockClient/unlock lock-service token)]
-                (do (replace-token token-store token-store-key nil current-store-version)
+                (do (replace-token! token-store token-store-key nil current-store-version)
                   (assoc-ok-value op response token)))
               :refresh
               (let [token (@token-store token-store-key)
                     response (LockClient/refresh lock-service token)]
-                (do (replace-token token-store token-store-key token current-store-version)
+                (do (replace-token! token-store token-store-key token current-store-version)
                   (assoc-ok-value op response token)))))
           (catch Exception e
             (assoc op :type :fail :error (.toString e))))))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -28,7 +28,7 @@
     (if (compare-and-set! store current-map (assoc current-map version-name target-version))
       target-version
       nil)))
-(defn update-token!
+(defn replace-token!
   "Updates a token in the store, if the version in the store matches our expected version.
   Returns true if and only if the store was successfully updated.
   "
@@ -74,7 +74,7 @@
         (try
           (let [lock-name (:value op)
                 token-store-key (str client-name lock-name)
-                current-store-version (version-bump! store)]
+                current-store-version (version-bump! token-store)]
             (case (:f op)
               :lock
               (let [response (LockClient/lock lock-service client-name lock-name)]

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -11,14 +11,35 @@
   (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
   (:import com.palantir.atlasdb.http.LockClient))
 
-(def lock-names ["bob" "sarah" "alfred" "shelly"])
+(def lock-names ["alpha" "bravo" "charlie" "delta"])
+(def version-name "version")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Client creation and invocations (i.e. locking, unlocking refreshing)
+;; Relevant utility methods, including administration of the token store's simple MVCC protocol
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn nullable-to-string    [obj] (if (nil? obj) "" (.toString obj)))
-(defn create-token-store    [] (atom {}))
-(defn replace-token         [store key obj] (swap! store assoc key obj))
+
+(defn create-token-store    [] (atom {version-name 0}))
+(defn version-bump!
+  "Attempts to increment the version key in a token store. Returns the version number if CAS succeded, nil if failed."
+  [store]
+  (let [current-map @store
+        target-version (inc (get current-map version-name))]
+    (if (compare-and-set! store current-map (assoc current-map version-name target-version))
+      target-version
+      nil)))
+(defn update-token!
+  "Updates a token in the store, if the version in the store matches our expected version.
+  Returns true if and only if the store was successfully updated.
+  "
+  [store key obj expected-version]
+  (loop [current-map @store]
+    (if-not (== (get current-map version-name) expected-version)
+       false
+       (if (compare-and-set! store current-map (assoc current-map key obj))
+         true
+         (recur @store)))))
+
 (defn assoc-ok-value
   "Associate the map with ':ok', meaning that the server response was 200.
    Also capture the server response and the query parameters we used."
@@ -27,6 +48,9 @@
     :value (nullable-to-string response)
     :query-params (nullable-to-string query-params)))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Client creation and invocations (i.e. locking, unlocking refreshing)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn create-client
   "Creates an object that implements the client/Client protocol.
    The object defines how you create a lock client, and how to request locks from it. The first call to this
@@ -49,21 +73,22 @@
         (assoc op :type :fail :error :timeout)
         (try
           (let [lock-name (:value op)
-                token-store-key (str client-name lock-name)]
+                token-store-key (str client-name lock-name)
+                current-store-version (version-bump! store)]
             (case (:f op)
               :lock
               (let [response (LockClient/lock lock-service client-name lock-name)]
-                (do (replace-token token-store token-store-key response)
+                (do (replace-token! token-store token-store-key response current-store-version)
                   (assoc-ok-value op response [client-name lock-name])))
               :unlock
               (let [token (@token-store token-store-key)
                     response (LockClient/unlock lock-service token)]
-                (do (replace-token token-store token-store-key nil)
+                (do (replace-token token-store token-store-key nil current-store-version)
                   (assoc-ok-value op response token)))
               :refresh
               (let [token (@token-store token-store-key)
                     response (LockClient/refresh lock-service token)]
-                (do (replace-token token-store token-store-key token)
+                (do (replace-token token-store token-store-key token current-store-version)
                   (assoc-ok-value op response token)))))
           (catch Exception e
             (assoc op :type :fail :error (.toString e))))))

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/LockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/LockClient.java
@@ -44,12 +44,6 @@ public final class LockClient {
                 .build();
         LockRefreshToken token = service.lock(client, request);
 
-        // Some implementations of the lock service are uninterruptible.
-        // However, correctness of the Jepsen verifier relies on workers maintaining at most one open request.
-        // So we want to treat this request as cancelled.
-        if (Thread.currentThread().isInterrupted()) {
-            throw new InterruptedException("lock() was interrupted");
-        }
         return token;
     }
 


### PR DESCRIPTION
**Goals (and why)**: Fix at least one source of false positives returned by the Jepsen tests (see run 17 on internal build 258).

**Implementation Description (bullets)**:
- In the Jepsen lock client, throw `InterruptedException` if a thread was interrupted, rather than returning the lock token.

Background: We observed cases where we were able to successfully refresh lock tokens which seemed to never be returned from a successful lock request. The `IsolatedProcessCorrectnessChecker` correctly flags these as violations.

Our hypothesis here is that we submitted a lock request with a timeout of 30 seconds in `lock.clj`. This is asynchronous, and after 30 seconds we interrupt the request and continue. The problem is that our code wasn't responsive to interrupts, so we wait anyway (even though our lock requests are do-not-block, we could still block for >=30 seconds if there was no quorum, or the leader we tried to talk to got into a minority partition).

**Concerns (what feedback would you like?)**:
- Should I use `Throwables.propagate()` here instead? I threw the`InterruptedException` so that if later on we want to catch this and do some more cleanup or behave in a different way, we can.
- Let's wait for the internal job that runs these tests to report success before we merge, too.

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: soon - we can identify violations that conform to this pattern if the tests fail again, but it's pretty unpleasant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2035)
<!-- Reviewable:end -->
