### PR TITLE
Jepsen Enhancements, Part 2: Fix Race Condition on the Lock Client

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -130,9 +130,9 @@
     :generator (->> generator
                  (gen/stagger 0.05)
                  (gen/nemesis
-                   (gen/seq (cycle [(gen/sleep 75)
+                   (gen/seq (cycle [(gen/sleep 5)
                                     {:type :info, :f :start}
-                                    (gen/sleep 15)
+                                    (gen/sleep 85)
                                     {:type :info, :f :stop}])))
                  (gen/time-limit 360))
     :db (timelock/create-db)

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -13,33 +13,14 @@
   (:import com.palantir.atlasdb.http.SynchronousLockClient))
 
 (def lock-names ["alpha" "bravo" "charlie" "delta"])
-(def version-name "version")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Relevant utility methods, including administration of the token store's simple MVCC protocol
+;; Relevant utility methods, including administration of the token store
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn nullable-to-string    [obj] (if (nil? obj) "" (.toString obj)))
-
-(defn create-token-store    [] (atom {version-name 0}))
-(defn version-bump!
-  "Attempts to increment the version key in a token store. Returns the version number if CAS succeded, nil if failed."
-  [store]
-  (let [current-map @store
-        target-version (inc (get current-map version-name))]
-    (if (compare-and-set! store current-map (assoc current-map version-name target-version))
-      target-version
-      nil)))
-(defn replace-token!
-  "Updates a token in the store, if the version in the store matches our expected version.
-  Returns true if and only if the store was successfully updated.
-  "
-  [store key obj expected-version]
-  (loop [current-map @store]
-    (if-not (== (get current-map version-name) expected-version)
-       false
-       (if (compare-and-set! store current-map (assoc current-map key obj))
-         true
-         (recur @store)))))
+(defn create-token-store    [] (atom {}))
+(defn replace-token!        [store key obj] (swap! store assoc key obj))
+(defn token-store-key       [client-name lock-name] (str client-name lock-name))
 
 (defn assoc-ok-value
   "Associate the map with ':ok', meaning that the server response was 200.
@@ -49,15 +30,47 @@
     :value (nullable-to-string response)
     :query-params (nullable-to-string query-params)))
 
