### PR TITLE
Fix flaky test

### DIFF
--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/NonBlockingAppenderIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.timelock;
 
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -30,6 +31,11 @@ public class NonBlockingAppenderIntegrationTest {
 
     @ClassRule
     public static final RuleChain ruleChain = CLUSTER.getRuleChain();
+
+    @BeforeClass
+    public static void setUp() {
+        CLUSTER.waitUntilLeaderIsElected();
+    }
 
     @Test
     public void canDeserializeConfigAndStart() {


### PR DESCRIPTION
**Goals (and why)**: Fix NonBlockingAppenderIntegrationTest#canDeserializeConfigAndStart.

**Implementation Description (bullets)**: Wait for server to start before asking for a timestamp.

**Concerns (what feedback would you like?)**: -

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: EOD.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2211)
<!-- Reviewable:end -->
