### PR TITLE
Added rowComponents function to table command

### DIFF
--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -50,7 +50,7 @@ class AtlasCoreModule implements AtlasConsoleModule {
                          Ex: def x = table('stream_value')
 
                          To retrieve metadata about a table, use <TABLE>.describe(),
-                         <TABLE>.isDynamic(), and <TABLE>.columnNames().'''.stripIndent(),
+                         <TABLE>.isDynamic(), <TABLE>.rowComponents(), and <TABLE>.columnNames().'''.stripIndent(),
             'transactions': '''\
                          Atomic transactions used to avoid read/write or write/write
                          conflicts. Use startTransaction() to start, currentTransaction()

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
@@ -58,6 +58,9 @@ class Table {
         getDescription()['columns'].collect {it['long_name']}
     }
 
+    List rowComponents() {
+        getDescription()['row'].collect() {it['name']}
+    }
     /**
      * Get data from atlas by specifying the row of data to return
      * @param row  A single row to get, where the row is a List of components

--- a/atlasdb-console/src/test/groovy/com/palantir/atlasdb/console/groovy/TableTest.groovy
+++ b/atlasdb-console/src/test/groovy/com/palantir/atlasdb/console/groovy/TableTest.groovy
@@ -48,6 +48,10 @@ class TableTest {
     void testDescribe() {
         final Map DESC = [
             isDynamic:false,
+            row: [
+                [name: 'foo'],
+                [name: 'bar']
+            ],
             columns: [
                 [long_name: 'alice'],
                 [long_name: 'bob']
@@ -58,6 +62,7 @@ class TableTest {
             assertEquals(DESC, table.describe())
             assert !table.isDynamic()
             assertEquals(['alice', 'bob'], table.columnNames())
+            assertEquals(['foo', 'bar'], table.rowComponents())
         }
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -70,6 +70,7 @@ develop
     *    - |new|
          - Added a rowComponents() function to the AtlasConsole table() command to allow you to easily view the
            fields that make up a row key.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2037>`__)
 
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -67,6 +67,10 @@ develop
          - The priority of logging on background sweep was increased from debug to info or warn.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2031>`__)
 
+    *    - |new|
+         - Added a rowComponents() function to the AtlasConsole table() command to allow you to easily view the
+           fields that make up a row key.
+
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**: When using AtlasConsole for PG, you often need to know the row components to look things up. It's kind of difficult to obtain them at the moment, this will make it simple.

**Implementation Description (bullets)**: Added a one-line function and some tests

**Concerns (what feedback would you like?)**: None

**Where should we start reviewing?**: Simple change

**Priority (whenever / two weeks / yesterday)**: Within a week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2037)
<!-- Reviewable:end -->