+(defn transform-store!
+  "Given an operation and a token store, applies the results of the operation to the token store."
+  [token-store op lock-name op-value client-name]
+  (let [store-key (token-store-key client-name lock-name)]
+    (case (:f op)
+      (:lock :refresh)
+        (replace-token! token-store store-key op-value)
+      :unlock
+        (replace-token! token-store store-key nil))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Client creation and invocations (i.e. locking, unlocking refreshing)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defn lock-operation-with-timeout
+  "Executes an operation on the supplied lock service with a specified timeout. This method returns a hash-map
+   indicating the success or failure of the operation, along with any attendant payload.
+   Successful requests are associated with a :value, while failed requests are associated with an :error."
+  [lock-client op time-limit client-name lock-name token-store]
+  (timeout time-limit
+    {:outcome :fail :error :timeout}
+    (try
+      (let [result {:outcome :success}]
+        (case (:f op)
+          :lock
+          (let [response (.lock lock-client client-name lock-name)]
+            (assoc result :value response :query-params [client-name lock-name]))
+          :unlock
+          (let [token (@token-store (str client-name lock-name))
+                response (.unlockSingle lock-client token)]
+            (assoc result :value response :query-params token))
+          :refresh
+          (let [token (@token-store (str client-name lock-name))
+                response (.refreshSingle lock-client token)]
+            (assoc result :value response :query-params token))))
+      (catch Exception e {:outcome :fail :error (.toString e)}))))
+
 (defn create-client
   "Creates an object that implements the client/Client protocol.
    The object defines how you create a lock client, and how to request locks from it. The first call to this
-   function will return an invalid object: you should call 'setup' on the returned object to get a valid one.
-  "
-  [lock-client, client-name, token-store, client-supplier]
+   function will return an invalid object: you should call 'setup' on the returned object to get a valid one."
+  [lock-client client-name token-store client-supplier]
   (reify client/Client
     (setup!
       [this test node]
@@ -70,31 +83,44 @@
 
     (invoke!
       [this test op]
-      "Run an operation on our client"
-      (timeout (* 30 1000)
-        (assoc op :type :fail :error :timeout)
-        (try
-          (let [lock-name (:value op)
-                token-store-key (str client-name lock-name)
-                current-store-version (version-bump! token-store)]
-            (if ((complement nil?) current-store-version)
-              (case (:f op)
-                :lock
-                (let [response (.lock lock-client client-name lock-name)]
-                  (do (replace-token! token-store token-store-key response current-store-version)
-                    (assoc-ok-value op response [client-name lock-name])))
-                :unlock
-                (let [token (@token-store token-store-key)
-                      response (.unlockSingle lock-client token)]
-                  (do (replace-token! token-store token-store-key nil current-store-version)
-                    (assoc-ok-value op response token)))
-                :refresh
-                (let [token (@token-store token-store-key)
-                      response (.refreshSingle lock-client token)]
-                  (do (replace-token! token-store token-store-key token current-store-version)
-                    (assoc-ok-value op response token))))))
-          (catch Exception e
-            (assoc op :type :fail :error (.toString e))))))
+      "Run an operation on our client with a timeout, and then update the token store."
+      (let [lock-name (:value op)
+            result (lock-operation-with-timeout lock-client op (* 30 1000) client-name lock-name token-store)]
+        (case (:outcome result)
+          :fail
+          (assoc op :type :fail :error (:error result))
+          :success
+          (let [result-value (:value result)]
+            (do (transform-store! token-store op lock-name result-value client-name)
+                (assoc-ok-value op result-value (:query-params result)))))))
+
+    ;(invoke!
+    ;  [this test op]
+    ;  "Run an operation on our client"
+    ;  (timeout (* 30 1000)
+    ;    (assoc op :type :fail :error :timeout)
+    ;    (try
+    ;      (let [lock-name (:value op)
+    ;            token-store-key (str client-name lock-name)
+    ;            current-store-version (version-bump! token-store)]
+    ;        (if ((complement nil?) current-store-version)
+    ;          (case (:f op)
+    ;            :lock
+    ;            (let [response (.lock lock-client client-name lock-name)]
+    ;              (do (replace-token! token-store token-store-key response current-store-version)
+    ;                (assoc-ok-value op response [client-name lock-name])))
+    ;            :unlock
+    ;            (let [token (@token-store token-store-key)
+    ;                  response (.unlockSingle lock-client token)]
+    ;              (do (replace-token! token-store token-store-key nil current-store-version)
+    ;                (assoc-ok-value op response token)))
+    ;            :refresh
+    ;            (let [token (@token-store token-store-key)
+    ;                  response (.refreshSingle lock-client token)]
+    ;              (do (replace-token! token-store token-store-key token current-store-version)
+    ;                (assoc-ok-value op response token))))))
+    ;      (catch Exception e
+    ;        (assoc op :type :fail :error (.toString e))))))
 
     (teardown! [_ test])))
 
@@ -132,9 +158,9 @@
     :generator (->> generator
                  (gen/stagger 0.05)
                  (gen/nemesis
-                   (gen/seq (cycle [(gen/sleep 5)
+                   (gen/seq (cycle [(gen/sleep 75)
                                     {:type :info, :f :start}
-                                    (gen/sleep 85)
+                                    (gen/sleep 15)
                                     {:type :info, :f :stop}])))
                  (gen/time-limit 360))
     :db (timelock/create-db)

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -94,34 +94,6 @@
             (do (transform-store! token-store op lock-name result-value client-name)
                 (assoc-ok-value op result-value (:query-params result)))))))
 
