### PR TITLE
Validate returned connections ourselves.

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -95,6 +95,14 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
                 } catch (SQLException e) {
                     log.error("Dropping connection which failed validation", e);
                     dataSourcePool.evictConnection(conn);
+
+                    if (System.currentTimeMillis() > start + connConfig.getCheckoutTimeout()) {
+                        // it's been long enough that had hikari been
+                        // validating internally it would have given up rather
+                        // than retry
+                        throw e;
+                    }
+
                     continue;
                 }
 


### PR DESCRIPTION
Hikari apparently doesn't for connections which have been in the pool
for a short enough time (as of writing).  In particular, it was observed
that java interrupts could corrupt the Oracle driver's connections in a
way Hikari did not detect.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2142)
<!-- Reviewable:end -->
