### PR TITLE
Fix deadlock encountered in internal security product

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -451,6 +451,14 @@ public final class TransactionManagers {
             Supplier<RemoteLockService> lock,
             Supplier<TimestampService> time,
             String userAgent) {
+        if (leaderConfig.leaders().size() == 1) {
+            // Attempting to connect to ourself while processing a request can lead to deadlock if incoming request
+            // volume is high, as all Jetty threads end up waiting for the timestamp server, and no threads remain to
+            // actually handle the timestamp server requests. If there is a single leader, it must be us, and we can
+            // avoid the deadlock entirely; the leader block is only there to allow other services reading the
+            // configuration to find the timestamp server.
+            return createRawEmbeddedServices(env, lock, time, userAgent);
+        }
         LeaderElectionService leader = Leaders.create(env, leaderConfig, userAgent);
 
         env.register(AwaitingLeadershipProxy.newProxyInstance(RemoteLockService.class, lock, leader));

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.factory;
 
 import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -96,7 +95,6 @@ import com.palantir.timestamp.TimestampStoreInvalidator;
 
 public final class TransactionManagers {
     private static final Logger log = LoggerFactory.getLogger(TransactionManagers.class);
-    private static final ServiceLoader<AtlasDbFactory> loader = ServiceLoader.load(AtlasDbFactory.class);
     public static final LockClient LOCK_CLIENT = LockClient.of("atlas instance");
 
     private TransactionManagers() {


### PR DESCRIPTION
**Goals (and why)**:

Attempting to connect to ourself to get a timestamp while processing a request can lead to deadlock if incoming request volume is high, as all Jetty threads end up waiting for the timestamp server, and no threads remain to actually handle the timestamp server requests. 

**Implementation Description (bullets)**:

If there is a single leader, it must be us, and we can avoid the deadlock entirely; the leader block is only there to allow other services reading the configuration to find the timestamp server. Simply have createRawLeaderServices delegate to createRawEmbeddedServices in this instance.

HA instances will have to switch to using the standalone timestamp server to fix this issue, as it is unavoidable there.

**Concerns (what feedback would you like?)**:

Are there any landmines to this approach?

**Where should we start reviewing?**:

It's only three lines + comment so...

**Priority (whenever / two weeks / yesterday)**:

Is causing significant instability for a customer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2089)
<!-- Reviewable:end -->
