### PR TITLE
Nziebart/async lock logging

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/v2/LockRequestV2.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockRequestV2.java
@@ -16,6 +16,7 @@
 
 package com.palantir.lock.v2;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -39,8 +40,23 @@ public interface LockRequestV2 {
     @Value.Parameter
     long getAcquireTimeoutMs();
 
+    @Value.Parameter
+    Optional<String> getClientDescription();
+
     static LockRequestV2 of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs) {
-        return ImmutableLockRequestV2.of(UUID.randomUUID(), lockDescriptors, acquireTimeoutMs);
+        return ImmutableLockRequestV2.of(
+                UUID.randomUUID(),
+                lockDescriptors,
+                acquireTimeoutMs,
+                Optional.of("Thread: " + Thread.currentThread().getName()));
+    }
+
+    static LockRequestV2 of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs, String clientDescription) {
+        return ImmutableLockRequestV2.of(
+                UUID.randomUUID(),
+                lockDescriptors,
+                acquireTimeoutMs,
+                Optional.of(clientDescription));
     }
 
 }

--- a/lock-api/src/main/java/com/palantir/lock/v2/WaitForLocksRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/WaitForLocksRequest.java
@@ -47,8 +47,10 @@ public interface WaitForLocksRequest {
         return ImmutableWaitForLocksRequest.of(UUID.randomUUID(), lockDescriptors, acquireTimeoutMs, Optional.empty());
     }
 
-    static WaitForLocksRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs, String clientDescription) {
-        return ImmutableWaitForLocksRequest.of(UUID.randomUUID(), lockDescriptors, acquireTimeoutMs, Optional.of(clientDescription));
+    static WaitForLocksRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs,
+            String clientDescription) {
+        return ImmutableWaitForLocksRequest.of(UUID.randomUUID(), lockDescriptors, acquireTimeoutMs,
+                Optional.of(clientDescription));
     }
 
 }

--- a/lock-api/src/main/java/com/palantir/lock/v2/WaitForLocksRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/WaitForLocksRequest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.lock.v2;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -39,8 +40,15 @@ public interface WaitForLocksRequest {
     @Value.Parameter
     long getAcquireTimeoutMs();
 
+    @Value.Parameter
+    Optional<String> getClientDescription();
+
     static WaitForLocksRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs) {
-        return ImmutableWaitForLocksRequest.of(UUID.randomUUID(), lockDescriptors, acquireTimeoutMs);
+        return ImmutableWaitForLocksRequest.of(UUID.randomUUID(), lockDescriptors, acquireTimeoutMs, Optional.empty());
+    }
+
+    static WaitForLocksRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs, String clientDescription) {
+        return ImmutableWaitForLocksRequest.of(UUID.randomUUID(), lockDescriptors, acquireTimeoutMs, Optional.of(clientDescription));
     }
 
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
@@ -26,9 +26,6 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.palantir.atlasdb.timelock.lock.AsyncResult;
 import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.lock.v2.LockImmutableTimestampRequest;
