### PR TITLE
Ensure timely reaping of locks.

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,6 +63,11 @@ develop
          - The default lock timeout is now configurable. 
            Currently, the default lock timeout is 2 minutes. This can cause a large delay if a lock requester's connection has died at the time it receives the lock. Since TransactionManagers#create provides an auto-refreshing lock service, it is safe to lower the default timeout to reduce the delay that happens in this case.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2025>`__)
+           
+    *    - |fixed|
+         - Lock service now ensures that locks are reaped in a more timely manner. 
+           Previously the lock service could allow locks to be held past expiration, if they had a timeout shorter than the longest timeout in the expiration queue.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2041>`__)
 
     *    - |devbreak|
          - Switched from feign to openfeign and bumped version.

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -122,8 +122,6 @@ public final class LockServiceImpl
     @VisibleForTesting
     static final long DEBUG_SLOW_LOG_TRIGGER_MILLIS = 100;
 
-    private static final long MAX_LOCK_REAPER_SLEEP_TIME_MS = 2_000;
-
     /** Executor for the reaper threads. */
     private final ExecutorService executor = Tracers.wrap(PTExecutors.newCachedThreadPool(
             new NamedThreadFactory(LockServiceImpl.class.getName(), true)));
@@ -926,7 +924,7 @@ public final class LockServiceImpl
                     long timeUntilTokenExpiredMs = token.getExpirationDateMs() - currentTimeMillis()
                             + maxAllowedClockDrift.toMillis();
                     // it's possible that new lock requests will come in with a shorter timeout - so limit how long we sleep here
-                    long sleepTimeMs = Math.min(timeUntilTokenExpiredMs, MAX_LOCK_REAPER_SLEEP_TIME_MS);
+                    long sleepTimeMs = Math.min(timeUntilTokenExpiredMs, maxAllowedClockDrift.toMillis());
                     if (sleepTimeMs > 0) {
                         Thread.sleep(sleepTimeMs);
                     }


### PR DESCRIPTION
**Goals (and why)**:
See https://github.com/palantir/atlasdb/issues/743

Currently the lock service reaper can allow locks to be held far past expiration.

**Implementation Description (bullets)**:
Doing the quick and dirty fix of just enforcing a maximum sleep time. Ideally we'd probably use a `DelayQueue` here, but not sure it's worth the investment at the moment.

**Concerns (what feedback would you like?)**:
Is this an acceptable way to fix this?

**Where should we start reviewing?**:
one file

**Priority (whenever / two weeks / yesterday)**:
pretty soon - we recently committed https://github.com/palantir/atlasdb/pull/2026 and this is an important complement

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2041)
<!-- Reviewable:end -->
