### PR TITLE
[RFC] Remove V2 suffixes?

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/RawTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/RawTransaction.java
@@ -15,13 +15,13 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 
 public class RawTransaction extends ForwardingTransaction {
     private final SnapshotTransaction delegate;
-    private final LockTokenV2 lock;
+    private final LockToken lock;
 
-    public RawTransaction(SnapshotTransaction delegate, LockTokenV2 lock) {
+    public RawTransaction(SnapshotTransaction delegate, LockToken lock) {
         this.delegate = delegate;
         this.lock = lock;
     }
@@ -31,7 +31,7 @@ public class RawTransaction extends ForwardingTransaction {
         return delegate;
     }
 
-    LockTokenV2 getImmutableTsLock() {
+    LockToken getImmutableTsLock() {
         return lock;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -71,7 +71,7 @@ import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitableView;
 import com.palantir.common.collect.IterableUtils;
 import com.palantir.common.collect.Maps2;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.util.Pair;
 
@@ -105,7 +105,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    ConflictDetectionManager conflictDetectionManager,
                                    SweepStrategyManager sweepStrategyManager,
                                    long immutableTimestamp,
-                                   Optional<LockTokenV2> immutableTsLock,
+                                   Optional<LockToken> immutableTsLock,
                                    AdvisoryLockPreCommitCheck advisoryLockCheck,
                                    AtlasDbConstraintCheckingMode constraintCheckingMode,
                                    Long transactionTimeoutMillis,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -26,7 +26,7 @@ import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.impl.LegacyTimelockService;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampService;
 
@@ -99,7 +99,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
     @Override
     protected SnapshotTransaction createTransaction(long immutableTimestamp,
             Supplier<Long> startTimestampSupplier,
-            LockTokenV2 immutableTsLock,
+            LockToken immutableTsLock,
             AdvisoryLockPreCommitCheck advisoryLockCheck) {
         return new SerializableTransaction(
                 keyValueService,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -49,7 +49,7 @@ import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.v2.LockImmutableTimestampRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampService;
 
@@ -120,7 +120,7 @@ import com.palantir.timestamp.TimestampService;
         LockImmutableTimestampResponse immutableTsResponse = timelockService.lockImmutableTimestamp(
                 LockImmutableTimestampRequest.create());
         try {
-            LockTokenV2 immutableTsLock = immutableTsResponse.getLock();
+            LockToken immutableTsLock = immutableTsResponse.getLock();
             long immutableTs = immutableTsResponse.getImmutableTimestamp();
             recordImmutableTimestamp(immutableTs);
             Supplier<Long> startTimestampSupplier = getStartTimestampSupplier();
@@ -158,7 +158,7 @@ import com.palantir.timestamp.TimestampService;
     protected SnapshotTransaction createTransaction(
             long immutableTimestamp,
             Supplier<Long> startTimestampSupplier,
-            LockTokenV2 immutableTsLock,
+            LockToken immutableTsLock,
             AdvisoryLockPreCommitCheck advisoryLockCheck) {
         return new SnapshotTransaction(
                 keyValueService,

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockImmutableTimestampResponse.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockImmutableTimestampResponse.java
@@ -31,9 +31,9 @@ public interface LockImmutableTimestampResponse {
     long getImmutableTimestamp();
 
     @Value.Parameter
-    LockTokenV2 getLock();
+    LockToken getLock();
 
-    static LockImmutableTimestampResponse of(long timestamp, LockTokenV2 lock) {
+    static LockImmutableTimestampResponse of(long timestamp, LockToken lock) {
         return ImmutableLockImmutableTimestampResponse.of(timestamp, lock);
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockRequest.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.lock.LockDescriptor;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableLockRequestV2.class)
-@JsonDeserialize(as = ImmutableLockRequestV2.class)
+@JsonSerialize(as = ImmutableLockRequest.class)
+@JsonDeserialize(as = ImmutableLockRequest.class)
 public interface LockRequest {
 
     @Value.Parameter
@@ -44,7 +44,7 @@ public interface LockRequest {
     Optional<String> getClientDescription();
 
     static LockRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs) {
-        return ImmutableLockRequestV2.of(
+        return ImmutableLockRequest.of(
                 UUID.randomUUID(),
                 lockDescriptors,
                 acquireTimeoutMs,
@@ -52,7 +52,7 @@ public interface LockRequest {
     }
 
     static LockRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs, String clientDescription) {
-        return ImmutableLockRequestV2.of(
+        return ImmutableLockRequest.of(
                 UUID.randomUUID(),
                 lockDescriptors,
                 acquireTimeoutMs,

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockRequest.java
@@ -29,7 +29,7 @@ import com.palantir.lock.LockDescriptor;
 @Value.Immutable
 @JsonSerialize(as = ImmutableLockRequestV2.class)
 @JsonDeserialize(as = ImmutableLockRequestV2.class)
-public interface LockRequestV2 {
+public interface LockRequest {
 
     @Value.Parameter
     UUID getRequestId();
@@ -43,7 +43,7 @@ public interface LockRequestV2 {
     @Value.Parameter
     Optional<String> getClientDescription();
 
-    static LockRequestV2 of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs) {
+    static LockRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs) {
         return ImmutableLockRequestV2.of(
                 UUID.randomUUID(),
                 lockDescriptors,
@@ -51,7 +51,7 @@ public interface LockRequestV2 {
                 Optional.of("Thread: " + Thread.currentThread().getName()));
     }
 
-    static LockRequestV2 of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs, String clientDescription) {
+    static LockRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs, String clientDescription) {
         return ImmutableLockRequestV2.of(
                 UUID.randomUUID(),
                 lockDescriptors,

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockResponse.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockResponse.java
@@ -27,10 +27,10 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @Value.Immutable
 @JsonSerialize(as = ImmutableLockResponseV2.class)
 @JsonDeserialize(as = ImmutableLockResponseV2.class)
-public interface LockResponseV2 {
+public interface LockResponse {
 
     @Value.Parameter
-    Optional<LockTokenV2> getTokenOrEmpty();
+    Optional<LockToken> getTokenOrEmpty();
 
     @JsonIgnore
     default boolean wasSuccessful() {
@@ -38,18 +38,18 @@ public interface LockResponseV2 {
     }
 
     @JsonIgnore
-    default LockTokenV2 getToken() {
+    default LockToken getToken() {
         if (!wasSuccessful()) {
             throw new IllegalStateException("This lock response was not succesful");
         }
         return getTokenOrEmpty().get();
     }
 
-    static LockResponseV2 successful(LockTokenV2 token) {
+    static LockResponse successful(LockToken token) {
         return ImmutableLockResponseV2.of(Optional.of(token));
     }
 
-    static LockResponseV2 timedOut() {
+    static LockResponse timedOut() {
         return ImmutableLockResponseV2.of(Optional.empty());
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockResponse.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockResponse.java
@@ -25,8 +25,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableLockResponseV2.class)
-@JsonDeserialize(as = ImmutableLockResponseV2.class)
+@JsonSerialize(as = ImmutableLockResponse.class)
+@JsonDeserialize(as = ImmutableLockResponse.class)
 public interface LockResponse {
 
     @Value.Parameter
@@ -40,17 +40,17 @@ public interface LockResponse {
     @JsonIgnore
     default LockToken getToken() {
         if (!wasSuccessful()) {
-            throw new IllegalStateException("This lock response was not succesful");
+            throw new IllegalStateException("This lock response was not successful");
         }
         return getTokenOrEmpty().get();
     }
 
     static LockResponse successful(LockToken token) {
-        return ImmutableLockResponseV2.of(Optional.of(token));
+        return ImmutableLockResponse.of(Optional.of(token));
     }
 
     static LockResponse timedOut() {
-        return ImmutableLockResponseV2.of(Optional.empty());
+        return ImmutableLockResponse.of(Optional.empty());
     }
 
 }

--- a/lock-api/src/main/java/com/palantir/lock/v2/LockToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/LockToken.java
@@ -24,15 +24,15 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableLockTokenV2.class)
-@JsonDeserialize(as = ImmutableLockTokenV2.class)
-public interface LockTokenV2 {
+@JsonSerialize(as = ImmutableLockToken.class)
+@JsonDeserialize(as = ImmutableLockToken.class)
+public interface LockToken {
 
     @Value.Parameter
     UUID getRequestId();
 
-    static LockTokenV2 of(UUID requestId) {
-        return ImmutableLockTokenV2.of(requestId);
+    static LockToken of(UUID requestId) {
+        return ImmutableLockToken.of(requestId);
     }
 
 }

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -50,7 +50,7 @@ public interface TimelockService {
 
     @POST
     @Path("lock")
-    LockResponseV2 lock(LockRequestV2 request);
+    LockResponse lock(LockRequest request);
 
     @POST
     @Path("await-locks")
@@ -58,11 +58,11 @@ public interface TimelockService {
 
     @POST
     @Path("refresh-locks")
-    Set<LockTokenV2> refreshLockLeases(Set<LockTokenV2> tokens);
+    Set<LockToken> refreshLockLeases(Set<LockToken> tokens);
 
     @POST
     @Path("unlock")
-    Set<LockTokenV2> unlock(Set<LockTokenV2> tokens);
+    Set<LockToken> unlock(Set<LockToken> tokens);
 
     @POST
     @Path("current-time-millis")

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockRefreshingTimelockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockRefreshingTimelockService.java
@@ -23,9 +23,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.lock.v2.LockImmutableTimestampRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
-import com.palantir.lock.v2.LockRequestV2;
-import com.palantir.lock.v2.LockResponseV2;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
@@ -77,8 +77,8 @@ public class LockRefreshingTimelockService implements TimelockService {
     }
 
     @Override
-    public LockResponseV2 lock(LockRequestV2 request) {
-        LockResponseV2 response = delegate.lock(request);
+    public LockResponse lock(LockRequest request) {
+        LockResponse response = delegate.lock(request);
         if (response.wasSuccessful()) {
             lockRefresher.registerLock(response.getToken());
         }
@@ -91,12 +91,12 @@ public class LockRefreshingTimelockService implements TimelockService {
     }
 
     @Override
-    public Set<LockTokenV2> refreshLockLeases(Set<LockTokenV2> tokens) {
+    public Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
         return delegate.refreshLockLeases(tokens);
     }
 
     @Override
-    public Set<LockTokenV2> unlock(Set<LockTokenV2> tokens) {
+    public Set<LockToken> unlock(Set<LockToken> tokens) {
         lockRefresher.unregisterLocks(tokens);
         return delegate.unlock(tokens);
     }

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockTokenConverter.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockTokenConverter.java
@@ -22,18 +22,18 @@ import java.util.UUID;
 
 import com.google.common.base.Preconditions;
 import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 
 class LockTokenConverter {
     
     private LockTokenConverter() { }
 
-    static LockRefreshToken toLegacyToken(LockTokenV2 tokenV2) {
+    static LockRefreshToken toLegacyToken(LockToken tokenV2) {
         return new LockRefreshToken(toBigInteger(tokenV2.getRequestId()), Long.MIN_VALUE);
     }
 
-    static LockTokenV2 toTokenV2(LockRefreshToken legacyToken) {
-        return LockTokenV2.of(toUuid(legacyToken.getTokenId()));
+    static LockToken toTokenV2(LockRefreshToken legacyToken) {
+        return LockToken.of(toUuid(legacyToken.getTokenId()));
     }
 
     private static BigInteger toBigInteger(UUID uuid) {

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LegacyTimelockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LegacyTimelockServiceTest.java
@@ -48,7 +48,6 @@ import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
-import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.timestamp.TimestampRange;
 import com.palantir.timestamp.TimestampService;
@@ -59,7 +58,7 @@ public class LegacyTimelockServiceTest {
 
     private static final long FRESH_TIMESTAMP = 5L;
 
-    private static final LockTokenV2 LOCK_TOKEN_V2 = randomLockToken();
+    private static final LockToken LOCK_TOKEN_V2 = randomLockToken();
     private static final LockRefreshToken LOCK_REFRESH_TOKEN = toLegacyToken(LOCK_TOKEN_V2);
 
     private static final LockDescriptor LOCK_A = StringLockDescriptor.of("a");
@@ -163,8 +162,8 @@ public class LegacyTimelockServiceTest {
 
     @Test
     public void unlockReturnsSubsetThatWereUnlocked() {
-        LockTokenV2 tokenA = randomLockToken();
-        LockTokenV2 tokenB = randomLockToken();
+        LockToken tokenA = randomLockToken();
+        LockToken tokenB = randomLockToken();
 
         when(lockService.unlock(toLegacyToken(tokenA))).thenReturn(true);
         when(lockService.unlock(toLegacyToken(tokenB))).thenReturn(false);
@@ -173,8 +172,8 @@ public class LegacyTimelockServiceTest {
         assertEquals(expected, timelock.unlock(ImmutableSet.of(tokenA, tokenB)));
     }
 
-    private static LockTokenV2 randomLockToken() {
-        return LockTokenV2.of(UUID.randomUUID());
+    private static LockToken randomLockToken() {
+        return LockToken.of(UUID.randomUUID());
     }
 
     @Test
@@ -206,11 +205,11 @@ public class LegacyTimelockServiceTest {
         return lockMap;
     }
 
-    private static LockRefreshToken toLegacyToken(LockTokenV2 token) {
+    private static LockRefreshToken toLegacyToken(LockToken token) {
         return LockTokenConverter.toLegacyToken(token);
     }
 
-    private static LockTokenV2 toTokenV2(LockRefreshToken token) {
+    private static LockToken toTokenV2(LockRefreshToken token) {
         return LockTokenConverter.toTokenV2(token);
     }
 

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LockRefresherTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LockRefresherTest.java
@@ -31,16 +31,16 @@ import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 
 public class LockRefresherTest {
 
     private static final long REFRESH_INTERVAL_MILLIS = 1234L;
 
-    private static final LockTokenV2 TOKEN_1 = LockTokenV2.of(UUID.randomUUID());
-    private static final LockTokenV2 TOKEN_2 = LockTokenV2.of(UUID.randomUUID());
-    private static final Set<LockTokenV2> TOKENS = ImmutableSet.of(TOKEN_1, TOKEN_2);
+    private static final LockToken TOKEN_1 = LockToken.of(UUID.randomUUID());
+    private static final LockToken TOKEN_2 = LockToken.of(UUID.randomUUID());
+    private static final Set<LockToken> TOKENS = ImmutableSet.of(TOKEN_1, TOKEN_2);
 
     private final DeterministicScheduler executor = new DeterministicScheduler();
     private final TimelockService timelock = mock(TimelockService.class);

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LockRefreshingTimelockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LockRefreshingTimelockServiceTest.java
@@ -35,18 +35,18 @@ import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.v2.LockImmutableTimestampRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
-import com.palantir.lock.v2.LockRequestV2;
-import com.palantir.lock.v2.LockResponseV2;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.timestamp.TimestampRange;
 
 public class LockRefreshingTimelockServiceTest {
 
-    private static final LockTokenV2 TOKEN_1 = LockTokenV2.of(UUID.randomUUID());
-    private static final LockTokenV2 TOKEN_2 = LockTokenV2.of(UUID.randomUUID());
-    private static final Set<LockTokenV2> TOKENS = ImmutableSet.of(TOKEN_1, TOKEN_2);
+    private static final LockToken TOKEN_1 = LockToken.of(UUID.randomUUID());
+    private static final LockToken TOKEN_2 = LockToken.of(UUID.randomUUID());
+    private static final Set<LockToken> TOKENS = ImmutableSet.of(TOKEN_1, TOKEN_2);
 
     private static final Set<LockDescriptor> LOCKS = ImmutableSet.of(StringLockDescriptor.of("foo"));
 
@@ -67,8 +67,8 @@ public class LockRefreshingTimelockServiceTest {
 
     @Test
     public void registersLocks() {
-        LockRequestV2 request = LockRequestV2.of(LOCKS, TIMEOUT);
-        when(delegate.lock(request)).thenReturn(LockResponseV2.successful(TOKEN_1));
+        LockRequest request = LockRequest.of(LOCKS, TIMEOUT);
+        when(delegate.lock(request)).thenReturn(LockResponse.successful(TOKEN_1));
 
         timelock.lock(request);
 

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LockTokenConverterTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LockTokenConverterTest.java
@@ -25,7 +25,7 @@ import java.util.Random;
 import org.junit.Test;
 
 import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 
 public class LockTokenConverterTest {
 
@@ -65,7 +65,7 @@ public class LockTokenConverterTest {
     }
 
     private void assertConversionFromAndToLegacyPreservesId(LockRefreshToken lockRefreshToken) {
-        LockTokenV2 tokenV2 = LockTokenConverter.toTokenV2(lockRefreshToken);
+        LockToken tokenV2 = LockTokenConverter.toTokenV2(lockRefreshToken);
         LockRefreshToken reconverted = LockTokenConverter.toLegacyToken(tokenV2);
 
         assertThat(reconverted).isEqualTo(lockRefreshToken);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
@@ -31,9 +31,9 @@ import com.palantir.atlasdb.timelock.lock.AsyncResult;
 import com.palantir.atlasdb.timelock.lock.LockLog;
 import com.palantir.lock.v2.LockImmutableTimestampRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
-import com.palantir.lock.v2.LockRequestV2;
-import com.palantir.lock.v2.LockResponseV2;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
 import com.palantir.timestamp.TimestampRange;
@@ -75,16 +75,16 @@ public class AsyncTimelockResource {
 
     @POST
     @Path("lock")
-    public void lock(@Suspended final AsyncResponse response, LockRequestV2 request) {
-        AsyncResult<LockTokenV2> result = timelock.lock(request);
+    public void lock(@Suspended final AsyncResponse response, LockRequest request) {
+        AsyncResult<LockToken> result = timelock.lock(request);
         LockLog.registerRequest(request, result);
         result.onComplete(() -> {
             if (result.isFailed()) {
                 response.resume(result.getError());
             } else if (result.isTimedOut()) {
-                response.resume(LockResponseV2.timedOut());
+                response.resume(LockResponse.timedOut());
             } else {
-                response.resume(LockResponseV2.successful(result.get()));
+                response.resume(LockResponse.successful(result.get()));
             }
         });
     }
@@ -107,13 +107,13 @@ public class AsyncTimelockResource {
 
     @POST
     @Path("refresh-locks")
-    public Set<LockTokenV2> refreshLockLeases(Set<LockTokenV2> tokens) {
+    public Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
         return timelock.refreshLockLeases(tokens);
     }
 
     @POST
     @Path("unlock")
-    public Set<LockTokenV2> unlock(Set<LockTokenV2> tokens) {
+    public Set<LockToken> unlock(Set<LockToken> tokens) {
         return timelock.unlock(tokens);
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
@@ -23,21 +23,21 @@ import com.palantir.atlasdb.timelock.lock.AsyncResult;
 import com.palantir.atlasdb.timelock.paxos.ManagedTimestampService;
 import com.palantir.lock.v2.LockImmutableTimestampRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
-import com.palantir.lock.v2.LockRequestV2;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.WaitForLocksRequest;
 
 public interface AsyncTimelockService extends ManagedTimestampService, Closeable {
 
     long currentTimeMillis();
 
-    Set<LockTokenV2> unlock(Set<LockTokenV2> tokens);
+    Set<LockToken> unlock(Set<LockToken> tokens);
 
-    Set<LockTokenV2> refreshLockLeases(Set<LockTokenV2> tokens);
+    Set<LockToken> refreshLockLeases(Set<LockToken> tokens);
 
     AsyncResult<Void> waitForLocks(WaitForLocksRequest request);
 
-    AsyncResult<LockTokenV2> lock(LockRequestV2 request);
+    AsyncResult<LockToken> lock(LockRequest request);
 
     long getImmutableTimestamp();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -25,8 +25,8 @@ import com.palantir.atlasdb.timelock.lock.TimeLimit;
 import com.palantir.atlasdb.timelock.paxos.ManagedTimestampService;
 import com.palantir.lock.v2.LockImmutableTimestampRequest;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
-import com.palantir.lock.v2.LockRequestV2;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.timestamp.TimestampRange;
 
@@ -55,7 +55,7 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
         long timestamp = timestampService.getFreshTimestamp();
 
         // this will always return synchronously
-        LockTokenV2 token = lockService.lockImmutableTimestamp(request.getRequestId(), timestamp).get();
+        LockToken token = lockService.lockImmutableTimestamp(request.getRequestId(), timestamp).get();
         long immutableTs = lockService.getImmutableTimestamp().orElse(timestamp);
 
         return LockImmutableTimestampResponse.of(immutableTs, token);
@@ -68,7 +68,7 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public AsyncResult<LockTokenV2> lock(LockRequestV2 request) {
+    public AsyncResult<LockToken> lock(LockRequest request) {
         return lockService.lock(
                 request.getRequestId(),
                 request.getLockDescriptors(),
@@ -84,12 +84,12 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public Set<LockTokenV2> refreshLockLeases(Set<LockTokenV2> tokens) {
+    public Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
         return lockService.refresh(tokens);
     }
 
     @Override
-    public Set<LockTokenV2> unlock(Set<LockTokenV2> tokens) {
+    public Set<LockToken> unlock(Set<LockToken> tokens) {
         return lockService.unlock(tokens);
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncLockService.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.lock.LockDescriptor;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 
 public class AsyncLockService implements Closeable {
 
@@ -80,13 +80,13 @@ public class AsyncLockService implements Closeable {
         }, 0, LeaseExpirationTimer.LEASE_TIMEOUT_MILLIS / 2, TimeUnit.MILLISECONDS);
     }
 
-    public AsyncResult<LockTokenV2> lock(UUID requestId, Set<LockDescriptor> lockDescriptors, TimeLimit timeout) {
+    public AsyncResult<LockToken> lock(UUID requestId, Set<LockDescriptor> lockDescriptors, TimeLimit timeout) {
         return heldLocks.getExistingOrAcquire(
                 requestId,
                 () -> acquireLocks(requestId, lockDescriptors, timeout));
     }
 
-    public AsyncResult<LockTokenV2> lockImmutableTimestamp(UUID requestId, long timestamp) {
+    public AsyncResult<LockToken> lockImmutableTimestamp(UUID requestId, long timestamp) {
         return heldLocks.getExistingOrAcquire(
                 requestId,
                 () -> acquireImmutableTimestampLock(requestId, timestamp));
@@ -119,19 +119,19 @@ public class AsyncLockService implements Closeable {
         return lockAcquirer.acquireLocks(requestId, OrderedLocks.fromSingleLock(immutableTsLock), TimeLimit.zero());
     }
 
-    public boolean unlock(LockTokenV2 token) {
+    public boolean unlock(LockToken token) {
         return unlock(ImmutableSet.of(token)).contains(token);
     }
 
-    public Set<LockTokenV2> unlock(Set<LockTokenV2> tokens) {
+    public Set<LockToken> unlock(Set<LockToken> tokens) {
         return heldLocks.unlock(tokens);
     }
 
-    public boolean refresh(LockTokenV2 token) {
+    public boolean refresh(LockToken token) {
         return refresh(ImmutableSet.of(token)).contains(token);
     }
 
-    public Set<LockTokenV2> refresh(Set<LockTokenV2> tokens) {
+    public Set<LockToken> refresh(Set<LockToken> tokens) {
         return heldLocks.refresh(tokens);
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/HeldLocks.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/HeldLocks.java
@@ -24,12 +24,12 @@ import javax.annotation.concurrent.GuardedBy;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.lock.LockDescriptor;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 
 public class HeldLocks {
 
     private final Collection<AsyncLock> acquiredLocks;
-    private final LockTokenV2 token;
+    private final LockToken token;
     private final LeaseExpirationTimer expirationTimer;
 
     @GuardedBy("this")
@@ -42,7 +42,7 @@ public class HeldLocks {
     @VisibleForTesting
     HeldLocks(Collection<AsyncLock> acquiredLocks, UUID requestId, LeaseExpirationTimer expirationTimer) {
         this.acquiredLocks = acquiredLocks;
-        this.token = LockTokenV2.of(requestId);
+        this.token = LockToken.of(requestId);
         this.expirationTimer = expirationTimer;
     }
 
@@ -81,7 +81,7 @@ public class HeldLocks {
         return true;
     }
 
-    public LockTokenV2 getToken() {
+    public LockToken getToken() {
         return token;
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockEvents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockEvents.java
@@ -30,7 +30,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Iterables;
 import com.palantir.lock.LockDescriptor;
-import com.palantir.lock.v2.LockRequestV2;
+import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
@@ -100,7 +100,7 @@ public class LockEvents {
         @Value.Parameter
         Set<LockDescriptor> lockDescriptors();
 
-        static RequestInfo of(LockRequestV2 request) {
+        static RequestInfo of(LockRequest request) {
             return ImmutableRequestInfo.of(
                     request.getRequestId(),
                     request.getClientDescription().orElse(EMPTY_DESCRIPTION),

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockLog.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 import com.palantir.atlasdb.timelock.lock.LockEvents.RequestInfo;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.lock.LockDescriptor;
-import com.palantir.lock.v2.LockRequestV2;
+import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.WaitForLocksRequest;
 
 public final class LockLog {
@@ -36,7 +36,7 @@ public final class LockLog {
         slowLockThresholdMillis = thresholdMillis;
     }
 
-    public static void registerRequest(LockRequestV2 request, AsyncResult<?> result) {
+    public static void registerRequest(LockRequest request, AsyncResult<?> result) {
         registerRequest(RequestInfo.of(request), result);
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -66,7 +66,7 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
     @Test
     public void locksAreExclusive() {
         LockToken token = cluster.lock(requestFor(LOCK_A)).getToken();
-        Future<LockTokenV2> futureToken = cluster.lockAsync(requestFor(LOCK_A))
+        Future<LockToken> futureToken = cluster.lockAsync(requestFor(LOCK_A))
                 .thenApply(LockResponse::getToken);
 
         assertNotYetLocked(futureToken);

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceIntegrationTest.java
@@ -176,8 +176,8 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
         LockToken token = cluster.lock(requestFor(LOCK_A)).getToken();
 
         LockRequest request = requestFor(LOCK_A);
-        CompletableFuture<LockResponseV2> response = cluster.lockAsync(request);
-        CompletableFuture<LockResponseV2> duplicateResponse = cluster.lockAsync(request);
+        CompletableFuture<LockResponse> response = cluster.lockAsync(request);
+        CompletableFuture<LockResponse> duplicateResponse = cluster.lockAsync(request);
 
         cluster.unlock(token);
 
@@ -197,11 +197,11 @@ public class AsyncTimelockServiceIntegrationTest extends AbstractAsyncTimelockSe
 
         WaitForLocksRequest request = waitRequestFor(LOCK_A);
         CompletableFuture<WaitForLocksResponse> response = cluster.waitForLocksAsync(request);
-        CompletableFuture<WaitForLocksResponse> duplicateLockResponse = cluster.waitForLocksAsync(request);
+        CompletableFuture<WaitForLocksResponse> duplicateResponse = cluster.waitForLocksAsync(request);
 
         cluster.unlock(token);
 
-        assertThat(response.join()).isEqualTo(duplicateLockResponse.join());
+        assertThat(response.join()).isEqualTo(duplicateResponse.join());
     }
 
     private LockRequest requestFor(LockDescriptor... locks) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -60,12 +60,11 @@ import com.palantir.leader.PingableLeader;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
 import com.palantir.lock.SimpleTimeDuration;
 import com.palantir.lock.StringLockDescriptor;
-import com.palantir.lock.v2.LockRequestV2;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
@@ -110,7 +109,7 @@ public class PaxosTimeLockServerIntegrationTest {
     private static final TimeLockServerHolder TIMELOCK_SERVER_HOLDER =
             new TimeLockServerHolder(TEMPORARY_CONFIG_HOLDER::getTemporaryConfigFileLocation);
 
-    private static final LockRequest REQUEST_LOCK_WITH_LONG_TIMEOUT = LockRequest
+    private static final com.palantir.lock.LockRequest REQUEST_LOCK_WITH_LONG_TIMEOUT = com.palantir.lock.LockRequest
             .builder(ImmutableSortedMap.of(StringLockDescriptor.of("lock"), LockMode.WRITE))
             .timeoutAfter(SimpleTimeDuration.of(20, TimeUnit.SECONDS))
             .blockForAtMost(SimpleTimeDuration.of(4, TimeUnit.SECONDS))
@@ -222,7 +221,7 @@ public class PaxosTimeLockServerIntegrationTest {
     public void lockServiceShouldAllowUsToTakeOutLocks() throws InterruptedException {
         RemoteLockService lockService = getLockService(CLIENT_1);
 
-        LockRefreshToken token = lockService.lock(LOCK_CLIENT_NAME, LockRequest.builder(LOCK_MAP)
+        LockRefreshToken token = lockService.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
                 .build());
 
@@ -236,10 +235,10 @@ public class PaxosTimeLockServerIntegrationTest {
         RemoteLockService lockService1 = getLockService(CLIENT_1);
         RemoteLockService lockService2 = getLockService(CLIENT_2);
 
-        LockRefreshToken token1 = lockService1.lock(LOCK_CLIENT_NAME, LockRequest.builder(LOCK_MAP)
+        LockRefreshToken token1 = lockService1.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
                 .build());
-        LockRefreshToken token2 = lockService2.lock(LOCK_CLIENT_NAME, LockRequest.builder(LOCK_MAP)
+        LockRefreshToken token2 = lockService2.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
                 .build());
 
@@ -255,7 +254,7 @@ public class PaxosTimeLockServerIntegrationTest {
         RemoteLockService lockService1 = getLockService(CLIENT_1);
         RemoteLockService lockService2 = getLockService(CLIENT_2);
 
-        LockRefreshToken token = lockService1.lock(LOCK_CLIENT_NAME, LockRequest.builder(LOCK_MAP)
+        LockRefreshToken token = lockService1.lock(LOCK_CLIENT_NAME, com.palantir.lock.LockRequest.builder(LOCK_MAP)
                 .doNotBlock()
                 .build());
 
@@ -270,7 +269,7 @@ public class PaxosTimeLockServerIntegrationTest {
     public void asyncLockServiceShouldAllowUsToTakeOutLocks() throws InterruptedException {
         TimelockService timelockService = getTimelockService(CLIENT_1);
 
-        LockTokenV2 token = timelockService.lock(newLockV2Request(LOCK_1)).getToken();
+        LockToken token = timelockService.lock(newLockV2Request(LOCK_1)).getToken();
 
         assertThat(timelockService.unlock(ImmutableSet.of(token))).contains(token);
     }
@@ -280,8 +279,8 @@ public class PaxosTimeLockServerIntegrationTest {
         TimelockService lockService1 = getTimelockService(CLIENT_1);
         TimelockService lockService2 = getTimelockService(CLIENT_2);
 
-        LockTokenV2 token1 = lockService1.lock(newLockV2Request(LOCK_1)).getToken();
-        LockTokenV2 token2 = lockService2.lock(newLockV2Request(LOCK_1)).getToken();
+        LockToken token1 = lockService1.lock(newLockV2Request(LOCK_1)).getToken();
+        LockToken token2 = lockService2.lock(newLockV2Request(LOCK_1)).getToken();
 
         lockService1.unlock(ImmutableSet.of(token1));
         lockService2.unlock(ImmutableSet.of(token2));
@@ -292,7 +291,7 @@ public class PaxosTimeLockServerIntegrationTest {
         TimelockService lockService1 = getTimelockService(CLIENT_1);
         TimelockService lockService2 = getTimelockService(CLIENT_2);
 
-        LockTokenV2 token = lockService1.lock(newLockV2Request(LOCK_1)).getToken();
+        LockToken token = lockService1.lock(newLockV2Request(LOCK_1)).getToken();
 
         assertThat(lockService1.refreshLockLeases(ImmutableSet.of(token))).isNotEmpty();
         assertThat(lockService2.refreshLockLeases(ImmutableSet.of(token))).isEmpty();
@@ -519,7 +518,7 @@ public class PaxosTimeLockServerIntegrationTest {
         assertThat(remoteException.getStatus()).isEqualTo(expectedStatus);
     }
 
-    private LockRequestV2 newLockV2Request(LockDescriptor lock) {
-        return LockRequestV2.of(ImmutableSet.of(lock), 10_000L);
+    private LockRequest newLockV2Request(LockDescriptor lock) {
+        return LockRequest.of(ImmutableSet.of(lock), 10_000L);
     }
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -151,7 +151,8 @@ public class TestableTimelockCluster {
         return timestampService().getFreshTimestamps(number);
     }
 
-    public LockRefreshToken remoteLock(String client, com.palantir.lock.LockRequest lockRequest) throws InterruptedException {
+    public LockRefreshToken remoteLock(String client, com.palantir.lock.LockRequest lockRequest)
+            throws InterruptedException {
         return lockService().lock(client, lockRequest);
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -34,11 +34,10 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.jayway.awaitility.Awaitility;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
-import com.palantir.lock.v2.LockRequestV2;
-import com.palantir.lock.v2.LockResponseV2;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
@@ -152,7 +151,7 @@ public class TestableTimelockCluster {
         return timestampService().getFreshTimestamps(number);
     }
 
-    public LockRefreshToken remoteLock(String client, LockRequest lockRequest) throws InterruptedException {
+    public LockRefreshToken remoteLock(String client, com.palantir.lock.LockRequest lockRequest) throws InterruptedException {
         return lockService().lock(client, lockRequest);
     }
 
@@ -160,23 +159,23 @@ public class TestableTimelockCluster {
         return lockService().unlock(token);
     }
 
-    public LockResponseV2 lock(LockRequestV2 requestV2) {
+    public LockResponse lock(LockRequest requestV2) {
         return timelockService().lock(requestV2);
     }
 
-    public CompletableFuture<LockResponseV2> lockAsync(LockRequestV2 requestV2) {
+    public CompletableFuture<LockResponse> lockAsync(LockRequest requestV2) {
         return CompletableFuture.supplyAsync(() -> lock(requestV2), executor);
     }
 
-    public boolean unlock(LockTokenV2 token) {
+    public boolean unlock(LockToken token) {
         return timelockService().unlock(ImmutableSet.of(token)).contains(token);
     }
 
-    public Set<LockTokenV2> refreshLockLeases(Set<LockTokenV2> tokens) {
+    public Set<LockToken> refreshLockLeases(Set<LockToken> tokens) {
         return timelockService().refreshLockLeases(tokens);
     }
 
-    public boolean refreshLockLease(LockTokenV2 token) {
+    public boolean refreshLockLease(LockToken token) {
         return refreshLockLeases(ImmutableSet.of(token)).contains(token);
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -51,7 +51,8 @@ public class TestableTimelockServer {
         return timestampService().getFreshTimestamp();
     }
 
-    public LockRefreshToken remoteLock(String client, com.palantir.lock.LockRequest lockRequest) throws InterruptedException {
+    public LockRefreshToken remoteLock(String client, com.palantir.lock.LockRequest lockRequest)
+            throws InterruptedException {
         return lockService().lock(client, lockRequest);
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -20,10 +20,9 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.leader.PingableLeader;
 import com.palantir.lock.LockRefreshToken;
-import com.palantir.lock.LockRequest;
 import com.palantir.lock.RemoteLockService;
-import com.palantir.lock.v2.LockRequestV2;
-import com.palantir.lock.v2.LockResponseV2;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
@@ -52,11 +51,11 @@ public class TestableTimelockServer {
         return timestampService().getFreshTimestamp();
     }
 
-    public LockRefreshToken remoteLock(String client, LockRequest lockRequest) throws InterruptedException {
+    public LockRefreshToken remoteLock(String client, com.palantir.lock.LockRequest lockRequest) throws InterruptedException {
         return lockService().lock(client, lockRequest);
     }
 
-    public LockResponseV2 lock(LockRequestV2 lockRequest) {
+    public LockResponse lock(LockRequest lockRequest) {
         return timelockService().lock(lockRequest);
     }
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -142,7 +142,7 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void waitForLocksRequestsAreIdempotent() {
-        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken token = lockSynchronously(REQUEST_1, LOCK_A);
 
         AsyncResult<Void> request = service.waitForLocks(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
         AsyncResult<Void> duplicate = service.waitForLocks(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -37,7 +37,7 @@ import com.palantir.common.time.Clock;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.StringLockDescriptor;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 
 public class AsyncLockServiceEteTest {
 
@@ -67,7 +67,7 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void canLockAndUnlock() {
-        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken token = lockSynchronously(REQUEST_1, LOCK_A);
         assertLocked(LOCK_A);
 
         assertTrue(service.unlock(token));
@@ -76,7 +76,7 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void canLockAndUnlockMultipleLocks() {
-        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A, LOCK_B, LOCK_C);
+        LockToken token = lockSynchronously(REQUEST_1, LOCK_A, LOCK_B, LOCK_C);
 
         assertTrue(service.unlock(token));
         assertNotLocked(LOCK_A);
@@ -86,9 +86,9 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void waitingRequestGetsTheLockAfterItIsUnlocked() {
-        LockTokenV2 request1 = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken request1 = lockSynchronously(REQUEST_1, LOCK_A);
 
-        AsyncResult<LockTokenV2> request2 = lock(REQUEST_2, LOCK_A);
+        AsyncResult<LockToken> request2 = lock(REQUEST_2, LOCK_A);
         assertThat(request2.isComplete()).isFalse();
 
         service.unlock(request1);
@@ -97,9 +97,9 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void waitingRequestGetsTheLockAfterItIsUnlockedWithMultipleLocks() {
-        LockTokenV2 request1 = lockSynchronously(REQUEST_1, LOCK_A, LOCK_C);
+        LockToken request1 = lockSynchronously(REQUEST_1, LOCK_A, LOCK_C);
 
-        AsyncResult<LockTokenV2> request2 = lock(REQUEST_2, LOCK_A, LOCK_B, LOCK_C, LOCK_D);
+        AsyncResult<LockToken> request2 = lock(REQUEST_2, LOCK_A, LOCK_B, LOCK_C, LOCK_D);
         assertThat(request2.isComplete()).isFalse();
 
         service.unlock(request1);
@@ -108,10 +108,10 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void requestsAreIdempotentDuringAcquisitionPhase() {
-        LockTokenV2 currentHolder = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken currentHolder = lockSynchronously(REQUEST_1, LOCK_A);
 
-        AsyncResult<LockTokenV2> tokenResult = lock(REQUEST_2, LOCK_A);
-        AsyncResult<LockTokenV2> duplicateResult = lock(REQUEST_2, LOCK_A);
+        AsyncResult<LockToken> tokenResult = lock(REQUEST_2, LOCK_A);
+        AsyncResult<LockToken> duplicateResult = lock(REQUEST_2, LOCK_A);
 
         service.unlock(currentHolder);
 
@@ -123,8 +123,8 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void requestsAreIdempotentAfterBeingAcquired() {
-        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
-        LockTokenV2 duplicate = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken token = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken duplicate = lockSynchronously(REQUEST_1, LOCK_A);
 
         assertThat(token).isEqualTo(duplicate);
     }
@@ -133,7 +133,7 @@ public class AsyncLockServiceEteTest {
     public void requestsAreIdempotentWithRespectToTimeout() {
         lockSynchronously(REQUEST_1, LOCK_A);
         service.lock(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
-        AsyncResult<LockTokenV2> duplicate = service.lock(REQUEST_2, descriptors(LOCK_A), LONG_TIMEOUT);
+        AsyncResult<LockToken> duplicate = service.lock(REQUEST_2, descriptors(LOCK_A), LONG_TIMEOUT);
 
         waitForTimeout(SHORT_TIMEOUT);
 
@@ -157,14 +157,14 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void locksCanBeRefreshed() {
-        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken token = lockSynchronously(REQUEST_1, LOCK_A);
 
         assertTrue(service.refresh(token));
     }
 
     @Test
     public void cannotRefreshAfterUnlocking() {
-        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken token = lockSynchronously(REQUEST_1, LOCK_A);
         service.unlock(token);
 
         assertFalse(service.refresh(token));
@@ -172,7 +172,7 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void cannotUnlockAfterUnlocking() {
-        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken token = lockSynchronously(REQUEST_1, LOCK_A);
         service.unlock(token);
 
         assertFalse(service.unlock(token));
@@ -180,7 +180,7 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void canUnlockAfterRefreshing() {
-        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken token = lockSynchronously(REQUEST_1, LOCK_A);
         service.refresh(token);
 
         assertTrue(service.unlock(token));
@@ -189,7 +189,7 @@ public class AsyncLockServiceEteTest {
     @Test
     public void canLockAndUnlockImmutableTimestamp() {
         long timestamp = 123L;
-        LockTokenV2 token = service.lockImmutableTimestamp(REQUEST_1, timestamp).get();
+        LockToken token = service.lockImmutableTimestamp(REQUEST_1, timestamp).get();
 
         assertThat(service.getImmutableTimestamp().get()).isEqualTo(123L);
 
@@ -200,7 +200,7 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void canWaitForLock() {
-        LockTokenV2 lockAHolder = lockSynchronously(REQUEST_1, LOCK_A);
+        LockToken lockAHolder = lockSynchronously(REQUEST_1, LOCK_A);
 
         AsyncResult<Void> waitResult = waitForLocks(REQUEST_2, LOCK_A);
         assertThat(waitResult.isComplete()).isFalse();
@@ -213,7 +213,7 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void canWaitForMultipleLocks() {
-        LockTokenV2 lockAHolder = lockSynchronously(REQUEST_1, LOCK_B, LOCK_C);
+        LockToken lockAHolder = lockSynchronously(REQUEST_1, LOCK_B, LOCK_C);
 
         AsyncResult<Void> waitResult = waitForLocks(REQUEST_2, LOCK_A, LOCK_B, LOCK_C);
         assertThat(waitResult.isComplete()).isFalse();
@@ -229,7 +229,7 @@ public class AsyncLockServiceEteTest {
     @Test
     public void lockRequestTimesOutWhenTimeoutPasses() {
         lockSynchronously(REQUEST_1, LOCK_A);
-        AsyncResult<LockTokenV2> result = service.lock(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
+        AsyncResult<LockToken> result = service.lock(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
         assertThat(result.isTimedOut()).isFalse();
 
         waitForTimeout(SHORT_TIMEOUT);
@@ -250,7 +250,7 @@ public class AsyncLockServiceEteTest {
 
     @Test
     public void timedOutRequestDoesNotHoldLocks() {
-        LockTokenV2 lockBToken = lockSynchronously(REQUEST_1, LOCK_B);
+        LockToken lockBToken = lockSynchronously(REQUEST_1, LOCK_B);
         service.lock(REQUEST_2, descriptors(LOCK_A, LOCK_B), SHORT_TIMEOUT);
 
         waitForTimeout(SHORT_TIMEOUT);
@@ -263,7 +263,7 @@ public class AsyncLockServiceEteTest {
     @Test
     public void outstandingRequestsReceiveNotCurrentLeaderExceptionOnClose() {
         lockSynchronously(REQUEST_1, LOCK_A);
-        AsyncResult<LockTokenV2> request2 = lock(REQUEST_2, LOCK_A);
+        AsyncResult<LockToken> request2 = lock(REQUEST_2, LOCK_A);
 
         service.close();
 
@@ -286,11 +286,11 @@ public class AsyncLockServiceEteTest {
         }
     }
 
-    private LockTokenV2 lockSynchronously(UUID requestId, String... locks) {
+    private LockToken lockSynchronously(UUID requestId, String... locks) {
         return lock(requestId, locks).get();
     }
 
-    private AsyncResult<LockTokenV2> lock(UUID requestId, String... locks) {
+    private AsyncResult<LockToken> lock(UUID requestId, String... locks) {
         return service.lock(requestId, descriptors(locks), TIMEOUT);
     }
 
@@ -305,12 +305,12 @@ public class AsyncLockServiceEteTest {
     }
 
     private void assertNotLocked(String lock) {
-        LockTokenV2 token = lockSynchronously(UUID.randomUUID(), lock);
+        LockToken token = lockSynchronously(UUID.randomUUID(), lock);
         assertTrue(service.unlock(token));
     }
 
     private void assertLocked(String... locks) {
-        AsyncResult<LockTokenV2> result = lock(UUID.randomUUID(), locks);
+        AsyncResult<LockToken> result = lock(UUID.randomUUID(), locks);
         assertFalse(result.isComplete());
 
         result.map(token -> service.unlock(token));

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/HeldLocksCollectionTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/HeldLocksCollectionTest.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.palantir.lock.v2.LockTokenV2;
+import com.palantir.lock.v2.LockToken;
 
 public class HeldLocksCollectionTest {
 
@@ -91,22 +91,22 @@ public class HeldLocksCollectionTest {
 
     @Test
     public void refreshReturnsSubsetOfUnlockedLocks() {
-        LockTokenV2 unlockableRequest = mockRefreshableRequest();
-        LockTokenV2 nonUnlockableRequest = mockNonRefreshableRequest();
+        LockToken unlockableRequest = mockRefreshableRequest();
+        LockToken nonUnlockableRequest = mockNonRefreshableRequest();
 
-        Set<LockTokenV2> expected = ImmutableSet.of(unlockableRequest);
-        Set<LockTokenV2> actual = heldLocksCollection.refresh(ImmutableSet.of(unlockableRequest, nonUnlockableRequest));
+        Set<LockToken> expected = ImmutableSet.of(unlockableRequest);
+        Set<LockToken> actual = heldLocksCollection.refresh(ImmutableSet.of(unlockableRequest, nonUnlockableRequest));
 
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void unlockReturnsSubsetOfUnlockedLocks() {
-        LockTokenV2 refreshableRequest = mockRefreshableRequest();
-        LockTokenV2 nonRefreshableRequest = mockNonRefreshableRequest();
+        LockToken refreshableRequest = mockRefreshableRequest();
+        LockToken nonRefreshableRequest = mockNonRefreshableRequest();
 
-        Set<LockTokenV2> expected = ImmutableSet.of(refreshableRequest);
-        Set<LockTokenV2> actual = heldLocksCollection.unlock(
+        Set<LockToken> expected = ImmutableSet.of(refreshableRequest);
+        Set<LockToken> actual = heldLocksCollection.unlock(
                 ImmutableSet.of(refreshableRequest, nonRefreshableRequest));
 
         assertThat(actual).isEqualTo(expected);
@@ -114,28 +114,28 @@ public class HeldLocksCollectionTest {
 
     @Test
     public void successfulUnlockRemovesHeldLocks() {
-        LockTokenV2 token = mockRefreshableRequest();
+        LockToken token = mockRefreshableRequest();
 
         heldLocksCollection.unlock(ImmutableSet.of(token));
 
         assertThat(heldLocksCollection.heldLocksById.isEmpty()).isTrue();
     }
 
-    private LockTokenV2 mockExpiredRequest() {
+    private LockToken mockExpiredRequest() {
         return mockHeldLocksForNewRequest(
                 heldLocks -> {
                     when(heldLocks.unlockIfExpired()).thenReturn(true);
                 });
     }
 
-    private LockTokenV2 mockNonExpiredRequest() {
+    private LockToken mockNonExpiredRequest() {
         return mockHeldLocksForNewRequest(
                 heldLocks -> {
                     when(heldLocks.unlockIfExpired()).thenReturn(false);
                 });
     }
 
-    private LockTokenV2 mockRefreshableRequest() {
+    private LockToken mockRefreshableRequest() {
         return mockHeldLocksForNewRequest(
                 heldLocks -> {
                     when(heldLocks.unlock()).thenReturn(true);
@@ -143,7 +143,7 @@ public class HeldLocksCollectionTest {
                 });
     }
 
-    private LockTokenV2 mockNonRefreshableRequest() {
+    private LockToken mockNonRefreshableRequest() {
         return mockHeldLocksForNewRequest(
                 heldLocks -> {
                     when(heldLocks.unlock()).thenReturn(false);
@@ -151,8 +151,8 @@ public class HeldLocksCollectionTest {
                 });
     }
 
-    private LockTokenV2 mockFailedRequest() {
-        LockTokenV2 request = LockTokenV2.of(UUID.randomUUID());
+    private LockToken mockFailedRequest() {
+        LockToken request = LockToken.of(UUID.randomUUID());
         AsyncResult failedLocks = new AsyncResult();
         failedLocks.fail(new RuntimeException());
 
@@ -161,8 +161,8 @@ public class HeldLocksCollectionTest {
         return request;
     }
 
-    private LockTokenV2 mockTimedOutRequest() {
-        LockTokenV2 request = LockTokenV2.of(UUID.randomUUID());
+    private LockToken mockTimedOutRequest() {
+        LockToken request = LockToken.of(UUID.randomUUID());
         AsyncResult timedOutResult = new AsyncResult();
         timedOutResult.timeout();
 
@@ -171,8 +171,8 @@ public class HeldLocksCollectionTest {
         return request;
     }
 
-    private LockTokenV2 mockHeldLocksForNewRequest(Consumer<HeldLocks> mockApplier) {
-        LockTokenV2 request = LockTokenV2.of(UUID.randomUUID());
+    private LockToken mockHeldLocksForNewRequest(Consumer<HeldLocks> mockApplier) {
+        LockToken request = LockToken.of(UUID.randomUUID());
         HeldLocks heldLocks = mock(HeldLocks.class);
         mockApplier.accept(heldLocks);
 


### PR DESCRIPTION
**Goals (and why)**:
Should we just remove these suffixes? The package name is already `v2`

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2149)
<!-- Reviewable:end -->
