### PR TITLE
Mark CassandraKeyValueService and DebugLogger as safe/unsafe

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -124,6 +124,7 @@ import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.exception.PalantirRuntimeException;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;
@@ -262,7 +263,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     CfDef clientSideCf = getCfForTable(tableRef, clusterSideMetadata);
                     if (!ColumnFamilyDefinitions.isMatchingCf(clientSideCf, clusterSideCf)) {
                         // mismatch; we have changed how we generate schema since we last persisted
-                        log.warn("Upgrading table {} to new internal Cassandra schema", tableRef);
+                        log.warn("Upgrading table {} to new internal Cassandra schema",
+                                UnsafeArg.of("table", tableRef));
                         tablesToUpgrade.put(tableRef, clusterSideMetadata);
                     }
                 } else if (!hiddenTables.isHidden(tableRef)) {
@@ -272,7 +274,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                             + " AtlasDB metadata. If you recently did a Palantir update, try waiting until"
                             + " schema upgrades are completed on all backend CLIs/services etc and restarting"
                             + " this service. If this error re-occurs on subsequent attempted startups, please"
-                            + " contact Palantir support.", tableRef.getQualifiedName());
+                            + " contact Palantir support.", UnsafeArg.of("table", tableRef.getQualifiedName()));
                 }
             }
 
@@ -410,9 +412,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             if (rowCount > fetchBatchCount) {
                 log.warn("Rebatched in getRows a call to {} that attempted to multiget {} rows; "
                         + "this may indicate overly-large batching on a higher level.\n{}",
-                        tableRef.getQualifiedName(),
-                        rowCount,
-                        CassandraKeyValueServices.getFilteredStackTrace("com.palantir"));
+                        UnsafeArg.of("table", tableRef.getQualifiedName()),
+                        SafeArg.of("rowCount", rowCount),
+                        UnsafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
             }
             return ImmutableMap.copyOf(result);
         } catch (Exception e) {
@@ -503,18 +505,22 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
         if (log.isTraceEnabled()) {
             log.trace("Loading {} cells from {} {}starting at timestamp {}, partitioned across {} nodes.",
-                    cells.size(), tableRef, loadAllTs ? "for all timestamps " : "", startTs, totalPartitions);
+                    SafeArg.of("cells", cells.size()),
+                    UnsafeArg.of("table", tableRef),
+                    SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
+                    SafeArg.of("startTs", startTs),
+                    SafeArg.of("totalPartitions", totalPartitions));
         }
 
         List<Callable<Void>> tasks = Lists.newArrayList();
         for (Map.Entry<InetSocketAddress, List<Cell>> hostAndCells : hostsAndCells.entrySet()) {
             if (log.isTraceEnabled()) {
                 log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
-                        hostsAndCells.values().size(),
-                        tableRef,
-                        loadAllTs ? "for all timestamps " : "",
-                        startTs,
-                        hostAndCells.getKey());
+                        SafeArg.of("cells", hostsAndCells.values().size()),
+                        UnsafeArg.of("table", tableRef),
+                        SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
+                        SafeArg.of("startTs", startTs),
+                        SafeArg.of("ipPort", hostAndCells.getKey()));
             }
 
             tasks.addAll(getLoadWithTsTasksForSingleHost(hostAndCells.getKey(),
@@ -550,10 +556,10 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             if (columnCells.size() > fetchBatchCount) {
                 log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to "
                                 + "multiget {} rows; this may indicate overly-large batching on a higher level.\n{}",
-                        host,
-                        tableRef,
-                        columnCells.size(),
-                        CassandraKeyValueServices.getFilteredStackTrace("com.palantir"));
+                        SafeArg.of("host", host),
+                        UnsafeArg.of("table", tableRef),
+                        SafeArg.of("rows", columnCells.size()),
+                        UnsafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
             }
             for (final List<Cell> partition : Lists.partition(ImmutableList.copyOf(columnCells), fetchBatchCount)) {
                 Callable<Void> multiGetCallable = () -> clientPool.runWithRetryOnHost(host,
@@ -573,11 +579,11 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
 
                                 if (log.isTraceEnabled()) {
                                     log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
-                                            partition.size(),
-                                            tableRef,
-                                            loadAllTs ? "for all timestamps " : "",
-                                            startTs,
-                                            host);
+                                            SafeArg.of("cells", partition.size()),
+                                            UnsafeArg.of("table", tableRef),
+                                            SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
+                                            SafeArg.of("startTs", startTs),
+                                            SafeArg.of("host", host));
                                 }
 
                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results =
@@ -1222,8 +1228,9 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             } catch (TException e) {
                 log.error("Cluster was unavailable while we attempted a truncate for table "
                         + "{}; we will try {} additional time(s).",
-                        tableRef.getQualifiedName(),
-                        CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries, e);
+                        UnsafeArg.of("table", tableRef.getQualifiedName()),
+                        SafeArg.of("retries", CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries),
+                        e);
                 if (CassandraConstants.MAX_TRUNCATION_ATTEMPTS - tries == 0) {
                     throw e;
                 }
