### PR TITLE
Unsuppress SLF4JConstantMessage in Lock Service and TimeLock

### DIFF
--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -369,7 +369,7 @@ public final class LockServiceImpl
 
             if (request.getBlockingMode() == BlockingMode.BLOCK_INDEFINITELY_THEN_RELEASE) {
                 if (log.isTraceEnabled()) {
-                    logNullResponse(client, request);
+                    logNullResponse(client, request, null);
                 }
                 if (requestLogger.isDebugEnabled()) {
                     requestLogger.debug("Timed out requesting {} for requesting thread {} after {} ms",
@@ -383,7 +383,7 @@ public final class LockServiceImpl
             if (locks.isEmpty() || ((request.getLockGroupBehavior() == LOCK_ALL_OR_NONE)
                     && (locks.size() < request.getLockDescriptors().size()))) {
                 if (log.isTraceEnabled()) {
-                    logNullResponse(client, request);
+                    logNullResponse(client, request, null);
                 }
                 if (requestLogger.isDebugEnabled()) {
                     requestLogger.debug("Failed to acquire all locks for {} for requesting thread {} after {} ms",
@@ -408,7 +408,7 @@ public final class LockServiceImpl
                     request.getLockTimeout(), request.getVersionId(), request.getCreatingThreadName());
             locks.clear();
             if (log.isTraceEnabled()) {
-                logNullResponse(client, request);
+                logNullResponse(client, request, token);
             }
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted while locking.");
@@ -436,10 +436,11 @@ public final class LockServiceImpl
         }
     }
 
-    private void logNullResponse(LockClient client, LockRequest request) {
-        log.trace(".lock({}, {}) returns null",
+    private void logNullResponse(LockClient client, LockRequest request, @Nullable HeldLocksToken token) {
+        log.trace(".lock({}, {}) returns {}",
                 SafeArg.of("client", client),
-                UnsafeArg.of("request", request));
+                UnsafeArg.of("request", request),
+                token == null ? UnsafeArg.of("lockToken", "null") : UnsafeArg.of("lockToken", token));
     }
 
     private void logLockAcquisitionFailure(Map<LockDescriptor, LockClient> failedLocks) {


### PR DESCRIPTION
**Goals (and why)**: 
Some of our packages don't have constant log format messages, which can get dangerous because sensitive information could be logged if users are not careful.

**Implementation Description (bullets)**:
- Expunge non-constant log format messages
- Also drive by fix of a bug in `logLockAcquisitionFailure`, which would always log `MAX_FAILED_LOCKS_TO_LOG` regardless of the number of failed locks (so you could get something like `Current holders of the first 20 of 1 total failed locks were ...`) 

**Concerns (what feedback would you like?)**:
- The log format is slightly different after this change. Are people relying on automatically parsing these?
- Is large internal product comfortable with modern SLS-style logging?
- Did I decide correctly regarding safe vs unsafe args for each of the params?

**Where should we start reviewing?**: either file

**Priority (whenever / two weeks / yesterday)**: whenever.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2055)
<!-- Reviewable:end -->
