### PR TITLE
Add backwards compatibility for passing row values in console functions

### DIFF
--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -52,35 +52,62 @@ class AtlasCoreModule implements AtlasConsoleModule {
                          Ex: def x = table('stream_value')
 
                          To retrieve metadata about a table, use <TABLE>.describe(),
-                         <TABLE>.isDynamic(), <TABLE>.rowComponents(), and <TABLE>.columnNames().'''.stripIndent(),
+                         <TABLE>.isDynamic(), <TABLE>.rowComponents(), and <TABLE>.columnNames().
+                         '''.stripIndent(),
+
             'transactions': '''\
                          Atomic transactions used to avoid read/write or write/write
-                         conflicts. Use startTransaction() to start, currentTransaction()
-                         to view all operations in the current transaction, endTransaction()
-                         to end and commit the current transaction, and abortTransaction()
-                         to end and abort (undo) the current transaction.'''.stripIndent(),
-            'pretty print': '''\
+                         conflicts.
+
+                         Use startTransaction() to start.
+                         Use currentTransaction() to view all operations in the current transaction.
+                         Use endTransaction() to end and commit the current transaction.
+                         Use abortTransaction() to end and abort (undo) the current transaction.
+                         '''.stripIndent(),
+
+            'prettyPrint': '''\
                          Print tables and objects in a more human-readable format.
 
                          Use pp() to print objects. Ex: pp(obj).
 
                          Use pptable() to print ranges or lists of rows from a table. Ex:
                          pptable(table(<TABLE-NAME>)).getRange(), ['row': [width: 30],
-                         'base_object': [width: 50, format: 'json']])'''.stripIndent(),
+                         'base_object': [width: 50, format: 'json']])
+                         '''.stripIndent(),
+
             'getRange': '''\
-                         Retrieve a range of rows from a table. Use getRange() to get all
-                         rows from the table, or getRange(args) to get a subset. Ex:
+                         Retrieve a range of rows from a table.
+
+                         Use getRange() to get all rows from the table
+
+                         Use getRange(args) to get a subset. Ex:
+
                          <TABLE>.getRange([start: <START-ROW-VALUE>, end: <END-ROW-VALUE>
-                         , prefix: <OBJECT-ID-OR-ROW-VALUE>, cols: [<COL-NAMES>]])'''.stripIndent(),
+                         , prefix: <OBJECT-ID-OR-ROW-VALUE>, cols: [<COL-NAMES>]])
+                         '''.stripIndent(),
+
             'getRow': '''\
                          Retrieve a single row from a table. Ex:
-                         <TABLE>.getRows(<ROW-VALUE>)'''.stripIndent(),
+
+                         <TABLE>.getRows(<ROW-VALUE>).
+
+                         <ROW-VALUE> here can be either a list of row component values (e.g. [0,1,2])
+                         or a map including the row component names (e.g. [obj_id:0, foo_id:1, bar_id:2])
+                         '''.stripIndent(),
+
             'getRows': '''\
                          Retrieve one or more rows from a table. Ex:
-                         <TABLE>.getRows([ <ROW-VALUE>, <ROW-VALUE> ])'''.stripIndent(),
+
+                         <TABLE>.getRows([ <ROW-VALUE>, <ROW-VALUE> ])
+
+                         <ROW-VALUE> here can be either a list of row component values (e.g. [0,1,2])
+                         or a map including the row component names (e.g. [obj_id:0, foo_id:1, bar_id:2])
+                         '''.stripIndent(),
+
             'join': '''\
-                         Retreive one or more rows from a table and match them up by row-key
+                         Retrieve one or more rows from a table and match them up by row-key
                          with corresponding values.  Ex:
+
                          <TABLE>.join([[ <ROW-VALUE-1> : <EXTRA-DATA-1>], [ <ROW-VALUE-2> : <EXTRA-DATA-2]])
                          Returns:
                          [["JOIN_KEY" : <ROW-VALUE-1>, "INPUT_VALUE" : <EXTRA-DATA-1>, "OUTPUT_VALUE" : <TABLE-ROW-1>], 
@@ -99,6 +126,7 @@ class AtlasCoreModule implements AtlasConsoleModule {
                          output.each { println it}
                          '''.stripIndent(),
 
