### PR TITLE
Variably Secure Components, Part 3: TableRenderer and ProfilingKVS

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -694,6 +694,7 @@ public interface KeyValueService extends AutoCloseable {
 
     /**
      * Provides a supplier that is able to determine whether constructs are safe for logging.
+     * This method should return quickly (at least amortised), as it may be called multiple times.
      */
     default KeyValueServiceArgSupplier getLoggingArgSupplier() {
         return KeyValueServiceArgSupplier.ALL_UNSAFE;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
@@ -38,6 +38,7 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.KeyValueServiceArgSupplier;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
@@ -222,5 +223,15 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     @Override
     public ClusterAvailabilityStatus getClusterAvailabilityStatus() {
         return delegate().getClusterAvailabilityStatus();
+    }
+
+    @Override
+    public void rehydrateLoggingArgSupplier() {
+        delegate().rehydrateLoggingArgSupplier();
+    }
+
+    @Override
+    public KeyValueServiceArgSupplier getLoggingArgSupplier() {
+        return delegate().getLoggingArgSupplier();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -50,6 +50,7 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.KeyValueServiceArgSupplier;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
@@ -471,6 +472,18 @@ public final class ProfilingKeyValueService implements KeyValueService {
                             cellBatchHint,
                             stopwatch.elapsed(TimeUnit.MILLISECONDS));
                 });
+    }
+
+
+    @Override
+    public void rehydrateLoggingArgSupplier() {
+        maybeLog(delegate::rehydrateLoggingArgSupplier,
+                logTime("rehydrateLoggingArgSupplier"));
+    }
+
+    @Override
+    public KeyValueServiceArgSupplier getLoggingArgSupplier() {
+        return delegate.getLoggingArgSupplier();
     }
 
     private static <T> long byteSize(Map<Cell, T> values) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -52,6 +52,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.logging.KeyValueServiceArgSupplier;
 import com.palantir.common.base.ClosableIterator;
