### PR TITLE
Reimplement KeyValueServiceScrubberStore

### DIFF
--- a/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/HintedHandOffManagerMBean.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/HintedHandOffManagerMBean.java
@@ -25,7 +25,7 @@ public interface HintedHandOffManagerMBean {
      *
      * @param host String rep. of endpoint address to delete hints for, either ip address ("127.0.0.1") or hostname
      */
-    void deleteHintsForEndpoint(final String host);
+    void deleteHintsForEndpoint(String host);
 
     /**
      *  Truncate all the hints.

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasCli.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasCli.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.cli.command.CleanCassLocksStateCommand;
 import com.palantir.atlasdb.cli.command.KvsMigrationCommand;
+import com.palantir.atlasdb.cli.command.ScrubQueueMigrationCommand;
 import com.palantir.atlasdb.cli.command.SweepCommand;
 import com.palantir.atlasdb.cli.command.timestamp.CleanTransactionRange;
 import com.palantir.atlasdb.cli.command.timestamp.FastForwardTimestamp;
@@ -43,7 +44,8 @@ public final class AtlasCli {
                 .withCommand(Help.class)
                 .withCommand(SweepCommand.class)
                 .withCommand(KvsMigrationCommand.class)
-                .withCommand(CleanCassLocksStateCommand.class);
+                .withCommand(CleanCassLocksStateCommand.class)
+                .withCommand(ScrubQueueMigrationCommand.class);
 
         builder.withGroup("timestamp")
                 .withDescription("Timestamp-centric commands")

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasCli.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/AtlasCli.java
@@ -36,29 +36,27 @@ public final class AtlasCli {
 
     private AtlasCli() {}
 
-    public static Cli<Callable> buildCli() {
-        Cli.CliBuilder<Callable> builder = Cli.<Callable>builder("atlasdb")
+    public static Cli<Callable<?>> buildCli() {
+        Cli.CliBuilder<Callable<?>> builder = Cli.<Callable<?>>builder("atlasdb")
                 .withDescription("Perform common AtlasDB tasks")
                 .withDefaultCommand(Help.class)
-                .withCommands(
-                        Help.class,
-                        SweepCommand.class,
-                        KvsMigrationCommand.class,
-                        CleanCassLocksStateCommand.class);
+                .withCommand(Help.class)
+                .withCommand(SweepCommand.class)
+                .withCommand(KvsMigrationCommand.class)
+                .withCommand(CleanCassLocksStateCommand.class);
 
         builder.withGroup("timestamp")
                 .withDescription("Timestamp-centric commands")
                 .withDefaultCommand(Help.class)
-                .withCommands(
-                        FetchTimestamp.class,
-                        CleanTransactionRange.class,
-                        FastForwardTimestamp.class);
+                .withCommand(FetchTimestamp.class)
+                .withCommand(CleanTransactionRange.class)
+                .withCommand(FastForwardTimestamp.class);
 
         return builder.build();
     }
 
     public static void main(String[] args) {
-        Cli<Callable> parser = buildCli();
+        Cli<Callable<?>> parser = buildCli();
         try {
             Object ret = parser.parse(args).call();
             if (ret instanceof Integer) {

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/ScrubQueueMigrationCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/ScrubQueueMigrationCommand.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.cli.command;
+
+import java.io.PrintWriter;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.services.AtlasDbServices;
+import com.palantir.common.base.ClosableIterator;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+@Command(name = "scrub-queue-migration",
+        description = "Move the contents of the old scrub queue into the new "
+                + "scrub queue. This operation is resumable.")
+public class ScrubQueueMigrationCommand extends SingleBackendCommand {
+    private static final byte[] EMPTY_CONTENTS = new byte[] {1};
+
+    @Option(name = {"--truncate"},
+            description = "Truncate the old scrub queue instead of moving it. "
+                    + "This is fine to do if you have not been running hard "
+                    + "deletes to satisfy legal requirements (a background "
+                    + "sweep run will eventually clean up any cells referenced "
+                    + "in the scrub queue).")
+    boolean truncateOldQueue;
+
+    @Option(name = {"--batch-size"},
+            description = "Batch size for copying rows, defaults to 1000.")
+    Integer batchSize;
+
+    @Override
+    public int execute(AtlasDbServices services) {
+        PrintWriter output = new PrintWriter(System.out, true);
+        if (truncateOldQueue) {
+            services.getKeyValueService().truncateTable(AtlasDbConstants.OLD_SCRUB_TABLE);
+            output.println("Truncated the old scrub queue.");
+        } else {
+            run(services.getKeyValueService(), output, MoreObjects.firstNonNull(batchSize, 1000));
+        }
+        return 0;
+    }
+
+    public static void run(KeyValueService kvs,
+                           PrintWriter output,
+                           int batchSize) {
+        Context context = new Context(kvs, output, batchSize);
+
+        // This potentially needs to iterate multiple times because getRange
+        // only grabs the most recent timestamp for each cell, but we care
+        // about every timestamp in the old scrub queue (this was the main
+        // problem with the old scrub queue). Each iteration will peel off the
+        // top version of each cell until the entire queue is drained.
+        for (int i = 0;; i++) {
+            output.println("Starting iteration " + i + " of scrub migration.");
+            Stopwatch watch = Stopwatch.createStarted();
+            try (ClosableIterator<RowResult<Value>> iter = kvs.getRange(
+                    AtlasDbConstants.OLD_SCRUB_TABLE, RangeRequest.all(), Long.MAX_VALUE)) {
+                if (!iter.hasNext()) {
+                    output.println("Finished all iterations of scrub migration.");
+                    break;
+                }
+                runOnce(context, iter);
+            }
+            output.println("Finished iteration " + i + " of scrub migration in "
+                    + watch.elapsed(TimeUnit.SECONDS) + " seconds.");
+        }
+    }
+
+    private static void runOnce(Context context,
+                                ClosableIterator<RowResult<Value>> iter) {
+        Multimap<Cell, Value> batchToCreate = ArrayListMultimap.create();
+        Multimap<Cell, Long> batchToDelete = ArrayListMultimap.create();
+        while (iter.hasNext()) {
+            RowResult<Value> rowResult = iter.next();
+            byte[] row = rowResult.getRowName();
+            for (Entry<byte[], Value> entry : rowResult.getColumns().entrySet()) {
+                byte[] col = entry.getKey();
+                Value value = entry.getValue();
+                long timestamp = value.getTimestamp();
+                String[] tableNames = StringUtils.split(
+                        PtBytes.toString(value.getContents()), '\0');
+                for (String tableName : tableNames) {
+                    byte[] tableBytes = EncodingUtils.encodeVarString(tableName);
+                    byte[] newCol = EncodingUtils.add(tableBytes, col);
+                    Cell newCell = Cell.create(row, newCol);
+                    batchToCreate.put(newCell, Value.create(EMPTY_CONTENTS, timestamp));
+                }
+                batchToDelete.put(Cell.create(row, col), timestamp);
+                if (batchToDelete.size() >= context.batchSize) {
+                    flush(context, batchToCreate, batchToDelete);
+                }
+            }
+        }
+        if (!batchToDelete.isEmpty()) {
+            flush(context, batchToCreate, batchToDelete);
+        }
+    }
+
+    private static void flush(Context context,
+                              Multimap<Cell, Value> batchToCreate,
+                              Multimap<Cell, Long> batchToDelete) {
+        context.kvs.delete(AtlasDbConstants.OLD_SCRUB_TABLE, batchToDelete);
+        context.totalDeletes += batchToDelete.size();
+        batchToDelete.clear();
+        try {
+            context.kvs.putWithTimestamps(AtlasDbConstants.SCRUB_TABLE, batchToCreate);
+        } catch (KeyAlreadyExistsException e) {
+            context.kvs.delete(AtlasDbConstants.SCRUB_TABLE,
+                    Multimaps.transformValues(batchToCreate, Value::getTimestamp));
+            context.kvs.putWithTimestamps(AtlasDbConstants.SCRUB_TABLE, batchToCreate);
+        }
+        context.totalPuts += batchToCreate.size();
+        batchToCreate.clear();
+        context.output.println("Moved " + context.totalDeletes + " cells from "
+                + "the old scrub queue into " + context.totalPuts + " cells in "
+                + "the new scrub queue.");
+    }
+
+    @Override
+    public boolean isOnlineRunSupported() {
+        return true;
+    }
+
+    private static class Context {
+        final KeyValueService kvs;
+        final PrintWriter output;
+        final int batchSize;
+        long totalPuts;
+        long totalDeletes;
+
+        Context(KeyValueService kvs, PrintWriter output, int batchSize) {
+            this.kvs = kvs;
+            this.output = output;
+            this.batchSize = batchSize;
+        }
+    }
+}

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestScrubQueueMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestScrubQueueMigrationCommand.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.cli.command;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.util.SortedMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cleaner.KeyValueServiceScrubberStore;
+import com.palantir.atlasdb.cleaner.ScrubberStore;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitables;
+
+public class TestScrubQueueMigrationCommand {
+    private KeyValueService kvs;
+    private ScrubberStore scrubStore;
+
+    @Before
+    public void before() {
+        kvs = new InMemoryKeyValueService(false, MoreExecutors.newDirectExecutorService());
+        scrubStore = KeyValueServiceScrubberStore.create(kvs);
+    }
+
+    @After
+    public void after() {
+        kvs.close();
+    }
+
+    @Test
+    public void testScrubQueueMigration() {
+        TableReference foo = TableReference.createWithEmptyNamespace("foo");
+        TableReference bar = TableReference.createWithEmptyNamespace("bar");
+        TableReference baz = TableReference.createWithEmptyNamespace("baz");
+        Cell cell1 = Cell.create(new byte[] {1, 2, 3}, new byte[] {4, 5, 6});
+        Cell cell2 = Cell.create(new byte[] {7, 8, 9}, new byte[] {4, 5, 6});
+        Cell cell3 = Cell.create(new byte[] {1, 2, 3}, new byte[] {7, 8, 9});
+        kvs.createTable(AtlasDbConstants.OLD_SCRUB_TABLE, new byte[] {0});
+        kvs.putWithTimestamps(AtlasDbConstants.OLD_SCRUB_TABLE, ImmutableMultimap.of(
+                cell1, Value.create("foo\0bar".getBytes(), 10),
+                cell1, Value.create("baz".getBytes(), 20),
+                cell2, Value.create("foo".getBytes(), 30),
+                cell3, Value.create("foo\0bar\0baz".getBytes(), 40)));
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ScrubQueueMigrationCommand.run(kvs, new PrintWriter(baos, true), 1000);
+        BatchingVisitable<SortedMap<Long, Multimap<TableReference, Cell>>> visitable =
+                scrubStore.getBatchingVisitableScrubQueue(
+                        Long.MAX_VALUE, PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY);
+        Assert.assertEquals(ImmutableSortedMap.of(
+                10L, ImmutableMultimap.of(foo, cell1, bar, cell1),
+                20L, ImmutableMultimap.of(baz, cell1),
+                30L, ImmutableMultimap.of(foo, cell2),
+                40L, ImmutableMultimap.of(foo, cell3, bar, cell3, baz, cell3)),
+                Iterables.getOnlyElement(BatchingVisitables.copyToList(visitable)));
+        String output = new String(baos.toByteArray());
+        Assert.assertTrue(output, output.contains("Starting iteration 2"));
+        Assert.assertTrue(output, output.contains("Moved 4 cells"));
+        Assert.assertTrue(output, output.contains("into 7 cells"));
+        Assert.assertTrue(output, output.contains("Finished all iterations"));
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -25,7 +25,8 @@ import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
 public class AtlasDbConstants {
     public static final TableReference PUNCH_TABLE = TableReference.createWithEmptyNamespace("_punch");
-    public static final TableReference SCRUB_TABLE = TableReference.createWithEmptyNamespace("_scrub");
+    public static final TableReference OLD_SCRUB_TABLE = TableReference.createWithEmptyNamespace("_scrub");
+    public static final TableReference SCRUB_TABLE = TableReference.createWithEmptyNamespace("_scrub2");
     public static final TableReference NAMESPACE_TABLE = TableReference.createWithEmptyNamespace("_namespace");
     public static final TableReference TIMESTAMP_TABLE = TableReference.createWithEmptyNamespace("_timestamp");
     public static final TableReference PERSISTED_LOCKS_TABLE = TableReference.createWithEmptyNamespace(
@@ -90,7 +91,6 @@ public class AtlasDbConstants {
     public static final long DEFAULT_BACKGROUND_SCRUB_FREQUENCY_MILLIS = 3600000L;
     public static final int DEFAULT_BACKGROUND_SCRUB_BATCH_SIZE = 2000;
     public static final long SCRUBBER_RETRY_DELAY_MILLIS = 500L;
-    public static final char SCRUB_TABLE_SEPARATOR_CHAR = '\0';
 
     public static final boolean DEFAULT_ENABLE_SWEEP = true;
     public static final long DEFAULT_SWEEP_PAUSE_MILLIS = 5 * 1000;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -91,6 +91,7 @@ public class AtlasDbConstants {
     public static final long DEFAULT_BACKGROUND_SCRUB_FREQUENCY_MILLIS = 3600000L;
     public static final int DEFAULT_BACKGROUND_SCRUB_BATCH_SIZE = 2000;
     public static final long SCRUBBER_RETRY_DELAY_MILLIS = 500L;
+    public static final char OLD_SCRUB_TABLE_SEPARATOR_CHAR = '\0';
 
     public static final boolean DEFAULT_ENABLE_SWEEP = true;
     public static final long DEFAULT_SWEEP_PAUSE_MILLIS = 5 * 1000;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnValueDescription.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ColumnValueDescription.java
@@ -110,7 +110,6 @@ public class ColumnValueDescription {
         return forPersistable(clazz, Compression.NONE);
     }
 
-    @SuppressWarnings("unchecked")
     public static ColumnValueDescription forPersistable(Class<? extends Persistable> clazz,
                                                         Compression compression) {
         Validate.notNull(Persistables.getHydrator(clazz), "Not a valid persistable class because it has no hydrator");

--- a/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCliCommand.java
+++ b/atlasdb-dropwizard-bundle/src/main/java/com/palantir/atlasdb/dropwizard/commands/AtlasDbCliCommand.java
@@ -49,7 +49,7 @@ public class AtlasDbCliCommand<T extends Configuration & AtlasDbConfigurationPro
     private static final Logger log = LoggerFactory.getLogger(AtlasDbCliCommand.class);
 
     private static final String COMMAND_NAME_ATTR = "airlineSubCommand";
-    private static final Cli<Callable> CLI = AtlasCli.buildCli();
+    private static final Cli<Callable<?>> CLI = AtlasCli.buildCli();
 
     public AtlasDbCliCommand(Class<T> configurationClass) {
         super(CLI.getMetadata().getName(), CLI.getMetadata().getDescription(), configurationClass);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
@@ -15,29 +15,27 @@
  */
 package com.palantir.atlasdb.cleaner;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 
-import org.apache.commons.lang3.StringUtils;
-
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
 import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
 import com.palantir.atlasdb.table.description.ColumnValueDescription;
 import com.palantir.atlasdb.table.description.DynamicColumnDescription;
@@ -49,7 +47,6 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.common.base.AbstractBatchingVisitable;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitableFromIterable;
-import com.palantir.common.base.BatchingVisitableView;
 import com.palantir.common.base.ClosableIterator;
 
 /**
@@ -60,22 +57,22 @@ import com.palantir.common.base.ClosableIterator;
  * @author ejin
  */
 public final class KeyValueServiceScrubberStore implements ScrubberStore {
+    private static final byte[] EMPTY_CONTENTS = new byte[] {1};
     private final KeyValueService keyValueService;
 
     public static ScrubberStore create(KeyValueService keyValueService) {
-        keyValueService.createTable(AtlasDbConstants.SCRUB_TABLE, new TableMetadata(
-                NameMetadataDescription.create(ImmutableList.of(new NameComponentDescription("cell", ValueType.BLOB))),
+        TableMetadata scrubTableMeta = new TableMetadata(
+                NameMetadataDescription.create(ImmutableList.of(
+                        new NameComponentDescription("row", ValueType.BLOB))),
                 new ColumnMetadataDescription(new DynamicColumnDescription(
                         NameMetadataDescription.create(ImmutableList.of(
-                                new NameComponentDescription("name", ValueType.STRING))),
-                        ColumnValueDescription.forType(ValueType.STRING))),
-                        ConflictHandler.IGNORE_ALL).persistToBytes());
+                                new NameComponentDescription("table", ValueType.VAR_STRING),
+                                new NameComponentDescription("col", ValueType.BLOB))),
+                        ColumnValueDescription.forType(ValueType.VAR_LONG))),
+                ConflictHandler.IGNORE_ALL);
+        keyValueService.createTables(ImmutableMap.of(
+                AtlasDbConstants.SCRUB_TABLE, scrubTableMeta.persistToBytes()));
         return new KeyValueServiceScrubberStore(keyValueService);
