### PR TITLE
Expose TransactionManagers method in which you can specify the user agent

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -198,7 +198,7 @@ public final class TransactionManagers {
                 UserAgents.fromClass(callingClass));
     }
 
-    private static SerializableTransactionManager create(
+    public static SerializableTransactionManager create(
             AtlasDbConfig config,
             java.util.function.Supplier<java.util.Optional<AtlasDbRuntimeConfig>> runtimeConfigSupplier,
             Set<Schema> schemas,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,10 @@ develop
          - Fixed an issue that could cause AtlasConsole to print unnecessary amounts of input when commands were run.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2130>`__)
 
+    *    - |new|
+         - TransactionManagers exposes a method in which it is possible to specify the user agent to be used.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2162>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 ======


### PR DESCRIPTION
**Goals (and why)**:
There are currently better ways to specify the user agent than inferring it from the jar manifest from a class. It would be nice to be able to use those methods in AtlasDB

**Implementation Description (bullets)**:
You will get it

**Concerns (what feedback would you like?)**:
Not really concerned

**Where should we start reviewing?**:
There is a single line

**Priority (whenever / two weeks / yesterday)**:
Whenever, but this is really small

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2162)
<!-- Reviewable:end -->
