### PR TITLE
[no release notes] String substitution for Preconditions in streamstore rendered code

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -258,7 +258,7 @@ public class StreamStoreRenderer {
                     line(StreamMetadataTable, " metaTable = tables.get", StreamMetadataTable, "(t);");
                     line(StreamMetadataRow, " row = ", StreamMetadataRow, ".of(id);");
                     line("StreamMetadata metadata = metaTable.getMetadatas(ImmutableSet.of(row)).values().iterator().next();");
-                    line("Preconditions.checkState(metadata.getStatus() == Status.STORING, \"This stream is being cleaned up while storing blocks: \" + id);");
+                    line("Preconditions.checkState(metadata.getStatus() == Status.STORING, \"This stream is being cleaned up while storing blocks: %s\", id);");
                     line("Builder builder = StreamMetadata.newBuilder(metadata);");
                     line("builder.setLength(blockNumber * BLOCK_SIZE_IN_BYTES + 1);");
                     line("metaTable.putMetadata(row, builder.build());");
@@ -497,7 +497,7 @@ public class StreamStoreRenderer {
                     line("for (Map.Entry<", StreamMetadataRow, ", StreamMetadata> e : metadatas.entrySet()) {"); {
                         line("StreamMetadata metadata = e.getValue();");
                         line("Preconditions.checkState(metadata.getStatus() == Status.STORED,");
-                        line("\"Stream: \" + e.getKey().getId() + \" has status: \" + metadata.getStatus());");
+                        line("\"Stream: %s has status: %s\", e.getKey().getId(), metadata.getStatus());");
                         line("metaTable.putMetadata(e.getKey(), metadata);");
                     } line("}");
                     line("SetView<", StreamMetadataRow, "> missingRows = Sets.difference(rows, metadatas.keySet());");


### PR DESCRIPTION
**Goals (and why)**: Fix errorprone bug: #2096 

**Implementation Description (bullets)**:
- Replace uses of string concat with string substitution.

**Concerns (what feedback would you like?)**:
- Did I miss anything? I searched in `com/palantir/atlasdb/table/description/render` for the string `Preconditions` and these were the only instances I found

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2097)
<!-- Reviewable:end -->
