### PR TITLE
Jdbc/emergency migration fix

### DIFF
--- a/atlasdb-cli-distribution/build.gradle
+++ b/atlasdb-cli-distribution/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
   // Unsupported KVSs (included for migration purposes)
   runtime project(':atlasdb-jdbc')
+  runtime project(':atlasdb-hikari')
   runtime project(':atlasdb-rocksdb')
 }
 

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -159,6 +159,7 @@
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-hikari",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api",
@@ -353,6 +354,9 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs"
             ]
         },
+        "com.palantir.atlasdb:atlasdb-hikari": {
+            "project": true
+        },
         "com.palantir.atlasdb:atlasdb-impl-shared": {
             "project": true,
             "transitive": [
@@ -361,7 +365,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-jdbc": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-hikari"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-lock-api": {
             "project": true,
@@ -537,6 +544,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-hikari",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api",
@@ -608,6 +616,7 @@
         "com.zaxxer:HikariCP": {
             "locked": "2.4.7",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-hikari",
                 "com.palantir.atlasdb:commons-db"
             ]
         },

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueConfiguration.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueConfiguration.java
@@ -43,6 +43,11 @@ public abstract class JdbcKeyValueConfiguration implements KeyValueServiceConfig
         return "at_";
     }
 
+    @Value.Default
+    public int getBatchSizeForReads() {
+        return 10_000;
+    }
+
     public abstract JdbcDataSourceConfiguration getDataSourceConfig();
 
     @Value.Check

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueConfiguration.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueConfiguration.java
@@ -43,6 +43,10 @@ public abstract class JdbcKeyValueConfiguration implements KeyValueServiceConfig
         return "at_";
     }
 
