### PR TITLE
Interrupt leftover threads in PaxosQuorumChecker

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
@@ -60,6 +60,7 @@ public final class AtlasDbFeignTargetFactory {
                 .encoder(encoder)
                 .decoder(decoder)
                 .errorDecoder(errorDecoder)
+                .retryer(new InterruptHonoringRetryer())
                 .client(FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent))
                 .target(type, uri);
     }
@@ -129,4 +130,5 @@ public final class AtlasDbFeignTargetFactory {
                 .options(feignOptions)
                 .target(failoverFeignTarget);
     }
+
 }

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/InterruptHonoringRetryer.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/InterruptHonoringRetryer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import java.io.InterruptedIOException;
+
+import feign.RetryableException;
+import feign.Retryer;
+
+/**
+ * Simple wrapper around the default Feign retryer that propagates {@link InterruptedIOException}s
+ * rather than retrying them. This allows the request thread to be interrupted.
+ */
+public class InterruptHonoringRetryer implements Retryer {
+
+    private final Retryer delegate = new Retryer.Default();
+
+    @Override
+    public void continueOrPropagate(RetryableException e) {
+        if (e.getCause() instanceof InterruptedIOException) {
+            throw new RuntimeException(e.getCause());
+        }
+
+        delegate.continueOrPropagate(e);
+    }
+
+    @Override
+    public Retryer clone() {
+        return new InterruptHonoringRetryer();
+    }
+}

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/InterruptHonoringRetryer.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/InterruptHonoringRetryer.java
@@ -30,14 +30,15 @@ public class InterruptHonoringRetryer implements Retryer {
     private final Retryer delegate = new Retryer.Default();
 
     @Override
-    public void continueOrPropagate(RetryableException e) {
-        if (e.getCause() instanceof InterruptedIOException) {
-            throw new RuntimeException(e.getCause());
+    public void continueOrPropagate(RetryableException error) {
+        if (error.getCause() instanceof InterruptedIOException) {
+            throw new RuntimeException(error.getCause());
         }
 
-        delegate.continueOrPropagate(e);
+        delegate.continueOrPropagate(error);
     }
 
+    @SuppressWarnings({"checkstyle:NoClone", "checkstyle:SuperClone"})
     @Override
     public Retryer clone() {
         return new InterruptHonoringRetryer();

--- a/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/InterruptHonoringRetryerTest.java
+++ b/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/InterruptHonoringRetryerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.InterruptedIOException;
+import java.sql.Date;
+import java.time.Instant;
+
+import org.junit.Test;
+
+import feign.RetryableException;
+
+public class InterruptHonoringRetryerTest {
+
+    private final InterruptHonoringRetryer retryer = new InterruptHonoringRetryer();
+
+    @Test
+    public void doesNotRetryInterruptedIoExceptions() {
+        RetryableException ex = retryable(new InterruptedIOException());
+
+        assertThatThrownBy(() -> retryer.continueOrPropagate(ex))
+                .hasCauseInstanceOf(InterruptedIOException.class);
+    }
+
+    @Test
+    public void retriesOtherRetryableExceptions() {
+        RetryableException ex = retryable(new RuntimeException());
+
+        retryer.continueOrPropagate(ex);
+    }
+
+    private RetryableException retryable(Throwable ex) {
+        return new RetryableException("", ex, Date.from(Instant.EPOCH));
+    }
+
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -75,6 +75,10 @@ develop
          - By default, AtlasConsole database mutation commands (namely ``put()`` and ``delete()``)
            are now disabled. To enable them, run AtlasConsole with the ``--mutations_enabled`` flag
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2155>`__)
+           
+    *    - |fixed|
+         - ``PaxosQuorumChecker`` will now interrupt outstanding requests after a quorum response has been collected. This prevents the number of paxos request threads from growing without bound.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2193>`__)
 
     *    - |improved| |devbreak|
          - OkHttp clients (created with ``FeignOkHttpClients``) will no longer silently retry connections.

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -184,7 +184,7 @@ public final class PaxosQuorumChecker {
         } finally {
             // cancel pending futures (during failures)
             for (Future<RESPONSE> future : allFutures) {
-                future.cancel(false);
+                future.cancel(true);
             }
 
             // reset interrupted flag

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -192,7 +192,7 @@ public final class PaxosQuorumChecker {
             }
 
         } finally {
-            // cancel pending futures (during failures)
+            // cancel pending futures
             cancelOutstandingRequestsAfterTimeout(allFutures);
 
             // reset interrupted flag

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -48,7 +48,7 @@ public final class PaxosQuorumChecker {
     // responses
     private static final ScheduledExecutorService CANCELLATION_EXECUTOR = Executors.newSingleThreadScheduledExecutor(
             new NamedThreadFactory("paxos-quorum-checker-canceller", true));
-    private static final long OUTSTANDING_REQUEST_CANCELLATION_TIMEOUT_MILLIS = 10;
+    private static final long OUTSTANDING_REQUEST_CANCELLATION_TIMEOUT_MILLIS = 2;
 
     private PaxosQuorumChecker() {
         // Private constructor. Disallow instantiation.
@@ -223,7 +223,7 @@ public final class PaxosQuorumChecker {
             for (Future<?> future : responseFutures) {
                 future.cancel(true);
             }
-        }, 10, TimeUnit.MILLISECONDS);
+        }, OUTSTANDING_REQUEST_CANCELLATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     public static boolean hasQuorum(List<? extends PaxosResponse> responses, int quorumSize) {


### PR DESCRIPTION
**Goals (and why)**:
Fixes https://github.com/palantir/atlasdb/issues/1823

**Implementation Description (bullets)**:
Unlike http/1 requests, http/2 requests can be interrupted. However, `InterruptedIOException` gets wrapped in `RetryableException`, which gets retried by the default feign retryer.

- Implemented a custom `Retryer` that honors interrupts.
- Interrupt leftover tasks in `PaxosQuorumChecker`

**Concerns (what feedback would you like?)**:

I'm not sure if this will actually fix the problems we saw in the field, as they seem to result from the connection getting into a bad state indefinitely. In tests, I saw that creating thousands of threads does not actually pose an issue by itself. However, this is probably still worth doing.

Also, this results in an exception being thrown on every paxos quorum check, since typically one request will return first and the other will be interrupted. Probably worth benchmarking to ensure that's not a significant perf hit.

**Where should we start reviewing?**:
`InterruptHonoringRetryer`

**Priority (whenever / two weeks / yesterday)**:
probably before next release

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2193)
<!-- Reviewable:end -->
