### PR TITLE
use new timelock endpoints

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -454,13 +454,13 @@ public final class TransactionManagers {
             String userAgent) {
         RemoteLockService lockService = new ServiceCreator<>(RemoteLockService.class, userAgent)
                 .apply(timelockServerListConfig);
-        TimestampService timeService = new ServiceCreator<>(TimestampService.class, userAgent)
+        TimelockService timelockService = new ServiceCreator<>(TimelockService.class, userAgent)
                 .apply(timelockServerListConfig);
 
         return ImmutableLockAndTimestampServices.builder()
                 .lock(lockService)
-                .timestamp(timeService)
-                .timelock(new LegacyTimelockService(timeService, lockService, LOCK_CLIENT))
+                .timestamp(new TimelockTimestampServiceAdapter(timelockService))
+                .timelock(timelockService)
                 .build();
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -86,10 +86,12 @@ public class TransactionManagersTest {
     private static final String LOCK_PATH = "/lock/current-time-millis";
     private static final MappingBuilder LOCK_MAPPING = post(urlEqualTo(LOCK_PATH));
 
-    private static final String TIMELOCK_TIMESTAMP_PATH = "/" + CLIENT + TIMESTAMP_PATH;
+    private static final String TIMELOCK_TIMESTAMP_PATH = "/" + CLIENT + "/timelock/fresh-timestamp";
     private static final MappingBuilder TIMELOCK_TIMESTAMP_MAPPING = post(urlEqualTo(TIMELOCK_TIMESTAMP_PATH));
-    private static final String TIMELOCK_LOCK_PATH = "/" + CLIENT + LOCK_PATH;
+    private static final String TIMELOCK_LOCK_PATH = "/" + CLIENT + "/timelock/current-time-millis";
     private static final MappingBuilder TIMELOCK_LOCK_MAPPING = post(urlEqualTo(TIMELOCK_LOCK_PATH));
+
+
     private static final String TIMELOCK_PING_PATH =  "/" + CLIENT + "/timestamp-management/ping";
     private static final MappingBuilder TIMELOCK_PING_MAPPING = get(urlEqualTo(TIMELOCK_PING_PATH));
     private static final String TIMELOCK_FF_PATH
@@ -153,6 +155,9 @@ public class TransactionManagersTest {
     @Test
     public void userAgentsPresentOnRequestsToTimelockServer() {
         when(config.timelock()).thenReturn(Optional.of(mockClientConfig));
+
+        availableServer.stubFor(post(urlMatching("/")).willReturn(aResponse().withStatus(200).withBody("3")));
+        availableServer.stubFor(TIMELOCK_LOCK_MAPPING.willReturn(aResponse().withStatus(200).withBody("4")));
 
         verifyUserAgentOnTimelockTimestampAndLockRequests();
     }
@@ -309,7 +314,7 @@ public class TransactionManagersTest {
                         invalidator,
                         USER_AGENT);
         lockAndTimestampServices.timelock().getFreshTimestamp();
-        lockAndTimestampServices.lock().currentTimeMillis();
+        lockAndTimestampServices.timelock().currentTimeMillis();
 
         availableServer.verify(postRequestedFor(urlMatching(timestampPath))
                 .withHeader(USER_AGENT_HEADER, WireMock.equalTo(USER_AGENT)));


### PR DESCRIPTION
**Goals (and why)**:
Hit the new /timelock endpoints with the atlas client

**Implementation Description (bullets)**:
Create a real `TimelockService` rather than `LegacyTimelockServiceAdapter`

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
one file

**Priority (whenever / two weeks / yesterday)**:
today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2135)
<!-- Reviewable:end -->
