### PR TITLE
AsyncLockService implements Closeable

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.timelock;
 
+import java.io.Closeable;
 import java.util.Set;
 
 import com.palantir.atlasdb.timelock.lock.AsyncResult;
@@ -26,7 +27,7 @@ import com.palantir.lock.v2.LockRequestV2;
 import com.palantir.lock.v2.LockTokenV2;
 import com.palantir.lock.v2.WaitForLocksRequest;
 
-public interface AsyncTimelockService extends ManagedTimestampService {
+public interface AsyncTimelockService extends ManagedTimestampService, Closeable {
 
     long currentTimeMillis();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.timelock;
 
+import java.io.IOException;
 import java.util.Set;
 
 import com.palantir.atlasdb.timelock.lock.AsyncLockService;
@@ -29,7 +30,6 @@ import com.palantir.lock.v2.LockTokenV2;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.timestamp.TimestampRange;
 
-// TODO(nziebart): implement Closeable
 public class AsyncTimelockServiceImpl implements AsyncTimelockService {
 
     private final AsyncLockService lockService;
@@ -108,4 +108,8 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
         return timestampService.ping();
     }
 
+    @Override
+    public void close() throws IOException {
+        lockService.close();
+    }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncResult.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncResult.java
@@ -69,6 +69,13 @@ public class AsyncResult<T> {
     }
 
     /**
+     * Marks this result as failed, if it has not already completed.
+     */
+    public void failIfNotCompleted(Throwable error) {
+        future.completeExceptionally(error);
+    }
+
+    /**
      * Marks this result as timed out, causing {@link #isTimedOut()} to return true.
      *
      * @throws {@link IllegalStateException} if this result is already completed.

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/HeldLocksCollection.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/HeldLocksCollection.java
@@ -19,7 +19,6 @@ package com.palantir.atlasdb.timelock.lock;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -64,10 +63,10 @@ public class HeldLocksCollection {
             }
         }
     }
-    
+
     public void failAllOutstandingRequestsWithNotCurrentLeaderException() {
         NotCurrentLeaderException ex = new NotCurrentLeaderException("This lock service has been closed");
-        heldLocksById.values().forEach(future -> future.completeExceptionally(ex));
+        heldLocksById.values().forEach(result -> result.failIfNotCompleted(ex));
     }
 
     private boolean shouldRemove(AsyncResult<HeldLocks> lockResult) {
@@ -87,10 +86,6 @@ public class HeldLocksCollection {
         }
 
         return filtered;
-    }
-
-    private boolean isFailed(CompletableFuture<?> future) {
-        return future.isCancelled() || future.isCompletedExceptionally();
     }
 
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/HeldLocksCollection.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/HeldLocksCollection.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.lock.v2.LockTokenV2;
 
 public class HeldLocksCollection {
@@ -62,6 +63,11 @@ public class HeldLocksCollection {
                 iterator.remove();
             }
         }
+    }
+    
+    public void failAllOutstandingRequestsWithNotCurrentLeaderException() {
+        NotCurrentLeaderException ex = new NotCurrentLeaderException("This lock service has been closed");
+        heldLocksById.values().forEach(future -> future.completeExceptionally(ex));
     }
 
     private boolean shouldRemove(AsyncResult<HeldLocks> lockResult) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -56,7 +56,7 @@ public class TestableTimelockServer {
         return lockService().lock(client, lockRequest);
     }
 
-    public LockResponseV2 lock(LockRequestV2 lockRequest) throws InterruptedException {
+    public LockResponseV2 lock(LockRequestV2 lockRequest) {
         return timelockService().lock(lockRequest);
     }
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.timelock.lock;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -26,6 +27,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -33,6 +35,7 @@ import org.junit.Test;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.common.time.Clock;
+import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.v2.LockTokenV2;
@@ -53,12 +56,14 @@ public class AsyncLockServiceEteTest {
     private static final TimeLimit SHORT_TIMEOUT = TimeLimit.of(500L);
     private static final TimeLimit LONG_TIMEOUT = TimeLimit.of(100_000L);
 
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    
     private final AsyncLockService service = new AsyncLockService(
             new LockCollection(() -> new ExclusiveLock()),
             new ImmutableTimestampTracker(),
             new LockAcquirer(Executors.newSingleThreadScheduledExecutor()),
             new HeldLocksCollection(),
-            Executors.newSingleThreadScheduledExecutor());
+            executor);
 
     @Test
     public void canLockAndUnlock() {
@@ -238,6 +243,23 @@ public class AsyncLockServiceEteTest {
         assertNotLocked(LOCK_A);
         service.unlock(lockBToken);
         assertNotLocked(LOCK_B);
+    }
+    
+    @Test
+    public void outstandingRequestsReceiveNotCurrentLeaderExceptionOnClose() {
+        lockSynchronously(REQUEST_1, LOCK_A);
+        CompletableFuture<LockTokenV2> request2 = lock(REQUEST_2, LOCK_A);
+        
+        service.close();
+        
+        assertThatThrownBy(() -> request2.get()).hasCauseInstanceOf(NotCurrentLeaderException.class);
+    }
+    
+    @Test
+    public void reaperIsShutDownOnClose() {
+        service.close();
+        
+        assertThat(executor.isShutdown()).isTrue();
     }
 
     private void waitForTimeout(TimeLimit timeout) {


### PR DESCRIPTION
**Goals (and why)**:
Implement Closeable for the async lock service, so that we handle failovers correctly

**Implementation Description (bullets)**:
On close, we:
- shut down the reaper executor
- fail all outstanding requests with `NotCurrentLeaderException`

**Concerns (what feedback would you like?)**:
Is this the right behavior?

**Where should we start reviewing?**:
`AsyncLockService`

**Priority (whenever / two weeks / yesterday)**:
this week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2103)
<!-- Reviewable:end -->