+    /**
+     * This value should be approximately 32k/3 to avoid https://github.com/pgjdbc/pgjdbc/issues/90. Lowering the value
+     * may cause a perf hit and increasing may exceed the parameter limit imposed by the driver.
+    **/
     @Value.Default
     public int getBatchSizeForReads() {
         return 10_000;
@@ -57,6 +61,9 @@ public abstract class JdbcKeyValueConfiguration implements KeyValueServiceConfig
         }
         if (!getTablePrefix().matches("[A-Za-z0-9_]*")) {
             throw new IllegalArgumentException("The table prefix can only contain letters, numbers, and underscores.");
+        }
+        if (getBatchSizeForReads() <= 0 || getBatchSizeForReads() > 20_000) {
+            throw new IllegalArgumentException("The batchSizeForReads should be an integer greater than 0 and less than 20,000.");
         }
     }
 }

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -139,7 +139,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
 public class JdbcKeyValueService implements KeyValueService {
     private final static int PARTITION_SIZE = 1000;
-    private static final int GET_BATCH_SIZE = 20_000;
+    private static final int GET_BATCH_SIZE = 20;
     private final String tablePrefix;
     private final SQLDialect sqlDialect;
     private final DataSource dataSource;

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -286,12 +286,12 @@ public class JdbcKeyValueService implements KeyValueService {
 
         Map<Cell, Value> toReturn = new HashMap<>();
 
-        for (List<Entry<Cell, Long>> parition : Iterables.partition(timestampByCell.entrySet(), batchSizeForReads)) {
+        for (List<Entry<Cell, Long>> partition : Iterables.partition(timestampByCell.entrySet(), batchSizeForReads)) {
             toReturn.putAll(run(ctx -> {
                 Select<? extends Record> query = getLatestTimestampQueryManyTimestamps(
                         ctx,
                         tableRef,
-                        toRows(parition));
+                        toRows(partition));
                 Result<? extends Record> records = fetchValues(ctx, tableRef, query);
                 Map<Cell, Value> results = Maps.newHashMapWithExpectedSize(records.size());
                 for (Record record : records) {

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -139,6 +139,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
 public class JdbcKeyValueService implements KeyValueService {
     private final static int PARTITION_SIZE = 1000;
+    private static final int GET_BATCH_SIZE = 20_000;
     private final String tablePrefix;
     private final SQLDialect sqlDialect;
     private final DataSource dataSource;
@@ -281,7 +282,7 @@ public class JdbcKeyValueService implements KeyValueService {
 
         Map<Cell, Value> toReturn = new HashMap<>();
 
-        for (List<Entry<Cell, Long>> parition : Iterables.partition(timestampByCell.entrySet(), PARTITION_SIZE)) {
+        for (List<Entry<Cell, Long>> parition : Iterables.partition(timestampByCell.entrySet(), GET_BATCH_SIZE)) {
             toReturn.putAll(run(ctx -> {
                 Select<? extends Record> query = getLatestTimestampQueryManyTimestamps(
                         ctx,
@@ -297,6 +298,8 @@ public class JdbcKeyValueService implements KeyValueService {
                 return results;
             }));
         }
+
+        return toReturn;
     }
 
     @Override

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -149,15 +149,15 @@ public class JdbcKeyValueService implements KeyValueService {
 
     private JdbcKeyValueService(
             Settings settings,
-            String tablePrefix,
             SQLDialect sqlDialect,
             DataSource dataSource,
+            String tablePrefix,
             int batchSizeForReads) {
-        this.batchSizeForReads = batchSizeForReads;
-        this.tablePrefix = tablePrefix;
+        this.settings = settings;
         this.sqlDialect = sqlDialect;
         this.dataSource = dataSource;
-        this.settings = settings;
+        this.tablePrefix = tablePrefix;
+        this.batchSizeForReads = batchSizeForReads;
 
         METADATA_TABLE = table(tablePrefix + "_metadata");
     }
@@ -168,8 +168,12 @@ public class JdbcKeyValueService implements KeyValueService {
         DataSource dataSource = dataSourceConfig.createDataSource();
         Settings settings = new Settings();
         settings.setRenderNameStyle(RenderNameStyle.AS_IS);
-        final JdbcKeyValueService kvs = new JdbcKeyValueService(settings, config.getTablePrefix(), sqlDialect,
-                dataSource, config.getBatchSizeForReads());
+        final JdbcKeyValueService kvs = new JdbcKeyValueService(
+                settings,
+                sqlDialect,
+                dataSource,
+                config.getTablePrefix(),
+                config.getBatchSizeForReads());
 
         kvs.run(new Function<DSLContext, Void>() {
             @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,6 +42,17 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - JDBC KVS now batches cells in get operations via the config parameter ``batchSizeForReads``.
+           This will prevent the driver from throwing due to many parameters in the resulting SQL select query.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2063>`__)
+
+    *    - |fixed|
+         - The CLI distribution can now be run against JDBC with hikari connection pools.
+           In the past, it would fail to resolve the configuration due to a missing runtime dependency.
+           Note, this is not the problem if running with the dropwizard bundle.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2063>`__)
+
     *    - |new|
          - Added a getRow() command to AtlasConsole for retrieving a single row.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1992>`__)
@@ -49,7 +60,7 @@ develop
     *    - |fixed|
          - Fixed an issue where the lock service was not properly shut down after losing leadership, which could result in threads blocking unnecessarily.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2014>`__)
-           
+
     *    - |fixed|
          - Lock refresh requests are no longer restricted by lock service threadpool limiting. 
            This allows transactions to make progress even when the threadpool is full.


### PR DESCRIPTION
**Goals (and why)**: Batch reads in JDBC to support migrations without overflowing the driver 2-byte limit for number of parameters.

We have seen the error in the field due to this issue:

```
Caused by: org.postgresql.util.PSQLException: An I/O error occurred while sending to the backend.
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:244)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:421)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
	at org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:159)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.execute(ProxyPreparedStatement.java:44)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.execute(HikariProxyPreparedStatement.java)
	at org.jooq.tools.jdbc.DefaultPreparedStatement.execute(DefaultPreparedStatement.java:194)
	at org.jooq.impl.AbstractResultQuery.execute(AbstractResultQuery.java:252)
	at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:342)
	... 44 more
Caused by: java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: 150009
	at org.postgresql.core.PGStream.SendInteger2(PGStream.java:214)
	at org.postgresql.core.v3.QueryExecutorImpl.sendParse(QueryExecutorImpl.java:1346)
	at org.postgresql.core.v3.QueryExecutorImpl.sendOneQuery(QueryExecutorImpl.java:1649)
	at org.postgresql.core.v3.QueryExecutorImpl.sendQuery(QueryExecutorImpl.java:1233)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:214)
	... 52 more
``` 

**Implementation Description (bullets)**: Implement batching with configurable the batch size. Also, hikari was added as a runtime dependency to the CLI to support JDBC migrations via the CLI distribution. Note: the CLI dist was broken earlier for JDBC migrations using hikari connection pool.

**Concerns (what feedback would you like?)**: nothing really, smoke tested on a stack and the config param makes it pretty safe.

**Where should we start reviewing?**: JDBCKVS.java

**Priority (whenever / two weeks / yesterday)**: by tomorrow.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2063)
<!-- Reviewable:end -->
