### PR TITLE
React to openjdk-8 changes / "Docker container changed underneath us."

### DIFF
--- a/atlasdb-ete-tests/Dockerfile
+++ b/atlasdb-ete-tests/Dockerfile
@@ -3,7 +3,10 @@ FROM openjdk:8u131-jre
 ENV DOCKERIZE_VERSION v0.2.0
 
 RUN wget --no-check-certificate http://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && apt-get update \
+    && apt-get install -y procps \
+    && sed -i 's/assistive_technologies=org.GNOME.Accessibility.AtkWrapper//' /etc/java-8-openjdk/accessibility.properties
 
 EXPOSE 3828
 


### PR DESCRIPTION
**Goals (and why)**: Fix recurrent build sadness on Circle, because Docker-based tests that required CLIs / Console would refuse to run.

**Implementation Description (bullets)**:
* Add `ps` since the openjdk image no longer seems to ship with it - https://github.com/docker-library/openjdk/commit/ae4562dcd2d99eb9d6224517f9e6b4ab4c2b4672
* Disable the Gnome Assistive Technology - https://askubuntu.com/questions/695560/assistive-technology-not-found-error-while-building-aprof-plot

**Concerns (what feedback would you like?)**: nothing much

**Where should we start reviewing?**: +4/-1 😅 

**Priority (whenever / two weeks / yesterday)**: very soon; this makes all circle builds red, and by proxy prevents recent changes from merging at all

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2113)
<!-- Reviewable:end -->