@@ -1502,7 +1509,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         client.system_drop_column_family(internalTableName(table));
                         putMetadataWithoutChangingSettings(table, PtBytes.EMPTY_BYTE_ARRAY);
                     } else {
-                        log.warn("Ignored call to drop a table ({}) that did not exist.", table);
+                        log.warn("Ignored call to drop a table ({}) that did not exist.", UnsafeArg.of("table", table));
                     }
                 }
                 CassandraKeyValueServices.waitForSchemaVersions(
@@ -1599,13 +1606,14 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                     if (Arrays.equals(
                             existingTableMetadata.get(Iterables.getOnlyElement(matchingTables)), newMetadata)) {
                         log.debug("Case-insensitive matched table already existed with same metadata,"
-                                + " skipping update to {}", tableReference);
+                                + " skipping update to {}", UnsafeArg.of("table", tableReference));
                     } else { // existing table has different metadata, so we should perform an update
                         tableMetadataUpdates.put(tableReference, newMetadata);
                     }
                 }
             } else {
-                log.debug("Table already existed with same metadata, skipping update to {}", tableReference);
+                log.debug("Table already existed with same metadata, skipping update to {}",
+                        UnsafeArg.of("table", tableReference));
             }
         }
 
@@ -1630,7 +1638,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 if (!existingTablesLowerCased.contains(tableRefLowerCased)) {
                     filteredTables.put(table, metadata);
                 } else {
-                    log.debug("Filtering out existing table ({}) that already existed (case insensitive).", table);
+                    log.debug("Filtering out existing table ({}) that already existed (case insensitive).",
+                            UnsafeArg.of("table", table));
                 }
             }
         } catch (Exception e) {
@@ -1704,10 +1713,11 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 .findFirst();
 
         if (!match.isPresent()) {
-            log.debug("Couldn't find table metadata for {}", tableRef);
+            log.debug("Couldn't find table metadata for {}", UnsafeArg.of("table", tableRef));
             return AtlasDbConstants.EMPTY_TABLE_METADATA;
         } else {
-            log.debug("Found table metadata for {} at matching name {}", tableRef, match.get().getKey());
+            log.debug("Found table metadata for {} at matching name {}", UnsafeArg.of("table", tableRef),
+                    UnsafeArg.of("matchingTable", match.get().getKey()));
             return match.get().getValue();
         }
     }
@@ -1915,7 +1925,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                 runTruncateInternal(ImmutableSet.of(tableRef));
             } catch (TException e) {
                 log.info("Tried to make a deleteRange({}, RangeRequest.all())"
-                        + " into a more garbage-cleanup friendly truncate(), but this failed.", tableRef, e);
+                                + " into a more garbage-cleanup friendly truncate(), but this failed.",
+                        UnsafeArg.of("table", tableRef), e);
 
                 super.deleteRange(tableRef, range);
             }
@@ -2104,7 +2115,8 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             log.error("No compaction client was configured, but compact was called."
                     + " If you actually want to clear deleted data immediately"
                     + " from Cassandra, lower your gc_grace_seconds setting and"
-                    + " run `nodetool compact {} {}`.", config.keyspace(), internalTableName(tableRef));
+                    + " run `nodetool compact {} {}`.", UnsafeArg.of("keyspace", config.keyspace()),
+                    UnsafeArg.of("table", internalTableName(tableRef)));
             return;
         }
         long timeoutInSeconds = config.jmx().get().compactionTimeoutSeconds();
