### PR TITLE
Async Lock Service Part 2: Client-Side Timelock Abstraction

### DIFF
--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -428,6 +428,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestFastForwardTimestampCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestFastForwardTimestampCommand.java
@@ -31,6 +31,8 @@ import com.palantir.atlasdb.services.ServicesConfig;
 import com.palantir.atlasdb.services.ServicesConfigModule;
 import com.palantir.atlasdb.services.test.DaggerTestAtlasDbServices;
 import com.palantir.atlasdb.services.test.TestAtlasDbServices;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.impl.LegacyTimelockService;
 import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.timestamp.InMemoryTimestampService;
 
@@ -104,9 +106,11 @@ public class TestFastForwardTimestampCommand {
 
         @Override
         public TransactionManagers.LockAndTimestampServices provideLockAndTimestampServices(ServicesConfig config) {
+            RemoteLockService lockService = LockServiceImpl.create();
             return ImmutableLockAndTimestampServices.builder()
                     .lock(LockServiceImpl.create())
-                    .time(timestampService)
+                    .timestamp(timestampService)
+                    .timelock(new LegacyTimelockService(timestampService, lockService, TransactionManagers.LOCK_CLIENT))
                     .build();
         }
     }

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -363,6 +363,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -1093,6 +1094,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -83,6 +83,7 @@ import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
+import com.palantir.atlasdb.transaction.impl.TimelockTimestampServiceAdapter;
 import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
