### PR TITLE
Disable OkHttp Retries

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
@@ -60,7 +60,7 @@ public final class AtlasDbFeignTargetFactory {
                 .encoder(encoder)
                 .decoder(decoder)
                 .errorDecoder(errorDecoder)
-                .client(FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent, type))
+                .client(FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent))
                 .target(type, uri);
     }
 
@@ -74,7 +74,7 @@ public final class AtlasDbFeignTargetFactory {
                 .encoder(encoder)
                 .decoder(decoder)
                 .errorDecoder(new RsErrorDecoder())
-                .client(FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent, type))
+                .client(FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent))
                 .target(type, uri);
     }
 
@@ -118,7 +118,7 @@ public final class AtlasDbFeignTargetFactory {
             String userAgent) {
         FailoverFeignTarget<T> failoverFeignTarget = new FailoverFeignTarget<>(endpointUris, maxBackoffMillis, type);
         Client client = failoverFeignTarget.wrapClient(
-                FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent, type));
+                FeignOkHttpClients.newOkHttpClient(sslSocketFactory, userAgent));
         return Feign.builder()
                 .contract(contract)
                 .encoder(encoder)

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -93,7 +93,8 @@ public final class FeignOkHttpClients {
         return new OkHttpClient(newRawOkHttpClient(sslSocketFactory, userAgent));
     }
 
-    private static okhttp3.OkHttpClient newRawOkHttpClient(Optional<SSLSocketFactory> sslSocketFactory,
+    @VisibleForTesting
+    static okhttp3.OkHttpClient newRawOkHttpClient(Optional<SSLSocketFactory> sslSocketFactory,
             String userAgent) {
         // Don't allow retrying on connection failures - see ticket #2194
         okhttp3.OkHttpClient.Builder builder = new okhttp3.OkHttpClient.Builder()

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.http;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
@@ -25,8 +24,6 @@ import javax.net.ssl.SSLSocketFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.palantir.lock.RemoteLockService;
 
 import feign.Client;
 import feign.okhttp.OkHttpClient;
@@ -42,10 +39,6 @@ public final class FeignOkHttpClients {
     static final String USER_AGENT_HEADER = "User-Agent";
     private static final int CONNECTION_POOL_SIZE = 100;
     private static final long KEEP_ALIVE_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES);
-
-    // See internal ticket PDS-50301, and/or #1680
-    @VisibleForTesting
-    static final Set<Class<?>> CLASSES_TO_NOT_RETRY = ImmutableSet.of(RemoteLockService.class);
 
     private static final ImmutableList<ConnectionSpec> CONNECTION_SPEC_WITH_CYPHER_SUITES = ImmutableList.of(
             new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
@@ -96,30 +89,22 @@ public final class FeignOkHttpClients {
      */
     public static <T> Client newOkHttpClient(
             Optional<SSLSocketFactory> sslSocketFactory,
-            String userAgent,
-            Class<T> clazz) {
-        return newOkHttpClient(sslSocketFactory, userAgent, shouldAllowRetrying(clazz));
+            String userAgent) {
+        return new OkHttpClient(newRawOkHttpClient(sslSocketFactory, userAgent));
     }
 
-    private static Client newOkHttpClient(
-            Optional<SSLSocketFactory> sslSocketFactory,
-            String userAgent,
-            boolean retryOnConnectionFailure) {
+    private static okhttp3.OkHttpClient newRawOkHttpClient(Optional<SSLSocketFactory> sslSocketFactory,
+            String userAgent) {
+        // Don't allow retrying on connection failures - see ticket #2194
         okhttp3.OkHttpClient.Builder builder = new okhttp3.OkHttpClient.Builder()
                 .connectionSpecs(CONNECTION_SPEC_WITH_CYPHER_SUITES)
                 .connectionPool(new ConnectionPool(CONNECTION_POOL_SIZE, KEEP_ALIVE_TIME_MILLIS, TimeUnit.MILLISECONDS))
-                .retryOnConnectionFailure(retryOnConnectionFailure);
+                .retryOnConnectionFailure(false);
         if (sslSocketFactory.isPresent()) {
             builder.sslSocketFactory(sslSocketFactory.get());
         }
         builder.interceptors().add(new UserAgentAddingInterceptor(userAgent));
-        return new OkHttpClient(builder.build());
-    }
-
-    @VisibleForTesting
-    static <T> boolean shouldAllowRetrying(Class<T> clazz) {
-        // Subclasses of this class should NOT be considered for retrying.
-        return !CLASSES_TO_NOT_RETRY.contains(clazz);
+        return builder.build();
     }
 
     private static final class UserAgentAddingInterceptor implements Interceptor {

--- a/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/FeignOkHttpClientsTest.java
+++ b/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/FeignOkHttpClientsTest.java
@@ -17,37 +17,16 @@ package com.palantir.atlasdb.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Optional;
 
 import org.junit.Test;
 
-import com.palantir.lock.RemoteLockService;
-import com.palantir.lock.client.LockRefreshingRemoteLockService;
+import okhttp3.OkHttpClient;
 
 public class FeignOkHttpClientsTest {
     @Test
-    public void classesSpecifiedNotToRetryAreNotRetriable() {
-        FeignOkHttpClients.CLASSES_TO_NOT_RETRY.forEach(
-                clazz -> assertThat(FeignOkHttpClients.shouldAllowRetrying(clazz)).isFalse());
-    }
-
-    @Test
-    public void remoteLockServiceIsNotRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(RemoteLockService.class)).isFalse();
-    }
-
-    @Test
-    public void subclassesOfClassesSpecifiedNotToRetryAreRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(ExtendedRemoteLockService.class)).isTrue();
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(LockRefreshingRemoteLockService.class)).isTrue();
-    }
-
-    @Test
-    public void classesNotSpecifiedNotToRetryAreRetriable() {
-        assertThat(FeignOkHttpClients.shouldAllowRetrying(AtomicReference.class)).isTrue();
-    }
-
-    private interface ExtendedRemoteLockService extends RemoteLockService {
-        // Marker interface used for testing that subclasses aren't affected
+    public void clientDoesNotRetryAtTheOkHttpLevel() {
+        OkHttpClient okHttpClient = FeignOkHttpClients.newRawOkHttpClient(Optional.empty(), "userAgent");
+        assertThat(okHttpClient.retryOnConnectionFailure()).isFalse();
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,6 +62,13 @@ develop
            are now disabled. To enable them, run AtlasConsole with the ``--mutations_enabled`` flag
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2155>`__)
 
+    *    - |improved| |devbreak|
+         - OkHttp clients (created with ``FeignOkHttpClients``) will no longer silently retry connections.
+           We have already implemented retries, including retries from connection failures, at the Feign level in ``FailoverFeignTarget``.
+           If you require silent retry, please contact the AtlasDB team.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/TODO>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
**Goals (and why)**: Fix #2194 

**Implementation Description (bullets)**:
- Set `FeignOkHttpClients` to always create an `OkHttpClient` that doesn't retry
- Remove obsolete unit tests that verify that this behaviour only happens for `RemoteLockService`
- Add new unit test verifying that a client created doesn't retry.

**Concerns (what feedback would you like?)**:
- Is the assertion that we have already implemented retries at Feign sufficient for both the default retryer and for `FailoverFeignTarget`?

**Where should we start reviewing?**: `FeignOkHttpClients.java` 

**Priority (whenever / two weeks / yesterday)**: original ticket was a P1, so a few days would be good

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2197)
<!-- Reviewable:end -->
