### PR TITLE
Batch at most deleteBatchSize cells

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -189,6 +189,7 @@ public class SweepTaskRunner {
         }
     }
 
+    // Each batch has at least deleteBatchSize and at most (2*deleteBatchSize-1) cells.
     private Iterator<BatchOfCellsToSweep> getBatchesToSweep(Iterator<List<CandidateCellForSweeping>> candidates,
                                                             SweepBatchConfig batchConfig,
                                                             SweepableCellFilter sweepableCellFilter,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.sweep;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.LongSupplier;
 
 import org.slf4j.Logger;
@@ -194,10 +193,11 @@ public class SweepTaskRunner {
                                                             SweepBatchConfig batchConfig,
                                                             SweepableCellFilter sweepableCellFilter,
                                                             ExaminedCellLimit limit) {
-        candidates = Iterators.filter(candidates, Objects::nonNull);
-        candidates = Iterators.filter(candidates, list -> !list.isEmpty());
+        Iterator<List<CandidateCellForSweeping>> validCandidates =
+                Iterators.filter(candidates, list -> list != null && !list.isEmpty());
 
-        Iterator<Iterator<List<CandidateCellForSweeping>>> batchedCandidatesIterator = Iterators.transform(candidates,
+        Iterator<Iterator<List<CandidateCellForSweeping>>> batchedCandidatesIterator = Iterators.transform(
+                validCandidates,
                 (List<CandidateCellForSweeping> candidateList) ->
                         Iterators.partition(candidateList.iterator(), batchConfig.deleteBatchSize()));
         Iterator<List<CandidateCellForSweeping>> batchedCandidates = Iterators.concat(batchedCandidatesIterator);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -52,7 +52,6 @@ import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
-import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -21,8 +21,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
@@ -30,10 +35,13 @@ import java.util.function.LongSupplier;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -44,6 +52,7 @@ import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
@@ -68,15 +77,17 @@ public abstract class AbstractSweepTaskRunnerTest {
     protected LockAwareTransactionManager txManager;
     protected TransactionService txService;
     protected PersistentLockManager persistentLockManager;
+    protected SweepStrategyManager ssm;
+    protected LongSupplier tsSupplier;
 
     @Before
     public void setup() {
         TimestampService tsService = new InMemoryTimestampService();
         kvs = SweepStatsKeyValueService.create(getKeyValueService(), tsService);
-        SweepStrategyManager ssm = SweepStrategyManagers.createDefault(kvs);
+        ssm = SweepStrategyManagers.createDefault(kvs);
         txService = TransactionServices.createTransactionService(kvs);
         txManager = SweepTestUtils.setupTxManager(kvs, tsService, ssm, txService);
-        LongSupplier tsSupplier = sweepTimestamp::get;
+        tsSupplier = sweepTimestamp::get;
         persistentLockManager = new PersistentLockManager(
                 SweepTestUtils.getPersistentLockService(kvs),
                 AtlasDbConstants.DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS);
@@ -356,6 +367,83 @@ public abstract class AbstractSweepTaskRunnerTest {
         SweepResults results = completeSweep(mixedCaseTable, 30);
         assertEquals(1, results.getStaleValuesDeleted());
         assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSweepBatchesDownToDeleteBatchSize() {
+        CellsSweeper cellsSweeper =
+                Mockito.spy(new CellsSweeper(txManager, kvs, persistentLockManager, ImmutableList.of()));
+        SweepTaskRunner spiedSweepRunner =
+                new SweepTaskRunner(kvs, tsSupplier, tsSupplier, txService, ssm, cellsSweeper);
+
+        putEightValuesInFourColumns();
+
+        spiedSweepRunner.run(TABLE_NAME, ImmutableSweepBatchConfig.builder()
+                    .deleteBatchSize(1)
+                    .candidateBatchSize(8)
+                    .maxCellTsPairsToExamine(8)
+                    .build(),
+                PtBytes.EMPTY_BYTE_ARRAY);
+
+        ArgumentCaptor<List> cells = ArgumentCaptor.forClass(List.class);
+        verify(cellsSweeper, times(4)).sweepCells(eq(TABLE_NAME), any(), cells.capture());
+        List actualCells = cells.getAllValues();
+
+        List<List<Cell>> expectedCells = Lists.newArrayList(
+                wrappedCell("row", "c1"),
+                wrappedCell("row", "c2"),
+                wrappedCell("row", "c3"),
+                wrappedCell("row", "c4"));
+        assertEquals(actualCells, expectedCells);
+    }
+
+    @Test
+    public void testSweepBatchesUpToDeleteBatchSize() {
+        CellsSweeper cellsSweeper =
+                Mockito.spy(new CellsSweeper(txManager, kvs, persistentLockManager, ImmutableList.of()));
+        SweepTaskRunner spiedSweepRunner =
+                new SweepTaskRunner(kvs, tsSupplier, tsSupplier, txService, ssm, cellsSweeper);
+
+        putEightValuesInFourColumns();
+
+        spiedSweepRunner.run(TABLE_NAME, ImmutableSweepBatchConfig.builder()
+                        .deleteBatchSize(4)
+                        .candidateBatchSize(1)
+                        .maxCellTsPairsToExamine(1)
+                        .build(),
+                PtBytes.EMPTY_BYTE_ARRAY);
+
+        List<Cell> expectedCellList = Lists.newArrayList(
+                Cell.create("row".getBytes(StandardCharsets.UTF_8), "c1".getBytes(StandardCharsets.UTF_8)),
+                Cell.create("row".getBytes(StandardCharsets.UTF_8), "c2".getBytes(StandardCharsets.UTF_8)),
+                Cell.create("row".getBytes(StandardCharsets.UTF_8), "c3".getBytes(StandardCharsets.UTF_8)),
+                Cell.create("row".getBytes(StandardCharsets.UTF_8), "c4".getBytes(StandardCharsets.UTF_8)));
+
+        verify(cellsSweeper, times(1)).sweepCells(eq(TABLE_NAME), any(), eq(expectedCellList));
+    }
+
+    private void putEightValuesInFourColumns() {
+        createTable(SweepStrategy.CONSERVATIVE);
+
+        put(TABLE_NAME, "row", "c1", "val1", 1);
+        put(TABLE_NAME, "row", "c1", "val2", 5);
+
+        put(TABLE_NAME, "row", "c2", "val1", 10);
+        put(TABLE_NAME, "row", "c2", "val2", 15);
+
+        put(TABLE_NAME, "row", "c3", "val1", 20);
+        put(TABLE_NAME, "row", "c3", "val2", 25);
+
+        put(TABLE_NAME, "row", "c4", "val1", 30);
+        put(TABLE_NAME, "row", "c4", "val2", 35);
+
+        sweepTimestamp.set(40);
+    }
+
+    private List<Cell> wrappedCell(String rowName, String colName) {
+        return Lists.newArrayList(
+                Cell.create(rowName.getBytes(StandardCharsets.UTF_8), colName.getBytes(StandardCharsets.UTF_8)));
     }
 
     private void testSweepManyRows(SweepStrategy strategy) {


### PR DESCRIPTION
**Goals (and why)**: Make sweep able to scale down the number of cells to delete on errors. This implements a fix for one of the problems we've seen internally: sweep cannot progress when encountering wide AtlasDB rows. With this fix, sweep is able to batch deletes down to the cell level, being able to delete at most one cell at a time if needed. Note that, if the cell is too wide (i.e. the cell has many mutations), the delete may still fail.

**Implementation Description (bullets)**: Consider the deleteBatchSize 

**Concerns (what feedback would you like?)**: Should I add more tests? Does my fix make sense?

**Where should we start reviewing?**: One file.

**Priority (whenever / two weeks / yesterday)**: Soon, since this has been affecting several internal products.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2058)
<!-- Reviewable:end -->
