### PR TITLE
table compression backport for 039x

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableDefinitionBuilder.java
@@ -154,7 +154,7 @@ public class StreamTableDefinitionBuilder {
                     appendHeavyAndReadLight();
                 }
                 if (dbSideCompressionForBlocks) {
-                    explicitCompressionBlockSizeKB(GenericStreamStore.BLOCK_SIZE_IN_BYTES / 2);
+                    explicitCompressionBlockSizeKB(Integer.highestOneBit(GenericStreamStore.BLOCK_SIZE_IN_BYTES / 2));
                 }
                 ignoreHotspottingChecks();
             }};

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/AbstractDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/AbstractDefinition.java
@@ -18,7 +18,9 @@ package com.palantir.atlasdb.table.description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.math.IntMath;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.CachePriority;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ExpirationStrategy;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.PartitionStrategy;
@@ -98,6 +100,7 @@ abstract class AbstractDefinition {
     }
 
     public void explicitCompressionBlockSizeKB(int blockSizeKB) {
+        Preconditions.checkArgument(IntMath.isPowerOfTwo(blockSizeKB), "explicitCompressionBlockSizeKB must be a power of 2");
         explicitCompressionBlockSizeKB = blockSizeKB;
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
@@ -169,6 +169,9 @@ public class TableMetadata implements Persistable {
         builder.setCachePriority(cachePriority);
         builder.setPartitionStrategy(partitionStrategy);
         builder.setRangeScanAllowed(rangeScanAllowed);
+        if (explicitCompressionBlockSizeKB != 0) {
+            builder.setExplicitCompressionBlockSizeKiloBytes(explicitCompressionBlockSizeKB);
+        }
         builder.setNegativeLookups(negativeLookups);
         builder.setSweepStrategy(sweepStrategy);
         // expiration strategy doesn't need to be persisted.

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableMetadataPersistenceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableMetadataPersistenceTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.table.description;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.Lists;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+
+@RunWith(Parameterized.class)
+public class TableMetadataPersistenceTest {
+
+    private static final int CUSTOM_COMPRESSION_BLOCK_SIZE = 32;
+
+    private final TableDefinition tableDefinition;
+    private final int compressionBlockSizeKB;
+
+    @Parameters
+    public static Collection<Object[]> testCases() {
+        Collection<Object[]> params = Lists.newArrayList();
+
+        params.add(new Object[] {getRangeScanWithoutCompression(), 0});
+        params.add(new Object[] {getDefaultExplicit(), AtlasDbConstants.DEFAULT_TABLE_COMPRESSION_BLOCK_SIZE_KB});
+        params.add(new Object[] {getDefaultRangeScanExplicit(), AtlasDbConstants.DEFAULT_TABLE_WITH_RANGESCANS_COMPRESSION_BLOCK_SIZE_KB});
+        params.add(new Object[] {getCustomExplicitCompression(), CUSTOM_COMPRESSION_BLOCK_SIZE});
+        params.add(new Object[] {getCustomTable(), CUSTOM_COMPRESSION_BLOCK_SIZE});
+
+        return params;
+    }
+
+    public TableMetadataPersistenceTest(TableDefinition tableDefinition, int compressionBlockSizeKB) {
+        this.tableDefinition = tableDefinition;
+        this.compressionBlockSizeKB = compressionBlockSizeKB;
+    }
+
+    @Test
+    public void testSerializeAndDeserialize() {
+        TableMetadata metadata = tableDefinition.toTableMetadata();
+        byte[] metadataAsBytes = metadata.persistToBytes();
+        TableMetadata metadataFromBytes = TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadataAsBytes);
+        Assert.assertEquals(metadata, metadataFromBytes);
+    }
+
+    @Test
+    public void testMetadataHasExpectedCompressionBlockSize() {
+        TableMetadata metadata = tableDefinition.toTableMetadata();
+        Assert.assertEquals(compressionBlockSizeKB, metadata.getExplicitCompressionBlockSizeKB());
+    }
+
+    private static TableDefinition getRangeScanWithoutCompression() {
+        return new TableDefinition() {{
+            javaTableName("RangeScanWithoutCompression");
+
+            rowName();
+            rowComponent("component1", ValueType.STRING);
+
+            columns();
+            column("column1", "c", ValueType.VAR_LONG);
+
+            rangeScanAllowed();
+        }};
+    }
+
+    private static TableDefinition getDefaultExplicit() {
+        return new TableDefinition() {{
+            javaTableName("DefaultTableWithCompression");
+
+            rowName();
+            rowComponent("component1", ValueType.STRING);
+
+            columns();
+            column("column1", "c", ValueType.VAR_LONG);
+
+            explicitCompressionRequested();
+        }};
+    }
+
+    private static TableDefinition getDefaultRangeScanExplicit() {
+        return new TableDefinition() {{
+            javaTableName("RangeScanWithCompression");
+
+            rowName();
+            rowComponent("component1", ValueType.STRING);
+
+            columns();
+            column("column1", "c", ValueType.VAR_LONG);
+
+            rangeScanAllowed();
+            explicitCompressionRequested();
+        }};
+    }
+
+    private static TableDefinition getCustomExplicitCompression() {
+        return new TableDefinition() {{
+            javaTableName("CustomExplicitCompression");
+
+            rowName();
+            rowComponent("component1", ValueType.STRING);
+
+            columns();
+            column("column1", "c", ValueType.VAR_LONG);
+
+            explicitCompressionBlockSizeKB(CUSTOM_COMPRESSION_BLOCK_SIZE);
+        }};
+    }
+
+    private static TableDefinition getCustomTable() {
+        return new TableDefinition() {{
+            javaTableName("CustomTable");
+
+            rowName();
+            rowComponent("component1", ValueType.VAR_LONG, TableMetadataPersistence.ValueByteOrder.DESCENDING);
+            rowComponent("component2", ValueType.FIXED_LONG_LITTLE_ENDIAN);
+
+            columns();
+            column("column1", "c", ValueType.UUID);
+            column("column2", "d", ValueType.BLOB);
+
+            // setting everything explicitly to test serialization
+            conflictHandler(ConflictHandler.SERIALIZABLE);
+            sweepStrategy(TableMetadataPersistence.SweepStrategy.THOROUGH);
+            partitionStrategy(TableMetadataPersistence.PartitionStrategy.HASH);
+            cachePriority(TableMetadataPersistence.CachePriority.COLD);
+            explicitCompressionBlockSizeKB(CUSTOM_COMPRESSION_BLOCK_SIZE);
+            negativeLookups();
+            appendHeavyAndReadLight();
+        }};
+    }
+
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -1189,7 +1189,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
             rangeScanAllowed();
             sweepStrategy(TableMetadataPersistence.SweepStrategy.CONSERVATIVE);
             explicitCompressionRequested();
-            explicitCompressionBlockSizeKB(100);
+            explicitCompressionBlockSizeKB(128);
         }}.toTableMetadata().persistToBytes();
         keyValueService.putMetadataForTable(TEST_TABLE, bytes);
         bytesRead = keyValueService.getMetadataForTable(TEST_TABLE);


### PR DESCRIPTION
**Goals (and why)**:
It's far easier for {internal project that has its own strictly-ordered upgrade task framework} to have this backported, which in turn will mean they can backport the upgrade task that moves them onto this compression, and then backport the upgrade task on top of this compression one that they /actually/ care about backporting and that they are blocked on.
 
**Implementation Description (bullets)**:
Cherry pick of sberler's #1995 onto 0.39.x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2075)
<!-- Reviewable:end -->