@@ -96,7 +97,9 @@ import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.client.LockRefreshingRemoteLockService;
+import com.palantir.lock.impl.LegacyTimelockService;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.timestamp.TimestampService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
@@ -219,7 +222,8 @@ public final class TransactionManagers {
 
         KeyValueService kvs = NamespacedKeyValueServices.wrapWithStaticNamespaceMappingKvs(rawKvs);
         kvs = ProfilingKeyValueService.create(kvs, config.getKvsSlowLogThresholdMillis());
-        kvs = SweepStatsKeyValueService.create(kvs, lockAndTimestampServices.time());
+        kvs = SweepStatsKeyValueService.create(kvs,
+                new TimelockTimestampServiceAdapter(lockAndTimestampServices.timelock()));
         kvs = TracingKeyValueService.create(kvs);
         kvs = AtlasDbMetrics.instrument(KeyValueService.class, kvs,
                 MetricRegistry.name(KeyValueService.class, userAgent));
@@ -245,9 +249,7 @@ public final class TransactionManagers {
 
         Cleaner cleaner = new DefaultCleanerBuilder(
                 kvs,
-                lockAndTimestampServices.lock(),
-                lockAndTimestampServices.time(),
-                LOCK_CLIENT,
+                lockAndTimestampServices.timelock(),
                 ImmutableList.of(follower),
                 transactionService)
                 .setBackgroundScrubAggressively(config.backgroundScrubAggressively())
@@ -259,8 +261,7 @@ public final class TransactionManagers {
                 .buildCleaner();
 
         SerializableTransactionManager transactionManager = new SerializableTransactionManager(kvs,
-                lockAndTimestampServices.time(),
-                LOCK_CLIENT,
+                lockAndTimestampServices.timelock(),
                 lockAndTimestampServices.lock(),
                 transactionService,
                 Suppliers.ofInstance(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS),
@@ -411,6 +412,7 @@ public final class TransactionManagers {
 
     private static LockAndTimestampServices withRefreshingLockService(
             LockAndTimestampServices lockAndTimestampServices) {
+        // TODO(nziebart): refreshing timelock service
         return ImmutableLockAndTimestampServices.builder()
                 .from(lockAndTimestampServices)
                 .lock(LockRefreshingRemoteLockService.create(lockAndTimestampServices.lock()))
@@ -455,7 +457,8 @@ public final class TransactionManagers {
 
         return ImmutableLockAndTimestampServices.builder()
                 .lock(lockService)
-                .time(timeService)
+                .timestamp(timeService)
+                .timelock(new LegacyTimelockService(timeService, lockService, LOCK_CLIENT))
                 .build();
     }
 
@@ -532,13 +535,15 @@ public final class TransactionManagers {
                     TimestampService.class, localTime, remoteTime, useLocalServicesFuture);
             return ImmutableLockAndTimestampServices.builder()
                     .lock(dynamicLockService)
-                    .time(dynamicTimeService)
+                    .timestamp(dynamicTimeService)
+                    .timelock(new LegacyTimelockService(dynamicTimeService, dynamicLockService, LOCK_CLIENT))
                     .build();
 
         } else {
             return ImmutableLockAndTimestampServices.builder()
                     .lock(remoteLock)
-                    .time(remoteTime)
+                    .timestamp(remoteTime)
+                    .timelock(new LegacyTimelockService(remoteTime, remoteLock, LOCK_CLIENT))
                     .build();
         }
     }
@@ -551,7 +556,8 @@ public final class TransactionManagers {
 
         return ImmutableLockAndTimestampServices.builder()
                 .lock(lockService)
-                .time(timeService)
+                .timestamp(timeService)
+                .timelock(new LegacyTimelockService(timeService, lockService, LOCK_CLIENT))
                 .build();
     }
 
@@ -572,14 +578,16 @@ public final class TransactionManagers {
 
         return ImmutableLockAndTimestampServices.builder()
                 .lock(lockService)
-                .time(timeService)
+                .timestamp(timeService)
+                .timelock(new LegacyTimelockService(timeService, lockService, LOCK_CLIENT))
                 .build();
     }
 
     @Value.Immutable
     public interface LockAndTimestampServices {
         RemoteLockService lock();
-        TimestampService time();
+        TimestampService timestamp();
+        TimelockService timelock();
     }
 
     public interface Environment {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -198,7 +198,7 @@ public class TransactionManagersTest {
                         USER_AGENT);
         availableServer.verify(getRequestedFor(urlMatching(LEADER_UUID_PATH)));
 
-        lockAndTimestampServices.time().getFreshTimestamp();
+        lockAndTimestampServices.timelock().getFreshTimestamp();
         lockAndTimestampServices.lock().currentTimeMillis();
 
         availableServer.verify(postRequestedFor(urlMatching(TIMESTAMP_PATH))
@@ -235,7 +235,7 @@ public class TransactionManagersTest {
                         USER_AGENT);
         availableServer.verify(getRequestedFor(urlMatching(LEADER_UUID_PATH)));
 
-        lockAndTimestampServices.time().getFreshTimestamp();
+        lockAndTimestampServices.timelock().getFreshTimestamp();
         lockAndTimestampServices.lock().currentTimeMillis();
 
         availableServer.verify(0, postRequestedFor(urlMatching(TIMESTAMP_PATH))
@@ -291,7 +291,7 @@ public class TransactionManagersTest {
                         InMemoryTimestampService::new,
                         invalidator,
                         USER_AGENT);
-        lockAndTimestampServices.time().getFreshTimestamp();
+        lockAndTimestampServices.timelock().getFreshTimestamp();
         lockAndTimestampServices.lock().currentTimeMillis();
 
         availableServer.verify(postRequestedFor(urlMatching(timestampPath))

--- a/atlasdb-config/versions.lock
+++ b/atlasdb-config/versions.lock
@@ -274,7 +274,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -779,7 +780,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -417,6 +417,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-console/versions.lock
+++ b/atlasdb-console/versions.lock
@@ -302,7 +302,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -871,7 +872,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/AtlasDbServices.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/AtlasDbServices.java
@@ -24,6 +24,7 @@ import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampService;
 
 import dagger.Component;
@@ -34,6 +35,8 @@ import dagger.Component;
 public abstract class AtlasDbServices implements AutoCloseable {
 
     public abstract AtlasDbConfig getAtlasDbConfig();
+
+    public abstract TimelockService getTimelockService();
 
     public abstract TimestampService getTimestampService();
 

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/LockAndTimestampModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/LockAndTimestampModule.java
@@ -20,6 +20,7 @@ import javax.inject.Singleton;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.impl.LockServiceImpl;
+import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampService;
 
 import dagger.Module;
@@ -40,8 +41,14 @@ public class LockAndTimestampModule {
 
     @Provides
     @Singleton
+    public TimelockService provideTimelockService(TransactionManagers.LockAndTimestampServices lts) {
+        return lts.timelock();
+    }
+
+    @Provides
+    @Singleton
     public TimestampService provideTimestampService(TransactionManagers.LockAndTimestampServices lts) {
-        return lts.time();
+        return lts.timestamp();
     }
 
     @Provides

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -33,8 +33,7 @@ import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.lock.LockClient;
-import com.palantir.lock.RemoteLockService;
-import com.palantir.timestamp.TimestampService;
+import com.palantir.lock.v2.TimelockService;
 
 import dagger.Module;
 import dagger.Provides;
@@ -58,17 +57,13 @@ public class TransactionManagerModule {
     @Singleton
     public Cleaner provideCleaner(ServicesConfig config,
                                   @Named("kvs") KeyValueService kvs,
-                                  RemoteLockService rlc,
-                                  TimestampService tss,
-                                  LockClient lockClient,
+                                  TimelockService timelock,
                                   Follower follower,
                                   TransactionService transactionService) {
         AtlasDbConfig atlasDbConfig = config.atlasDbConfig();
         return new DefaultCleanerBuilder(
                 kvs,
-                rlc,
-                tss,
-                lockClient,
+                timelock,
                 ImmutableList.of(follower),
                 transactionService)
                 .setBackgroundScrubAggressively(atlasDbConfig.backgroundScrubAggressively())
@@ -92,8 +87,7 @@ public class TransactionManagerModule {
                                                                     Cleaner cleaner) {
         return new SerializableTransactionManager(
                 kvs,
-                lts.time(),
-                lockClient,
+                lts.timelock(),
                 lts.lock(),
                 transactionService,
                 Suppliers.ofInstance(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS),

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -93,8 +93,7 @@ public class TestTransactionManagerModule {
                                                                     Cleaner cleaner) {
         return new SerializableTransactionManager(
                 kvs,
-                lts.time(),
-                lockClient,
+                lts.timelock(),
                 lts.lock(),
                 transactionService,
                 Suppliers.ofInstance(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS),

--- a/atlasdb-dagger/versions.lock
+++ b/atlasdb-dagger/versions.lock
@@ -305,7 +305,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -864,7 +865,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -285,6 +285,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -861,6 +862,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -247,6 +247,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -724,6 +725,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -404,6 +404,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -1596,6 +1597,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -428,6 +428,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -1714,6 +1715,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-feign/versions.lock
+++ b/atlasdb-feign/versions.lock
@@ -5,7 +5,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -63,7 +64,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -113,6 +115,12 @@
         "com.palantir.atlasdb:lock-api": {
             "project": true
         },
+        "com.palantir.atlasdb:timestamp-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:lock-api"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0"
         },
@@ -123,11 +131,12 @@
             ]
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.1",
+            "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.squareup.okhttp3:okhttp": {
@@ -153,6 +162,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting2:error-handling"
             ]
         },
@@ -183,7 +193,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -241,7 +252,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -291,6 +303,12 @@
         "com.palantir.atlasdb:lock-api": {
             "project": true
         },
+        "com.palantir.atlasdb:timestamp-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:lock-api"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0"
         },
@@ -301,11 +319,12 @@
             ]
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.1",
+            "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.squareup.okhttp3:okhttp": {
@@ -331,6 +350,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting2:error-handling"
             ]
         },

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -26,13 +26,13 @@ import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.time.Clock;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.impl.LegacyTimelockService;
+import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampService;
 
 public class DefaultCleanerBuilder {
     private final KeyValueService keyValueService;
-    private final RemoteLockService lockService;
-    private final TimestampService timestampService;
-    private final LockClient lockClient;
+    private final TimelockService timelockService;
     private final List<Follower> followerList;
     private final TransactionService transactionService;
 
@@ -45,15 +45,21 @@ public class DefaultCleanerBuilder {
     private int backgroundScrubBatchSize = AtlasDbConstants.DEFAULT_BACKGROUND_SCRUB_BATCH_SIZE;
 
     public DefaultCleanerBuilder(KeyValueService keyValueService,
-                                 RemoteLockService lockService,
-                                 TimestampService timestampService,
-                                 LockClient lockClient,
-                                 List<? extends Follower> followerList,
-                                 TransactionService transactionService) {
+            RemoteLockService lockService,
+            TimestampService timestampService,
+            LockClient lockClient,
+            List<? extends Follower> followerList,
+            TransactionService transactionService) {
+        this(keyValueService, new LegacyTimelockService(timestampService, lockService, lockClient), followerList,
+                transactionService);
+    }
+
+    public DefaultCleanerBuilder(KeyValueService keyValueService,
+            TimelockService timelockService,
+            List<? extends Follower> followerList,
+            TransactionService transactionService) {
         this.keyValueService = keyValueService;
-        this.lockService = lockService;
-        this.timestampService = timestampService;
-        this.lockClient = lockClient;
+        this.timelockService = timelockService;
         this.followerList = ImmutableList.copyOf(followerList);
         this.transactionService = transactionService;
     }
@@ -98,7 +104,7 @@ public class DefaultCleanerBuilder {
         PuncherStore cachingPuncherStore = CachingPuncherStore.create(
                 keyValuePuncherStore,
                 punchIntervalMillis * 3);
-        Clock clock = GlobalClock.create(lockService);
+        Clock clock = GlobalClock.create(timelockService);
         SimplePuncher simplePuncher = SimplePuncher.create(
                 cachingPuncherStore,
                 clock,
@@ -127,7 +133,7 @@ public class DefaultCleanerBuilder {
     public Cleaner buildCleaner() {
         Puncher puncher = buildPuncher();
         Supplier<Long> immutableTs = ImmutableTimestampSupplier
-                .createMemoizedWithExpiration(lockService, timestampService, lockClient);
+                .createMemoizedWithExpiration(timelockService);
         Scrubber scrubber = buildScrubber(puncher.getTimestampSupplier(), immutableTs);
         return new SimpleCleaner(
                 scrubber,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/GlobalClock.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/GlobalClock.java
@@ -15,8 +15,11 @@
  */
 package com.palantir.atlasdb.cleaner;
 
+import java.util.function.Supplier;
+
 import com.palantir.common.time.Clock;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.v2.TimelockService;
 
 /**
  * Clock implementation that delegates to a LockService.
@@ -24,18 +27,22 @@ import com.palantir.lock.RemoteLockService;
  * @author jweel
  */
 public final class GlobalClock implements Clock {
-    private final RemoteLockService lockService;
+    private final Supplier<Long> globalTimeSupplier;
 
-    private GlobalClock(RemoteLockService lockService) {
-        this.lockService = lockService;
+    private GlobalClock(Supplier<Long> globalTimeSupplier) {
+        this.globalTimeSupplier = globalTimeSupplier;
     }
 
     public static GlobalClock create(RemoteLockService lockService) {
-        return new GlobalClock(lockService);
+        return new GlobalClock(lockService::currentTimeMillis);
+    }
+
+    public static GlobalClock create(TimelockService timelockService) {
+        return new GlobalClock(timelockService::currentTimeMillis);
     }
 
     @Override
     public long getTimeMillis() {
-        return lockService.currentTimeMillis();
+        return globalTimeSupplier.get();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockPreCommitCheck.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockPreCommitCheck.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.logsafe.UnsafeArg;
+
+/**
+ * Checks that advisory locks are still held immediately before committing a transaction.
+ */
+final class AdvisoryLockPreCommitCheck {
+
+    private static final Logger log = LoggerFactory.getLogger(AdvisoryLockPreCommitCheck.class);
+
+    private final Runnable check;
+
+    private AdvisoryLockPreCommitCheck(Runnable check) {
+        this.check = check;
+    }
+
+    public static final AdvisoryLockPreCommitCheck NO_OP = new AdvisoryLockPreCommitCheck(() -> { });
+
+    public static AdvisoryLockPreCommitCheck forLockServiceLocks(Iterable<LockRefreshToken> tokens,
+            RemoteLockService lockService) {
+        Set<LockRefreshToken> toRefresh = ImmutableSet.copyOf(tokens);
+        if (toRefresh.isEmpty()) {
+            return NO_OP;
+        }
+
+        return new AdvisoryLockPreCommitCheck(() -> {
+            Set<LockRefreshToken> refreshed = lockService.refreshLockRefreshTokens(toRefresh);
+            Set<LockRefreshToken> notRefreshed = Sets.difference(toRefresh, refreshed).immutableCopy();
+            if (!notRefreshed.isEmpty()) {
+                log.warn("Lock service locks were no longer valid at commit time",
+                        UnsafeArg.of("invalidTokens", notRefreshed));
+                throw new TransactionLockTimeoutException(
+                        "Lock service locks were no longer valid at commit time: " + notRefreshed);
+            }
+        });
+    }
+
+    public void throwIfLocksExpired() {
+        check.run();
+    }
+
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/RawTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/RawTransaction.java
@@ -15,13 +15,13 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.v2.LockTokenV2;
 
 public class RawTransaction extends ForwardingTransaction {
     private final SnapshotTransaction delegate;
-    private final LockRefreshToken lock;
+    private final LockTokenV2 lock;
 
-    public RawTransaction(SnapshotTransaction delegate, LockRefreshToken lock) {
+    public RawTransaction(SnapshotTransaction delegate, LockTokenV2 lock) {
         this.delegate = delegate;
         this.lock = lock;
     }
@@ -31,7 +31,7 @@ public class RawTransaction extends ForwardingTransaction {
         return delegate;
     }
 
-    LockRefreshToken getImmutableTsLock() {
+    LockTokenV2 getImmutableTsLock() {
         return lock;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockService;
+import com.palantir.lock.v2.TimelockService;
 
 /**
  * This {@link TransactionManager} will provide transactions that will read the most recently
@@ -160,6 +161,11 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
 
     @Override
     public LockService getLockService() {
+        return null;
+    }
+
+    @Override
+    public TimelockService getTimelockService() {
         return null;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -16,11 +16,11 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentMap;
@@ -71,9 +71,8 @@ import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitableView;
 import com.palantir.common.collect.IterableUtils;
 import com.palantir.common.collect.Maps2;
-import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.RemoteLockService;
-import com.palantir.timestamp.TimestampService;
+import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.TimelockService;
 import com.palantir.util.Pair;
 
 /**
@@ -99,30 +98,30 @@ public class SerializableTransaction extends SnapshotTransaction {
     final ConcurrentMap<TableReference, Set<RowRead>> rowsRead = Maps.newConcurrentMap();
 
     public SerializableTransaction(KeyValueService keyValueService,
-                                   RemoteLockService lockService,
-                                   TimestampService timestampService,
+                                   TimelockService timelockService,
                                    TransactionService transactionService,
                                    Cleaner cleaner,
                                    Supplier<Long> startTimeStamp,
                                    ConflictDetectionManager conflictDetectionManager,
                                    SweepStrategyManager sweepStrategyManager,
                                    long immutableTimestamp,
-                                   Iterable<LockRefreshToken> tokensValidForCommit,
+                                   Optional<LockTokenV2> immutableTsLock,
+                                   AdvisoryLockPreCommitCheck advisoryLockCheck,
                                    AtlasDbConstraintCheckingMode constraintCheckingMode,
                                    Long transactionTimeoutMillis,
                                    TransactionReadSentinelBehavior readSentinelBehavior,
                                    boolean allowHiddenTableAccess,
                                    TimestampCache timestampCache) {
         super(keyValueService,
-              lockService,
-              timestampService,
+              timelockService,
               transactionService,
               cleaner,
               startTimeStamp,
               conflictDetectionManager,
               sweepStrategyManager,
               immutableTimestamp,
-              tokensValidForCommit,
+              immutableTsLock,
+              advisoryLockCheck,
               constraintCheckingMode,
               transactionTimeoutMillis,
               readSentinelBehavior,
@@ -709,15 +708,15 @@ public class SerializableTransaction extends SnapshotTransaction {
     private Transaction getReadOnlyTransaction(final long commitTs) {
         return new SnapshotTransaction(
                 keyValueService,
-                lockService,
-                timestampService,
+                timelockService,
                 defaultTransactionService,
                 NoOpCleaner.INSTANCE,
                 Suppliers.ofInstance(commitTs + 1),
                 ConflictDetectionManagers.createWithNoConflictDetection(),
                 sweepStrategyManager,
                 immutableTimestamp,
-                Collections.emptyList(),
+                Optional.empty(),
+                AdvisoryLockPreCommitCheck.NO_OP,
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 transactionReadTimeoutMillis,
                 getReadSentinelBehavior(),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TimelockTimestampServiceAdapter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TimelockTimestampServiceAdapter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.timestamp.TimestampRange;
+import com.palantir.timestamp.TimestampService;
+
+public class TimelockTimestampServiceAdapter implements TimestampService {
+
+    private final TimelockService timelockService;
+
+    public TimelockTimestampServiceAdapter(TimelockService timelockService) {
+        this.timelockService = timelockService;
+    }
+
+    @Override
+    public long getFreshTimestamp() {
+        return timelockService.getFreshTimestamp();
+    }
+
+    @Override
+    public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
+        return timelockService.getFreshTimestamps(numTimestampsRequested);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTransactionManager.java
@@ -25,6 +25,7 @@ import com.palantir.atlasdb.transaction.api.TransactionTask;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.v2.TimelockService;
 
 public abstract class WrappingTransactionManager extends ForwardingLockAwareTransactionManager {
     private final LockAwareTransactionManager delegate;
@@ -69,6 +70,11 @@ public abstract class WrappingTransactionManager extends ForwardingLockAwareTran
     @Override
     public RemoteLockService getLockService() {
         return delegate.getLockService();
+    }
+
+    @Override
+    public TimelockService getTimelockService() {
+        return delegate.getTimelockService();
     }
 
     private <T, E extends Exception> TransactionTask<T, E> wrapTask(TransactionTask<T, E> task) {

--- a/atlasdb-impl-shared/versions.lock
+++ b/atlasdb-impl-shared/versions.lock
@@ -180,7 +180,8 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.patches.sourceforge:trove3": {
@@ -539,7 +540,8 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.patches.sourceforge:trove3": {

--- a/atlasdb-jepsen-tests/versions.lock
+++ b/atlasdb-jepsen-tests/versions.lock
@@ -293,7 +293,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -838,7 +839,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {

--- a/atlasdb-lock-api/src/main/java/com/palantir/atlasdb/transaction/api/LockAwareTransactionManager.java
+++ b/atlasdb-lock-api/src/main/java/com/palantir/atlasdb/transaction/api/LockAwareTransactionManager.java
@@ -19,6 +19,7 @@ import com.google.common.base.Supplier;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.v2.TimelockService;
 
 public interface LockAwareTransactionManager extends TransactionManager {
     /**
@@ -77,4 +78,6 @@ public interface LockAwareTransactionManager extends TransactionManager {
      * @return the lock service for this transaction manager
      */
     RemoteLockService getLockService();
+
+    TimelockService getTimelockService();
 }

--- a/atlasdb-lock-api/versions.lock
+++ b/atlasdb-lock-api/versions.lock
@@ -69,7 +69,8 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.remoting2:ssl-config": {
@@ -199,7 +200,8 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-api"
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.remoting2:ssl-config": {

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -432,6 +432,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -1337,6 +1338,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -331,7 +331,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -1368,6 +1369,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-service/versions.lock
+++ b/atlasdb-service/versions.lock
@@ -293,7 +293,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {
@@ -836,7 +837,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.config.crypto:encrypted-config-value": {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
@@ -57,7 +58,7 @@ import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.impl.LegacyTimelockService;
 import com.palantir.remoting2.tracing.Tracers;
 
 
@@ -86,15 +87,15 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 ConflictHandler.IGNORE_ALL);
         return new SerializableTransaction(
                 keyValueService,
-                lockService,
-                timestampService,
+                new LegacyTimelockService(timestampService, lockService, lockClient),
                 transactionService,
                 NoOpCleaner.INSTANCE,
                 Suppliers.ofInstance(timestampService.getFreshTimestamp()),
                 TestConflictDetectionManagers.createWithStaticConflictDetection(tablesToWriteWrite),
                 SweepStrategyManagers.createDefault(keyValueService),
                 0L,
-                ImmutableList.<LockRefreshToken>of(),
+                Optional.empty(),
+                AdvisoryLockPreCommitCheck.NO_OP,
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 null,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -77,6 +77,7 @@ import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.collect.IterableView;
 import com.palantir.common.collect.MapEntries;
+import com.palantir.lock.impl.LegacyTimelockService;
 import com.palantir.util.Pair;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
@@ -91,8 +92,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     protected Transaction startTransaction() {
         return new SnapshotTransaction(
                 keyValueService,
-                lockService,
-                timestampService,
+                new LegacyTimelockService(timestampService, lockService, lockClient),
                 transactionService,
                 NoOpCleaner.INSTANCE,
                 timestampService.getFreshTimestamp(),

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -95,11 +95,10 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
         conflictHandlersWithOverrides.putAll(conflictHandlerOverrides);
         return new SnapshotTransaction(
                 keyValueService,
-                lockService,
-                timestampService,
+                timelockService,
                 transactionService,
                 cleaner,
-                timestampService.getFreshTimestamp(),
+                timelockService.getFreshTimestamp(),
                 TestConflictDetectionManagers.createWithStaticConflictDetection(conflictHandlersWithOverrides),
                 constraintModeSupplier.get(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -111,6 +111,7 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.TimeDuration;
+import com.palantir.lock.impl.LegacyTimelockService;
 import com.palantir.remoting2.tracing.Tracers;
 
 @SuppressWarnings("checkstyle:all")
@@ -285,8 +286,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         SnapshotTransaction snapshot = new SnapshotTransaction(
                 kvMock,
-                lock,
-                timestampService,
+                new LegacyTimelockService(timestampService, lock, lockClient),
                 transactionService,
                 NoOpCleaner.INSTANCE,
                 transactionTs,
@@ -341,8 +341,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
 
         SnapshotTransaction snapshot = new SnapshotTransaction(
                 kv,
-                lockService,
-                timestampService,
+                new LegacyTimelockService(timestampService, lockService, lockClient),
                 transactionService,
                 NoOpCleaner.INSTANCE,
                 transactionTs,

--- a/atlasdb-tests-shared/versions.lock
+++ b/atlasdb-tests-shared/versions.lock
@@ -211,7 +211,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.patches.sourceforge:trove3": {
@@ -649,7 +650,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api"
             ]
         },
         "com.palantir.patches.sourceforge:trove3": {

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -13,6 +13,7 @@ repositories {
 libsDirName = file('build/artifacts')
 dependencies {
     compile project(":atlasdb-commons")
+    compile project(":timestamp-api")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockImmutableTimestampRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockImmutableTimestampRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.util.UUID;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLockImmutableTimestampRequest.class)
+@JsonDeserialize(as = ImmutableLockImmutableTimestampRequest.class)
+public interface LockImmutableTimestampRequest {
+
+    @Value.Parameter
+    UUID getRequestId();
+
+    static LockImmutableTimestampRequest create() {
+        return ImmutableLockImmutableTimestampRequest.of(UUID.randomUUID());
+    }
+
+}

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockImmutableTimestampResponse.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockImmutableTimestampResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+// TODO(nziebart): also return a start timestamp here?
+@Value.Immutable
+@JsonSerialize(as = ImmutableLockImmutableTimestampResponse.class)
+@JsonDeserialize(as = ImmutableLockImmutableTimestampResponse.class)
+public interface LockImmutableTimestampResponse {
+
+    @Value.Parameter
+    long getImmutableTimestamp();
+
+    @Value.Parameter
+    LockTokenV2 getLock();
+
+    static LockImmutableTimestampResponse of(long timestamp, LockTokenV2 lock) {
+        return ImmutableLockImmutableTimestampResponse.of(timestamp, lock);
+    }
+
+}

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockRequestV2.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockRequestV2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.lock.LockDescriptor;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLockRequestV2.class)
+@JsonDeserialize(as = ImmutableLockRequestV2.class)
+public interface LockRequestV2 {
+
+    @Value.Parameter
+    Set<LockDescriptor> getLockDescriptors();
+
+    @Value.Parameter
+    UUID getRequestId();
+
+    static LockRequestV2 of(Set<LockDescriptor> lockDescriptors) {
+        return ImmutableLockRequestV2.of(lockDescriptors, UUID.randomUUID());
+    }
+
+}

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.palantir.timestamp.TimestampRange;
+
+@Path("/timelock")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface TimelockService {
+
+    @POST
+    @Path("fresh-timestamp")
+    long getFreshTimestamp();
+
+    @POST
+    @Path("fresh-timestamps")
+    TimestampRange getFreshTimestamps(@QueryParam("number") int numTimestampsRequested);
+
+    @POST
+    @Path("lock-immutable-timestamp")
+    LockImmutableTimestampResponse lockImmutableTimestamp(LockImmutableTimestampRequest request);
+
+    @POST
+    @Path("immutable-timestamp")
+    long getImmutableTimestamp();
+
+    @POST
+    @Path("lock")
+    LockTokenV2 lock(LockRequestV2 request);
+
+    @POST
+    @Path("await-locks")
+    void waitForLocks(WaitForLocksRequest request);
+
+    @POST
+    @Path("refresh-locks")
+    Set<LockTokenV2> refreshLockLeases(Set<LockTokenV2> tokens);
+
+    @POST
+    @Path("unlock")
+    Set<LockTokenV2> unlock(Set<LockTokenV2> tokens);
+
+    @POST
+    @Path("current-time-millis")
+    long currentTimeMillis();
+
+}

--- a/lock-api/src/main/java/com/palantir/lock/v2/WaitForLocksRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/WaitForLocksRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.lock.LockDescriptor;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableWaitForLocksRequest.class)
+@JsonDeserialize(as = ImmutableWaitForLocksRequest.class)
+public interface WaitForLocksRequest {
+
+    @Value.Parameter
+    Set<LockDescriptor> getLockDescriptors();
+
+    @Value.Parameter
+    UUID getRequestId();
+
+    static WaitForLocksRequest of(Set<LockDescriptor> lockDescriptors) {
+        return ImmutableWaitForLocksRequest.of(lockDescriptors, UUID.randomUUID());
+    }
+
+}

--- a/lock-api/versions.lock
+++ b/lock-api/versions.lock
@@ -4,7 +4,8 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -20,7 +21,8 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:commons-executors"
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -44,11 +46,15 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "com.palantir.atlasdb:timestamp-api": {
+            "project": true
+        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:commons-executors"
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {
@@ -61,7 +67,8 @@
             "locked": "2.0.1",
             "requested": "2.0.1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "net.jpountz.lz4:lz4": {
@@ -83,7 +90,8 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -99,7 +107,8 @@
             "locked": "2.0.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:commons-executors"
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -123,11 +132,15 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "com.palantir.atlasdb:timestamp-api": {
+            "project": true
+        },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:commons-executors"
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {
@@ -140,7 +153,8 @@
             "locked": "2.0.1",
             "requested": "2.0.1",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "net.jpountz.lz4:lz4": {

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -17,4 +17,6 @@ dependencies {
 
   testCompile group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
   testCompile group: 'org.assertj', name: 'assertj-core'
+  testCompile group: 'org.hamcrest', name: 'hamcrest-core'
+  testCompile group: 'org.mockito', name: 'mockito-core'
 }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.palantir.common.base.Throwables;
+import com.palantir.lock.AtlasTimestampLockDescriptor;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.v2.LockImmutableTimestampRequest;
+import com.palantir.lock.v2.LockImmutableTimestampResponse;
+import com.palantir.lock.v2.LockRequestV2;
+import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.timestamp.TimestampRange;
+import com.palantir.timestamp.TimestampService;
+
+/**
+ * A {@link TimelockService} implementation that delegates to a {@link RemoteLockService} and {@link TimestampService}.
+ */
+public class LegacyTimelockService implements TimelockService {
+
+    private final TimestampService timestampService;
+    private final RemoteLockService lockService;
+    private final LockClient immutableTsLockClient;
+
+    public LegacyTimelockService(TimestampService timestampService, RemoteLockService lockService,
+            LockClient immutableTsLockClient) {
+        this.timestampService = timestampService;
+        this.lockService = lockService;
+        this.immutableTsLockClient = immutableTsLockClient;
+    }
+
+    @Override
+    public long getFreshTimestamp() {
+        return timestampService.getFreshTimestamp();
+    }
+
+    @Override
+    public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
+        return timestampService.getFreshTimestamps(numTimestampsRequested);
+    }
+
+    @Override
+    public LockImmutableTimestampResponse lockImmutableTimestamp(LockImmutableTimestampRequest request) {
+        long immutableLockTs = timestampService.getFreshTimestamp();
+        LockDescriptor lockDesc = AtlasTimestampLockDescriptor.of(immutableLockTs);
+        LockRequest lockRequest = LockRequest.builder(ImmutableSortedMap.of(lockDesc, LockMode.READ))
+                .withLockedInVersionId(immutableLockTs).build();
+        LockRefreshToken lock;
+
+        try {
+            lock = lockService.lock(immutableTsLockClient.getClientId(), lockRequest);
+        } catch (InterruptedException e) {
+            throw Throwables.throwUncheckedException(e);
+        }
+
+        try {
+            return LockImmutableTimestampResponse.of(
+                    getImmutableTimestampInternal(immutableLockTs),
+                    new LockRefreshTokenV2Adapter(lock));
+        } catch (Throwable e) {
+            if (lock != null) {
+                lockService.unlock(lock);
+            }
+            throw Throwables.rewrapAndThrowUncheckedException(e);
+        }
+    }
+
+    @Override
+    public long getImmutableTimestamp() {
+        long ts = timestampService.getFreshTimestamp();
+        return getImmutableTimestampInternal(ts);
+    }
+
+    @Override
+    public LockRefreshTokenV2Adapter lock(LockRequestV2 request) {
+        LockRequest legacyRequest = toLegacyLockRequest(request);
+
+        LockRefreshToken legacyToken = lockAnonymous(legacyRequest);
+        return new LockRefreshTokenV2Adapter(legacyToken);
+    }
+
+    @Override
+    public void waitForLocks(WaitForLocksRequest request) {
+        LockRequest legacyRequest = toLegacyWaitForLocksRequest(request.getLockDescriptors());
+
+        lockAnonymous(legacyRequest);
+    }
+
+    private LockRequest toLegacyLockRequest(LockRequestV2 request) {
+       SortedMap<LockDescriptor, LockMode> locks = buildLockMap(request.getLockDescriptors(), LockMode.WRITE);
+       return LockRequest.builder(locks).build();
+    }
+
+    private LockRequest toLegacyWaitForLocksRequest(Set<LockDescriptor> lockDescriptors) {
+        SortedMap<LockDescriptor, LockMode> locks = buildLockMap(lockDescriptors, LockMode.READ);
+        return LockRequest.builder(locks).lockAndRelease().build();
+    }
+
+    @Override
+    public Set<LockTokenV2> refreshLockLeases(Set<LockTokenV2> tokens) {
+        Set<LockRefreshToken> refreshTokens = tokens.stream()
+                .map(this::getRefreshToken)
+                .collect(Collectors.toSet());
+        return lockService.refreshLockRefreshTokens(refreshTokens).stream()
+                .map(LockRefreshTokenV2Adapter::new)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<LockTokenV2> unlock(Set<LockTokenV2> tokens) {
+        Set<LockTokenV2> unlocked = Sets.newHashSet();
+        for (LockTokenV2 tokenV2 : tokens) {
+            if (lockService.unlock(getRefreshToken(tokenV2))) {
+                unlocked.add(tokenV2);
+            }
+        }
+        return unlocked;
+    }
+
+    private LockRefreshToken getRefreshToken(LockTokenV2 tokenV2) {
+        Preconditions.checkArgument(
+                (tokenV2 instanceof LockRefreshTokenV2Adapter),
+                "The LockTokenV2 instance passed to LegacyTimelockService was of an unexpected type. "
+                        + "LegacyTimelockService only supports operations on the tokens it returns.");
+        return ((LockRefreshTokenV2Adapter) tokenV2).getToken();
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return lockService.currentTimeMillis();
+    }
+
+    private long getImmutableTimestampInternal(long ts) {
+        Long minLocked = lockService.getMinLockedInVersionId(immutableTsLockClient.getClientId());
+        return minLocked == null ? ts : minLocked;
+    }
+
+    private LockRefreshToken lockAnonymous(LockRequest lockRequest) {
+        try {
+            return lockService.lock(LockClient.ANONYMOUS.getClientId(), lockRequest);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private SortedMap<LockDescriptor, LockMode> buildLockMap(Set<LockDescriptor> lockDescriptors, LockMode lockMode) {
+        SortedMap<LockDescriptor, LockMode> locks = Maps.newTreeMap();
+        for (LockDescriptor descriptor : lockDescriptors) {
+            locks.put(descriptor, lockMode);
+        }
+        return locks;
+    }
+
+    @VisibleForTesting
+    static class LockRefreshTokenV2Adapter implements LockTokenV2 {
+
+        private final LockRefreshToken token;
+        private final UUID requestId;
+
+        LockRefreshTokenV2Adapter(LockRefreshToken token) {
+            this.token = token;
+            this.requestId = getRequestId(token);
+        }
+
+        @Override
+        public UUID getRequestId() {
+            return requestId;
+        }
+
+        public LockRefreshToken getToken() {
+            return token;
+        }
+
+        private static UUID getRequestId(LockRefreshToken token) {
+            long msb = token.getTokenId().shiftRight(64).longValue();
+            long lsb = token.getTokenId().longValue();
+            return new UUID(msb, lsb);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            LockRefreshTokenV2Adapter that = (LockRefreshTokenV2Adapter) o;
+            return Objects.equals(token, that.token) &&
+                    Objects.equals(requestId, that.requestId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(token, requestId);
+        }
+    }
+}

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LegacyTimelockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LegacyTimelockServiceTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
+import com.palantir.lock.AtlasTimestampLockDescriptor;
+import com.palantir.lock.LockClient;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.LockMode;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockRequest;
+import com.palantir.lock.RemoteLockService;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.impl.LegacyTimelockService.LockRefreshTokenV2Adapter;
+import com.palantir.lock.v2.LockImmutableTimestampRequest;
+import com.palantir.lock.v2.LockImmutableTimestampResponse;
+import com.palantir.lock.v2.LockRequestV2;
+import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.timestamp.TimestampRange;
+import com.palantir.timestamp.TimestampService;
+
+public class LegacyTimelockServiceTest {
+
+    private static final LockClient LOCK_CLIENT = LockClient.of("foo");
+
+    private static final long FRESH_TIMESTAMP = 5L;
+
+    private static final LockRefreshTokenV2Adapter LOCK_TOKEN_V2 = randomLockToken();
+    private static final LockRefreshToken LOCK_REFRESH_TOKEN = LOCK_TOKEN_V2.getToken();
+
+    private static final LockDescriptor LOCK_A = StringLockDescriptor.of("a");
+    private static final LockDescriptor LOCK_B = StringLockDescriptor.of("b");
+
+    private final TimestampService timestampService = mock(TimestampService.class);
+    private final RemoteLockService lockService = mock(RemoteLockService.class);
+
+    private final TimelockService timelock = new LegacyTimelockService(timestampService, lockService, LOCK_CLIENT);
+
+    @Before
+    public void before() {
+        when(timestampService.getFreshTimestamp()).thenReturn(FRESH_TIMESTAMP);
+    }
+
+    @Test
+    public void freshTimestampDelegatesToTimestampService() {
+        assertEquals(FRESH_TIMESTAMP, timelock.getFreshTimestamp());
+    }
+
+    @Test
+    public void freshTimestampsDelegatesToTimestampService() {
+        int numTimestamps = 10;
+        TimestampRange range = TimestampRange.createInclusiveRange(21L, 30L);
+        when(timestampService.getFreshTimestamps(numTimestamps)).thenReturn(range);
+
+        assertEquals(range, timelock.getFreshTimestamps(numTimestamps));
+    }
+
+    @Test
+    public void lockImmutableTimestampLocksFreshTimestamp() throws InterruptedException {
+        long immutableTs = 3L;
+
+        LockRefreshToken expectedToken = mockImmutableTsLockResponse();
+        mockMinLockedInVersionIdResponse(immutableTs);
+
+        LockImmutableTimestampResponse expectedResponse = LockImmutableTimestampResponse.of(immutableTs,
+                new LockRefreshTokenV2Adapter(expectedToken));
+        assertEquals(expectedResponse, timelock.lockImmutableTimestamp(LockImmutableTimestampRequest.create()));
+    }
+
+    @Test
+    public void getImmutableTimestampDelegatesInProperOrder() throws InterruptedException {
+        long immutableTs = 3L;
+
+        InOrder inOrder = Mockito.inOrder(timestampService, lockService);
+
+        mockMinLockedInVersionIdResponse(immutableTs);
+
+        assertEquals(immutableTs, timelock.getImmutableTimestamp());
+        inOrder.verify(timestampService).getFreshTimestamp();
+        inOrder.verify(lockService).getMinLockedInVersionId(LOCK_CLIENT.getClientId());
+    }
+
+    @Test
+    public void getImmutableTimestampReturnsFreshTimestampIfMinLockedInVersionIsNull() throws InterruptedException {
+        mockMinLockedInVersionIdResponse(null);
+
+        assertEquals(FRESH_TIMESTAMP, timelock.getImmutableTimestamp());
+    }
+
+    @Test
+    public void lockDelegatesToLockService() throws InterruptedException {
+        LockRequest legacyRequest = LockRequest.builder(buildLockMap(LockMode.WRITE)).build();
+
+        when(lockService.lock(LockClient.ANONYMOUS.getClientId(), legacyRequest)).thenReturn(LOCK_REFRESH_TOKEN);
+
+        assertEquals(LOCK_TOKEN_V2, timelock.lock(LockRequestV2.of(ImmutableSet.of(LOCK_A, LOCK_B))));
+        verify(lockService).lock(LockClient.ANONYMOUS.getClientId(), legacyRequest);
+    }
+
+    @Test
+    public void waitForLocksDelegatesToLockService() throws InterruptedException {
+        LockRequest legacyRequest = LockRequest.builder(buildLockMap(LockMode.READ)).lockAndRelease().build();
+
+        when(lockService.lock(LockClient.ANONYMOUS.getClientId(), legacyRequest)).thenReturn(LOCK_REFRESH_TOKEN);
+
+        timelock.waitForLocks(WaitForLocksRequest.of(ImmutableSet.of(LOCK_A, LOCK_B)));
+        verify(lockService).lock(LockClient.ANONYMOUS.getClientId(), legacyRequest);
+    }
+
+    @Test
+    public void refreshLockLeasesDelegatesToLockService() {
+        Set<LockTokenV2> tokens = ImmutableSet.of(LOCK_TOKEN_V2);
+        timelock.refreshLockLeases(tokens);
+
+        verify(lockService).refreshLockRefreshTokens(ImmutableSet.of(LOCK_REFRESH_TOKEN));
+    }
+
+    @Test
+    public void unlockDelegatesToLockService() {
+        timelock.unlock(ImmutableSet.of(LOCK_TOKEN_V2));
+
+        verify(lockService).unlock(LOCK_REFRESH_TOKEN);
+    }
+
+    @Test
+    public void unlockReturnsSubsetThatWereUnlocked() {
+        LockRefreshTokenV2Adapter tokenA = randomLockToken();
+        LockRefreshTokenV2Adapter tokenB = randomLockToken();
+
+        when(lockService.unlock(tokenA.getToken())).thenReturn(true);
+        when(lockService.unlock(tokenB.getToken())).thenReturn(false);
+
+        Set<LockTokenV2> expected = ImmutableSet.of(tokenA);
+        assertEquals(expected, timelock.unlock(ImmutableSet.of(tokenA, tokenB)));
+    }
+
+    private static LockRefreshTokenV2Adapter randomLockToken() {
+        LockRefreshToken token = new LockRefreshToken(BigInteger.valueOf(ThreadLocalRandom.current().nextLong()), 123L);
+        return new LockRefreshTokenV2Adapter(token);
+    }
+
+    @Test
+    public void currentTimeMillisDelegatesToLockService() {
+        long time = 456L;
+        when(lockService.currentTimeMillis()).thenReturn(time);
+
+        assertEquals(time, timelock.currentTimeMillis());
+    }
+
+    private void mockMinLockedInVersionIdResponse(Long immutableTs) {
+        when(lockService.getMinLockedInVersionId(LOCK_CLIENT.getClientId())).thenReturn(immutableTs);
+    }
+
+    private LockRefreshToken mockImmutableTsLockResponse() throws InterruptedException {
+        LockDescriptor descriptor = AtlasTimestampLockDescriptor.of(FRESH_TIMESTAMP);
+        LockRequest expectedRequest = LockRequest.builder(ImmutableSortedMap.of(descriptor, LockMode.READ))
+                .withLockedInVersionId(FRESH_TIMESTAMP).build();
+        LockRefreshToken expectedToken = new LockRefreshToken(BigInteger.ONE, 123L);
+        when(lockService.lock(LOCK_CLIENT.getClientId(), expectedRequest)).thenReturn(expectedToken);
+        return expectedToken;
+    }
+
+    private SortedMap<LockDescriptor, LockMode> buildLockMap(LockMode mode) {
+        SortedMap<LockDescriptor, LockMode> lockMap = Maps.newTreeMap();
+        lockMap.put(LOCK_A, mode);
+        lockMap.put(LOCK_B, mode);
+
+        return lockMap;
+    }
+
+}

--- a/lock-impl/versions.lock
+++ b/lock-impl/versions.lock
@@ -5,7 +5,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -62,7 +63,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -94,6 +96,12 @@
         "com.palantir.atlasdb:lock-api": {
             "project": true
         },
+        "com.palantir.atlasdb:timestamp-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:lock-api"
+            ]
+        },
         "com.palantir.patches.sourceforge:trove3": {
             "locked": "3.0.3-p5",
             "requested": "3.0.3-p5"
@@ -112,7 +120,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {
@@ -125,7 +134,8 @@
             "locked": "2.0.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "joda-time:joda-time": {
@@ -155,7 +165,8 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -212,7 +223,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.google.code.findbugs:jsr305": {
@@ -244,6 +256,12 @@
         "com.palantir.atlasdb:lock-api": {
             "project": true
         },
+        "com.palantir.atlasdb:timestamp-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:lock-api"
+            ]
+        },
         "com.palantir.patches.sourceforge:trove3": {
             "locked": "3.0.3-p5",
             "requested": "3.0.3-p5"
@@ -262,7 +280,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {
@@ -275,7 +294,8 @@
             "locked": "2.0.1",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "joda-time:joda-time": {

--- a/timelock-impl/versions.lock
+++ b/timelock-impl/versions.lock
@@ -258,6 +258,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -753,6 +754,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/timelock-server-distribution/versions.lock
+++ b/timelock-server-distribution/versions.lock
@@ -359,6 +359,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -344,6 +344,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -1401,6 +1402,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },


### PR DESCRIPTION
**Goals (and why)**:
Refactor the client code to depend on a TimelockService abstraction that relies on the new async lock apis

**Implementation Description (bullets)**:
- Create a `TimelockService` interface
- Update transaction manager and transaction classes to use it
- Create a legacy implementation that relies on the old `RemoteLockService` interface

To continue supporting the existing advisory locking APIs (`runTaskWithLocks`):
- Introduce a `PreCommitValidation` that wraps advisory locks obtained from `RemoteLockService`. I went back and forth on whether or not to do this, but ultimately decided it was better to do this than have the new `TimelockService` return `LockRefreshToken`. I don't like the idea of mixing tokens returned by the two services.

**Concerns (what feedback would you like?)**:
- Did I break any of the transaction protocol with this refactor?
- Did I break any public APIs used by internal products that won't be easily fixable?
- We now have both a `RemoteLockService` and a `TimelockService` in the transaction manager. I didn't see a way to avoid this, as large internal product still needs the `RemoteLockService` APIs and thus it's unlikely to go away for a while.

**Where should we start reviewing?**:
`LegacyTimelockService`, `SnapshotTransactionManager`, `SnapshotTransaction`, `PreCommitValidation`

**Priority (whenever / two weeks / yesterday)**:
Soon, if we're going to require async lock before GAing timelock

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2072)
<!-- Reviewable:end -->