@@ -44,8 +41,6 @@ import com.palantir.timestamp.TimestampRange;
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class AsyncTimelockResource {
-
-    private static final Logger log = LoggerFactory.getLogger(AsyncTimelockResource.class);
 
     private final AsyncTimelockService timelock;
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLock.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLock.java
@@ -18,6 +18,8 @@ package com.palantir.atlasdb.timelock.lock;
 
 import java.util.UUID;
 
+import com.palantir.lock.LockDescriptor;
+
 public interface AsyncLock {
 
     AsyncResult<Void> lock(UUID requestId);
@@ -27,5 +29,7 @@ public interface AsyncLock {
     void unlock(UUID requestId);
 
     void timeout(UUID requestId);
+
+    LockDescriptor getDescriptor();
 
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
@@ -43,7 +43,7 @@ public class AsyncLockService {
             ScheduledExecutorService reaperExecutor,
             ScheduledExecutorService timeoutExecutor) {
         return new AsyncLockService(
-                new LockCollection(() -> new ExclusiveLock()),
+                new LockCollection(),
                 new ImmutableTimestampTracker(),
                 new LockAcquirer(timeoutExecutor),
                 new HeldLocksCollection(),

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/ExclusiveLock.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/ExclusiveLock.java
@@ -26,14 +26,21 @@ import javax.annotation.concurrent.NotThreadSafe;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.timelock.util.LoggableIllegalStateException;
+import com.palantir.lock.LockDescriptor;
 import com.palantir.logsafe.SafeArg;
 
 public class ExclusiveLock implements AsyncLock {
+
+    private final LockDescriptor descriptor;
 
     @GuardedBy("this")
     private final LockRequestQueue queue = new LockRequestQueue();
     @GuardedBy("this")
     private UUID currentHolder = null;
+
+    public ExclusiveLock(LockDescriptor descriptor) {
+        this.descriptor = descriptor;
+    }
 
     @Override
     public synchronized AsyncResult<Void> lock(UUID requestId) {
@@ -56,6 +63,11 @@ public class ExclusiveLock implements AsyncLock {
     @Override
     public synchronized void timeout(UUID requestId) {
         queue.timeoutAndRemoveIfStillQueued(requestId);
+    }
+
+    @Override
+    public LockDescriptor getDescriptor() {
+        return descriptor;
     }
 
     @VisibleForTesting

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/ImmutableTimestampLock.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/ImmutableTimestampLock.java
@@ -20,6 +20,9 @@ import java.util.UUID;
 
 import javax.ws.rs.NotSupportedException;
 
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.StringLockDescriptor;
+
 public class ImmutableTimestampLock implements AsyncLock {
 
     private final long timestamp;
@@ -49,5 +52,10 @@ public class ImmutableTimestampLock implements AsyncLock {
     @Override
     public void timeout(UUID requestId) {
         throw new NotSupportedException();
+    }
+
+    @Override
+    public LockDescriptor getDescriptor() {
+        return StringLockDescriptor.of("ImmutableTimestamp:" + timestamp);
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockCollection.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockCollection.java
@@ -20,7 +20,6 @@ package com.palantir.atlasdb.timelock.lock;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -30,17 +29,15 @@ import com.palantir.lock.LockDescriptor;
 
 public class LockCollection {
 
-    private final Supplier<ExclusiveLock> lockFactory;
     private final LoadingCache<LockDescriptor, ExclusiveLock> locksById;
 
-    public LockCollection(Supplier<ExclusiveLock> lockFactory) {
-        this.lockFactory = lockFactory;
+    public LockCollection() {
         locksById = CacheBuilder.newBuilder()
                 .weakValues()
                 .build(new CacheLoader<LockDescriptor, ExclusiveLock>() {
                     @Override
-                    public ExclusiveLock load(LockDescriptor key) throws Exception {
-                        return lockFactory.get();
+                    public ExclusiveLock load(LockDescriptor descriptor) throws Exception {
+                        return new ExclusiveLock(descriptor);
                     }
                 });
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockEvents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockEvents.java
@@ -45,14 +45,14 @@ public class LockEvents {
     private final Meter lockExpiredMeter;
 
     public LockEvents(MetricRegistry metrics) {
-        requestTimer = metrics.timer("lock.lock-request");
+        requestTimer = metrics.timer("lock.blocking-time");
         successfulSlowAcquisitionMeter = metrics.meter("lock.successful-slow-acquisition");
         timedOutSlowAcquisitionMeter = metrics.meter("lock.timeout-slow-acquisition");
         lockExpiredMeter = metrics.meter("lock.expired");
     }
 
-    public void requestComplete(long durationMillis) {
-        requestTimer.update(durationMillis, TimeUnit.MILLISECONDS);
+    public void requestComplete(long blockingTimeMillis) {
+        requestTimer.update(blockingTimeMillis, TimeUnit.MILLISECONDS);
     }
 
     public void lockExpired(UUID requestId, Collection<LockDescriptor> lockDescriptors) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockEvents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockEvents.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.lock;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
+
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.v2.LockRequestV2;
+import com.palantir.lock.v2.WaitForLocksRequest;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+
+
+public class LockEvents {
+
+    private static final Logger log = LoggerFactory.getLogger("async-lock");
+
+    private final Meter successfulSlowAcquisitionMeter;
+    private final Meter timedOutSlowAcquisitionMeter;
+    private final Meter lockExpiredMeter;
+
+    public LockEvents(MetricRegistry metrics) {
+        successfulSlowAcquisitionMeter = metrics.meter("lock.successful-slow-acquisition");
+        timedOutSlowAcquisitionMeter = metrics.meter("lock.timeout-slow-acquisition");
+        lockExpiredMeter = metrics.meter("lock.expired");
+    }
+
+    public void lockExpired(UUID requestId, Collection<LockDescriptor> lockDescriptors) {
+        log.warn("Lock expired",
+                SafeArg.of("requestId", requestId),
+                UnsafeArg.of("lockDescriptors", lockDescriptors));
+        lockExpiredMeter.mark();
+    }
+
+    public void successfulSlowAcquisition(RequestInfo request, long acquisitionTimeMillis) {
+        log.warn("Locks took a long time to acquire",
+                SafeArg.of("requestId", request.id()),
+                SafeArg.of("acquisitionTimeMillis", acquisitionTimeMillis),
+                UnsafeArg.of("lockDescriptors", request.lockDescriptors()),
+                UnsafeArg.of("clientDescription", request.clientDescription()));
+        successfulSlowAcquisitionMeter.mark();
+    }
+
+    public void timedOutSlowAcquisition(RequestInfo request, long acquisitionTimeMillis) {
+        log.warn("Request timed out before obtaining locks",
+                SafeArg.of("requestId", request.id()),
+                SafeArg.of("acquisitionTimeMillis", acquisitionTimeMillis),
+                UnsafeArg.of("lockDescriptors", request.lockDescriptors()),
+                UnsafeArg.of("clientDescription", request.clientDescription()));
+        timedOutSlowAcquisitionMeter.mark();
+    }
+
+
+    @Value.Immutable
+    public interface RequestInfo {
+
+        String EMPTY_DESCRIPTION = "<no description provided>";
+
+        @Value.Parameter
+        UUID id();
+
+        @Value.Parameter
+        String clientDescription();
+
+        @Value.Parameter
+        Set<LockDescriptor> lockDescriptors();
+
+        static RequestInfo of(LockRequestV2 request) {
+            return ImmutableRequestInfo.of(
+                    request.getRequestId(),
+                    request.getClientDescription().orElse(EMPTY_DESCRIPTION),
+                    request.getLockDescriptors());
+        }
+
+        static RequestInfo of(WaitForLocksRequest request) {
+            return ImmutableRequestInfo.of(
+                    request.getRequestId(),
+                    request.getClientDescription().orElse(EMPTY_DESCRIPTION),
+                    request.getLockDescriptors());
+        }
+    }
+
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.lock;
+
+import java.util.Collection;
+import java.util.UUID;
+
+import com.palantir.atlasdb.timelock.lock.LockEvents.RequestInfo;
+import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.v2.LockRequestV2;
+import com.palantir.lock.v2.WaitForLocksRequest;
+
+public final class LockLog {
+
+    private static final long SLOW_LOCK_THRESHOLD_MILLIS = 1_000;
+    private static final LockEvents events = new LockEvents(AtlasDbMetrics.getMetricRegistry());
+
+    private LockLog() { }
+
+    public static void registerRequest(LockRequestV2 request, AsyncResult<?> result) {
+        registerRequest(RequestInfo.of(request), result);
+    }
+
+    public static void registerRequest(WaitForLocksRequest request, AsyncResult<?> result) {
+        registerRequest(RequestInfo.of(request), result);
+    }
+
+    private static void registerRequest(RequestInfo requestInfo, AsyncResult<?> result) {
+        if (result.isComplete()) {
+            return;
+        }
+
+        long start = System.currentTimeMillis();
+        result.onComplete(() -> {
+            long duration = System.currentTimeMillis() - start;
+            if (duration < SLOW_LOCK_THRESHOLD_MILLIS) {
+                return;
+            }
+
+            if (result.isCompletedSuccessfully()) {
+                events.successfulSlowAcquisition(requestInfo, duration);
+            } else if (result.isTimedOut()) {
+                events.timedOutSlowAcquisition(requestInfo, duration);
+            }
+        });
+    }
+
+    public static void lockExpired(UUID requestId, Collection<LockDescriptor> lockDescriptors) {
+        events.lockExpired(requestId, lockDescriptors);
+    }
+
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
@@ -27,7 +27,7 @@ import com.palantir.lock.v2.WaitForLocksRequest;
 
 public final class LockLog {
 
-    private static final long SLOW_LOCK_THRESHOLD_MILLIS = 1_000;
+    private static final long SLOW_LOCK_THRESHOLD_MILLIS = 2_000;
     private static final LockEvents events = new LockEvents(AtlasDbMetrics.getMetricRegistry());
 
     private LockLog() { }
@@ -56,17 +56,17 @@ public final class LockLog {
     private static void requestComplete(
             RequestInfo requestInfo,
             AsyncResult<?> result,
-            long durationMillis) {
-        events.requestComplete(durationMillis);
+            long blockingTimeMillis) {
+        events.requestComplete(blockingTimeMillis);
 
-        if (durationMillis < SLOW_LOCK_THRESHOLD_MILLIS) {
+        if (blockingTimeMillis < SLOW_LOCK_THRESHOLD_MILLIS) {
             return;
         }
 
         if (result.isCompletedSuccessfully()) {
-            events.successfulSlowAcquisition(requestInfo, durationMillis);
+            events.successfulSlowAcquisition(requestInfo, blockingTimeMillis);
         } else if (result.isTimedOut()) {
-            events.timedOutSlowAcquisition(requestInfo, durationMillis);
+            events.timedOutSlowAcquisition(requestInfo, blockingTimeMillis);
         }
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -449,7 +449,7 @@ public class PaxosTimeLockServerIntegrationTest {
         assertContainsTimer(metrics, "com.palantir.paxos.PaxosProposer.test.propose");
 
         // async lock
-        assertContainsTimer(metrics, "lock.lock-request");
+        assertContainsTimer(metrics, "lock.blocking-time");
     }
 
     private static void assertContainsTimer(JsonNode metrics, String name) {

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -54,7 +54,7 @@ public class AsyncLockServiceEteTest {
     private static final TimeLimit LONG_TIMEOUT = TimeLimit.of(100_000L);
 
     private final AsyncLockService service = new AsyncLockService(
-            new LockCollection(() -> new ExclusiveLock()),
+            new LockCollection(),
             new ImmutableTimestampTracker(),
             new LockAcquirer(Executors.newSingleThreadScheduledExecutor()),
             new HeldLocksCollection(),

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -46,6 +46,8 @@ public class AsyncLockServiceTest {
 
     private static final UUID REQUEST_ID = UUID.randomUUID();
 
+    private static final LockDescriptor LOCK_DESCRIPTOR = StringLockDescriptor.of("foo");
+
     private static final String LOCK_A = "a";
     private static final String LOCK_B = "b";
     public static final long REAPER_PERIOD_MS = LeaseExpirationTimer.LEASE_TIMEOUT_MILLIS / 2;
@@ -142,7 +144,7 @@ public class AsyncLockServiceTest {
     }
 
     private ExclusiveLock newLock() {
-        return new ExclusiveLock();
+        return new ExclusiveLock(LOCK_DESCRIPTOR);
     }
 
     private Set<LockDescriptor> descriptors(String... lockNames) {

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/ExclusiveLockTests.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/ExclusiveLockTests.java
@@ -24,13 +24,18 @@ import java.util.UUID;
 
 import org.junit.Test;
 
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.StringLockDescriptor;
+
 public class ExclusiveLockTests {
 
     private static final UUID REQUEST_1 = UUID.randomUUID();
     private static final UUID REQUEST_2 = UUID.randomUUID();
     private static final UUID REQUEST_3 = UUID.randomUUID();
 
-    private final ExclusiveLock lock = new ExclusiveLock();
+    private static final LockDescriptor LOCK_DESCRIPTOR = StringLockDescriptor.of("foo");
+
+    private final ExclusiveLock lock = new ExclusiveLock(LOCK_DESCRIPTOR);
 
     @Test
     public void canLockAndUnlock() {

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/HeldLocksTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/HeldLocksTest.java
@@ -29,13 +29,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.StringLockDescriptor;
 
 public class HeldLocksTest {
 
     private static final UUID REQUEST_ID = UUID.randomUUID();
 
-    private final ExclusiveLock lockA = spy(new ExclusiveLock());
-    private final ExclusiveLock lockB = spy(new ExclusiveLock());
+    private static final LockDescriptor LOCK_DESCRIPTOR = StringLockDescriptor.of("foo");
+
+    private final ExclusiveLock lockA = spy(new ExclusiveLock(LOCK_DESCRIPTOR));
+    private final ExclusiveLock lockB = spy(new ExclusiveLock(LOCK_DESCRIPTOR));
 
     private final LeaseExpirationTimer timer = mock(LeaseExpirationTimer.class);
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LockAcquirerTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LockAcquirerTest.java
@@ -38,19 +38,23 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.StringLockDescriptor;
 
 public class LockAcquirerTest {
 
     private static final UUID REQUEST_ID = UUID.randomUUID();
     private static final UUID OTHER_REQUEST_ID = UUID.randomUUID();
 
+    private static final LockDescriptor LOCK_DESCRIPTOR = StringLockDescriptor.of("foo");
+
     private static final TimeLimit TIMEOUT = TimeLimit.of(123L);
 
     private final DeterministicScheduler executor = new DeterministicScheduler();
 
-    private final ExclusiveLock lockA = spy(new ExclusiveLock());
-    private final ExclusiveLock lockB = spy(new ExclusiveLock());
-    private final ExclusiveLock lockC = spy(new ExclusiveLock());
+    private final ExclusiveLock lockA = spy(new ExclusiveLock(LOCK_DESCRIPTOR));
+    private final ExclusiveLock lockB = spy(new ExclusiveLock(LOCK_DESCRIPTOR));
+    private final ExclusiveLock lockC = spy(new ExclusiveLock(LOCK_DESCRIPTOR));
 
     private final LockAcquirer lockAcquirer = new LockAcquirer(executor);
 
@@ -83,7 +87,7 @@ public class LockAcquirerTest {
     @Test(timeout = 10_000)
     public void doesNotStackOverflowIfLocksAreAcquiredSynchronously() {
         List<AsyncLock> locks = IntStream.range(0, 10_000)
-                .mapToObj(i -> new ExclusiveLock())
+                .mapToObj(i -> new ExclusiveLock(LOCK_DESCRIPTOR))
                 .collect(Collectors.toList());
 
         AsyncResult<HeldLocks> acquisitions = acquire(locks);

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LockCollectionTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LockCollectionTest.java
@@ -33,8 +33,7 @@ import com.palantir.lock.StringLockDescriptor;
 
 public class LockCollectionTest {
 
-    private final LockCollection lockCollection = new LockCollection(
-            () -> new ExclusiveLock());
+    private final LockCollection lockCollection = new LockCollection();
 
     @Test
     public void createsLocksOnDemand() {


### PR DESCRIPTION
**Goals (and why)**:
Add basic logging and metrics for async lock

**Implementation Description (bullets)**:
The following events are recorded:
- request that took more than 1s to acquire locks, whether successfully or not
- locks that expired

**Concerns (what feedback would you like?)**:
- Is this a sufficient minimal set of events to record, to give us good signal and debuggability of early async lock deployment tests?

**Where should we start reviewing?**:
`LockLog`

**Priority (whenever / two weeks / yesterday)**:
today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2133)
<!-- Reviewable:end -->
