### PR TITLE
make await locks idempotent

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollection.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollection.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.lock;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+
+// TODO(nziebart): can we combine this logic with HeldLocksCollection?
+// Or, should awaitLocks just be implemented by a lock + unlock?
+public class AwaitedLocksCollection {
+
+    @VisibleForTesting
+    final ConcurrentMap<UUID, AsyncResult<Void>> requestsById = Maps.newConcurrentMap();
+
+    public AsyncResult<Void> getExistingOrAwait(
+            UUID requestId,
+            Supplier<AsyncResult<Void>> lockAwaiter) {
+        AsyncResult<Void> result = requestsById.computeIfAbsent(
+                requestId,
+                ignored -> lockAwaiter.get());
+
+        registerCompletionHandler(requestId, result);
+        return result;
+    }
+
+    private void registerCompletionHandler(UUID requestId, AsyncResult<Void> result) {
+        result.onComplete(() -> {
+            requestsById.remove(requestId);
+        });
+    }
+
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollectionTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollectionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+public class AwaitedLocksCollectionTest {
+
+    private static final UUID REQUEST_1 = UUID.randomUUID();
+    private static final UUID REQUEST_2 = UUID.randomUUID();
+
+    private AwaitedLocksCollection awaitedLocks = new AwaitedLocksCollection();
+
+    @Test
+    public void callsSupplierForNewRequests() {
+        Supplier<AsyncResult<Void>> supplier = mock(Supplier.class);
+        when(supplier.get()).thenReturn(new AsyncResult<>());
+        awaitedLocks.getExistingOrAwait(REQUEST_1, supplier);
+        awaitedLocks.getExistingOrAwait(REQUEST_2, supplier);
+
+        verify(supplier, times(2)).get();
+    }
+
+    @Test
+    public void doesNotCallSupplierForExistingRequest() {
+        awaitedLocks.getExistingOrAwait(REQUEST_1, () -> new AsyncResult<>());
+
+        Supplier<AsyncResult<Void>> supplier = mock(Supplier.class);
+        awaitedLocks.getExistingOrAwait(REQUEST_1, supplier);
+
+        verifyNoMoreInteractions(supplier);
+    }
+
+    @Test
+    public void removesRequestWhenComplete() {
+        AsyncResult<Void> result = new AsyncResult<>();
+        awaitedLocks.getExistingOrAwait(REQUEST_1, () -> result);
+
+        assertThat(awaitedLocks.requestsById).containsKey(REQUEST_1);
+
+        result.complete(null);
+        assertThat(awaitedLocks.requestsById).doesNotContainKey(REQUEST_1);
+    }
+
+    @Test
+    public void removesRequestIfCompleteSynchronously() {
+        AsyncResult<Void> result = AsyncResult.completedResult();
+        awaitedLocks.getExistingOrAwait(REQUEST_1, () -> result);
+
+        assertThat(awaitedLocks.requestsById).doesNotContainKey(REQUEST_1);
+    }
+
+    @Test
+    public void removesRequestIfSupplierThrows() {
+        assertThatThrownBy(() -> {
+                    awaitedLocks.getExistingOrAwait(REQUEST_1, () -> {
+                        throw new RuntimeException("foo");
+                    });
+                }).isInstanceOf(RuntimeException.class);
+
+        assertThat(awaitedLocks.requestsById).doesNotContainKey(REQUEST_1);
+    }
+
+    @Test
+    public void removesRequestWhenFailedOrTimesOut() {
+        AsyncResult<Void> result1 = new AsyncResult<>();
+        AsyncResult<Void> result2 = new AsyncResult<>();
+        awaitedLocks.getExistingOrAwait(REQUEST_1, () -> result1);
+        awaitedLocks.getExistingOrAwait(REQUEST_1, () -> result2);
+
+        result1.fail(new RuntimeException("test"));
+        result2.timeout();
+
+        assertThat(awaitedLocks.requestsById).doesNotContainKeys(REQUEST_1, REQUEST_2);
+    }
+
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollectionTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollectionTest.java
@@ -78,10 +78,10 @@ public class AwaitedLocksCollectionTest {
     @Test
     public void removesRequestIfSupplierThrows() {
         assertThatThrownBy(() -> {
-                    awaitedLocks.getExistingOrAwait(REQUEST_1, () -> {
-                        throw new RuntimeException("foo");
-                    });
-                }).isInstanceOf(RuntimeException.class);
+            awaitedLocks.getExistingOrAwait(REQUEST_1, () -> {
+                throw new RuntimeException("foo");
+            });
+        }).isInstanceOf(RuntimeException.class);
 
         assertThat(awaitedLocks.requestsById).doesNotContainKey(REQUEST_1);
     }

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -140,6 +140,21 @@ public class AsyncLockServiceEteTest {
     }
 
     @Test
+    public void waitForLocksRequestsAreIdempotent() {
+        LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
+
+        AsyncResult<Void> request = service.waitForLocks(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
+        AsyncResult<Void> duplicate = service.waitForLocks(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
+
+        assertThat(request).isEqualTo(duplicate);
+
+        service.unlock(token);
+
+        assertThat(request.isCompletedSuccessfully()).isTrue();
+        assertThat(duplicate.isCompletedSuccessfully()).isTrue();
+    }
+
+    @Test
     public void locksCanBeRefreshed() {
         LockTokenV2 token = lockSynchronously(REQUEST_1, LOCK_A);
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -62,6 +62,7 @@ public class AsyncLockServiceEteTest {
             new ImmutableTimestampTracker(),
             new LockAcquirer(Executors.newSingleThreadScheduledExecutor()),
             new HeldLocksCollection(),
+            new AwaitedLocksCollection(),
             executor);
 
     @Test

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -65,6 +65,7 @@ public class AsyncLockServiceTest {
     @Before
     public void before() {
         when(acquirer.acquireLocks(any(), any(), any())).thenReturn(new AsyncResult<>());
+        when(acquirer.waitForLocks(any(), any(), any())).thenReturn(new AsyncResult<>());
         when(locks.getAll(any())).thenReturn(OrderedLocks.fromSingleLock(newLock()));
         when(immutableTimestampTracker.getImmutableTimestamp()).thenReturn(Optional.empty());
         when(immutableTimestampTracker.getLockFor(anyLong())).thenReturn(newLock());


### PR DESCRIPTION
**Goals (and why)**:
Current await locks requests are not idempotent, and cause `IllegalStateException` if the same request is received twice

**Implementation Description (bullets)**:
- Create an `AwaitedLocksCollection` that is similar in function to `HeldLocksCollection`

**Concerns (what feedback would you like?)**:
- Are there edge cases where entries in the map don't get cleaned up?
- Would this be better added to `HeldLocksCollection` somehow?

**Where should we start reviewing?**:
`AwaitedLocksCollection`

**Priority (whenever / two weeks / yesterday)**:
before release

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2165)
<!-- Reviewable:end -->
