### PR TITLE
Bound PaxosQuorumChecker thread pools

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -54,6 +54,9 @@ import com.palantir.paxos.PaxosProposer;
 import com.palantir.paxos.PaxosProposerImpl;
 
 public final class Leaders {
+    // Random high number to not leave thread pool unbounded.
+    private static final int THREAD_POOL_SIZE = 346;
+
     private Leaders() {
         // Utility class
     }
@@ -125,7 +128,7 @@ public final class Leaders {
                 remotePaxosServerSpec.remoteLeaderUris(), sslSocketFactory, userAgent);
 
         InstrumentedExecutorService proposerExecutorService = new InstrumentedExecutorService(
-                Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+                Executors.newFixedThreadPool(THREAD_POOL_SIZE, new ThreadFactoryBuilder()
                         .setNameFormat("atlas-proposer-%d")
                         .setDaemon(true)
                         .build()),
@@ -136,7 +139,7 @@ public final class Leaders {
                 leaderUuid, proposerExecutorService));
 
         InstrumentedExecutorService leaderElectionExecutor = new InstrumentedExecutorService(
-                Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+                Executors.newFixedThreadPool(THREAD_POOL_SIZE, new ThreadFactoryBuilder()
                         .setNameFormat("atlas-leaders-election-%d")
                         .setDaemon(true)
                         .build()),

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -122,16 +122,16 @@ public final class PaxosQuorumChecker {
         List<Throwable> toLog = Lists.newArrayList();
         boolean interrupted = false;
         List<RESPONSE> receivedResponses = new ArrayList<RESPONSE>();
-        int acksRecieved = 0;
-        int nacksRecieved = 0;
+        int acksReceived = 0;
+        int nacksReceived = 0;
 
         try {
             long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(remoteRequestTimeoutInSec);
             // handle responses
-            while (acksRecieved < quorumSize) {
+            while (acksReceived < quorumSize) {
                 try {
                     // check if quorum is impossible (nack quorum failure)
-                    if (shortcircuitIfQuorumImpossible && nacksRecieved > remotes.size() - quorumSize) {
+                    if (shortcircuitIfQuorumImpossible && nacksReceived > remotes.size() - quorumSize) {
                         break;
                     }
 
@@ -146,9 +146,9 @@ public final class PaxosQuorumChecker {
                     // reject invalid or repeat promises
                     RESPONSE response = responseFuture.get();
                     if (response.isSuccessful()) {
-                        acksRecieved++;
+                        acksReceived++;
                     } else {
-                        nacksRecieved++;
+                        nacksReceived++;
                     }
 
                     // record response
@@ -158,7 +158,7 @@ public final class PaxosQuorumChecker {
                     interrupted = true;
                     break;
                 } catch (ExecutionException e) {
-                    nacksRecieved++;
+                    nacksReceived++;
                     if (onlyLogOnQuorumFailure) {
                         toLog.add(e.getCause());
                     } else {
@@ -192,7 +192,7 @@ public final class PaxosQuorumChecker {
                 Thread.currentThread().interrupt();
             }
 
-            if (onlyLogOnQuorumFailure && acksRecieved < quorumSize) {
+            if (onlyLogOnQuorumFailure && acksReceived < quorumSize) {
                 for (Throwable throwable : toLog) {
                     log.warn(PAXOS_MESSAGE_ERROR, throwable);
                 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -52,6 +52,8 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
 
     private static final int QUORUM_OF_ONE = 1;
     private static final boolean ONLY_LOG_ON_QUORUM_FAILURE = true;
+    // Random high number to not leave thread pool unbounded.
+    private static final int THREAD_POOL_SIZE = 368;
 
     private final PaxosProposer proposer;
     private final PaxosLearner knowledge;
@@ -63,8 +65,8 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
     @GuardedBy("this")
     private SequenceAndBound agreedState;
 
-    private final ExecutorService executor = Tracers.wrap(PTExecutors.newCachedThreadPool(
-            PTExecutors.newNamedThreadFactory(true)));
+    private final ExecutorService executor = Tracers.wrap(PTExecutors.newFixedThreadPool(
+            THREAD_POOL_SIZE, PTExecutors.newNamedThreadFactory(true)));
 
     public PaxosTimestampBoundStore(PaxosProposer proposer,
             PaxosLearner knowledge,


### PR DESCRIPTION
**Goals (and why)**: We've seen cases where unbounded thread pools can cause servers to die on #1823. This implements the simple fix of bounding the thread pools before we figure out a way of closing the underlying stream.

**Implementation Description (bullets)**: Bound the thread pools to random high numbers - high enough to not cause problems in most cases, but not high enough to make a server die.

**Concerns (what feedback would you like?)**: Are the thread pool sizes reasonable?

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: -

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2191)
<!-- Reviewable:end -->
