### PR TITLE
Use getBytes over getBlob, as our Oracle driver doesn't support getBlob

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/UpdateExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/UpdateExecutor.java
@@ -89,7 +89,7 @@ public class UpdateExecutor {
                 cell.getColumnName(),
                 ts);
         List<byte[]> actualValues = Lists.newArrayList();
-        results.iterator().forEachRemaining(row -> actualValues.add(row.getBlob(DbKvs.VAL)));
+        results.iterator().forEachRemaining(row -> actualValues.add(row.getBytes(DbKvs.VAL)));
         return actualValues;
     }
 }


### PR DESCRIPTION
**Goals (and why)**: Fix the Oracle driver tests

**Implementation Description (bullets)**: Use getBytes instead of getBlob. It's deprecated in commons-db, but our driver doesn't support getBlob, so we need to use getBytes instead.

**Concerns (what feedback would you like?)**: -

**Where should we start reviewing?**: one file

**Priority (whenever / two weeks / yesterday)**: yesterday

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2221)
<!-- Reviewable:end -->