+
             'getCells': '''\
                          Retrieve one or more cells from a table, specified by row and
                          column.
@@ -107,7 +135,8 @@ class AtlasCoreModule implements AtlasConsoleModule {
                          col: <COL-NAME>])
 
                          Ex (for dynamic columns): <TABLE>.getCells([row: <ROW-VALUE>,
-                         col: <COL-INDEX>])'''.stripIndent(),
+                         col: <COL-INDEX>])
+                         '''.stripIndent(),
             'put': '''\
                          Insert or update one or more rows in a table.
 
@@ -115,15 +144,21 @@ class AtlasCoreModule implements AtlasConsoleModule {
                          [<COL-NAME>: <COL-VALUE>]])
 
                          Ex (for dynamic columns): <TABLE>.put([row: <ROW-VALUE>, col:
-                         <COL-INDEX>, val: <COL-VALUE>])'''.stripIndent(),
+                         <COL-INDEX>, val: <COL-VALUE>])
+                         '''.stripIndent(),
+
             'delete': '''\
-                         Delete one or more rows in a table.
-                         Ex: <TABLE>.delete([row: <ROW-VALUE>, cols: [<COL-NAME>,
-                          <COL-NAME>]])'''.stripIndent(),
+                         Delete one or more rows in a table. Ex:
+
+                         <TABLE>.delete([row: <ROW-VALUE>, cols: [<COL-NAME>, <COL-NAME>]])
+                          '''.stripIndent(),
+
             'connect': '''\
                           Connect to an atlas server using settings from a dropwizard yaml