@@ -2113,10 +2125,13 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
             alterGcAndTombstone(keyspace, tableRef, 0, 0.0f);
             compactionManager.get().performTombstoneCompaction(timeoutInSeconds, keyspace, tableRef);
         } catch (TimeoutException e) {
-            log.error("Compaction for {}.{} could not finish in {} seconds.", keyspace, tableRef, timeoutInSeconds, e);
-            log.error("Compaction status: {}", compactionManager.get().getCompactionStatus());
+            log.error("Compaction for {}.{} could not finish in {} seconds.", UnsafeArg.of("keyspace", keyspace),
+                    UnsafeArg.of("table", tableRef), SafeArg.of("timeout", timeoutInSeconds), e);
+            log.error("Compaction status: {}",
+                    UnsafeArg.of("compactionStatus", compactionManager.get().getCompactionStatus()));
         } catch (InterruptedException e) {
-            log.error("Compaction for {}.{} was interrupted.", keyspace, tableRef);
+            log.error("Compaction for {}.{} was interrupted.", UnsafeArg.of("keyspace", keyspace),
+                    UnsafeArg.of("table", tableRef));
         } finally {
             alterGcAndTombstone(
                     keyspace,
@@ -2230,19 +2245,21 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                 tableRef.getQualifiedName(),
                                 configManager.getConfig().schemaMutationTimeoutMillis());
                         log.trace("gc_grace_seconds is set to {} for {}.{}",
-                                gcGraceSeconds, keyspace, tableRef);
+                                SafeArg.of("gcGraceSeconds", gcGraceSeconds), UnsafeArg.of("keyspace", keyspace),
+                                UnsafeArg.of("table", tableRef));
                         log.trace("tombstone_threshold_ratio is set to {} for {}.{}",
-                                tombstoneThresholdRatio, keyspace, tableRef);
+                                SafeArg.of("tombstoneThresholdRatio", tombstoneThresholdRatio),
+                                UnsafeArg.of("keyspace", keyspace), SafeArg.of("table", tableRef));
                     }
                 }
                 return null;
             });
         } catch (Exception e) {
             log.error("Exception encountered while setting gc_grace_seconds:{} and tombstone_threshold:{} for {}.{}",
-                    gcGraceSeconds,
-                    tombstoneThresholdRatio,
-                    keyspace,
-                    tableRef,
+                    SafeArg.of("gcGraceSeconds", gcGraceSeconds),
+                    SafeArg.of("tombstoneThresholdRatio", tombstoneThresholdRatio),
+                    UnsafeArg.of("keyspace", keyspace),
+                    UnsafeArg.of("table", tableRef),
                     e);
         }
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -414,7 +414,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         + "this may indicate overly-large batching on a higher level.\n{}",
                         UnsafeArg.of("table", tableRef.getQualifiedName()),
                         SafeArg.of("rowCount", rowCount),
-                        UnsafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
+                        SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
             }
             return ImmutableMap.copyOf(result);
         } catch (Exception e) {
@@ -559,7 +559,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                         SafeArg.of("host", host),
                         UnsafeArg.of("table", tableRef),
                         SafeArg.of("rows", columnCells.size()),
-                        UnsafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
+                        SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
             }
             for (final List<Cell> partition : Lists.partition(ImmutableList.copyOf(columnCells), fetchBatchCount)) {
                 Callable<Void> multiGetCallable = () -> clientPool.runWithRetryOnHost(host,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -2249,7 +2249,7 @@ public class CassandraKeyValueService extends AbstractKeyValueService {
                                 UnsafeArg.of("table", tableRef));
                         log.trace("tombstone_threshold_ratio is set to {} for {}.{}",
                                 SafeArg.of("tombstoneThresholdRatio", tombstoneThresholdRatio),
-                                UnsafeArg.of("keyspace", keyspace), SafeArg.of("table", tableRef));
+                                UnsafeArg.of("keyspace", keyspace), UnsafeArg.of("table", tableRef));
                     }
                 }
                 return null;

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/DebugLogger.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/DebugLogger.java
@@ -18,6 +18,9 @@ package com.palantir.timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -37,14 +40,15 @@ public final class DebugLogger {
 
     public static void handedOutTimestamps(TimestampRange range) {
         long count = range.getUpperBound() - range.getLowerBound() + 1L;
-        logger.trace("Handing out {} timestamps, taking us to {}.", count, range.getUpperBound());
+        logger.trace("Handing out {} timestamps, taking us to {}.", SafeArg.of("count", count),
+                SafeArg.of("rangeUpperBound", range.getUpperBound()));
     }
 
     public static void createdPersistentTimestamp() {
         logger.info("Creating PersistentTimestamp object on thread {}."
                         + " If you are running embedded AtlasDB, this should only happen once."
                         + " If you are using Timelock, this should happen once per client per leadership election",
-                Thread.currentThread().getName());
+                UnsafeArg.of("threadName", Thread.currentThread().getName()));
     }
 
     public static void willStoreNewUpperLimit(long newLimit) {
@@ -52,7 +56,7 @@ public final class DebugLogger {
     }
 
     public static void didStoreNewUpperLimit(long newLimit) {
-        logger.trace("Stored; upper limit is now {}.", newLimit);
+        logger.trace("Stored; upper limit is now {}.", SafeArg.of("newLimit", newLimit));
     }
 
 }


### PR DESCRIPTION
**Goals (and why)**:

Mark more log messages in `CassandraKeyValueService` and `DebugLogger` as safe/unsafe.

**Concerns (what feedback would you like?)**:

Made these decisions:
- table/keyspace names are unsafe (seemed to follow precedent)
- host:ip of a cassandra node is safe
- introduced `timestampClause` value rather than modifying the log output that standard slf4j outputters would produce
- counts/timestamps are safe
- the partial stacktraces are unsafe

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2123)
<!-- Reviewable:end -->
