### PR TITLE
Jdbc/emergency migration fix ported back

### DIFF
--- a/atlasdb-cli-distribution/build.gradle
+++ b/atlasdb-cli-distribution/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
   // Unsupported KVSs (included for migration purposes)
   runtime project(':atlasdb-jdbc')
+  runtime project(':atlasdb-hikari')
   runtime project(':atlasdb-rocksdb')
 }
 

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -152,6 +152,7 @@
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-hikari",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api",
@@ -346,6 +347,9 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs"
             ]
         },
+        "com.palantir.atlasdb:atlasdb-hikari": {
+            "project": true
+        },
         "com.palantir.atlasdb:atlasdb-impl-shared": {
             "project": true,
             "transitive": [
@@ -354,7 +358,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-jdbc": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-hikari"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-lock-api": {
             "project": true,
@@ -523,6 +530,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
+                "com.palantir.atlasdb:atlasdb-hikari",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api",
@@ -594,6 +602,7 @@
         "com.zaxxer:HikariCP": {
             "locked": "2.4.7",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-hikari",
                 "com.palantir.atlasdb:commons-db"
             ]
         },

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueConfiguration.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueConfiguration.java
@@ -43,6 +43,15 @@ public abstract class JdbcKeyValueConfiguration implements KeyValueServiceConfig
         return "at_";
     }
 
+    /**
+     * This value should be approximately 32k/3 to avoid https://github.com/pgjdbc/pgjdbc/issues/90. Lowering the value
+     * may cause a perf hit and increasing may exceed the parameter limit imposed by the driver.
+    **/
+    @Value.Default
+    public int getBatchSizeForReads() {
+        return 10_000;
+    }
+
     public abstract JdbcDataSourceConfiguration getDataSourceConfig();
 
     @Value.Check
@@ -52,6 +61,9 @@ public abstract class JdbcKeyValueConfiguration implements KeyValueServiceConfig
         }
         if (!getTablePrefix().matches("[A-Za-z0-9_]*")) {
             throw new IllegalArgumentException("The table prefix can only contain letters, numbers, and underscores.");
+        }
+        if (getBatchSizeForReads() <= 0 || getBatchSizeForReads() > 20_000) {
+            throw new IllegalArgumentException("The batchSizeForReads should be an integer greater than 0 and less than 20,000.");
         }
     }
 }


### PR DESCRIPTION
**Goals (and why)**: allow application to pick fix.

**Implementation Description (bullets)**: Cherry-pick #2063 to 0.44.x-jdbc-fix. [Note 0.44.x already had fixes for timelock so this is a new protected branch for patching JDBC] Merge was clean except release notes :).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2065)
<!-- Reviewable:end -->