-                          file.
-                          Ex: connect(<PATH-TO-YAML-CONFIG>)'''.stripIndent(),
+                          file. Ex:
+
+                          connect(<PATH-TO-YAML-CONFIG>)
+                          '''.stripIndent(),
     ]
     private static final int COLUMN_PADDING = 5
 

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -56,13 +56,15 @@ class AtlasCoreModule implements AtlasConsoleModule {
                          '''.stripIndent(),
 
             'transactions': '''\
-                         Atomic transactions used to avoid read/write or write/write
-                         conflicts.
+                         AtlasDB implements fully ACID transactions with snapshot isolation. By
+                         default, a transaction will be created for every statement you execute.
+                         To group several statements in a single transaction, you can use the
+                         following commands:
 
-                         Use startTransaction() to start.
-                         Use currentTransaction() to view all operations in the current transaction.
-                         Use endTransaction() to end and commit the current transaction.
-                         Use abortTransaction() to end and abort (undo) the current transaction.
+                         - startTransaction() to start a transaction.
+                         - currentTransaction() to view all operations in the current transaction.
+                         - endTransaction() to end and commit the current transaction.
+                         - abortTransaction() to end and abort (undo) the current transaction.
                          '''.stripIndent(),
 
             'prettyPrint': '''\

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -138,6 +138,9 @@ class AtlasCoreModule implements AtlasConsoleModule {
 
                          Ex (for dynamic columns): <TABLE>.getCells([row: <ROW-VALUE>,
                          col: <COL-INDEX>])
+
+                         <ROW-VALUE> here can be either a list of row component values (e.g. [0,1,2])
+                         or a map including the row component names (e.g. [obj_id:0, foo_id:1, bar_id:2])
                          '''.stripIndent(),
             'put': '''\
                          Insert or update one or more rows in a table.

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/Table.groovy
@@ -124,10 +124,10 @@ class Table {
      */
     List getRows(rows, cols=null, TransactionToken token = service.getTransactionToken()) {
         def query = baseQuery()
-        rows = listify(rows).collect { listify(it) }
+        rows = listify(rows).collect { listifyUnlessMap(it) }
         query['rows'] = rows
         if (cols != null) {
-            cols = listify(cols).collect { listify(it) }
+            cols = listify(cols).collect { listifyUnlessMap(it) }
             query['cols'] = cols
         }
         return service.getRows(query, token)['data'] as List
@@ -310,7 +310,7 @@ class Table {
         list.collect { elem ->
             def map = [:]
             for (String key in keys) {
-                map.put(key, listify(elem.getAt(key)))
+                map.put(key, listifyUnlessMap(elem.getAt(key)))
             }
             return map
         }
@@ -322,6 +322,14 @@ class Table {
 
     private List listify(obj) {
         (obj instanceof List ? obj : [obj]) as List
+    }
+
+    private Object listifyUnlessMap(obj) {
+        if (obj instanceof Map || obj instanceof List) {
+            return obj
+        } else {
+            return [obj]
+        }
     }
 
     private Map<String, Set> columnFields() {

--- a/atlasdb-console/src/test/groovy/com/palantir/atlasdb/console/groovy/TableTest.groovy
+++ b/atlasdb-console/src/test/groovy/com/palantir/atlasdb/console/groovy/TableTest.groovy
@@ -82,7 +82,6 @@ class TableTest {
     @Test
     void testGetRow() {
         rowQueryRunner(['a'], [['a']])
-        rowQueryRunner(['a':'b', 'c':'d'], [['b', 'd']])
     }
 
     private void rowsQueryRunner(row, rowExpect, col=null, colExpect=null) {
@@ -104,7 +103,6 @@ class TableTest {
             rowsQueryRunner(it.key, it.value)
             rowsQueryRunner(it.key, it.value, it.key, it.value)
         }
-        rowQueryRunner(['a':'b', 'c':'d'], [['b', 'd']])
     }
 
     @Test

--- a/atlasdb-console/src/test/groovy/com/palantir/atlasdb/console/groovy/TableTest.groovy
+++ b/atlasdb-console/src/test/groovy/com/palantir/atlasdb/console/groovy/TableTest.groovy
@@ -82,6 +82,7 @@ class TableTest {
     @Test
     void testGetRow() {
         rowQueryRunner(['a'], [['a']])
+        rowQueryRunner(['a':'b', 'c':'d'], [['b', 'd']])
     }
 
     private void rowsQueryRunner(row, rowExpect, col=null, colExpect=null) {
@@ -103,6 +104,7 @@ class TableTest {
             rowsQueryRunner(it.key, it.value)
             rowsQueryRunner(it.key, it.value, it.key, it.value)
         }
+        rowQueryRunner(['a':'b', 'c':'d'], [['b', 'd']])
     }
 
     @Test

--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/AtlasDeserializers.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/AtlasDeserializers.java
@@ -79,14 +79,22 @@ public final class AtlasDeserializers {
                 "Received %s values for a row with %s components.", size, components.size());
         byte[][] bytes = new byte[size][];
         for (int i = 0; i < size; i++) {
-            JsonNode value = node.get(components.get(i).getComponentName());
             NameComponentDescription component = components.get(i);
-            bytes[i] = component.getType().convertFromJson(value.toString());
+            String value = getRowValue(i, component, node);
+            bytes[i] = component.getType().convertFromJson(value);
             if (component.isReverseOrder()) {
                 EncodingUtils.flipAllBitsInPlace(bytes[i]);
             }
         }
         return Bytes.concat(bytes);
+    }
+
+    private static String getRowValue(int i, NameComponentDescription component, JsonNode node) {
+        if (node.has(component.getComponentName())) {
+            return node.get(component.getComponentName()).toString();
+        } else {
+            return node.get(i).toString();
+        }
     }
 
     public static Iterable<byte[]> deserializeRows(final NameMetadataDescription description,

--- a/atlasdb-service/src/test/java/com/palantir/atlasdb/jackson/AtlasDeserializersTest.java
+++ b/atlasdb-service/src/test/java/com/palantir/atlasdb/jackson/AtlasDeserializersTest.java
@@ -30,7 +30,7 @@ import com.palantir.atlasdb.table.description.ValueType;
 public class AtlasDeserializersTest {
 
     @Test
-    public void testDeserializeRowFromJsonArray() throws Exception {
+    public void testDeserializeRowFromJsonList() throws Exception {
         JsonNode jsonNode = new ObjectMapper().readTree("[68, \"Smeagol\"]");
         NameMetadataDescription nameMetadataDescription = NameMetadataDescription.create(ImmutableList.of(
                 new NameComponentDescription("age", ValueType.FIXED_LONG),

--- a/atlasdb-service/src/test/java/com/palantir/atlasdb/jackson/AtlasDeserializersTest.java
+++ b/atlasdb-service/src/test/java/com/palantir/atlasdb/jackson/AtlasDeserializersTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.jackson;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Bytes;
+import com.palantir.atlasdb.table.description.NameComponentDescription;
+import com.palantir.atlasdb.table.description.NameMetadataDescription;
+import com.palantir.atlasdb.table.description.ValueType;
+
+public class AtlasDeserializersTest {
+
+    @Test
+    public void testDeserializeRowFromJsonArray() throws Exception {
+        JsonNode jsonNode = new ObjectMapper().readTree("[68, \"Smeagol\"]");
+        NameMetadataDescription nameMetadataDescription = NameMetadataDescription.create(ImmutableList.of(
+                new NameComponentDescription("age", ValueType.FIXED_LONG),
+                new NameComponentDescription("name", ValueType.STRING)));
+        byte[] row = AtlasDeserializers.deserializeRow(nameMetadataDescription, jsonNode);
+        byte[] expectedRow = Bytes.concat(ValueType.FIXED_LONG.convertFromString("68"),
+                                          ValueType.STRING.convertFromString("Smeagol"));
+        Assert.assertArrayEquals(expectedRow, row);
+    }
+
+    @Test
+    public void testDeserializeRowFromJsonMap() throws Exception {
+        JsonNode jsonNode = new ObjectMapper().readTree("{\"age\":68, \"name\":\"Smeagol\"}");
+        NameMetadataDescription nameMetadataDescription = NameMetadataDescription.create(ImmutableList.of(
+                new NameComponentDescription("age", ValueType.FIXED_LONG),
+                new NameComponentDescription("name", ValueType.STRING)));
+        byte[] row = AtlasDeserializers.deserializeRow(nameMetadataDescription, jsonNode);
+        byte[] expectedRow = Bytes.concat(ValueType.FIXED_LONG.convertFromString("68"),
+                                          ValueType.STRING.convertFromString("Smeagol"));
+        Assert.assertArrayEquals(expectedRow, row);
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -161,6 +161,10 @@ develop
            the batch size for getRows is now controlled by a config parameter ``rowBatchSize``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2093>`__)
 
+    *    - |fixed|
+         - Added backwards compatibility for passing row values into AtlasConsole functions
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2080>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 ======
@@ -261,7 +265,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2048>`__)
 
     *    - |improved|
-         - Improved the way rows and named columns are output in AtlasConsole to be more intuitive and easier to use. Note that this may break existing AtlasConsole scripts.
+         - Improved the way rows and named columns are outputted in AtlasConsole to be more intuitive and easier to use. Note that this may break existing AtlasConsole scripts.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2067>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -261,7 +261,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2048>`__)
 
     *    - |improved|
-         - Improved the way rows and named columns are outputted in AtlasConsole to be more intuitive and easier to use. Note that this may break existing AtlasConsole scripts.
+         - Improved the way rows and named columns are output in AtlasConsole to be more intuitive and easier to use. Note that this may break existing AtlasConsole scripts.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2067>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>


### PR DESCRIPTION
Followup on: #2067

I realized that after the changes in #2067, you can no longer use many of the Console functions in the convenient ways you used to, so I added some backwards compatibility to the deserializer which should help to break old Console scripts less, and provide the user with more flexibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2080)
<!-- Reviewable:end -->