-    ;(invoke!
-    ;  [this test op]
-    ;  "Run an operation on our client"
-    ;  (timeout (* 30 1000)
-    ;    (assoc op :type :fail :error :timeout)
-    ;    (try
-    ;      (let [lock-name (:value op)
-    ;            token-store-key (str client-name lock-name)
-    ;            current-store-version (version-bump! token-store)]
-    ;        (if ((complement nil?) current-store-version)
-    ;          (case (:f op)
-    ;            :lock
-    ;            (let [response (.lock lock-client client-name lock-name)]
-    ;              (do (replace-token! token-store token-store-key response current-store-version)
-    ;                (assoc-ok-value op response [client-name lock-name])))
-    ;            :unlock
-    ;            (let [token (@token-store token-store-key)
-    ;                  response (.unlockSingle lock-client token)]
-    ;              (do (replace-token! token-store token-store-key nil current-store-version)
-    ;                (assoc-ok-value op response token)))
-    ;            :refresh
-    ;            (let [token (@token-store token-store-key)
-    ;                  response (.refreshSingle lock-client token)]
-    ;              (do (replace-token! token-store token-store-key token current-store-version)
-    ;                (assoc-ok-value op response token))))))
-    ;      (catch Exception e
-    ;        (assoc op :type :fail :error (.toString e))))))
-
     (teardown! [_ test])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -15,9 +15,9 @@
 (deftest sync-lock-test-partition
   (is (:valid? (:results (jepsen/run! (lock/sync-lock-test (nemesis/partition-random-halves)))))))
 
-(deftest timestamp-test-crash
-  (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test timelock/crash-nemesis))))))
-
-(deftest timestamp-test-partition
-  (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))
+;(deftest timestamp-test-crash
+;  (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test timelock/crash-nemesis))))))
+;
+;(deftest timestamp-test-partition
+;  (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))
 

--- a/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
+++ b/atlasdb-jepsen-tests/test/jepsen/atlasdb_test.clj
@@ -15,9 +15,8 @@
 (deftest sync-lock-test-partition
   (is (:valid? (:results (jepsen/run! (lock/sync-lock-test (nemesis/partition-random-halves)))))))
 
-;(deftest timestamp-test-crash
-;  (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test timelock/crash-nemesis))))))
-;
-;(deftest timestamp-test-partition
-;  (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))
+(deftest timestamp-test-crash
+  (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test timelock/crash-nemesis))))))
 
+(deftest timestamp-test-partition
+  (is (:valid? (:results (jepsen/run! (timestamp/timestamp-test (nemesis/partition-random-halves)))))))


### PR DESCRIPTION
**Goals (and why)**: Fix #2118, and take the opportunity to significantly simplify the Jepsen lock client (it previously held a mini-MVCC protocol!)

**Implementation Description (bullets)**:
* Decompose the `invoke!` method of a Jepsen client into two pieces - running the operation itself (`lock-operation-with-timeout`), and then updating the token store (`transform-store!`). 
  - The first half (running the operation) is subject to a timeout plus standard remoting failures.
  - If this fails we just return a Jepsen `fail`.
  - If this succeeds, then we update the token store and return a Jepsen `ok`.
  - The timeout only applies to part 1, so we avoid problems with timing out whilst updating the store (which is what triggered #2118).
  - It's possible that the timeout preempts a response from the server, but that's okay - from the point of view of our clients it's as though some additional client `n6` has taken out the lock.
* Since a Jepsen client is singlethreaded, there is no need for the mini-MVCC protocol any longer.

**Concerns (what feedback would you like?)**:
* Is the reasoning about concurrency sound?
* Does the new design actually make sense?

**Where should we start reviewing?**: `lock.clj`

**Priority (whenever / two weeks / yesterday)**: soon, this would help avoid flakes given that we're going to be pointing Jepsen aggressively at the async lock service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2121)
<!-- Reviewable:end -->
