### PR TITLE
TransactionTests: Use a valid lock service in tests

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -18,9 +18,7 @@ package com.palantir.atlasdb.transaction.impl;
 import java.util.Map;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -48,51 +46,36 @@ public abstract class TransactionTestSetup {
     protected static final TableReference TEST_TABLE = TableReference.createFromFullyQualifiedName(
             "ns.atlasdb_transactions_test_table");
 
-    protected static LockClient lockClient = null;
-    protected static LockServiceImpl lockService = null;
+    protected LockClient lockClient;
+    protected LockServiceImpl lockService;
 
-    protected static KeyValueService keyValueService;
+    protected KeyValueService keyValueService;
     protected TimestampService timestampService;
     protected TransactionService transactionService;
     protected ConflictDetectionManager conflictDetectionManager;
     protected SweepStrategyManager sweepStrategyManager;
     protected TransactionManager txMgr;
 
-    @BeforeClass
-    public static void setupLockClient() {
-        if (lockClient == null) {
-            lockClient = LockClient.of("fake lock client");
-        }
-    }
-
-    @BeforeClass
-    public static void setupLockService() {
-        if (lockService == null) {
-            lockService = LockServiceImpl.create(new LockServerOptions() {
-                protected static final long serialVersionUID = 1L;
-
-                @Override
-                public boolean isStandaloneServer() {
-                    return false;
-                }
-
-            });
-        }
-    }
-
     @Before
     public void setUp() throws Exception {
-        if (keyValueService == null) {
-            keyValueService = getKeyValueService();
+        lockService = LockServiceImpl.create(new LockServerOptions() {
+            protected static final long serialVersionUID = 1L;
 
-            keyValueService.createTables(ImmutableMap.of(
-                    TEST_TABLE,
-                    AtlasDbConstants.GENERIC_TABLE_METADATA,
-                    TransactionConstants.TRANSACTION_TABLE,
-                    TransactionConstants.TRANSACTION_TABLE_METADATA.persistToBytes()));
-            keyValueService.truncateTables(ImmutableSet.of(TEST_TABLE, TransactionConstants.TRANSACTION_TABLE));
-        }
+            @Override
+            public boolean isStandaloneServer() {
+                return false;
+            }
+        });
+        lockClient = LockClient.of("test_client");
 
+
+        keyValueService = getKeyValueService();
+        keyValueService.createTables(ImmutableMap.of(
+                TEST_TABLE,
+                AtlasDbConstants.GENERIC_TABLE_METADATA,
+                TransactionConstants.TRANSACTION_TABLE,
+                TransactionConstants.TRANSACTION_TABLE_METADATA.persistToBytes()));
+        keyValueService.truncateTables(ImmutableSet.of(TEST_TABLE, TransactionConstants.TRANSACTION_TABLE));
         timestampService = new InMemoryTimestampService();
 
         transactionService = TransactionServices.createTransactionService(keyValueService);
@@ -103,23 +86,8 @@ public abstract class TransactionTestSetup {
 
     @After
     public void tearDown() {
-        keyValueService.truncateTables(ImmutableSet.of(TEST_TABLE, TransactionConstants.TRANSACTION_TABLE));
-    }
-
-    @AfterClass
-    public static void tearDownKvs() {
-        if (keyValueService != null) {
-            keyValueService.close();
-            keyValueService = null;
-        }
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-        if (lockService != null) {
-            lockService.close();
-            lockService = null;
-        }
+        lockService.close();
+        keyValueService.close();
     }
 
     protected TransactionManager getManager() {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -68,7 +68,6 @@ public abstract class TransactionTestSetup {
         });
         lockClient = LockClient.of("test_client");
 
-
         keyValueService = getKeyValueService();
         keyValueService.createTables(ImmutableMap.of(
                 TEST_TABLE,


### PR DESCRIPTION
**Goals (and why)**: Dont create/close the lock service at the end of entire test classes.

**Implementation Description (bullets)**: This ensures a lock service is created for each test so that the TransactionManager has a valid lockService during its lifetime. Cleaned up tests a bit more.

**Concerns (what feedback would you like?)**: na

**Where should we start reviewing?**: TransactionTestSetup

**Priority (whenever / two weeks / yesterday)**: this or next week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2153)
<!-- Reviewable:end -->
