### PR TITLE
Long instead of int

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OverflowSequenceSupplier.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OverflowSequenceSupplier.java
@@ -42,7 +42,7 @@ public final class OverflowSequenceSupplier implements Supplier<Long> {
             return currentBatchStartId + currentIdIndex++;
         }
         currentBatchStartId = conns.get()
-                .selectIntegerUnregisteredQuery(
+                .selectLongUnregisteredQuery(
                         "SELECT " + tablePrefix + AtlasDbConstants.ORACLE_OVERFLOW_SEQUENCE + ".NEXTVAL FROM DUAL");
         currentIdIndex = 0;
         return currentBatchStartId + currentIdIndex++;

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OverflowSequenceSupplierTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OverflowSequenceSupplierTest.java
@@ -36,7 +36,7 @@ public class OverflowSequenceSupplierTest {
         final SqlConnection sqlConnection = mock(SqlConnection.class);
 
         when(conns.get()).thenReturn(sqlConnection);
-        when(sqlConnection.selectIntegerUnregisteredQuery(anyString())).thenReturn(1);
+        when(sqlConnection.selectLongUnregisteredQuery(anyString())).thenReturn(1L);
 
         OverflowSequenceSupplier sequenceSupplier = OverflowSequenceSupplier.create(conns, "a_");
         long firstSequenceId = sequenceSupplier.get();
@@ -51,7 +51,7 @@ public class OverflowSequenceSupplierTest {
         final SqlConnection sqlConnection = mock(SqlConnection.class);
 
         when(conns.get()).thenReturn(sqlConnection);
-        when(sqlConnection.selectIntegerUnregisteredQuery(anyString())).thenReturn(1, 1001);
+        when(sqlConnection.selectLongUnregisteredQuery(anyString())).thenReturn(1L, 1001L);
 
         long firstSequenceId = OverflowSequenceSupplier.create(conns, "a_").get();
         long secondSequenceId = OverflowSequenceSupplier.create(conns, "a_").get();
@@ -65,7 +65,7 @@ public class OverflowSequenceSupplierTest {
         final SqlConnection sqlConnection = mock(SqlConnection.class);
 
         when(conns.get()).thenReturn(sqlConnection);
-        when(sqlConnection.selectIntegerUnregisteredQuery(anyString())).thenReturn(1, 1001, 2001);
+        when(sqlConnection.selectLongUnregisteredQuery(anyString())).thenReturn(1L, 1001L, 2001L);
 
         OverflowSequenceSupplier firstSupplier = OverflowSequenceSupplier.create(conns, "a_");
         firstSupplier.get(); // gets 1

--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/SqlConnection.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/SqlConnection.java
@@ -33,6 +33,7 @@ public interface SqlConnection {
     boolean selectExists(String key, Object... vs) throws PalantirSqlException, PalantirInterruptedException;
     boolean selectExists(final RegisteredSQLString sql, Object... vs) throws PalantirSqlException, PalantirInterruptedException;
     int selectIntegerUnregisteredQuery(String sql, Object... vs) throws PalantirSqlException, PalantirInterruptedException;
+    long selectLongUnregisteredQuery(String sql, Object... vs) throws PalantirSqlException, PalantirInterruptedException;
     int selectInteger(String key, Object... vs) throws PalantirSqlException, PalantirInterruptedException;
     int selectInteger(final RegisteredSQLString sql, Object... vs) throws PalantirSqlException, PalantirInterruptedException;
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,6 +45,10 @@ develop
          - Change
 
     *    - |fixed|
+         - Fixed a critical bug in Oracle that limits the number of writes with values greater than 2000 bytes to ``Integer.MAX_VALUE``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2224>`__)
+
+    *    - |fixed|
          - Change schemas in the codebase so that they use JAVA8 Optionals instead of Guava.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2210>`__)
 


### PR DESCRIPTION
**Goals (and why)**: Fix #2226.

**Implementation Description (bullets)**: The query for overflow sequence Oracle should return long rather than typecasting it to an int.

Smoke tested by inserting more than INT_MAX value into the DB after a repro.

**Concerns (what feedback would you like?)**: not really.

**Where should we start reviewing?**: Small change.

**Priority (whenever / two weeks / yesterday)**: today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2224)
<!-- Reviewable:end -->
