### PR TITLE
logging limits

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockEvents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockEvents.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.common.collect.Iterables;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockRequestV2;
 import com.palantir.lock.v2.WaitForLocksRequest;
@@ -58,7 +59,7 @@ public class LockEvents {
     public void lockExpired(UUID requestId, Collection<LockDescriptor> lockDescriptors) {
         log.warn("Lock expired",
                 SafeArg.of("requestId", requestId),
-                UnsafeArg.of("lockDescriptors", lockDescriptors));
+                UnsafeArg.of("firstTenLockDescriptors", firstTen(lockDescriptors)));
         lockExpiredMeter.mark();
     }
 
@@ -66,7 +67,7 @@ public class LockEvents {
         log.warn("Locks took a long time to acquire",
                 SafeArg.of("requestId", request.id()),
                 SafeArg.of("acquisitionTimeMillis", acquisitionTimeMillis),
-                UnsafeArg.of("lockDescriptors", request.lockDescriptors()),
+                UnsafeArg.of("firstTenLockDescriptors", firstTen(request.lockDescriptors())),
                 UnsafeArg.of("clientDescription", request.clientDescription()));
         successfulSlowAcquisitionMeter.mark();
     }
@@ -75,9 +76,13 @@ public class LockEvents {
         log.warn("Request timed out before obtaining locks",
                 SafeArg.of("requestId", request.id()),
                 SafeArg.of("acquisitionTimeMillis", acquisitionTimeMillis),
-                UnsafeArg.of("lockDescriptors", request.lockDescriptors()),
+                UnsafeArg.of("firstTenLockDescriptors", firstTen(request.lockDescriptors())),
                 UnsafeArg.of("clientDescription", request.clientDescription()));
         timedOutSlowAcquisitionMeter.mark();
+    }
+
+    private Iterable<LockDescriptor> firstTen(Collection<LockDescriptor> lockDescriptors) {
+        return Iterables.limit(lockDescriptors, 10);
     }
 
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
@@ -27,7 +27,8 @@ import com.palantir.lock.v2.WaitForLocksRequest;
 
 public final class LockLog {
 
-    private static final long SLOW_LOCK_THRESHOLD_MILLIS = 2_000;
+    // TODO(nziebart): make this configurable
+    private static final long SLOW_LOCK_THRESHOLD_MILLIS = 5_000;
     private static final LockEvents events = new LockEvents(AtlasDbMetrics.getMetricRegistry());
 
     private LockLog() { }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
@@ -27,11 +27,14 @@ import com.palantir.lock.v2.WaitForLocksRequest;
 
 public final class LockLog {
 
-    // TODO(nziebart): make this configurable
-    private static final long SLOW_LOCK_THRESHOLD_MILLIS = 5_000;
+    private static volatile long slowLockThresholdMillis = 10_000;
     private static final LockEvents events = new LockEvents(AtlasDbMetrics.getMetricRegistry());
 
     private LockLog() { }
+
+    public static void setSlowLockThresholdMillis(long thresholdMillis) {
+        slowLockThresholdMillis = thresholdMillis;
+    }
 
     public static void registerRequest(LockRequestV2 request, AsyncResult<?> result) {
         registerRequest(RequestInfo.of(request), result);
@@ -60,7 +63,7 @@ public final class LockLog {
             long blockingTimeMillis) {
         events.requestComplete(blockingTimeMillis);
 
-        if (blockingTimeMillis < SLOW_LOCK_THRESHOLD_MILLIS) {
+        if (blockingTimeMillis < slowLockThresholdMillis) {
             return;
         }
 

--- a/timelock-server/src/integTest/resources/paxosSingleServer.yml
+++ b/timelock-server/src/integTest/resources/paxosSingleServer.yml
@@ -14,6 +14,7 @@ clients:
   - learner
   - acceptor
 
+useAsyncLockService: true
 useClientRequestLimit: true
 useAsyncLockService: true
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
@@ -55,6 +55,7 @@ import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 import com.palantir.atlasdb.timelock.lock.AsyncLockService;
 import com.palantir.atlasdb.timelock.lock.BlockingTimeLimitedLockService;
 import com.palantir.atlasdb.timelock.lock.BlockingTimeouts;
+import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.atlasdb.timelock.util.AsyncOrLegacyTimelockService;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.leader.LeaderElectionService;
@@ -187,6 +188,8 @@ public class PaxosTimeLockServer implements TimeLockServer {
                 RemoteLockService.class,
                 createLockService(slowLogTriggerMillis),
                 client);
+
+        LockLog.setSlowLockThresholdMillis(slowLogTriggerMillis);
 
         if (timeLockServerConfiguration.useAsyncLockService()) {
             return createTimeLockServicesWithAsync(client, rawTimestampServiceSupplier, lockService);


### PR DESCRIPTION
**Goals (and why)**:
Limit the logging for slow locks, to avoid spamming logs.
Since we have a meter for lock blocking time, we can evaluate in the field if we need to lower this limit or make it configurable

**Implementation Description (bullets)**:
- Limit number of lock descriptors logged
- Increase logging threshold
- Drive by change to fix integration test config

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2146)
<!-- Reviewable:end -->
