### PR TITLE
Make LockServiceImpl.close idempotent and enable assertions on tests

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,6 +54,10 @@ develop
            and blocks certain internal products from upgrading to versions thereafter.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2122>`__)
 
+    *    - |fixed|
+         - ``LockServiceImpl.close()`` is now idempotent. Previously, calling the referred method more than once could fail an assertion and throw an exception. This has been fixed.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2144>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 ======

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -90,6 +90,8 @@ tasks.withType(Test) {
         reports.junitXml.destination = new File(System.env.CIRCLE_TEST_REPORTS, it.getName())
     }
 
+    enableAssertions = true
+
     testLogging {
         showExceptions true
         exceptionFormat "full"

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -1061,10 +1061,12 @@ public final class LockServiceImpl
 
     @Override
     public void close() {
+        if (!isShutDown) {
+            executor.shutdownNow();
+            wakeIndefiniteBlockers();
+            callOnClose.run();
+        }
         isShutDown = true;
-        executor.shutdownNow();
-        wakeIndefiniteBlockers();
-        callOnClose.run();
     }
 
     private void wakeIndefiniteBlockers() {

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
@@ -177,7 +178,7 @@ public final class LockServiceImpl
     private final TimeDuration maxNormalLockAge;
     private final int randomBitCount;
     private final Runnable callOnClose;
-    private volatile boolean isShutDown = false;
+    private final AtomicBoolean isShutDown = new AtomicBoolean(false);
     private final String lockStateLoggerDir;
 
     private final LockClientIndices clientIndices = new LockClientIndices();
@@ -346,7 +347,7 @@ public final class LockServiceImpl
                     request, request.getCreatingThreadName());
         }
         Map<ClientAwareReadWriteLock, LockMode> locks = Maps.newLinkedHashMap();
-        if (isShutDown) {
+        if (isShutDown.get()) {
             throw new ServiceNotAvailableException("This lock server is shut down.");
         }
         try {
@@ -943,7 +944,7 @@ public final class LockServiceImpl
             // If interrupt signal happens right after try {} catch (InterruptedException),
             // the interrupt state MIGHT be swallowed in catch (Throwable t) {}; so threads will
             // miss the shutdown signal.
-            if (isShutDown) {
+            if (isShutDown.get()) {
                 break;
             }
             try {
@@ -958,7 +959,7 @@ public final class LockServiceImpl
                         Thread.sleep(sleepTimeMs);
                     }
                 } catch (InterruptedException e) {
-                    if (isShutDown) {
+                    if (isShutDown.get()) {
                         break;
                     } else {
                         log.warn("The lock server reaper thread should not be " +
@@ -1061,12 +1062,11 @@ public final class LockServiceImpl
 
     @Override
     public void close() {
-        if (!isShutDown) {
+        if (isShutDown.compareAndSet(false, true)) {
             executor.shutdownNow();
             wakeIndefiniteBlockers();
             callOnClose.run();
         }
-        isShutDown = true;
     }
 
     private void wakeIndefiniteBlockers() {


### PR DESCRIPTION
**Goals (and why)**: The following stacktrace was thrown in an internal testing build:
```
ERROR [2017-07-12 11:31:34,814] [Test worker] com.palantir.util.JMXUtils - Assertion Failed to unregister mbean for name com.palantir.lock:type=LockServer_52 with exception javax.management.InstanceNotFoundException: com.palantir.lock:type=LockServer_52
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getMBean(DefaultMBeanServerInterceptor.java:1095)
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.exclusiveUnregisterMBean(DefaultMBeanServerInterceptor.java:427)
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.unregisterMBean(DefaultMBeanServerInterceptor.java:415)
at com.sun.jmx.mbeanserver.JmxMBeanServer.unregisterMBean(JmxMBeanServer.java:546)
at com.palantir.util.JMXUtils.unregisterMBeanCatchAndLogExceptions(JMXUtils.java:155)
at com.palantir.lock.impl.LockServiceImpl$4.run(LockServiceImpl.java:246)
at com.palantir.lock.impl.LockServiceImpl.close(LockServiceImpl.java:1067)
...
```

We believe that making LockServiceImpl.close idempotent should fix this problem. We're also enabling assertions on our tests, since this was the reason for our test infrastructure not catching this.

**Implementation Description (bullets)**: -

**Concerns (what feedback would you like?)**: Should I make `isShutDown` an atomic boolean?

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: -

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2144)
<!-- Reviewable:end -->
