### PR TITLE
more reliable failover

### DIFF
--- a/timelock-server/src/integTest/resources/paxosMultiServer0.yml
+++ b/timelock-server/src/integTest/resources/paxosMultiServer0.yml
@@ -1,5 +1,6 @@
 algorithm:
   type: paxos
+  leaderPingResponseWaitMs: 1000
   paxosDataDir: <TEMP_DATA_DIR>
 
 cluster:

--- a/timelock-server/src/integTest/resources/paxosMultiServer1.yml
+++ b/timelock-server/src/integTest/resources/paxosMultiServer1.yml
@@ -1,5 +1,6 @@
 algorithm:
   type: paxos
+  leaderPingResponseWaitMs: 1000
   paxosDataDir: <TEMP_DATA_DIR>
 
 cluster:

--- a/timelock-server/src/integTest/resources/paxosMultiServer2.yml
+++ b/timelock-server/src/integTest/resources/paxosMultiServer2.yml
@@ -1,5 +1,6 @@
 algorithm:
   type: paxos
+  leaderPingResponseWaitMs: 1000
   paxosDataDir: <TEMP_DATA_DIR>
 
 cluster:


### PR DESCRIPTION
**Goals (and why)**:
Improve reliability of failovers in ete tests.

**Implementation Description (bullets)**:
- Lower the leader ping timeout to 1s so leader elections will happen quickly
- Add a finite number of retries to force a failover

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
two files

**Priority (whenever / two weeks / yesterday)**:
soon, it's a pretty small change and is flaky on develop

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2095)
<!-- Reviewable:end -->
