### PR TITLE
Non-Blocking Request Log Appender

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,6 +65,11 @@ develop
     *    - |fixed|
          - Fixed a bug in AtlasConsole that caused valid table names to not be recognized.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2192>`__)
+           
+    *    - |new|
+         - Timelock server now supports a ``NonBlockingFileAppenderFactory`` which prevents requests from blocking if the request log queue is full. 
+           To use this appender, the ``type`` property should be set to ``non-blocking-file`` in the logging appender configuration. Note that using this appender may result in request logs being dropped.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2198>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class NonBlockingAppenderIntegrationTest {
+    private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
+            "http://localhost",
+            "test",
+            "paxosSingleServerWithNonBlockingAppender.yml");
+
+    private static final TestableTimelockServer SERVER = CLUSTER.servers().get(0);
+
+    @ClassRule
+    public static final RuleChain ruleChain = CLUSTER.getRuleChain();
+
+    @Test
+    public void canDeserializeConfigAndStart() {
+        SERVER.getFreshTimestamp();
+    }
+
+}

--- a/timelock-server/src/integTest/resources/paxosSingleServerWithNonBlockingAppender.yml
+++ b/timelock-server/src/integTest/resources/paxosSingleServerWithNonBlockingAppender.yml
@@ -1,0 +1,25 @@
+algorithm:
+  type: paxos
+  paxosDataDir: <TEMP_DATA_DIR>
+
+cluster:
+  localServer: localhost:9030
+  servers:
+    - localhost:9030
+
+clients:
+  - test
+
+server:
+  requestLog:
+    appenders:
+      - archivedFileCount: 10
+        maxFileSize: 1GB
+        archivedLogFilenamePattern: "var/log/timelock-server-request-%i.log.gz"
+        currentLogFilename: var/log/timelock-server-request.log
+        threshold: INFO
+        timeZone: UTC
+        type: non-blocking-file
+  applicationConnectors:
+    - type: http
+      port: 9030

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
+import com.palantir.atlasdb.timelock.logging.NonBlockingFileAppenderFactory;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.remoting2.servers.jersey.HttpRemotingJerseyFeature;
 import com.palantir.tritium.metrics.MetricRegistries;
@@ -40,6 +41,7 @@ public class TimeLockServerLauncher extends Application<TimeLockServerConfigurat
         MetricRegistry metricRegistry = MetricRegistries.createWithHdrHistogramReservoirs();
         AtlasDbMetrics.setMetricRegistry(metricRegistry);
         bootstrap.setMetricRegistry(metricRegistry);
+        bootstrap.getObjectMapper().registerSubtypes(NonBlockingFileAppenderFactory.class);
         super.initialize(bootstrap);
     }
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/logging/NonBlockingFileAppenderFactory.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/logging/NonBlockingFileAppenderFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.logging;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+
+// CHECKSTYLE:OFF
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AsyncAppenderBase;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+// CHECKSTYLE:ON
+import io.dropwizard.logging.FileAppenderFactory;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+
+/**
+ * A wrapper around the default Dropwizard file appender factory, which sets the neverBlock property to true on the
+ * appender. This prevents request log rollovers from blocking request threads.
+ * TODO(nziebart): remove this when we switch to internal web framework
+ */
+@JsonTypeName("non-blocking-file")
+public class NonBlockingFileAppenderFactory<E extends DeferredProcessingAware> extends FileAppenderFactory<E> {
+
+    @Override
+    public Appender<E> build(LoggerContext context, String applicationName, LayoutFactory<E> layoutFactory,
+            LevelFilterFactory<E> levelFilterFactory, AsyncAppenderFactory<E> asyncAppenderFactory) {
+        Appender<E> appender = super.build(context, applicationName, layoutFactory, levelFilterFactory,
+                asyncAppenderFactory);
+
+        Preconditions.checkState(
+                appender instanceof AsyncAppenderBase,
+                "The Dropwizard logging factory returned an unexpected appender of type " + appender.getClass()
+                        + ". NonBlockingFileAppenderFactory requires an async appender to set the neverBlock "
+                        + "property.");
+        ((AsyncAppenderBase) appender).setNeverBlock(true);
+
+        return appender;
+    }
+
+}


### PR DESCRIPTION
**Goals (and why)**:
Prevent request log rollovers from blocking request threads.

The default Dropwizard `FileAppenderFactory` creates a `FixedWindowRollingPolicy`, which unfortunately performs gzip compression synchronously during rollover. Once we move to internal web framework, this issue should go away as the internal logging framework uses a `SizeAndTimeBasedRollingPolicy` which performs compression async.

Fixes https://github.com/palantir/atlasdb/issues/2188

**Implementation Description (bullets)**:
- Create a `NonBlockingFileAppenderFactory` which wraps the default Dropwizard factory and sets the `neverBlock` property to true

**Concerns (what feedback would you like?)**:
- I'm fairly sure the answer is no, but can we solve this a better way?

**Where should we start reviewing?**:
- `NonBlockingFileAppenderFactory`

**Priority (whenever / two weeks / yesterday)**:
- Before next release 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2198)
<!-- Reviewable:end -->
