### PR TITLE
Reduce log level from info to debug for frequent statement

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -125,7 +125,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
             }
         });
 
-        DebugLogger.logger.info("[GET] Setting cached timestamp limit to {}.", currentLimit);
+        DebugLogger.logger.debug("[GET] Setting cached timestamp limit to {}.", currentLimit);
         currentLimit = upperLimit;
         return currentLimit;
     }
@@ -179,7 +179,7 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
             DebugLogger.logger.error("Thread dump: {}", ThreadDumps.programmaticThreadDump());
             throw err;
         } else {
-            DebugLogger.logger.info("[CAS] Setting cached limit to {}.", newVal);
+            DebugLogger.logger.debug("[CAS] Setting cached limit to {}.", newVal);
             currentLimit = newVal;
         }
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -83,7 +83,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2037>`__)
 
     *    - |changed|
-         - Reduced the logging level of some messages relating to check-and-set operations in ``CassandraTimestampBoundStore`` to reduce noise in the logs.  These were designed to help debugging the ``MultipleRunningTimestampServicesException`` issues.
+         - Reduced the logging level of some messages relating to check-and-set operations in ``CassandraTimestampBoundStore`` to reduce noise in the logs.  These were designed to help debugging the ``MultipleRunningTimestampServicesException`` issues but we no longer require them to log all the time.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2048>`__)
 
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -82,6 +82,10 @@ develop
            fields that make up a row key.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2037>`__)
 
+    *    - |changed|
+         - Reduced the logging level of some messages relating to check-and-set operations in ``CassandraTimestampBoundStore`` to reduce noise in the logs.  These were designed to help debugging the ``MultipleRunningTimestampServicesException`` issues.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2048>`__)
+
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
Fixes #2048 

Reduce log levels for frequently called CAS statement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2049)
<!-- Reviewable:end -->
