### PR TITLE
Don't fail to startup if sweep configs are enabled on old config

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -239,14 +239,6 @@ public abstract class AtlasDbConfig {
 
         Preconditions.checkState(lock().isPresent() == timestamp().isPresent(),
                 "Lock and timestamp server blocks must either both be present or both be absent.");
-
-        Preconditions.checkState(getSweepBatchSize() == null
-                        && getSweepCellBatchSize() == null
-                        && getSweepReadLimit() == null
-                        && getSweepCandidateBatchHint() == null
-                        && getSweepDeleteBatchHint() == null,
-                "Your configuration specifies sweep parameters on the install config."
-                        + " Please use the runtime config to specify them.");
     }
 
     private boolean areTimeAndLockConfigsAbsent() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -292,7 +292,7 @@ public final class TransactionManagers {
                 || config.getSweepReadLimit() != null
                 || config.getSweepCandidateBatchHint() != null
                 || config.getSweepDeleteBatchHint() != null) {
-            log.error("Your configuration specifies sweep parameters on the install config."
+            log.error("Your configuration specifies sweep parameters on the install config. They will be ignored."
                     + " Please use the runtime config to specify them.");
         }
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -202,6 +202,8 @@ public final class TransactionManagers {
             LockServerOptions lockServerOptions,
             boolean allowHiddenTableAccess,
             String userAgent) {
+        checkInstallConfig(config);
+
         ServiceDiscoveringAtlasSupplier atlasFactory =
                 new ServiceDiscoveringAtlasSupplier(config.keyValueService(), config.leader());
 
@@ -282,6 +284,17 @@ public final class TransactionManagers {
                 persistentLockManager);
 
         return transactionManager;
+    }
+
+    private static void checkInstallConfig(AtlasDbConfig config) {
+        if (config.getSweepBatchSize() != null
+                || config.getSweepCellBatchSize() != null
+                || config.getSweepReadLimit() != null
+                || config.getSweepCandidateBatchHint() != null
+                || config.getSweepDeleteBatchHint() != null) {
+            log.error("Your configuration specifies sweep parameters on the install config."
+                    + " Please use the runtime config to specify them.");
+        }
     }
 
     private static void initializeSweepEndpointAndBackgroundProcess(

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,6 +45,10 @@ develop
          - Change
 
     *    - |fixed|
+         - Instead of failing to startup, log an error if old sweep configs are specified in the AtlasDbConfig block.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2134>`__)
+
+    *    - |fixed|
          - ``TransactionManager.close()`` now closes the lock service (provided it is closeable), and also shuts down the Background Sweeper.
            Previously, the lock service's background threads as well as background sweeper would continue to run (potentially indefinitely) even after a transaction manager was closed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2102>`__)


### PR DESCRIPTION
**Goals (and why)**: Don't fail to startup if sweep configs are specified on AtlasDbConfig, to make it a smoother transition to people picking up the newest version.

**Implementation Description (bullets)**: -

**Concerns (what feedback would you like?)**: -

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: -

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2134)
<!-- Reviewable:end -->
