### PR TITLE
Jepsen Enhancements, Part 1: Parameterised Jepsen Lock Client

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -142,4 +142,4 @@
 
 (defn sync-lock-test
   [nem]
-    lock-test nem (fn [] (SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5"))))
+    (lock-test nem (fn [] (SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5")))))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -125,9 +125,9 @@
 ;; Defining the Jepsen test
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn lock-test
-  [nem]
+  [nem lock-client-supplier]
   (assoc tests/noop-test
-    :client (create-client nil nil nil (fn [] (SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5"))))
+    :client (create-client nil nil nil lock-client-supplier)
     :nemesis nem
     :generator (->> generator
                  (gen/stagger 0.05)
@@ -139,3 +139,7 @@
                  (gen/time-limit 360))
     :db (timelock/create-db)
     :checker checker))
+
+(defn sync-lock-test
+  [nem]
+    lock-test nem (fn [] (SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5"))))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -85,12 +85,12 @@
                     (assoc-ok-value op response [client-name lock-name])))
                 :unlock
                 (let [token (@token-store token-store-key)
-                      response (.unlock lock-client token)]
+                      response (.unlockSingle lock-client token)]
                   (do (replace-token! token-store token-store-key nil current-store-version)
                     (assoc-ok-value op response token)))
                 :refresh
                 (let [token (@token-store token-store-key)
-                      response (.refresh lock-client token)]
+                      response (.refreshSingle lock-client token)]
                   (do (replace-token! token-store token-store-key token current-store-version)
                     (assoc-ok-value op response token))))))
           (catch Exception e

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -57,15 +57,16 @@
    The object defines how you create a lock client, and how to request locks from it. The first call to this
    function will return an invalid object: you should call 'setup' on the returned object to get a valid one.
   "
-  [lock-client, client-name, token-store]
+  [lock-client, client-name, token-store, client-supplier]
   (reify client/Client
     (setup!
       [this test node]
       "Factory that returns an object implementing client/Client"
       (create-client
-        (SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5"))
+        (apply client-supplier)
         (name node)
-        (create-token-store)))
+        (create-token-store)
+        client-supplier))
 
     (invoke!
       [this test op]
@@ -126,7 +127,7 @@
 (defn lock-test
   [nem]
   (assoc tests/noop-test
-    :client (create-client nil nil nil)
+    :client (create-client nil nil nil #(SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5")))
     :nemesis nem
     :generator (->> generator
                  (gen/stagger 0.05)

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -63,7 +63,7 @@
       [this test node]
       "Factory that returns an object implementing client/Client"
       (create-client
-        (apply client-supplier)
+        (apply client-supplier [])
         (name node)
         (create-token-store)
         client-supplier))
@@ -127,7 +127,7 @@
 (defn lock-test
   [nem]
   (assoc tests/noop-test
-    :client (create-client nil nil nil #(SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5")))
+    :client (create-client nil nil nil (fn [] (SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5"))))
     :nemesis nem
     :generator (->> generator
                  (gen/stagger 0.05)

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timelock.clj
@@ -42,7 +42,7 @@
     (log-files [_ test node]
       ["/timelock-server/var/log/timelock-server-startup.log"])))
 
-(defn mostly-small-nonempty-subset-at-most-two
+(defn mostly-small-nonempty-subset
   "Returns a subset of the given collection, with a logarithmically decreasing
   probability of selecting more elements. Always selects at least one element.
       (->> #(mostly-small-nonempty-subset [1 2 3 4 5])
@@ -65,7 +65,7 @@
 (def crash-nemesis
   "A nemesis that crashes a random subset of nodes."
   (nemesis/node-start-stopper
-    mostly-small-nonempty-subset-at-most-two
+    mostly-small-nonempty-subset
     (fn start [test node] (c/su
                             (c/exec :killall :-9 :java))
       ; the following line would also wipe the paxos directory, but we wanted a less aggressive nemesis

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/JepsenLockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/JepsenLockClient.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+public interface JepsenLockClient<TOKEN> {
+    TOKEN lock(String client, String lockName) throws InterruptedException;
+
+    Set<TOKEN> unlock(Set<TOKEN> tokens) throws InterruptedException;
+
+    Set<TOKEN> refresh(Set<TOKEN> tokens) throws InterruptedException;
+
+    @SuppressWarnings("ConstantConditions") // If the token is null, we shortcircuit and return null.
+    default boolean unlockSingle(TOKEN token) throws InterruptedException {
+        return token == null ? null : !unlock(ImmutableSet.of(token)).isEmpty();
+    }
+
+    default TOKEN refreshSingle(TOKEN token) throws InterruptedException {
+        return token == null ? null : Iterables.getOnlyElement(refresh(ImmutableSet.of(token)), null);
+    }
+}

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/JepsenLockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/JepsenLockClient.java
@@ -28,9 +28,8 @@ public interface JepsenLockClient<TOKEN> {
 
     Set<TOKEN> refresh(Set<TOKEN> tokens) throws InterruptedException;
 
-    @SuppressWarnings("ConstantConditions") // If the token is null, we shortcircuit and return null.
     default boolean unlockSingle(TOKEN token) throws InterruptedException {
-        return token == null ? null : !unlock(ImmutableSet.of(token)).isEmpty();
+        return token != null && !unlock(ImmutableSet.of(token)).isEmpty();
     }
 
     default TOKEN refreshSingle(TOKEN token) throws InterruptedException {

--- a/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/LockClient.java
+++ b/atlasdb-jepsen-tests/src/main/java/com/palantir/atlasdb/http/LockClient.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.http;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedMap;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
@@ -29,7 +30,8 @@ import com.palantir.lock.StringLockDescriptor;
 public class LockClient implements JepsenLockClient<LockRefreshToken> {
     private final RemoteLockService remoteLockService;
 
-    private LockClient(RemoteLockService remoteLockService) {
+    @VisibleForTesting
+    LockClient(RemoteLockService remoteLockService) {
         this.remoteLockService = remoteLockService;
     }
 

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
@@ -31,15 +31,19 @@ import static org.mockito.Mockito.when;
 import java.util.Set;
 
 import org.junit.Test;
+import org.mockito.stubbing.Answer;
 
 import com.google.common.collect.ImmutableSet;
 
 public class JepsenLockClientTest {
-    @SuppressWarnings("unchecked") // Mock in a test
-    private final JepsenLockClient<String> mockClient = (JepsenLockClient<String>) mock(JepsenLockClient.class);
-    private final StringLockClient client = new StringLockClient(mockClient);
-
     private static final String LOCK_TOKEN = "foo";
+
+    @SuppressWarnings("unchecked") // Answer concerning mock behaviour
+    private static final Answer<Object> REPLY_WITH_FIRST_TOKEN = invocation -> invocation.getArguments()[0];
+
+    @SuppressWarnings("unchecked") // Mock in a test
+    private final JepsenLockClient<String> mockClient = mock(JepsenLockClient.class);
+    private final StringLockClient client = new StringLockClient(mockClient);
 
     @Test
     public void unlockSingleDoesNotCallUnlockWithNull() throws InterruptedException {
@@ -55,7 +59,7 @@ public class JepsenLockClientTest {
 
     @Test
     public void unlockSingleReturnsTrueIfTokenCanBeUnlocked() throws InterruptedException {
-        when(mockClient.unlock(any())).thenReturn(ImmutableSet.of(LOCK_TOKEN));
+        when(mockClient.unlock(any())).then(REPLY_WITH_FIRST_TOKEN);
         assertTrue(client.unlockSingle(LOCK_TOKEN));
     }
 
@@ -79,7 +83,7 @@ public class JepsenLockClientTest {
 
     @Test
     public void refreshSingleReturnsTokenIfCanBeRefreshed() throws InterruptedException {
-        when(mockClient.refresh(any())).thenReturn(ImmutableSet.of(LOCK_TOKEN));
+        when(mockClient.refresh(any())).then(REPLY_WITH_FIRST_TOKEN);
         assertEquals(client.refreshSingle(LOCK_TOKEN), LOCK_TOKEN);
     }
 

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+public class JepsenLockClientTest {
+    @SuppressWarnings("unchecked") // Mock in a test
+    private final JepsenLockClient<String> mockClient = (JepsenLockClient<String>) mock(JepsenLockClient.class);
+    private final StringLockClient client = new StringLockClient(mockClient);
+
+    private static final String LOCK_TOKEN = "foo";
+
+    @Before
+    public void setUp() throws InterruptedException {
+        // todo
+    }
+
+    @Test
+    public void unlockSingleDoesNotCallUnlockWithNull() throws InterruptedException {
+        client.unlockSingle(null);
+        verify(mockClient, never()).unlock(any());
+    }
+
+    @Test
+    public void unlockSingleCallsUnlockWithMatchingArgument() throws InterruptedException {
+        client.unlockSingle(LOCK_TOKEN);
+        verify(mockClient).unlock(eq(ImmutableSet.of(LOCK_TOKEN)));
+    }
+
+    @Test
+    public void unlockSingleReturnsTrueIfTokenCanBeUnlocked() throws InterruptedException {
+        when(mockClient.unlock(any())).thenReturn(ImmutableSet.of(LOCK_TOKEN));
+        assertTrue(client.unlockSingle(LOCK_TOKEN));
+    }
+
+    @Test
+    public void unlockSingleReturnsFalseIfTokenCannotBeUnlocked() throws InterruptedException {
+        when(mockClient.unlock(any())).thenReturn(ImmutableSet.of());
+        assertFalse(client.unlockSingle(LOCK_TOKEN));
+    }
+
+    @Test
+    public void refreshSingleDoesNotCallRefreshWithNull() throws InterruptedException {
+        client.refreshSingle(null);
+        verify(mockClient, never()).refresh(any());
+    }
+
+    @Test
+    public void refreshSingleCallsRefreshWithMatchingArgument() throws InterruptedException {
+        client.refreshSingle(LOCK_TOKEN);
+        verify(mockClient).refresh(eq(ImmutableSet.of(LOCK_TOKEN)));
+    }
+
+    @Test
+    public void refreshSingleReturnsTokenIfCanBeRefreshed() throws InterruptedException {
+        when(mockClient.refresh(any())).thenReturn(ImmutableSet.of(LOCK_TOKEN));
+        assertThat(client.refreshSingle(LOCK_TOKEN), equalTo(LOCK_TOKEN));
+    }
+
+    @Test
+    public void refreshSingleReturnsNullIfCannotRefresh() throws InterruptedException {
+        when(mockClient.refresh(any())).thenReturn(ImmutableSet.of());
+        assertThat(client.refreshSingle(LOCK_TOKEN), nullValue());
+    }
+
+    static class StringLockClient implements JepsenLockClient<String> {
+        private final JepsenLockClient<String> delegate;
+
+        StringLockClient(JepsenLockClient<String> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String lock(String client, String lockName) throws InterruptedException {
+            return delegate.lock(client, lockName);
+        }
+
+        @Override
+        public Set<String> unlock(Set<String> strings) throws InterruptedException {
+            return delegate.unlock(strings);
+        }
+
+        @Override
+        public Set<String> refresh(Set<String> strings) throws InterruptedException {
+            return delegate.refresh(strings);
+        }
+    }
+}

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
@@ -16,8 +16,8 @@
 
 package com.palantir.atlasdb.http;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -80,7 +80,7 @@ public class JepsenLockClientTest {
     @Test
     public void refreshSingleReturnsTokenIfCanBeRefreshed() throws InterruptedException {
         when(mockClient.refresh(any())).thenReturn(ImmutableSet.of(LOCK_TOKEN));
-        assertThat(client.refreshSingle(LOCK_TOKEN), equalTo(LOCK_TOKEN));
+        assertEquals(client.refreshSingle(LOCK_TOKEN), LOCK_TOKEN);
     }
 
     @Test

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Set;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
@@ -41,11 +40,6 @@ public class JepsenLockClientTest {
     private final StringLockClient client = new StringLockClient(mockClient);
 
     private static final String LOCK_TOKEN = "foo";
-
-    @Before
-    public void setUp() throws InterruptedException {
-        // todo
-    }
 
     @Test
     public void unlockSingleDoesNotCallUnlockWithNull() throws InterruptedException {

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/LockClientTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/LockClientTest.java
@@ -38,43 +38,44 @@ import com.palantir.lock.RemoteLockService;
 
 public class LockClientTest {
     private static final RemoteLockService LOCK_SERVICE = mock(RemoteLockService.class);
+    private static final LockClient LOCK_CLIENT = new LockClient(LOCK_SERVICE);
     private static final LockRefreshToken TOKEN = new LockRefreshToken(BigInteger.ONE, 1L);
     private static final String CLIENT = "client";
     private static final String LOCK_NAME = "lock";
 
     @Test
     public void lockRequestIsNonBlocking() throws InterruptedException {
-        when(LockClient.lock(LOCK_SERVICE, CLIENT, LOCK_NAME)).thenAnswer((invocation) -> {
+        when(LOCK_CLIENT.lock(CLIENT, LOCK_NAME)).thenAnswer((invocation) -> {
             LockRequest request = (LockRequest) invocation.getArguments()[1];
             assertThat(request.getBlockingMode(), is(BlockingMode.DO_NOT_BLOCK));
             return null;
         });
-        LockClient.lock(LOCK_SERVICE, CLIENT, LOCK_NAME);
+        LOCK_CLIENT.lock(CLIENT, LOCK_NAME);
     }
 
     @Test
     public void lockRequestIsWrite() throws InterruptedException {
-        when(LockClient.lock(LOCK_SERVICE, CLIENT, LOCK_NAME)).thenAnswer((invocation) -> {
+        when(LOCK_CLIENT.lock(CLIENT, LOCK_NAME)).thenAnswer((invocation) -> {
             LockRequest request = (LockRequest) invocation.getArguments()[1];
             assertThat(request.getLocks(), contains(hasProperty("lockMode", is(LockMode.WRITE))));
             return null;
         });
-        LockClient.lock(LOCK_SERVICE, CLIENT, LOCK_NAME);
+        LOCK_CLIENT.lock(CLIENT, LOCK_NAME);
     }
 
     @Test
     public void unlockReturnsFalseIfTokenIsNull() throws InterruptedException {
-        assertFalse(LockClient.unlock(LOCK_SERVICE, null));
+        assertFalse(LOCK_CLIENT.unlockSingle(null));
     }
 
     @Test
-    public void refreshReturnsNullIfTokenIsNull() {
-        assertNull(LockClient.refresh(LOCK_SERVICE, null));
+    public void refreshReturnsNullIfTokenIsNull() throws InterruptedException {
+        assertNull(LOCK_CLIENT.refreshSingle(null));
     }
 
     @Test
-    public void refreshReturnsNullIfThereAreNoRefreshTokens() {
+    public void refreshReturnsNullIfThereAreNoRefreshTokens() throws InterruptedException {
         when(LOCK_SERVICE.refreshLockRefreshTokens(any())).thenReturn(Collections.emptySet());
-        assertNull(LockClient.refresh(LOCK_SERVICE, TOKEN));
+        assertNull(LOCK_CLIENT.refreshSingle(TOKEN));
     }
 }

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -15,8 +15,8 @@
 (deftest timestamp-test-partition
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))
 
-(deftest lock-test-crash
-  (is (:valid? (:results (jepsen/run! (lock/lock-test timelock/crash-nemesis))))))
+(deftest lock-test-crash-sync
+  (is (:valid? (:results (jepsen/run! (lock/lock-test () timelock/crash-nemesis))))))
 
-(deftest lock-test-partition
-  (is (:valid? (:results (jepsen/run! (lock/lock-test (nemesis/partition-random-halves)))))))
+(deftest lock-test-partition-sync
+  (is (:valid? (:results (jepsen/run! (lock/lock-test () (nemesis/partition-random-halves)))))))

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -9,15 +9,15 @@
 ;; Using Clojure's testing framework, we initiate our test runs
 ;; Tests successful iff the value for the key ":valid?" is truthy
 
-(deftest lock-test-crash-sync
-  (is (:valid? (:results (jepsen/run! (lock/sync-lock-test timelock/crash-nemesis))))))
-
-(deftest lock-test-partition-sync
-  (is (:valid? (:results (jepsen/run! (lock/sync-lock-test (nemesis/partition-random-halves)))))))
-
 (deftest timestamp-test-crash
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test timelock/crash-nemesis))))))
 
 (deftest timestamp-test-partition
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))
+
+(deftest sync-lock-test-crash
+         (is (:valid? (:results (jepsen/run! (lock/sync-lock-test timelock/crash-nemesis))))))
+
+(deftest sync-lock-test-partition
+         (is (:valid? (:results (jepsen/run! (lock/sync-lock-test (nemesis/partition-random-halves)))))))
 

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -9,14 +9,15 @@
 ;; Using Clojure's testing framework, we initiate our test runs
 ;; Tests successful iff the value for the key ":valid?" is truthy
 
+(deftest lock-test-crash-sync
+  (is (:valid? (:results (jepsen/run! (lock/lock-test timelock/crash-nemesis))))))
+
+(deftest lock-test-partition-sync
+  (is (:valid? (:results (jepsen/run! (lock/lock-test (nemesis/partition-random-halves)))))))
+
 (deftest timestamp-test-crash
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test timelock/crash-nemesis))))))
 
 (deftest timestamp-test-partition
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))
 
-(deftest lock-test-crash-sync
-  (is (:valid? (:results (jepsen/run! (lock/lock-test timelock/crash-nemesis))))))
-
-(deftest lock-test-partition-sync
-  (is (:valid? (:results (jepsen/run! (lock/lock-test (nemesis/partition-random-halves)))))))

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -16,7 +16,7 @@
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))
 
 (deftest lock-test-crash-sync
-  (is (:valid? (:results (jepsen/run! (lock/lock-test () timelock/crash-nemesis))))))
+  (is (:valid? (:results (jepsen/run! (lock/lock-test timelock/crash-nemesis))))))
 
 (deftest lock-test-partition-sync
-  (is (:valid? (:results (jepsen/run! (lock/lock-test () (nemesis/partition-random-halves)))))))
+  (is (:valid? (:results (jepsen/run! (lock/lock-test (nemesis/partition-random-halves)))))))

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -10,10 +10,10 @@
 ;; Tests successful iff the value for the key ":valid?" is truthy
 
 (deftest lock-test-crash-sync
-  (is (:valid? (:results (jepsen/run! (lock/lock-test timelock/crash-nemesis))))))
+  (is (:valid? (:results (jepsen/run! (lock/sync-lock-test timelock/crash-nemesis))))))
 
 (deftest lock-test-partition-sync
-  (is (:valid? (:results (jepsen/run! (lock/lock-test (nemesis/partition-random-halves)))))))
+  (is (:valid? (:results (jepsen/run! (lock/sync-lock-test (nemesis/partition-random-halves)))))))
 
 (deftest timestamp-test-crash
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test timelock/crash-nemesis))))))

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -9,15 +9,15 @@
 ;; Using Clojure's testing framework, we initiate our test runs
 ;; Tests successful iff the value for the key ":valid?" is truthy
 
+(deftest sync-lock-test-crash
+  (is (:valid? (:results (jepsen/run! (lock/sync-lock-test timelock/crash-nemesis))))))
+
+(deftest sync-lock-test-partition
+  (is (:valid? (:results (jepsen/run! (lock/sync-lock-test (nemesis/partition-random-halves)))))))
+
 (deftest timestamp-test-crash
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test timelock/crash-nemesis))))))
 
 (deftest timestamp-test-partition
   (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))
-
-(deftest sync-lock-test-crash
-         (is (:valid? (:results (jepsen/run! (lock/sync-lock-test timelock/crash-nemesis))))))
-
-(deftest sync-lock-test-partition
-         (is (:valid? (:results (jepsen/run! (lock/sync-lock-test (nemesis/partition-random-halves)))))))
 


### PR DESCRIPTION
**Goals (and why)**: 
Prepare the Jepsen tests for testing the asynchronous lock service, while trying to avoid code duplication in the process (in particular, we want systems under test to operate within the assumptions our verifiers make, and we don't want to duplicate the logic of the event generators and/or the CAS-based token store).

**Implementation Description (bullets)**:
- Introduce a `JepsenLockClient` interface that deals with arbitrary tokens
- Refactor `SynchronousLockClient` to work based on an instance as opposed to being a static method
- Parameterise the `lock-test` in Jepsen to admit arbitrary classes implementing the `JepsenLockClient` interface

**Concerns (what feedback would you like?)**:
- Are there any landmines in the process that I'm not aware of?
- Should we bother even including the Set-based methods (and instead just only allow unlockSingle, refreshSingle and lock)? Main concern is that the semantics for being granted requests/refreshes for multiple locks may not necessarily be expressible as a bunch of successes of individual locks, if we end up doing more complex verification in the future.

**Where should we start reviewing?**: lock.clj

**Priority (whenever / two weeks / yesterday)**: no rush; blocked on #2084, and also there won't be any immediate value here; we need a follow up PR that is wired up to the async lock service as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2094)
<!-- Reviewable:end -->