-    }
-
-    public static ScrubberStore createWithInMemoryKvs() {
-        KeyValueService inMemoryKvs = new InMemoryKeyValueService(false);
-        return create(inMemoryKvs);
     }
 
     private KeyValueServiceScrubberStore(KeyValueService keyValueService) {
@@ -90,11 +87,11 @@ public final class KeyValueServiceScrubberStore implements ScrubberStore {
         Map<Cell, byte[]> values = Maps.newHashMap();
         for (Map.Entry<Cell, Collection<TableReference>> entry : cellToTableRefs.asMap().entrySet()) {
             Cell cell = entry.getKey();
-            Collection<TableReference> tableRefs = entry.getValue();
-            // Doing the join here is safe--queueCellsForScrubbing is only called once per transaction
-            // so we'll have all the table names for a given scrubTimestamp
-            String joined = StringUtils.join(tableRefs, AtlasDbConstants.SCRUB_TABLE_SEPARATOR_CHAR);
-            values.put(cell, PtBytes.toBytes(joined));
+            for (TableReference tableRef : entry.getValue()) {
+                byte[] tableBytes = EncodingUtils.encodeVarString(tableRef.getQualifiedName());
+                byte[] col = EncodingUtils.add(tableBytes, cell.getColumnName());
+                values.put(Cell.create(cell.getRowName(), col), EMPTY_CONTENTS);
+            }
         }
         for (List<Entry<Cell, byte[]>> batch : Iterables.partition(values.entrySet(), batchSize)) {
             Map<Cell, byte[]> batchMap = Maps.newHashMap();
@@ -109,41 +106,51 @@ public final class KeyValueServiceScrubberStore implements ScrubberStore {
     }
 
     @Override
-    public void markCellsAsScrubbed(Multimap<Cell, Long> cellToScrubTimestamp, int batchSize) {
-        for (List<Entry<Cell, Long>> batch : Iterables.partition(cellToScrubTimestamp.entries(), batchSize)) {
-            Multimap<Cell, Long> batchMultimap = HashMultimap.create();
-            for (Entry<Cell, Long> e : batch) {
-                batchMultimap.put(e.getKey(), e.getValue());
+    public void markCellsAsScrubbed(Map<TableReference, Multimap<Cell, Long>> cellToScrubTimestamp, int batchSize) {
+        Multimap<Cell, Long> batch = ArrayListMultimap.create();
+        for (Entry<TableReference, Multimap<Cell, Long>> tableEntry : cellToScrubTimestamp.entrySet()) {
+            byte[] tableBytes = EncodingUtils.encodeVarString(tableEntry.getKey().getQualifiedName());
+            for (Entry<Cell, Collection<Long>> cellEntry : tableEntry.getValue().asMap().entrySet()) {
+                byte[] col = EncodingUtils.add(tableBytes, cellEntry.getKey().getColumnName());
+                Cell cell = Cell.create(cellEntry.getKey().getRowName(), col);
+                for (Long timestamp : cellEntry.getValue()) {
+                    batch.put(cell, timestamp);
+                    if (batch.size() >= batchSize) {
+                        keyValueService.delete(AtlasDbConstants.SCRUB_TABLE, batch);
+                        batch.clear();
+                    }
+                }
             }
-            keyValueService.delete(
-                    AtlasDbConstants.SCRUB_TABLE,
-                    batchMultimap);
+        }
+        if (!batch.isEmpty()) {
+            keyValueService.delete(AtlasDbConstants.SCRUB_TABLE, batch);
         }
     }
 
     @Override
     public BatchingVisitable<SortedMap<Long, Multimap<TableReference, Cell>>> getBatchingVisitableScrubQueue(
-            int cellsToScrubBatchSize,
             long maxScrubTimestamp /* exclusive */,
             byte[] startRow,
             byte[] endRow) {
-        ClosableIterator<RowResult<Value>> iterator =
-                getIteratorToScrub(cellsToScrubBatchSize, maxScrubTimestamp, startRow, endRow);
-        final BatchingVisitable<RowResult<Value>> results = BatchingVisitableFromIterable.create(iterator);
-        return BatchingVisitableView.of(
-                new AbstractBatchingVisitable<SortedMap<Long, Multimap<TableReference, Cell>>>() {
-                    @Override
-                    protected <K extends Exception> void batchAcceptSizeHint(
-                            int batchSizeHint,
-                            ConsistentVisitor<SortedMap<Long, Multimap<TableReference, Cell>>, K> visitor) throws K {
-                        results.batchAccept(cellsToScrubBatchSize, batch ->
-                                visitor.visit(ImmutableList.of(transformRows(batch))));
-                    }
-                });
+        return new AbstractBatchingVisitable<SortedMap<Long, Multimap<TableReference, Cell>>>() {
+            @Override
+            protected <K extends Exception> void batchAcceptSizeHint(
+                    int batchSizeHint,
+                    ConsistentVisitor<SortedMap<Long, Multimap<TableReference, Cell>>, K> visitor) throws K {
+                ClosableIterator<RowResult<Value>> iterator =
+                        getIteratorToScrub(batchSizeHint, maxScrubTimestamp, startRow, endRow);
+                try {
+                    BatchingVisitableFromIterable.create(iterator).batchAccept(
+                            batchSizeHint, batch -> visitor.visitOne(transformRows(batch)));
+                } finally {
+                    iterator.close();
+                }
+            }
+        };
     }
 
     private ClosableIterator<RowResult<Value>> getIteratorToScrub(
-            int cellsToScrubBatchSize,
+            int batchSizeHint,
             long maxScrubTimestamp,
             byte[] startRow,
             byte[] endRow) {
@@ -156,40 +163,29 @@ public final class KeyValueServiceScrubberStore implements ScrubberStore {
         }
         return keyValueService.getRange(
                 AtlasDbConstants.SCRUB_TABLE,
-                range.batchHint(cellsToScrubBatchSize).build(),
+                range.batchHint(batchSizeHint).build(),
                 maxScrubTimestamp);
     }
 
     private SortedMap<Long, Multimap<TableReference, Cell>> transformRows(List<RowResult<Value>> input) {
         SortedMap<Long, Multimap<TableReference, Cell>> scrubTimestampToTableNameToCell = Maps.newTreeMap();
         for (RowResult<Value> rowResult : input) {
-            for (Map.Entry<Cell, Value> entry : rowResult.getCells()) {
-                Cell cell = entry.getKey();
-                Value value = entry.getValue();
-                long scrubTimestamp = value.getTimestamp();
-                String[] tableNames = StringUtils.split(
-                        PtBytes.toString(value.getContents()),
-                        AtlasDbConstants.SCRUB_TABLE_SEPARATOR_CHAR);
-                if (!scrubTimestampToTableNameToCell.containsKey(scrubTimestamp)) {
-                    scrubTimestampToTableNameToCell.put(scrubTimestamp, HashMultimap.create());
+            byte[] row = rowResult.getRowName();
+            for (Entry<byte[], Value> entry : rowResult.getColumns().entrySet()) {
+                byte[] fullCol = entry.getKey();
+                String table = EncodingUtils.decodeVarString(fullCol);
+                byte[] col = Arrays.copyOfRange(fullCol, EncodingUtils.sizeOfVarString(table), fullCol.length);
+                TableReference tableRef = TableReference.fromString(table);
+                Cell cell = Cell.create(row, col);
+                long timestamp = entry.getValue().getTimestamp();
+                Multimap<TableReference, Cell> cells = scrubTimestampToTableNameToCell.get(timestamp);
+                if (cells == null) {
+                    cells = ArrayListMultimap.create();
+                    scrubTimestampToTableNameToCell.put(timestamp, cells);
                 }
-                for (String tableName : tableNames) {
-                    scrubTimestampToTableNameToCell.get(scrubTimestamp)
-                            .put(TableReference.createUnsafe(tableName), cell);
-                }
+                cells.put(tableRef, cell);
             }
         }
         return scrubTimestampToTableNameToCell;
     }
-
-    @Override
-    public int getNumberRemainingScrubCells(int maxCellsToScan) {
-        ClosableIterator<RowResult<Value>> iterator = getIteratorToScrub(maxCellsToScan, Long.MAX_VALUE, null, null);
-        try {
-            return Iterators.size(Iterators.limit(iterator, maxCellsToScan));
-        } finally {
-            iterator.close();
-        }
-    }
-
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -36,15 +36,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Functions;
 import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableMultimap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
@@ -67,7 +69,6 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.base.BatchingVisitable;
-import com.palantir.common.base.BatchingVisitableView;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.collect.Maps2;
 import com.palantir.common.concurrent.ExecutorInheritableThreadLocal;
@@ -255,9 +256,8 @@ public final class Scrubber {
             final byte[] endRow = rangeBoundaries.get(i + 1);
             readerFutures.add(readerExec.submit(() -> {
                 BatchingVisitable<SortedMap<Long, Multimap<TableReference, Cell>>> scrubQueue = scrubberStore
-                        .getBatchingVisitableScrubQueue(batchSize, maxScrubTimestamp, startRow, endRow);
-                // Take one at a time since we already batched them together in KeyValueServiceScrubberStore.
-                BatchingVisitableView.of(scrubQueue).batchAccept(1, batch -> {
+                        .getBatchingVisitableScrubQueue(maxScrubTimestamp, startRow, endRow);
+                scrubQueue.batchAccept(batchSize, batch -> {
                     for (SortedMap<Long, Multimap<TableReference, Cell>> cells : batch) {
                         // We may actually get more cells than the batch size. The batch size is used
                         // for pulling off the scrub queue, and a single entry in the scrub queue may
@@ -323,14 +323,6 @@ public final class Scrubber {
                 // Here we don't need to check scrub timestamps because we guarantee that scrubImmediately is called
                 // AFTER the transaction commits
                 scrubCells(txManager, batchMultimap, scrubTimestamp, TransactionType.AGGRESSIVE_HARD_DELETE);
-
-                Multimap<Cell, Long> cellToScrubTimestamp = HashMultimap.create();
-
-                cellToScrubTimestamp = Multimaps.invertFrom(
-                        Multimaps.index(batchMultimap.values(), Functions.constant(scrubTimestamp)),
-                        cellToScrubTimestamp);
-
-                scrubberStore.markCellsAsScrubbed(cellToScrubTimestamp, batchSizeSupplier.get());
 
                 log.debug("Completed scrub immediately.");
                 return null;
@@ -425,25 +417,33 @@ public final class Scrubber {
             return 0; // No cells left to scrub
         }
 
-        Multimap<Long, Cell> toRemoveFromScrubQueue = HashMultimap.create();
-
         int numCellsReadFromScrubTable = 0;
         List<Future<Void>> scrubFutures = Lists.newArrayList();
+        Map<TableReference, Multimap<Cell, Long>> failedWrites = Maps.newHashMap();
+
         for (Map.Entry<Long, Multimap<TableReference, Cell>> entry : scrubTimestampToTableNameToCell.entrySet()) {
             final long scrubTimestamp = entry.getKey();
             final Multimap<TableReference, Cell> tableNameToCell = entry.getValue();
 
             numCellsReadFromScrubTable += tableNameToCell.size();
 
+            // This is CRITICAL; don't scrub if the hard delete transaction didn't actually finish
+            // (we still remove it from the _scrub table with the call to markCellsAsScrubbed though),
+            // or else we could cause permanent data loss if the hard delete transaction failed after
+            // queuing cells to scrub but before successfully committing
             long commitTimestamp = getCommitTimestampRollBackIfNecessary(scrubTimestamp, tableNameToCell);
-            if (commitTimestamp >= maxScrubTimestamp) {
-                // We cannot scrub this yet because not all transactions can read this value.
-                continue;
-            } else if (commitTimestamp != TransactionConstants.FAILED_COMMIT_TS) {
-                // This is CRITICAL; don't scrub if the hard delete transaction didn't actually finish
-                // (we still remove it from the _scrub table with the call to markCellsAsScrubbed though),
-                // or else we could cause permanent data loss if the hard delete transaction failed after
-                // queuing cells to scrub but before successfully committing
+            if (commitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
+                for (Entry<TableReference, Collection<Cell>> cells : tableNameToCell.asMap().entrySet()) {
+                    Multimap<Cell, Long> failedCells = failedWrites.get(cells.getKey());
+                    if (failedCells == null) {
+                        failedCells = ArrayListMultimap.create(cells.getValue().size(), 2);
+                        failedWrites.put(cells.getKey(), failedCells);
+                    }
+                    for (Cell cell : cells.getValue()) {
+                        failedCells.put(cell, scrubTimestamp);
+                    }
+                }
+            } else if (commitTimestamp < maxScrubTimestamp) {
                 for (final List<Entry<TableReference, Cell>> batch :
                         Iterables.partition(tableNameToCell.entries(), batchSizeSupplier.get())) {
                     final Multimap<TableReference, Cell> batchMultimap = HashMultimap.create();
@@ -458,17 +458,18 @@ public final class Scrubber {
                     }));
                 }
             }
-            toRemoveFromScrubQueue.putAll(scrubTimestamp, tableNameToCell.values());
+            // else {
+            //     We cannot scrub this yet because not all transactions can read this value.
+            // }
         }
 
         for (Future<Void> future : scrubFutures) {
             Futures.getUnchecked(future);
         }
 
-        Multimap<Cell, Long> cellToScrubTimestamp = HashMultimap.create();
-        scrubberStore.markCellsAsScrubbed(
-                Multimaps.invertFrom(toRemoveFromScrubQueue, cellToScrubTimestamp),
-                batchSizeSupplier.get());
+        if (!failedWrites.isEmpty()) {
+            scrubberStore.markCellsAsScrubbed(failedWrites, batchSizeSupplier.get());
+        }
 
         log.trace("Finished scrubbing cells: {}", scrubTimestampToTableNameToCell);
 
@@ -523,6 +524,7 @@ public final class Scrubber {
                 batch.stream().forEach(e -> builder.put(e));
                 keyValueService.delete(tableRef, builder.build());
             }
+            scrubberStore.markCellsAsScrubbed(ImmutableMap.of(tableRef, cellToTimestamp), batchSizeSupplier.get());
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.cleaner;
 
+import java.util.Map;
 import java.util.SortedMap;
 
 import com.google.common.collect.Multimap;
@@ -31,13 +32,10 @@ import com.palantir.common.base.BatchingVisitable;
 public interface ScrubberStore {
     void queueCellsForScrubbing(Multimap<Cell, TableReference> cellToTableRefs, long scrubTimestamp, int batchSize);
 
-    void markCellsAsScrubbed(Multimap<Cell, Long> cellToScrubTimestamp, int batchSize);
+    void markCellsAsScrubbed(Map<TableReference, Multimap<Cell, Long>> cellToScrubTimestamp, int batchSize);
 
     BatchingVisitable<SortedMap<Long, Multimap<TableReference, Cell>>> getBatchingVisitableScrubQueue(
-            int cellsToScrubBatchSize,
             long maxScrubTimestamp /* exclusive */,
             byte[] startRow,
             byte[] endRow);
-
-    int getNumberRemainingScrubCells(int maxCellsToScan);
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/scrub/KeyValueServiceScrubberStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/scrub/KeyValueServiceScrubberStoreTest.java
@@ -79,11 +79,10 @@ public class KeyValueServiceScrubberStoreTest {
                 getScrubQueue());
         scrubStore.markCellsAsScrubbed(ImmutableMap.of(
                 ref2, ImmutableMultimap.of(cell3, timestamp2),
-                ref1, ImmutableMultimap.of(cell1, timestamp1)), 1000);
+                ref1, ImmutableMultimap.of(cell1, timestamp1, cell1, timestamp2)), 1000);
         Assert.assertEquals(
                 ImmutableList.of(ImmutableSortedMap.of(
-                        timestamp1, ImmutableMultimap.of(ref1, cell2),
-                        timestamp2, ImmutableMultimap.of(ref1, cell1))),
+                        timestamp1, ImmutableMultimap.of(ref1, cell2))),
                 getScrubQueue());
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/scrub/KeyValueServiceScrubberStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/scrub/KeyValueServiceScrubberStoreTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.scrub;
+
+import java.util.List;
+import java.util.SortedMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.cleaner.KeyValueServiceScrubberStore;
+import com.palantir.atlasdb.cleaner.ScrubberStore;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitables;
+
+public class KeyValueServiceScrubberStoreTest {
+    private KeyValueService kvs;
+    private ScrubberStore scrubStore;
+
+    @Before
+    public void before() {
+        kvs = new InMemoryKeyValueService(false, MoreExecutors.newDirectExecutorService());
+        scrubStore = KeyValueServiceScrubberStore.create(kvs);
+    }
+
+    @After
+    public void after() {
+        kvs.close();
+    }
+
+    @Test
+    public void testEmptyStoreReturnsNothing() {
+        Assert.assertEquals(ImmutableList.of(), getScrubQueue());
+    }
+
+    @Test
+    public void testSingleEntryStore() {
+        Cell cell = Cell.create(new byte[] {1, 2, 3}, new byte[] {4, 5, 6});
+        TableReference ref = TableReference.fromString("foo.bar");
+        long timestamp = 10;
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell, ref), timestamp, 1000);
+        Assert.assertEquals(
+                ImmutableList.of(ImmutableSortedMap.of(timestamp, ImmutableMultimap.of(ref, cell))),
+                getScrubQueue());
+        scrubStore.markCellsAsScrubbed(ImmutableMap.of(ref, ImmutableMultimap.of(cell, timestamp)), 1000);
+        Assert.assertEquals(ImmutableList.of(), getScrubQueue());
+    }
+
+    @Test
+    public void testMultipleEntryStore() {
+        Cell cell1 = Cell.create(new byte[] {1, 2, 3}, new byte[] {4, 5, 6});
+        Cell cell2 = Cell.create(new byte[] {7, 8, 9}, new byte[] {4, 5, 6});
+        Cell cell3 = Cell.create(new byte[] {1, 2, 3}, new byte[] {7, 8, 9});
+        TableReference ref1 = TableReference.fromString("foo.bar");
+        TableReference ref2 = TableReference.fromString("foo.baz");
+        long timestamp1 = 10;
+        long timestamp2 = 20;
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell1, ref1, cell2, ref1), timestamp1, 1000);
+        scrubStore.queueCellsForScrubbing(ImmutableMultimap.of(cell1, ref1, cell3, ref2), timestamp2, 1000);
+        Assert.assertEquals(
+                ImmutableList.of(ImmutableSortedMap.of(
+                        timestamp1, ImmutableMultimap.of(ref1, cell2),
+                        timestamp2, ImmutableMultimap.of(ref2, cell3, ref1, cell1))),
+                getScrubQueue());
+        scrubStore.markCellsAsScrubbed(ImmutableMap.of(
+                ref2, ImmutableMultimap.of(cell3, timestamp2),
+                ref1, ImmutableMultimap.of(cell1, timestamp1)), 1000);
+        Assert.assertEquals(
+                ImmutableList.of(ImmutableSortedMap.of(
+                        timestamp1, ImmutableMultimap.of(ref1, cell2),
+                        timestamp2, ImmutableMultimap.of(ref1, cell1))),
+                getScrubQueue());
+    }
+
+    private List<SortedMap<Long, Multimap<TableReference, Cell>>> getScrubQueue() {
+        BatchingVisitable<SortedMap<Long, Multimap<TableReference, Cell>>> visitable =
+                scrubStore.getBatchingVisitableScrubQueue(
+                        Long.MAX_VALUE, PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY);
+        return BatchingVisitables.copyToList(visitable);
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,6 +62,10 @@ develop
          - Change schemas in the codebase so that they use JAVA8 Optionals instead of Guava.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2210>`__)
 
+    *    - |fixed|
+         - The scrubber can no longer get backed up if the same cell is overwritten multiple times by hard delete transactions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2232>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
also adds a cli to either truncate the old scrub queue or migrate its
contents to the new scrub queue.

Fixes #2230

**Goals (and why)**:

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2232)
<!-- Reviewable:end -->
