### PR TITLE
fix deadlock

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncResult.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AsyncResult.java
@@ -184,6 +184,10 @@ public class AsyncResult<T> {
         future.whenComplete((result, error) -> completionHandler.run());
     }
 
+    public void onCompleteAsync(Runnable completionHandler) {
+        future.whenCompleteAsync((result, error) -> completionHandler.run());
+    }
+
     private static boolean isTimeout(Throwable ex) {
         return ex instanceof TimeoutException || ex.getCause() instanceof TimeoutException;
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollection.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollection.java
@@ -42,6 +42,9 @@ public class AwaitedLocksCollection {
     }
 
     private void registerCompletionHandler(UUID requestId, AsyncResult<Void> result) {
+        // Modifying the map synchronously in this callback can deadlock.
+        // The thread that completes this result will be inside a synchronized method on AsyncLock; if a supplier
+        // passed to #computeIfAbsent simultaneously tries to call a method on the same AsyncLock, we will deadlock.
         result.onCompleteAsync(() -> {
             requestsById.remove(requestId);
         });

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollection.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/AwaitedLocksCollection.java
@@ -42,7 +42,7 @@ public class AwaitedLocksCollection {
     }
 
     private void registerCompletionHandler(UUID requestId, AsyncResult<Void> result) {
-        result.onComplete(() -> {
+        result.onCompleteAsync(() -> {
             requestsById.remove(requestId);
         });
     }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockServerConfiguration.java
@@ -58,7 +58,7 @@ public class TimeLockServerConfiguration extends Configuration {
         this.algorithm = MoreObjects.firstNonNull(algorithm, PaxosConfiguration.DEFAULT);
         this.cluster = cluster;
         this.clients = clients;
-        this.useAsyncLockService = MoreObjects.firstNonNull(useAsyncLockService, false);
+        this.useAsyncLockService = MoreObjects.firstNonNull(useAsyncLockService, true);
         this.useClientRequestLimit = MoreObjects.firstNonNull(useClientRequestLimit, false);
         this.timeLimiterConfiguration =
                 MoreObjects.firstNonNull(timeLimiterConfiguration, TimeLimiterConfiguration.getDefaultConfiguration());


### PR DESCRIPTION
**Goals (and why)**:
Fix a deadlock potential with `AwaitedLocksCollection`.

The deadlock scenario is as follows:
Thread A:
- A WaitForLocksRequest comes in, executes `ConcurrentHashMap#computeIfAbsent`.
- Within that function, `ConcurrentHashMap` takes a lock
- Within that function, we call `AsyncLock#waitUntilAvailable`, a synchronized method
- The `AsyncLock`'s monitor is currently held by Thread B, so we block here

Thread B:
- An unlock request comes in
- We call `AsyncLock#unlock`, a synchronized method
- We acquire the monitor on the `AsyncLock` (this is where Thread A is blocked)
- There is a `WaitForLocksRequest` waiting on the lock, so we complete its future
- There is a callback registered on that future which removes the corresponding entry from the `ConcurrentHashMap` in `AwaitedLocksCollection`
- `ConcurrentHashMap#remove` tries to obtain the same lock that Thread A took above; thus we deadlock

**Implementation Description (bullets)**:
Perform the `ConcurrentHashMap#remove` call above asynchronously

Also, drive by enable async lock by default

**Concerns (what feedback would you like?)**:
Is this the only scenario that can deadlock? The stress test did not find any others.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2173)
<!-- Reviewable:end -->
