### PR TITLE
Release Notes 0.48.0

### DIFF
--- a/docs/source/cluster_management/sweep.rst
+++ b/docs/source/cluster_management/sweep.rst
@@ -53,7 +53,7 @@ Note that some of these parameters are just used as a hint. Sweep dynamically mo
    :header: "AtlasDB Runtime Config", "Endpoint Option", "Default", "Description"
    :widths: 20, 20, 40, 200
 
-   ``enabled``, "Only specified in config", "1,000", "Target number of (cell, timestamp) pairs to examine in a single run."
+   ``enabled``, "Only specified in config", "true", "Whether the background sweeper should run."
    ``readLimit``, ``maxCellTsPairsToExamine``, "1,000", "Target number of (cell, timestamp) pairs to examine in a single run."
    ``candidateBatchHint``, ``candidateBatchSize``, "1", "Target number of candidate (cell, timestamp) pairs to load at once. Decrease this if sweep fails to complete (for example if the sweep job or the underlying KVS runs out of memory). Increasing it may improve sweep performance."
    ``deleteBatchHint``, ``deleteBatchSize``, "1,000", "Target number of (cell, timestamp) pairs to delete in a single batch. Decrease if sweep cannot progress pass a large row or a large cell. Increasing it may improve sweep performance."

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -69,9 +69,10 @@ develop
            Products that do not use this class directly are not affected.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2083>`__)
 
-    *    - |fixed|
+    *    - |fixed| |devbreak|
          - ``TransactionManager.close()`` now closes the lock service (provided it is closeable), and also shuts down the Background Sweeper.
            Previously, the lock service's background threads as well as background sweeper would continue to run (potentially indefinitely) even after a transaction manager was closed.
+           Note that services that relied on the lock service being available even after a transaction manager was shut down may no longer behave properly, and should ensure that the transaction manager is not shut down while the lock service is still needed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2102>`__)
 
     *    - |fixed|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -80,7 +80,8 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2122>`__)
 
     *    - |fixed|
-         - ``LockServiceImpl.close()`` is now idempotent. Previously, calling the referred method more than once could fail an assertion and throw an exception. This has been fixed.
+         - ``LockServiceImpl.close()`` is now idempotent.
+           Previously, calling the referred method more than once could fail an assertion and throw an exception.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2144>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,14 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - If sweep configs are specified in the AtlasDbConfig block, they will be ignored, but AtlasDB will no longer fail to start.
+           This effectively fixes the Sweep-related user break change of version ``0.47.0``.
+           Note that users of products that upgraded from ``0.45.0`` to ``0.48.0`` will need to move configuration overrides from the regular ``atlasdb`` config to the ``atlasdb-runtime`` config for them to continue taking effect.
+           Please reference the Sweep :ref:`configuration docs <sweep_tunable_parameters>` for more details.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2134>`__)
 
-    *    - |improved|
+    *    - |new|
          - AtlasDB now supports batching of timestamp requests on the client-side; see :ref:`Timestamp Client Options <timestamp-client-config>` for details.
            On internal benchmarks, the AtlasDB team has obtained an almost 2x improvement in timestamp throughput and latency under modest load (32 threads), and an over 10x improvement under heavy load (8,192 threads).
            There may be a very small increase in latency under extremely light load (e.g. 2-4 threads).
@@ -60,12 +66,8 @@ develop
 
     *    - |devbreak|
          - The ``RateLimitingTimestampService`` in ``timestamp-impl`` has been renamed to ``RequestBatchingTimestampService``, to better reflect what the service does and avoid confusion with the ``ThreadPooledLockService`` (which performs resource-limiting).
+           Products that do not use this class directly are not affected.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2083>`__)
-
-    *    - |fixed|
-         - If sweep configs are specified in the AtlasDbConfig block, they will be ignored, but AtlasDB will no longer fail to start.
-           This effectively fixes the user break change of version ``0.47.0``.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2134>`__)
 
     *    - |fixed|
          - ``TransactionManager.close()`` now closes the lock service (provided it is closeable), and also shuts down the Background Sweeper.
@@ -73,8 +75,8 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2102>`__)
 
     *    - |fixed|
-         - ``common-executors`` now uses Java 6 when compiling from source and generates classes targeting Java 6. Java 6 support was removed in AtlasDB ``0.41.0``
-           and blocks certain internal products from upgrading to subsequent versions.
+         - ``commons-executors`` now uses Java 6 when compiling from source and generates classes targeting Java 6.
+           Java 6 support was removed in AtlasDB ``0.41.0`` and blocks certain internal products from upgrading to subsequent versions.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2122>`__)
 
     *    - |fixed|


### PR DESCRIPTION
**Goals (and why)**: Cleanup the release notes in preparation for the 0.48.0 release

**Implementation Description (bullets)**: Cleanup the release notes.

**Concerns (what feedback would you like?)**:
* Should the entry for Commons-Executors be marked as a dev break, because developers working with AtlasDB from source need Java 6 to compile now?
* Should the entry for TM.close() closing the lock service be marked as a dev break in that it breaks services using lock services outside of the transaction protocol?

**Where should we start reviewing?**: release-notes.rst

**Priority (whenever / two weeks / yesterday)**: today, please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2145)
<!-- Reviewable:end -->
