### PR TITLE
Don't hard-fail in GetRowsColumnRange(committed tx) to unblock internal product

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -334,9 +334,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
         Preconditions.checkArgument(allowHiddenTableAccess || !AtlasDbConstants.hiddenTables.contains(tableRef));
 
-        boolean transactionUncommitted = state.get() == State.UNCOMMITTED || state.get() == State.COMMITTING;
+        boolean transactionNotCommittedYet = state.get() == State.UNCOMMITTED || state.get() == State.COMMITTING;
 
-        if (transactionUncommitted) {
+        if (transactionNotCommittedYet) {
             log.warn("Attempted to perform a get operation on a transaction after said transaction has committed."
                     + " This is dangerous; AtlasDB may not offer its standard transactional guarantees in this case.",
                     UnsafeArg.of("affectedTable", tableRef));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -367,7 +367,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             TableReference tableRef,
             Iterable<byte[]> rows,
             BatchColumnRangeSelection columnRangeSelection) {
-        checkGetPreconditions(tableRef);
+        // TODO (jkong): Add a call to checkGetPreconditions() here once large internal product is fixed
         if (Iterables.isEmpty(rows)) {
             return ImmutableMap.of();
         }
@@ -390,7 +390,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                                                                 Iterable<byte[]> rows,
                                                                 ColumnRangeSelection columnRangeSelection,
                                                                 int batchHint) {
-        checkGetPreconditions(tableRef);
+        // TODO (jkong): Add a call to checkGetPreconditions() here once large internal product is fixed
         if (Iterables.isEmpty(rows)) {
             return Collections.emptyIterator();
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -336,7 +336,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
         boolean transactionNotCommittedYet = state.get() == State.UNCOMMITTED || state.get() == State.COMMITTING;
 
-        if (transactionNotCommittedYet) {
+        if (!transactionNotCommittedYet) {
             log.warn("Attempted to perform a get operation on a transaction after said transaction has committed."
                     + " This is dangerous; AtlasDB may not offer its standard transactional guarantees in this case.",
                     UnsafeArg.of("affectedTable", tableRef));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -126,6 +126,7 @@ import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.timestamp.TimestampService;
 import com.palantir.util.AssertUtils;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -321,14 +322,28 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return transactionTimer;
     }
 
+    // TODO (jkong): simplify to one method once hardFail is no longer needed
     protected void checkGetPreconditions(TableReference tableRef) {
+        checkGetPreconditions(tableRef, true);
+    }
+
+    private void checkGetPreconditions(TableReference tableRef, boolean hardFail) {
         if (transactionReadTimeoutMillis != null
                 && System.currentTimeMillis() - timeCreated > transactionReadTimeoutMillis) {
             throw new TransactionFailedRetriableException("Transaction timed out.");
         }
         Preconditions.checkArgument(allowHiddenTableAccess || !AtlasDbConstants.hiddenTables.contains(tableRef));
-        Preconditions.checkState(state.get() == State.UNCOMMITTED || state.get() == State.COMMITTING,
-                "Transaction must be uncommitted.");
+
+        boolean transactionUncommitted = state.get() == State.UNCOMMITTED || state.get() == State.COMMITTING;
+
+        if (transactionUncommitted) {
+            log.warn("Attempted to perform a get operation on a transaction after said transaction has committed."
+                    + " This is dangerous; AtlasDB may not offer its standard transactional guarantees in this case.",
+                    UnsafeArg.of("affectedTable", tableRef));
+            if (hardFail) {
+                throw new IllegalStateException("Transaction must be uncommitted.");
+            }
+        }
     }
 
     @Override
@@ -367,7 +382,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             TableReference tableRef,
             Iterable<byte[]> rows,
             BatchColumnRangeSelection columnRangeSelection) {
-        // TODO (jkong): Add a call to checkGetPreconditions() here once large internal product is fixed
+        checkGetPreconditions(tableRef, false);
         if (Iterables.isEmpty(rows)) {
             return ImmutableMap.of();
         }
@@ -390,7 +405,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                                                                 Iterable<byte[]> rows,
                                                                 ColumnRangeSelection columnRangeSelection,
                                                                 int batchHint) {
-        // TODO (jkong): Add a call to checkGetPreconditions() here once large internal product is fixed
+        checkGetPreconditions(tableRef, false);
         if (Iterables.isEmpty(rows)) {
             return Collections.emptyIterator();
         }


### PR DESCRIPTION
**Goals (and why)**:
* Make BigProduct Compile Again (it broke after #2106 because we added the preconditinos checks), so we can release 0.46

**Implementation Description (bullets)**:
* Make the already-committed check log rather than hard-fail for the calls in `getRowsColumnRange()`
* Add a TODO to reinstate the checks once the product is happy (though this doesn't look trivial to me 😰)

**Concerns (what feedback would you like?)**:
* Is this the right thing to do here? (I think it is because there is no regression, in a sense, and large internal product would break)

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: soon, blocks release 0.46

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2112)
<!-- Reviewable:end -->
