### PR TITLE
Return actual value when throwing CheckAndSetException for DbKvs

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/UpdateExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/UpdateExecutor.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
-import static com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs.VAL;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -91,7 +89,7 @@ public class UpdateExecutor {
                 cell.getColumnName(),
                 ts);
         List<byte[]> actualValues = Lists.newArrayList();
-        results.iterator().forEachRemaining(row -> actualValues.add(row.getBlob(VAL)));
+        results.iterator().forEachRemaining(row -> actualValues.add(row.getBlob(DbKvs.VAL)));
         return actualValues;
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.impl;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -1207,8 +1208,13 @@ public abstract class AbstractKeyValueServiceTest {
         CheckAndSetRequest request = CheckAndSetRequest.newCell(TEST_TABLE, TEST_CELL, value00);
         keyValueService.checkAndSet(request);
 
-        CheckAndSetRequest secondRequest = CheckAndSetRequest.singleCell(TEST_TABLE, TEST_CELL, value01, value00);
-        keyValueService.checkAndSet(secondRequest);
+        try {
+            CheckAndSetRequest secondRequest = CheckAndSetRequest.singleCell(TEST_TABLE, TEST_CELL, value01, value00);
+            keyValueService.checkAndSet(secondRequest);
+        } catch (CheckAndSetException ex) {
+            assertThat(ex.getActualValues(), contains(value00));
+            throw ex;
+        }
     }
 
     @Test(expected = CheckAndSetException.class)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,6 +62,10 @@ develop
            are now disabled. To enable them, run AtlasConsole with the ``--mutations_enabled`` flag
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2155>`__)
 
+    *    - |fixed|
+         - For DbKvs, the ``actualValues`` field is now populated when a ``CheckAndSetException`` is thrown.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2196>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -81,23 +85,23 @@ v0.49.0
          - Timelock server now can process lock requests using async Jetty servlets, rather than blocking request threads. This leads to more stability and higher throughput during periods of heavy lock contention.
            To enable this behavior, use the ``useAsyncLockService`` option to switch between the new and old lock service implementation. This option defaults to ``true``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2084>`__)
-           
+
     *    - |devbreak| |improved|
          - The maximum time that a transaction will block while waiting for commit locks is now configurable, and defaults to 1 minute. This can be configured via the ``transaction.lockAcquireTimeoutMillis`` option in ``AtlasDbRuntimeConfig``.
            This differs from the previous behavior, which was to block indefinitely. However, the previous behavior can be effectively restored by configuring a large timeout.
            If creating a ``SerializableTransactionManager`` directly, use the new constructor which accepts a timeout parameter.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2158>`__)
-           
+
     *    - |devbreak|
          - ``randomBitCount`` and ``maxAllowedBlockingDuration`` are deprecated and no longer configurable in ``LockServerOptions``. If specified, they will be silently ignored.
            If your service relies on either of these configuration options, please contact the AtlasDB team.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2161>`__)
-           
+
     *    - |userbreak|
-         - This version of the AtlasDB client will **require** a version of Timelock server that exposes the new ``/timelock`` endpoints. 
+         - This version of the AtlasDB client will **require** a version of Timelock server that exposes the new ``/timelock`` endpoints.
            Note that this only applies if running against Timelock server; clients running with embedded leader mode are not affected.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2135>`__)   
-	   
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2135>`__)
+
     *    - |userbreak|
          - The timestamp batching functionality introduced in 0.48.0 is temporarily no longer supported when running with Timelock server. We will re-enable support for this in a future release.
 
@@ -384,12 +388,12 @@ v0.45.0
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2037>`__)
 
     *    - |new|
-         - The default lock timeout is now configurable. 
+         - The default lock timeout is now configurable.
            Currently, the default lock timeout is 2 minutes.
            This can cause a large delay if a lock requester's connection has died at the time it receives the lock.
            Since TransactionManagers#create provides an auto-refreshing lock service, it is safe to lower the default timeout to reduce the delay that happens in this case.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2026>`__)
-           
+
     *    - |improved|
          - The priority of logging on background sweep was increased from debug to info or warn.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2031>`__)
@@ -434,7 +438,7 @@ v0.44.0
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1970>`__)
 
     *    - |improved|
-         - Read-only transactions will no longer make a remote call to fetch a timestamp, if no work is done on the transaction. 
+         - Read-only transactions will no longer make a remote call to fetch a timestamp, if no work is done on the transaction.
            This will benefit services that execute read-only transactions around in-memory cache operations, and frequently never fall through to perform a read.
            (`Pull Request <https://github.com/palantir/1996>`__)
 


### PR DESCRIPTION
**Goals (and why)**: Fixes #2195

**Implementation Description (bullets)**: When catching CheckAndSetException in UpdateExecutor (used by DbKvs), we perform an additional DB check to fetch the current value.

**Concerns (what feedback would you like?)**: This check is not synchronised, so there's a race condition where we might fail to update, then some successful update happens before we check what the current value is. Do we care about this?

**Where should we start reviewing?**: Look at the test. It used to fail on Postgres. The change in UpdateExecutor makes it pass.

**Priority (whenever / two weeks / yesterday)**: We should merge this week. Ideally before next release as it's fairly small and would help an internal product ( @chrisalice for SA)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2196)
<!-- Reviewable:end -->
