### PR TITLE
Fix Incorrect POM Generation for Shadow Jars

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,8 +44,11 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - AtlasDB now generates Maven POM files for shadowed jars correctly.
+           Previously, we would regenerate the XML for shadow dependencies by creating a node with corresponding groupId, artifactId, scope and version tags *only*, which is incorrect because it loses information about, for example, specific or transitive exclusions.
+           We now respect these additional tags.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
 
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/gradle/publish-jars.gradle
+++ b/gradle/publish-jars.gradle
@@ -48,7 +48,6 @@ publishing {
 private void replaceShadedDependencies(MavenPublication mavenPublication) {
     mavenPublication.pom.withXml {
         def targetDependencies = project.configurations.getByName('shadow').allDependencies
-        println targetDependencies.getClass()
 
         def newDependencyRoot = new Node(null, 'dependencies')
         def existingDependencies = asNode().getByName('dependencies')[0]
@@ -58,7 +57,6 @@ private void replaceShadedDependencies(MavenPublication mavenPublication) {
                     getGroupIdFromNode(dependency),
                     getArtifactIdFromNode(dependency))) {
                 newDependencyRoot.append(dependency)
-                println newDependencyRoot.children()
             }
         }
 
@@ -77,18 +75,19 @@ private static String hasMatchingDependency(DependencySet dependencies, String g
 
 // We assume that there is only one groupId tag, which has exactly one element in it.
 private static String getGroupIdFromNode(Node dependency) {
-    if (dependency.groupId.size() != 1 || dependency.groupId[0].children().size() != 1) {
-        throw new IllegalArgumentException("Encountered an XML node which had more than one groupId!");
-    }
-    return dependency.groupId[0].children()[0]
+    return getOnlyValue(dependency.groupId)
 }
 
 // We assume that there is only one artifactId tag, which has exactly one element in it.
 private static String getArtifactIdFromNode(Node dependency) {
-    if (dependency.artifactId.size() != 1 || dependency.artifactId[0].children().size() != 1) {
-        throw new IllegalArgumentException("Encountered an XML node which had more than one artifactId!");
+    return getOnlyValue(dependency.artifactId)
+}
+
+private static String getOnlyValue(List<Node> nodeList) {
+    if (nodeList.size() != 1 || nodeList[0].children().size() != 1) {
+        throw new IllegalArgumentException("getOnlyValue() called on a node list which didn't have an only value");
     }
-    return dependency.artifactId[0].children()[0]
+    return nodeList[0].children()[0]
 }
 
 // Bintray publish

--- a/gradle/publish-jars.gradle
+++ b/gradle/publish-jars.gradle
@@ -48,25 +48,47 @@ publishing {
 private void replaceShadedDependencies(MavenPublication mavenPublication) {
     mavenPublication.pom.withXml {
         def targetDependencies = project.configurations.getByName('shadow').allDependencies
+        println targetDependencies.getClass()
 
         def newDependencyRoot = new Node(null, 'dependencies')
-        targetDependencies.forEach { dependency ->
-            def dependencyNode = newDependencyRoot.appendNode('dependency')
-            dependencyNode.appendNode('groupId', dependency.getGroup())
-            dependencyNode.appendNode('artifactId', dependency.getName())
-            dependencyNode.appendNode('scope', 'runtime')
-
-            def version = getVersion(dependency, dependencyRecommendations)
-            dependencyNode.appendNode('version', version)
+        def existingDependencies = asNode().getByName('dependencies')[0]
+        existingDependencies.children().forEach { dependency ->
+            if (hasMatchingDependency(
+                    targetDependencies,
+                    getGroupIdFromNode(dependency),
+                    getArtifactIdFromNode(dependency))) {
+                newDependencyRoot.append(dependency)
+                println newDependencyRoot.children()
+            }
         }
+
         asNode().getByName('dependencies')[0].replaceNode(newDependencyRoot)
     }
 }
 
-private static String getVersion(Dependency dependency, provider) {
-    return dependency.getVersion() == null ?
-            provider.getRecommendedVersion(dependency.getGroup(), dependency.getName()) :
-            dependency.getVersion()
+/**
+ * Returns true if and only if there exists some dependency in the provided list of dependencies.
+ * We can consider this for further optimisation e.g. with a hashset if this is too slow.
+ */
+private static String hasMatchingDependency(DependencySet dependencies, String groupId, String artifactId) {
+    return dependencies.stream()
+                       .anyMatch({dep -> dep.getGroup().equals(groupId) && dep.getName().equals(artifactId)});
+}
+
+// We assume that there is only one groupId tag, which has exactly one element in it.
+private static String getGroupIdFromNode(Node dependency) {
+    if (dependency.groupId.size() != 1 || dependency.groupId[0].children().size() != 1) {
+        throw new IllegalArgumentException("Encountered an XML node which had more than one groupId!");
+    }
+    return dependency.groupId[0].children()[0]
+}
+
+// We assume that there is only one artifactId tag, which has exactly one element in it.
+private static String getArtifactIdFromNode(Node dependency) {
+    if (dependency.artifactId.size() != 1 || dependency.artifactId[0].children().size() != 1) {
+        throw new IllegalArgumentException("Encountered an XML node which had more than one artifactId!");
+    }
+    return dependency.artifactId[0].children()[0]
 }
 
 // Bintray publish

--- a/gradle/publish-jars.gradle
+++ b/gradle/publish-jars.gradle
@@ -79,13 +79,9 @@ private static Set<Tuple> getShadowDependencies(Project project) {
                            .collect(Collectors.toSet())
 }
 
-/**
- * Returns true if and only if there exists some dependency in the provided list of dependencies.
- * We can consider this for further optimisation e.g. with a hashset if this is too slow.
- */
+// Returns true if and only if there exists some dependency in the provided list of dependencies.
 private static boolean hasMatchingDependency(Set<Tuple> dependencies, String groupId, String artifactId) {
-    return dependencies.stream()
-                       .anyMatch({dep -> dep[0].equals(groupId) && dep[1].equals(artifactId)});
+    return dependencies.contains(new Tuple(groupId, artifactId));
 }
 
 // We assume that there is only one groupId tag, which has exactly one element in it.

--- a/gradle/publish-jars.gradle
+++ b/gradle/publish-jars.gradle
@@ -1,3 +1,5 @@
+import java.util.stream.Collectors;
+
 apply plugin: 'java'
 apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.jfrog.bintray'
@@ -47,30 +49,43 @@ publishing {
 
 private void replaceShadedDependencies(MavenPublication mavenPublication) {
     mavenPublication.pom.withXml {
-        def targetDependencies = project.configurations.getByName('shadow').allDependencies
+        def shadowDependencies = getShadowDependencies(project)
 
         def newDependencyRoot = new Node(null, 'dependencies')
         def existingDependencies = asNode().getByName('dependencies')[0]
         existingDependencies.children().forEach { dependency ->
             if (hasMatchingDependency(
-                    targetDependencies,
+                    shadowDependencies,
                     getGroupIdFromNode(dependency),
                     getArtifactIdFromNode(dependency))) {
                 newDependencyRoot.append(dependency)
             }
+            shadowDependencies.remove(new Tuple(getGroupIdFromNode(dependency), getArtifactIdFromNode(dependency)))
         }
+
+        addNodesForShadowDependenciesNotInCompileConfiguration(
+                newDependencyRoot,
+                shadowDependencies,
+                dependencyRecommendations)
 
         asNode().getByName('dependencies')[0].replaceNode(newDependencyRoot)
     }
+}
+
+private static Set<Tuple> getShadowDependencies(Project project) {
+    def rawDependencySet = project.configurations.getByName('shadow').allDependencies
+    return rawDependencySet.stream()
+                           .map({dep -> new Tuple(dep.getGroup(), dep.getName())})
+                           .collect(Collectors.toSet())
 }
 
 /**
  * Returns true if and only if there exists some dependency in the provided list of dependencies.
  * We can consider this for further optimisation e.g. with a hashset if this is too slow.
  */
-private static String hasMatchingDependency(DependencySet dependencies, String groupId, String artifactId) {
+private static boolean hasMatchingDependency(Set<Tuple> dependencies, String groupId, String artifactId) {
     return dependencies.stream()
-                       .anyMatch({dep -> dep.getGroup().equals(groupId) && dep.getName().equals(artifactId)});
+                       .anyMatch({dep -> dep[0].equals(groupId) && dep[1].equals(artifactId)});
 }
 
 // We assume that there is only one groupId tag, which has exactly one element in it.
@@ -88,6 +103,21 @@ private static String getOnlyValue(List<Node> nodeList) {
         throw new IllegalArgumentException("getOnlyValue() called on a node list which didn't have an only value");
     }
     return nodeList[0].children()[0]
+}
+
+private static void addNodesForShadowDependenciesNotInCompileConfiguration(
+        Node dependencyRoot,
+        Set<Tuple> remainingDeps,
+        recommender) {
+    remainingDeps.forEach { dependencyTuple ->
+        Node newDependency = dependencyRoot.appendNode('dependency')
+        newDependency.appendNode('groupId', dependencyTuple[0])
+        newDependency.appendNode('artifactId', dependencyTuple[1])
+        newDependency.appendNode('scope', 'runtime')
+
+        def version = recommender.getRecommendedVersion(dependency.getGroup(), dependency.getName())
+        newDependency.appendNode('version', version)
+    }
 }
 
 // Bintray publish


### PR DESCRIPTION
**Goals (and why)**: 
Fix POM XML generation for shadow jars. This was previously incorrect, because we would regenerate the XML by grabbing the groupId, artifactId, scope and version tags _only_. This is incorrect because it loses other information that may have been embedded in tags, such as transitives to exclude.

This manifested in a compile break for large internal product. See also #2090 

**Implementation Description (bullets)**:
* Change the algorithm; we previously regenerate the tags; I now traverse the old tree, and copy entire subtrees (that correspond to a dependency) if they match on the group and artifact IDs.
* Add a bit of sanity checks / validation since reading the group and artifact IDs from the Maven-generated XML trees is *super* janky

**Concerns (what feedback would you like?)**:
* Is there a cleaner way to do this?
* I verified the XML for `atlasdb-cassandra` is in line with that of the version as at 0.44.0 which is known to cooperate with large internal product.

**Where should we start reviewing?**: `publish-jars.gradle`

**Priority (whenever / two weeks / yesterday)**: Soon, blocks internal product's continuous delivery

@abaker14 for SA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2092)
<!-- Reviewable:end -->
