### PR TITLE
fix reads of hidden tables from console

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -367,6 +367,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             TableReference tableRef,
             Iterable<byte[]> rows,
             BatchColumnRangeSelection columnRangeSelection) {
+        checkGetPreconditions(tableRef);
         if (Iterables.isEmpty(rows)) {
             return ImmutableMap.of();
         }
@@ -389,6 +390,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                                                                 Iterable<byte[]> rows,
                                                                 ColumnRangeSelection columnRangeSelection,
                                                                 int batchHint) {
+        checkGetPreconditions(tableRef);
         if (Iterables.isEmpty(rows)) {
             return Collections.emptyIterator();
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -959,6 +959,17 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             }
         }
 
+        if (AtlasDbConstants.hiddenTables.contains(tableRef)) {
+            Preconditions.checkState(allowHiddenTableAccess, "hidden tables cannot be read in this transaction");
+            // hidden tables are used outside of the transaction protocol, and in general have invalid timestamps,
+            // so do not apply post-filtering as post-filtering would rollback (actually delete) the data incorrectly
+            // this case is hit when reading a hidden table from console
+            for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
+                results.put(e.getKey(), transformer.apply(e.getValue()));
+            }
+            return;
+        }
+
         Map<Cell, Value> remainingResultsToPostfilter = rawResults;
         while (!remainingResultsToPostfilter.isEmpty()) {
             remainingResultsToPostfilter = getWithPostFilteringInternal(

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,6 +62,10 @@ develop
            service, as they may also be vulnerable to this failure mode.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2091>`__)
 
+    *    - |fixed|
+         - Fixed a bug that caused hidden tables to be wiped when they were read from console.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2106>`__)
+
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**: Fix a bug in console that would cause data in hidden tables to be incorrectly deleted.

**Implementation Description (bullets)**: re-adds some very important lines of code that were incorrectly removed as part of removing support for temp tables nearly a year ago

**Concerns (what feedback would you like?)**: N/A small change

**Where should we start reviewing?**: N/A small change

**Priority (whenever / two weeks / yesterday)**: high -- bug causes complete data loss in hidden tables, which can render all data irrecoverable (for example if you lose the namespace table map it can be nearly impossible to restore correctly)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2106)
<!-- Reviewable:end -->