+import com.palantir.logsafe.Arg;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
 public final class ProfilingKeyValueService implements KeyValueService {
@@ -85,12 +86,18 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
 
-    private static BiConsumer<LoggingFunction, Stopwatch> logCellsAndSize(String method,
+    private BiConsumer<LoggingFunction, Stopwatch> logCellsAndSize(
+            String method,
             TableReference tableRef,
-            int numCells, long sizeInBytes) {
+            int numCells,
+            long sizeInBytes) {
         return (logger, stopwatch) ->
                 logger.log("Call to KVS.{} on table {} for {} cells of overall size {} bytes took {} ms.",
-                        method, tableRef, numCells, sizeInBytes, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+                        method,
+                        getLoggingArgForTableReference(tableRef),
+                        numCells,
+                        sizeInBytes,
+                        stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
     private static BiConsumer<LoggingFunction, Stopwatch> logTime(String method) {
@@ -98,10 +105,12 @@ public final class ProfilingKeyValueService implements KeyValueService {
                 logger.log("Call to KVS.{} took {} ms.", method, stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
-    private static BiConsumer<LoggingFunction, Stopwatch> logTimeAndTable(String method, TableReference tableRef) {
+    private BiConsumer<LoggingFunction, Stopwatch> logTimeAndTable(
+            String method,
+            TableReference tableRef) {
         return (logger, stopwatch) ->
                 logger.log("Call to KVS.{} on table {} took {} ms.",
-                        method, tableRef, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+                        method, getLoggingArgForTableReference(tableRef), stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
     private static BiConsumer<LoggingFunction, Stopwatch> logTimeAndTableCount(String method, int tableCount) {
@@ -110,12 +119,16 @@ public final class ProfilingKeyValueService implements KeyValueService {
                         method, tableCount, stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
-    private static BiConsumer<LoggingFunction, Stopwatch> logTimeAndTableRange(String method,
+    private BiConsumer<LoggingFunction, Stopwatch> logTimeAndTableRange(
+            String method,
             TableReference tableRef,
             RangeRequest range) {
         return (logger, stopwatch) ->
                 logger.log("Call to KVS.{} on table {} with range {} took {} ms.",
-                        method, tableRef, range, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+                        method,
+                        getLoggingArgForTableReference(tableRef),
+                        range,
+                        stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
     private static BiConsumer<LoggingFunction, Map<Cell, Value>> logCellResultSize(long overhead) {
@@ -449,7 +462,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
                 batchColumnRangeSelection, timestamp),
                 (logger, stopwatch) -> {
                     logger.log("Call to KVS.getRowsColumnRange on table {} for {} rows with range {} took {} ms.",
-                            tableRef, Iterables.size(rows), batchColumnRangeSelection,
+                            getLoggingArgForTableReference(tableRef), Iterables.size(rows), batchColumnRangeSelection,
                             stopwatch.elapsed(TimeUnit.MILLISECONDS));
                 });
     }
@@ -466,7 +479,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
                     logger.log(
                             "Call to KVS.getRowsColumnRange - CellBatch on table {} for {} rows with range {} "
                                     + "and batch hint {} took {} ms.",
-                            tableRef,
+                            getLoggingArgForTableReference(tableRef),
                             Iterables.size(rows),
                             columnRangeSelection,
                             cellBatchHint,
@@ -506,5 +519,9 @@ public final class ProfilingKeyValueService implements KeyValueService {
             sizeInBytes += Cells.getApproxSizeOfCell(cell) + values.get(cell).size();
         }
         return sizeInBytes;
+    }
+
+    private Arg<TableReference> getLoggingArgForTableReference(TableReference tableReference) {
+        return delegate.getLoggingArgSupplier().getTableReferenceArg("tableRef", tableReference);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -41,6 +41,7 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.KeyValueServiceArgSupplier;
 import com.palantir.atlasdb.tracing.CloseableTrace;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -380,5 +381,17 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
         }
     }
 
+    @Override
+    public void rehydrateLoggingArgSupplier() {
+        //noinspection unused - try-with-resources closes trace
+        try (CloseableTrace trace = startLocalTrace("rehydrateLoggingArgSupplier()")) {
+            delegate().rehydrateLoggingArgSupplier();
+        }
+    }
+
+    @Override
+    public KeyValueServiceArgSupplier getLoggingArgSupplier() {
+        return delegate().getLoggingArgSupplier();
+    }
 }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SweepSchema.java
@@ -20,6 +20,7 @@ import java.io.File;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.table.description.OptionalType;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
@@ -39,11 +40,14 @@ public enum SweepSchema implements AtlasSchema {
     private static Schema generateSchema() {
         Schema schema = new Schema("Sweep",
                 SweepSchema.class.getPackage().getName() + ".generated",
-                NAMESPACE);
+                NAMESPACE,
+                OptionalType.JAVA8);
 
         // This table tracks progress on a sweep job of a single table.
         schema.addTableDefinition("progress", new TableDefinition() {{
             javaTableName("SweepProgress");
+            tableNameIsSafeLoggable();
+            namedComponentsSafeByDefault();
             rowName();
                 // This table has at most one row.
                 rowComponent("dummy", ValueType.VAR_LONG);
@@ -68,6 +72,8 @@ public enum SweepSchema implements AtlasSchema {
         // in determining when and in which order they should be swept.
         schema.addTableDefinition("priority", new TableDefinition() {{
             javaTableName("SweepPriority");
+            tableNameIsSafeLoggable();
+            namedComponentsSafeByDefault();
             rowName();
                 rowComponent("full_table_name", ValueType.STRING);
             columns();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/NameComponentDescription.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/NameComponentDescription.java
@@ -55,9 +55,16 @@ public class NameComponentDescription {
     }
 
     public NameComponentDescription(String componentName,
-                                    ValueType type,
-                                    ValueByteOrder order) {
-        this(componentName, type, order, new UniformRowNamePartitioner(type), null);
+            ValueType type,
+            ValueByteOrder order) {
+        this(componentName, type, order, false);
+    }
+
+    public NameComponentDescription(String componentName,
+            ValueType type,
+            ValueByteOrder order,
+            boolean nameLoggable) {
+        this(componentName, type, order, new UniformRowNamePartitioner(type), null, nameLoggable);
     }
 
     public NameComponentDescription(String componentName,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/NameComponentDescription.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/NameComponentDescription.java
@@ -176,8 +176,12 @@ public class NameComponentDescription {
 
     @Override
     public String toString() {
-        return "NameComponentDescription [componentName=" + componentName
-                + ", order=" + order + ", type=" + type + "]";
+        return "NameComponentDescription[" +
+                "componentName=" + componentName +
+                ", type=" + type +
+                ", order=" + order +
+                ", nameLoggable=" + nameLoggable +
+                ']';
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
@@ -62,22 +62,48 @@ public class TableDefinition extends AbstractDefinition {
         state = State.DEFINING_CONSTRAINTS;
     }
 
-    public void column(String columnName, String shortName, Class<?> protoOrPersistable) {
-        column(columnName, shortName, protoOrPersistable, Compression.NONE);
+    public void tableNameIsSafeLoggable() {
+        Preconditions.checkState(state == State.NONE, "Specifying a table name is safe should be done outside of the"
+                + " subscopes of TableDefinition.");
+        tableNameLoggable = true;
     }
 
-    public void column(String columnName, String shortName, Class<?> protoOrPersistable, Compression compression) {
+    public void column(String columnName, String shortName, Class<?> protoOrPersistable) {
+        column(columnName, shortName, protoOrPersistable, false);
+    }
+
+    public void column(String columnName, String shortName, Class<?> protoOrPersistable, boolean columnNameLoggable) {
+        column(columnName, shortName, protoOrPersistable, Compression.NONE, columnNameLoggable);
+    }
+
+    public void column(
+            String columnName,
+            String shortName,
+            Class<?> protoOrPersistable,
+            Compression compression,
+            boolean columnNameLoggable) {
         Preconditions.checkState(state == State.DEFINING_COLUMNS);
         Preconditions.checkState(!noColumns);
         checkUniqueColumnNames(columnName, shortName);
-        fixedColumns.add(new NamedColumnDescription(shortName, columnName, getColumnValueDescription(protoOrPersistable, compression)));
+        fixedColumns.add(
+                new NamedColumnDescription(
+                        shortName,
+                        columnName,
+                        getColumnValueDescription(protoOrPersistable, compression),
+                        columnNameLoggable));
     }
 
     public void column(String columnName, String shortName, ValueType valueType) {
+        column(columnName, shortName, valueType, false);
+    }
+
+    public void column(String columnName, String shortName, ValueType valueType, boolean columnNameLoggable) {
         Preconditions.checkState(state == State.DEFINING_COLUMNS);
         Preconditions.checkState(!noColumns);
         checkUniqueColumnNames(columnName, shortName);
-        fixedColumns.add(new NamedColumnDescription(shortName, columnName, ColumnValueDescription.forType(valueType)));
+        fixedColumns.add(
+                new NamedColumnDescription(
+                        shortName, columnName, ColumnValueDescription.forType(valueType), columnNameLoggable));
     }
 
     public void noColumns() {
@@ -115,8 +141,13 @@ public class TableDefinition extends AbstractDefinition {
     }
 
     public void rowComponent(String componentName, ValueType valueType, ValueByteOrder valueByteOrder) {
+        rowComponent(componentName, valueType, valueByteOrder, false);
+    }
+
+    public void rowComponent(
+            String componentName, ValueType valueType, ValueByteOrder valueByteOrder, boolean rowNameLoggable) {
         Preconditions.checkState(state == State.DEFINING_ROW_NAME);
-        rowNameComponents.add(new NameComponentDescription(componentName, valueType, valueByteOrder));
+        rowNameComponents.add(new NameComponentDescription(componentName, valueType, valueByteOrder, rowNameLoggable));
     }
 
     /**
@@ -245,6 +276,7 @@ public class TableDefinition extends AbstractDefinition {
     private Set<String> fixedColumnShortNames = Sets.newHashSet();
     private Set<String> fixedColumnLongNames = Sets.newHashSet();
     private boolean noColumns = false;
+    private boolean tableNameLoggable = false;
 
     public TableMetadata toTableMetadata() {
         Preconditions.checkState(!rowNameComponents.isEmpty(), "No row name components defined.");
@@ -268,7 +300,8 @@ public class TableDefinition extends AbstractDefinition {
                 negativeLookups,
                 sweepStrategy,
                 expirationStrategy,
-                appendHeavyAndReadLight);
+                appendHeavyAndReadLight,
+                tableNameLoggable);
     }
 
     private ColumnMetadataDescription getColumnMetadataDescription() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
@@ -62,14 +62,29 @@ public class TableDefinition extends AbstractDefinition {
         state = State.DEFINING_CONSTRAINTS;
     }
 
+    /**
+     * Indicates that the name of the table being defined is safe for logging.
+     */
     public void tableNameIsSafeLoggable() {
         Preconditions.checkState(state == State.NONE, "Specifying a table name is safe should be done outside of the"
                 + " subscopes of TableDefinition.");
         tableNameLoggable = true;
     }
 
+    /**
+     * If specified, this indicates that the names of all row components and named columns should be marked as safe by
+     * default. Individual row components or named columns may still be marked as unsafe by explicitly creating them
+     * as unsafe (i.e. by constructing them with rowNameLoggable or columnNameLoggable as false, respectively).
+     * Note that specifying this by itself does NOT make the table name safe for logging.
+     */
+    public void namedComponentsSafeByDefault() {
+        Preconditions.checkState(state == State.NONE, "Specifying a table name is safe should be done outside of the"
+                + " subscopes of TableDefinition.");
+        defaultNamedComponentLogSafety = true;
+    }
+
     public void column(String columnName, String shortName, Class<?> protoOrPersistable) {
-        column(columnName, shortName, protoOrPersistable, false);
+        column(columnName, shortName, protoOrPersistable, defaultNamedComponentLogSafety);
     }
 
     public void column(String columnName, String shortName, Class<?> protoOrPersistable, boolean columnNameLoggable) {
@@ -94,7 +109,7 @@ public class TableDefinition extends AbstractDefinition {
     }
 
     public void column(String columnName, String shortName, ValueType valueType) {
-        column(columnName, shortName, valueType, false);
+        column(columnName, shortName, valueType, defaultNamedComponentLogSafety);
     }
 
     public void column(String columnName, String shortName, ValueType valueType, boolean columnNameLoggable) {
@@ -141,7 +156,7 @@ public class TableDefinition extends AbstractDefinition {
     }
 
     public void rowComponent(String componentName, ValueType valueType, ValueByteOrder valueByteOrder) {
-        rowComponent(componentName, valueType, valueByteOrder, false);
+        rowComponent(componentName, valueType, valueByteOrder, defaultNamedComponentLogSafety);
     }
 
     public void rowComponent(
@@ -277,6 +292,8 @@ public class TableDefinition extends AbstractDefinition {
     private Set<String> fixedColumnLongNames = Sets.newHashSet();
     private boolean noColumns = false;
     private boolean tableNameLoggable = false;
+
+    private boolean defaultNamedComponentLogSafety = false;
 
     public TableMetadata toTableMetadata() {
         Preconditions.checkState(!rowNameComponents.isEmpty(), "No row name components defined.");

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueServiceTest.java
@@ -40,6 +40,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.KeyValueServiceArgSupplier;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -93,6 +94,7 @@ public class ProfilingKeyValueServiceTest {
     @Before
     public void before() throws Exception {
         delegate = mock(KeyValueService.class);
+        when(delegate.getLoggingArgSupplier()).thenReturn(KeyValueServiceArgSupplier.ALL_UNSAFE);
         kvs = ProfilingKeyValueService.create(delegate, 1000);
     }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableDefinitionTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableDefinitionTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.table.description;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+
+public class TableDefinitionTest {
+    private static final TableReference TABLE_REF = TableReference.create(Namespace.DEFAULT_NAMESPACE, "foo");
+    private static final String ROW_NAME = "foo";
+    private static final String COLUMN_NAME = "bar";
+    private static final String COLUMN_SHORTNAME = "b";
+
+    private static final TableDefinition BASE_DEFINITION = new TableDefinition() {{
+        javaTableName(TABLE_REF.getTablename());
+        rowName();
+        rowComponent(ROW_NAME, ValueType.STRING);
+        columns();
+        column(COLUMN_NAME, COLUMN_SHORTNAME, ValueType.VAR_LONG);
+    }};
+
+    @Test
+    public void tableNameNotLoggableByDefault() {
+        assertThat(BASE_DEFINITION.toTableMetadata().isNameLoggable()).isFalse();
+    }
+
+    @Test
+    public void canSpecifyTableNameAsLoggable() {
+        TableDefinition definition = new TableDefinition() {{
+            tableNameIsSafeLoggable();
+            javaTableName(TABLE_REF.getTablename());
+            rowName();
+            rowComponent(ROW_NAME, ValueType.STRING);
+            noColumns();
+        }};
+        assertThat(definition.toTableMetadata().isNameLoggable()).isTrue();
+    }
+
+    @Test
+    public void cannotSpecifyTableNameAsLoggableWhenSpecifyingRowName() {
+        assertThatThrownBy(() -> new TableDefinition() {{
+            javaTableName(TABLE_REF.getTablename());
+            rowName();
+            tableNameIsSafeLoggable();
+            rowComponent(ROW_NAME, ValueType.STRING);
+            columns();
+            column(COLUMN_NAME, COLUMN_SHORTNAME, ValueType.VAR_LONG);
+        }}).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void cannotSpecifyTableNameAsLoggableWhenSpecifyingColumns() {
+        assertThatThrownBy(() -> new TableDefinition() {{
+            javaTableName(TABLE_REF.getTablename());
+            rowName();
+            rowComponent(ROW_NAME, ValueType.STRING);
+            columns();
+            tableNameIsSafeLoggable();
+            column(COLUMN_NAME, COLUMN_SHORTNAME, ValueType.VAR_LONG);
+        }}).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void componentsAreNotSafeByDefault() {
+        assertRowComponentSafety(BASE_DEFINITION, false);
+        assertNamedColumnSafety(BASE_DEFINITION, false);
+    }
+
+    @Test
+    public void canSpecifyComponentsAsSafeByDefault() {
+        TableDefinition definition = new TableDefinition() {{
+            namedComponentsSafeByDefault();
+            javaTableName(TABLE_REF.getTablename());
+            rowName();
+            rowComponent(ROW_NAME, ValueType.STRING);
+            columns();
+            column(COLUMN_NAME, COLUMN_SHORTNAME, ValueType.VAR_LONG);
+        }};
+
+        assertRowComponentSafety(definition, true);
+        assertNamedColumnSafety(definition, true);
+    }
+
+    @Test
+    public void cannotSpecifyComponentsAsSafeByDefaultWhenSpecifyingRowName() {
+        assertThatThrownBy(() -> new TableDefinition() {{
+            javaTableName(TABLE_REF.getTablename());
+            rowName();
+            namedComponentsSafeByDefault();
+            rowComponent(ROW_NAME, ValueType.STRING);
+            columns();
+            column(COLUMN_NAME, COLUMN_SHORTNAME, ValueType.VAR_LONG);
+        }}).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void cannotSpecifyComponentsAsSafeByDefaultWhenSpecifyingColumns() {
+        assertThatThrownBy(() -> new TableDefinition() {{
+            javaTableName(TABLE_REF.getTablename());
+            rowName();
+            rowComponent(ROW_NAME, ValueType.STRING);
+            columns();
+            namedComponentsSafeByDefault();
+            column(COLUMN_NAME, COLUMN_SHORTNAME, ValueType.VAR_LONG);
+        }}).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void canDeclareSpecificComponentsAsSafe() {
+        TableDefinition definition = new TableDefinition() {{
+            javaTableName(TABLE_REF.getTablename());
+            rowName();
+            rowComponent(ROW_NAME, ValueType.STRING, TableMetadataPersistence.ValueByteOrder.ASCENDING, true);
+            columns();
+            column(COLUMN_NAME, COLUMN_SHORTNAME, ValueType.VAR_LONG);
+        }};
+
+        assertRowComponentSafety(definition, true);
+        assertNamedColumnSafety(definition, false);
+    }
+
+    @Test
+    public void canDeclareComponentsAsSafeByDefaultAndSpecificComponentsAsUnsafe() {
+        TableDefinition definition = new TableDefinition() {{
+            namedComponentsSafeByDefault();
+            javaTableName(TABLE_REF.getTablename());
+            rowName();
+            rowComponent(ROW_NAME, ValueType.STRING, TableMetadataPersistence.ValueByteOrder.ASCENDING, false);
+            columns();
+            column(COLUMN_NAME, COLUMN_SHORTNAME, ValueType.VAR_LONG);
+        }};
+
+        assertRowComponentSafety(definition, false);
+        assertNamedColumnSafety(definition, true);
+    }
+
+    /**
+     * Asserts that the only row component for the TableDefinition object passed in has loggability matching
+     * expectedSafety. Throws if the actual safety doesn't match the expected safety, or if it is not the case that
+     * there is exactly one row component.
+     */
+    private static void assertRowComponentSafety(TableDefinition tableDefinition, boolean expectedSafety) {
+        TableMetadata metadata = tableDefinition.toTableMetadata();
+        NameComponentDescription nameComponent = Iterables.getOnlyElement(metadata.getRowMetadata().getRowParts());
+        assertThat(nameComponent.isNameLoggable()).isEqualTo(expectedSafety);
+    }
+
+    /**
+     * Asserts that the only named column for the TableDefinition object passed in has loggability matching
+     * expectedSafety. Throws if the actual safety doesn't match the expected safety, or if it is not the case that
+     * there is exactly one named column.
+     */
+    private static void assertNamedColumnSafety(TableDefinition tableDefinition, boolean expectedSafety) {
+        TableMetadata metadata = tableDefinition.toTableMetadata();
+        NamedColumnDescription namedColumn = Iterables.getOnlyElement(metadata.getColumns().getNamedColumns());
+        assertThat(namedColumn.isNameLoggable()).isEqualTo(expectedSafety);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -325,7 +325,8 @@ public final class TransactionManagers {
                 () -> getAtlasDbRuntimeConfig(runtimeConfigSupplier).sweep().enabled(),
                 () -> getAtlasDbRuntimeConfig(runtimeConfigSupplier).sweep().pauseMillis(),
                 persistentLockManager,
-                specificTableSweeper);
+                specificTableSweeper,
+                kvs.getLoggingArgSupplier());
 
         backgroundSweeper.runInBackground();
     }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/CheckAndSetSchema.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/CheckAndSetSchema.java
@@ -35,6 +35,8 @@ public class CheckAndSetSchema implements AtlasSchema {
                 Namespace.DEFAULT_NAMESPACE);
 
         schema.addTableDefinition(CAS_TABLE, new TableDefinition() {{
+                tableNameIsSafeLoggable();
+                namedComponentsSafeByDefault();
                 rowName();
                 rowComponent("id", ValueType.FIXED_LONG);
                 columns();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespaceMappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespaceMappingKeyValueService.java
@@ -40,6 +40,7 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.KeyValueServiceArgSupplier;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
@@ -266,5 +267,15 @@ public class NamespaceMappingKeyValueService extends ForwardingObject implements
     @Override
     public ClusterAvailabilityStatus getClusterAvailabilityStatus() {
         return delegate().getClusterAvailabilityStatus();
+    }
+
+    @Override
+    public void rehydrateLoggingArgSupplier() {
+        delegate().rehydrateLoggingArgSupplier();
+    }
+
+    @Override
+    public KeyValueServiceArgSupplier getLoggingArgSupplier() {
+        return delegate().getLoggingArgSupplier();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -45,6 +45,7 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.KeyValueServiceArgSupplier;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
@@ -438,4 +439,13 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
         return delegate().getClusterAvailabilityStatus();
     }
 
+    @Override
+    public void rehydrateLoggingArgSupplier() {
+        delegate().rehydrateLoggingArgSupplier();
+    }
+
+    @Override
+    public KeyValueServiceArgSupplier getLoggingArgSupplier() {
+        return delegate().getLoggingArgSupplier();
+    }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperTestSetup.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperTestSetup.java
@@ -62,7 +62,8 @@ public class SweeperTestSetup {
                 () -> sweepEnabled,
                 () -> 0L, // pauseMillis
                 Mockito.mock(PersistentLockManager.class),
-                specificTableSweeper);
+                specificTableSweeper,
+                KeyValueServiceArgSupplier.ALL_UNSAFE);
 
         when(kvs.getLoggingArgSupplier()).thenReturn(KeyValueServiceArgSupplier.ALL_UNSAFE);
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractBackgroundSweeperIntegrationTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractBackgroundSweeperIntegrationTest.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
+import com.palantir.atlasdb.logging.KeyValueServiceArgSupplier;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
 import com.palantir.atlasdb.sweep.priority.SweepPriority;
@@ -96,7 +97,8 @@ public abstract class AbstractBackgroundSweeperIntegrationTest {
                 () -> true, // sweepEnabled
                 () -> 10L, // sweepPauseMillis
                 persistentLockManager,
-                specificTableSweeper);
+                specificTableSweeper,
+                KeyValueServiceArgSupplier.ALL_UNSAFE);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -46,15 +46,15 @@ develop
 
     *    - |new|
          - AtlasDB now supports specifying the safety of table names as well as row and column component names following the `palantir/safe-logging <https://github.com/palantir/safe-logging>`__ library.
-           Please consult TODO schema definitions for details on how to set this up.
-           As AtlasDB regenerates its metadata on startup, changes will take effect after restarting your AtlasDB client. (In particular, you do NOT need to rerender your schemas.)
+           Please consult the documentation for :ref:`Tables and Indices <tables-and-indices>` for details on how to set this up.
+           As AtlasDB regenerates its metadata on startup, changes will take effect after restarting your AtlasDB client (in particular, you do NOT need to rerender your schemas.)
            Previously, all table names, row component names and column names were always treated as unsafe.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/VSC1>`__,
-            `Pull Request <https://github.com/palantir/atlasdb/pull/VSC2>`__ and
-            `Pull Request <https://github.com/palantir/atlasdb/pull/VSC3>`__)
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/VSC1>`__,
+           `Pull Request 2 <https://github.com/palantir/atlasdb/pull/VSC2>`__ and
+           `Pull Request 3 <https://github.com/palantir/atlasdb/pull/VSC3>`__)
 
     *    - |improved|
-         - The ``ProfilingKeyValueService`` and ``SpecificTableSweeper`` now log table names as safe arguments, if and only if these have been specified as safe in one's schema.
+         - The ``ProfilingKeyValueService`` and ``SpecificTableSweeper`` now log table names as safe arguments, if and only if these have been specified as safe in one's schemas.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/VSC3>`__)
 
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -37,6 +37,27 @@ develop
 
 .. replace this with the release date
 
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |new|
+         - AtlasDB now supports specifying the safety of table names as well as row and column component names following the `palantir/safe-logging <https://github.com/palantir/safe-logging>`__ library.
+           Please consult TODO schema definitions for details on how to set this up.
+           As AtlasDB regenerates its metadata on startup, changes will take effect after restarting your AtlasDB client. (In particular, you do NOT need to rerender your schemas.)
+           Previously, all table names, row component names and column names were always treated as unsafe.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/VSC1>`__,
+            `Pull Request <https://github.com/palantir/atlasdb/pull/VSC2>`__ and
+            `Pull Request <https://github.com/palantir/atlasdb/pull/VSC3>`__)
+
+    *    - |improved|
+         - The ``ProfilingKeyValueService`` and ``SpecificTableSweeper`` now log table names as safe arguments, if and only if these have been specified as safe in one's schema.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/VSC3>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 ======

--- a/docs/source/schemas/tables_and_indices.rst
+++ b/docs/source/schemas/tables_and_indices.rst
@@ -1,3 +1,5 @@
+.. _tables-and-indices:
+
 ==================
 Tables and Indices
 ==================
@@ -213,6 +215,24 @@ as descriptive as is useful. If this method is not called, the value
 will be derived by converting the table's AtlasDB name from snake\_case
 to CamelCase.
 
+.. code:: java
+
+    public void tableNameIsSafeLoggable();
+
+If called, this indicates that the table name is safe for logging.
+Table names are considered unsafe by default.
+
+.. code:: java
+
+    public void namedComponentsSafeByDefault();
+
+If called, then row components and named columns that are subsequently
+defined for this table will be assumed to be safe for logging unless
+specifically indicated as unsafe. By default, row components and named
+columns are assumed unsafe unless specifically indicated as safe.
+
+Note that the ambit of this method does not extend to the table name itself.
+
 Index-specific Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -269,6 +289,14 @@ range results are iterated in ascending order. If you need to access
 rows in reverse order, then adding the ``ValueByteOrder.DESCENDING``
 argument will store them in descending order instead.
 
+.. code:: java
+
+   public void rowComponent(String componentName, ValueType valueType, ValueByteOrder valueByteOrder, boolean rowNameLoggable);
+
+You may also identify a row component as being explicitly safe or unsafe
+for logging. (If this is not specified it defaults to unsafe, or safe if
+``namedComponentsSafeByDefault()`` was specified for this table.)
+
 .. _tables-and-indices-partitioners:
 
 Partitioners
@@ -324,6 +352,7 @@ type referenced by each column is specified by a single command.
 
     public void column(String columnName, String shortName, ValueType valueType)
     public void column(String columnName, String shortName, Class<?> protoOrPersistable, Compression compression = Compression.NONE)
+    public void column(String columnName, String shortName, Class<?> protoOrPersistable, Compression compression, boolean columnNameLoggable)
 
 The column name is the name of the column that will be used in the
 generated java code and table metadata. The short name is a one or two
@@ -336,8 +365,14 @@ space using the method you specify. Columns can not be overloaded with
 multiple types - each ``column()`` call must contain unique column names
 and short names.
 
-If instead you don't need the a row to have multiple columns and all
-table information can be encapsulted in the row components, then the
+Also, you may explicitly identify the name of this column to be safe or
+unsafe for logging. We don't currently support having different safety
+levels for the column name and the short name.
+(If this is not specified it defaults to unsafe, or safe if
+``namedComponentsSafeByDefault()`` was specified for this table.)
+
+If instead you don't need a row to have multiple columns and all
+table information can be encapsulated in the row components, then the
 section can instead be specified with ``noColumns()``, which defines the
 table to contain a single column "exists" with short name "e" and value
 type VAR\_LONG (always zero).


### PR DESCRIPTION
**Goals (and why)**: Allow users to specify table names as safe or unsafe.
This change also makes the sweep tables safe, and wires up:
* TransactionManagers to call the underlying KVS.hydrate() operation
* ProfilingKVS to use the arbiters

**Implementation Description (bullets)**:
* In TableDefinition add methods that accept a boolean indicating a parameter being safe/unsafe.
* Introduce a configurable default mode which defaults to unsafe, to avoid everyone having to add `, true)` to all of their methods in what I expect to be a majority of use cases.
* Have the forwarding TransactionManagers delegate calls to the raw KVS, which is usually the one that knows about logging.
* Docs.

**Concerns (what feedback would you like?)**:
* Is the API user-friendly / is there a better way I could have written this part of the API?
* TracingKeyValueService and ProfilingKVS: I didn't bother to wrap the getArbiter() method as that shouldn't be calling the raw KVS at all. Should I have wrapped them anyway?

**Where should we start reviewing?**:
TableDefinition and its tests are probably a good place

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2127)
<!-- Reviewable:end -->
