### PR TITLE
Nziebart/leader event logs

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
@@ -25,6 +25,9 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.PaxosRoundFailureException;
 import com.palantir.paxos.PaxosValue;
 
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
 class LeadershipEvents {
 
     private static final String LEADER_LOG_NAME = "leadership";
@@ -35,6 +38,9 @@ class LeadershipEvents {
     private final Meter noQuorum;
     private final Meter proposedLeadership;
     private final Meter proposalFailure;
+    private final Meter leaderPingFailure;
+    private final Meter leaderPingTimeout;
+    private final Meter leaderPingReturnedFalse;
 
     public LeadershipEvents(MetricRegistry metrics) {
         gainedLeadership = metrics.meter("leadership.gained");
@@ -42,6 +48,8 @@ class LeadershipEvents {
         noQuorum = metrics.meter("leadership.no-quorum");
         proposedLeadership = metrics.meter("leadership.proposed");
         proposalFailure = metrics.meter("leadership.proposed.failure");
+        leaderPingFailure = metrics.meter("leadership.ping-leader.failure");
+        leaderPingTimeout = metrics.meter("leadership.ping-leader.timeout");
     }
 
     public void proposedLeadershipFor(long round) {
@@ -65,13 +73,26 @@ class LeadershipEvents {
         noQuorum.mark();
     }
 
+    public void leaderPingFailure(Throwable error) {
+        leaderLog.warn("Failed to ping the current leader", error);
+        leaderPingFailure.mark();
+    }
+
+    public void leaderPingTimeout() {
+        leaderLog.warn("Timed out while attempting to ping the current leader");
+        leaderPingTimeout.mark();
+    }
+
+    public void leaderPingReturnedFalse() {
+        leaderLog.info("We contacted the suspected leader, but it reported that it was no longer leading");
+        leaderPingTimeout.mark();
+    }
+
     public void proposalFailure(PaxosRoundFailureException e) {
         leaderLog.warn("Leadership was not gained.\n"
                 + "We should recover automatically. If this recurs often, try to \n"
                 + "  (1) ensure that most other nodes are reachable over the network, and \n"
-                + "  (2) increase the randomWaitBeforeProposingLeadershipMs timeout in your configuration.\n"
-                + "See the debug-level leaderLog for more details.");
-        leaderLog.debug("Specifically, leadership was not gained because of the following exception", e);
+                + "  (2) increase the randomWaitBeforeProposingLeadershipMs timeout in your configuration.", e);
         proposalFailure.mark();
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/LeadershipEvents.java
@@ -50,6 +50,7 @@ class LeadershipEvents {
         proposalFailure = metrics.meter("leadership.proposed.failure");
         leaderPingFailure = metrics.meter("leadership.ping-leader.failure");
         leaderPingTimeout = metrics.meter("leadership.ping-leader.timeout");
+        leaderPingReturnedFalse = metrics.meter("leadership.ping-leader.returned-false");
     }
 
     public void proposedLeadershipFor(long round) {
@@ -85,7 +86,7 @@ class LeadershipEvents {
 
     public void leaderPingReturnedFalse() {
         leaderLog.info("We contacted the suspected leader, but it reported that it was no longer leading");
-        leaderPingTimeout.mark();
+        leaderPingReturnedFalse.mark();
     }
 
     public void proposalFailure(PaxosRoundFailureException e) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionEventRecorder.java
@@ -33,6 +33,15 @@ public interface PaxosLeaderElectionEventRecorder {
     /** Called when we attempt to propose a new value. */
     void recordProposalAttempt(long round);
 
+    /** Called when we are unable to ping the current leader. */
+    void recordLeaderPingFailure(Throwable error);
+
+    /** Called when an attempt to ping the current leader times out. */
+    void recordLeaderPingTimeout();
+
+    /** Called when we successfully contacted the suspected leader, but it reported that it was not the leader. */
+    void recordLeaderPingReturnedFalse();
+
     PaxosLeaderElectionEventRecorder NO_OP = new PaxosLeaderElectionEventRecorder() {
         @Override
         public void recordNotLeading(PaxosValue value) { }
@@ -45,6 +54,15 @@ public interface PaxosLeaderElectionEventRecorder {
 
         @Override
         public void recordProposalAttempt(long round) { }
+
+        @Override
+        public void recordLeaderPingFailure(Throwable error) { }
+
+        @Override
+        public void recordLeaderPingTimeout() { }
+
+        @Override
+        public void recordLeaderPingReturnedFalse() { }
     };
 
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Defaults;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -192,7 +193,8 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
         }
     }
 
-    private boolean getAndRecordLeaderPingResult(@Nullable Future<Boolean> pingFuture) throws InterruptedException {
+    @VisibleForTesting
+    boolean getAndRecordLeaderPingResult(@Nullable Future<Boolean> pingFuture) throws InterruptedException {
         if (pingFuture == null) {
             eventRecorder.recordLeaderPingTimeout();
             return false;

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
@@ -47,6 +47,16 @@ public class PaxosLeadershipEventRecorder implements PaxosKnowledgeEventRecorder
     }
 
     @Override
+    public void recordLeaderPingFailure(Throwable error) {
+        events.leaderPingFailure(error);
+    }
+
+    @Override
+    public void recordLeaderPingTimeout() {
+        events.leaderPingTimeout();
+    }
+
+    @Override
     public void recordProposalFailure(PaxosRoundFailureException e) {
         events.proposalFailure(e);
     }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeadershipEventRecorder.java
@@ -57,6 +57,11 @@ public class PaxosLeadershipEventRecorder implements PaxosKnowledgeEventRecorder
     }
 
     @Override
+    public void recordLeaderPingReturnedFalse() {
+        events.leaderPingReturnedFalse();
+    }
+
+    @Override
     public void recordProposalFailure(PaxosRoundFailureException e) {
         events.proposalFailure(e);
     }

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
@@ -158,6 +158,15 @@ public class LeadershipEventRecorderTest {
     }
 
     @Test
+    public void recordsUnableToPingLeader() {
+        Throwable error = new RuntimeException("foo");
+        recorder.recordUnableToPingLeader(error);
+
+        verify(events).leaderPingFailure(error);
+    }
+
+
+    @Test
     public void ignoresNullRounds() {
         recorder.recordRound(null);
         recorder.recordNotLeading(null);

--- a/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/LeadershipEventRecorderTest.java
@@ -158,13 +158,26 @@ public class LeadershipEventRecorderTest {
     }
 
     @Test
-    public void recordsUnableToPingLeader() {
+    public void recordsLeaderPingFailure() {
         Throwable error = new RuntimeException("foo");
-        recorder.recordUnableToPingLeader(error);
+        recorder.recordLeaderPingFailure(error);
 
         verify(events).leaderPingFailure(error);
     }
 
+    @Test
+    public void recordsLeaderPingTimeout() {
+        recorder.recordLeaderPingTimeout();
+
+        verify(events).leaderPingTimeout();
+    }
+
+    @Test
+    public void recordsLeaderPingReturnedFalse() {
+        recorder.recordLeaderPingReturnedFalse();
+
+        verify(events).leaderPingReturnedFalse();
+    }
 
     @Test
     public void ignoresNullRounds() {

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import com.palantir.paxos.PaxosLearner;
+import com.palantir.paxos.PaxosProposer;
+
+public class PaxosLeaderEventsTest {
+
+    PaxosLeadershipEventRecorder recorder = mock(PaxosLeadershipEventRecorder.class);
+    PaxosLeaderElectionService electionService = new PaxosLeaderElectionServiceBuilder()
+            .proposer(mock(PaxosProposer.class))
+            .knowledge(mock(PaxosLearner.class))
+            .potentialLeadersToHosts(ImmutableMap.<PingableLeader, HostAndPort>of())
+            .acceptors(ImmutableList.of())
+            .learners(ImmutableList.of())
+            .executor(Executors.newSingleThreadExecutor())
+            .pingRateMs(0L)
+            .randomWaitBeforeProposingLeadershipMs(0L)
+            .leaderPingResponseWaitMs(0L)
+            .eventRecorder(recorder)
+            .build();
+
+    @Test
+    public void recordsLeaderPingFailure() throws InterruptedException {
+        RuntimeException error = new RuntimeException("foo");
+        CompletableFuture<Boolean> pingFuture = new CompletableFuture<>();
+        pingFuture.completeExceptionally(error);
+
+        boolean result = electionService.getAndRecordLeaderPingResult(pingFuture);
+        assertThat(result).isFalse();
+
+        verify(recorder).recordLeaderPingFailure(error);
+        verifyNoMoreInteractions(recorder);
+    }
+
+    @Test
+    public void recordsLeaderPingTimeout() throws InterruptedException {
+        // a null result from ExecutorCompletionService indicates that no results were available before the timeout
+        CompletableFuture<Boolean> pingFuture = null;
+
+        boolean result = electionService.getAndRecordLeaderPingResult(pingFuture);
+        assertThat(result).isFalse();
+
+        verify(recorder).recordLeaderPingTimeout();
+        verifyNoMoreInteractions(recorder);
+    }
+
+    @Test
+    public void recordsLeaderPingReturnedFalse() throws InterruptedException {
+        CompletableFuture<Boolean> pingFuture = CompletableFuture.completedFuture(false);
+
+        boolean result = electionService.getAndRecordLeaderPingResult(pingFuture);
+        assertThat(result).isFalse();
+
+        verify(recorder).recordLeaderPingReturnedFalse();
+        verifyNoMoreInteractions(recorder);
+    }
+
+    @Test
+    public void doesNotRecordLeaderPingSuccess() throws InterruptedException {
+        CompletableFuture<Boolean> pingFuture = CompletableFuture.completedFuture(true);
+
+        boolean result = electionService.getAndRecordLeaderPingResult(pingFuture);
+        assertThat(result).isTrue();
+
+        verifyNoMoreInteractions(recorder);
+    }
+
+}


### PR DESCRIPTION
**Goals (and why)**:
Record the reason why a leader election happened. This is useful for debugging.

**Implementation Description (bullets)**:
Distinguish between the following causes of a leadership proposal:
- leader ping returned false
- leader ping failed with an exception
- leader ping timed out

**Concerns (what feedback would you like?)**:
- Is there any other information that would be useful here?

**Where should we start reviewing?**:
`PaxosLeaderElectionService`

**Priority (whenever / two weeks / yesterday)**:
ideally before release

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2166)
<!-- Reviewable:end -->
