### PR TITLE
Add clock went backwards event

### DIFF
--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -203,8 +203,8 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         for (TestableTimelockServer server : CLUSTER.servers()) {
             MetricsOutput metrics = server.getMetricsOutput();
 
-            metrics.assertContainsHistogram("clock-pace-remote");
-            assertThat(metrics.getHistogram("clock-pace-remote").get("count").intValue()).isGreaterThan(0);
+            metrics.assertContainsHistogram("clock.skew");
+            assertThat(metrics.getHistogram("clock.skew").get("count").intValue()).isGreaterThan(0);
         }
     }
 }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/clock/ClockSkewComparer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/clock/ClockSkewComparer.java
@@ -40,9 +40,9 @@ public class ClockSkewComparer {
         this.server = server;
         this.events = events;
 
-        maxElapsedTime = newRequest.localTimeAtEnd - previousRequest.localTimeAtStart;
-        minElapsedTime = newRequest.localTimeAtStart - previousRequest.localTimeAtEnd;
-        remoteElapsedTime = newRequest.remoteSystemTime - previousRequest.remoteSystemTime;
+        maxElapsedTime = newRequest.localTimeAtEnd() - previousRequest.localTimeAtStart();
+        minElapsedTime = newRequest.localTimeAtStart() - previousRequest.localTimeAtEnd();
+        remoteElapsedTime = newRequest.remoteSystemTime() - previousRequest.remoteSystemTime();
     }
 
     public void compare() {
@@ -64,11 +64,7 @@ public class ClockSkewComparer {
         }
 
         long skew = getSkew();
-        if (skew != 0) {
-            events.clockSkew(server, skew);
-        }
-
-        events.requestPace(server, minElapsedTime, maxElapsedTime, remoteElapsedTime);
+        events.clockSkew(server, skew);
     }
 
     private long getSkew() {

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/clock/ClockSkewMonitor.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/clock/ClockSkewMonitor.java
@@ -49,12 +49,12 @@ public final class ClockSkewMonitor {
     private final ReversalDetectingClockService localClockService;
 
     public static ClockSkewMonitor create(Set<String> remoteServers, Optional<SSLSocketFactory> optionalSecurity) {
-        Map<String, ClockService> monitors = Maps.toMap(
+        Map<String, ClockService> clocksByServer = Maps.toMap(
                 remoteServers,
                 (remoteServer) -> AtlasDbHttpClients.createProxy(optionalSecurity, remoteServer, ClockService.class));
 
         return new ClockSkewMonitor(
-                monitors,
+                clocksByServer,
                 new ClockSkewEvents(AtlasDbMetrics.getMetricRegistry()),
                 Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("clock-skew-monitor", true)),
                 new ClockServiceImpl());

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/clock/RequestTime.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/clock/RequestTime.java
@@ -16,44 +16,34 @@
 
 package com.palantir.atlasdb.timelock.clock;
 
-public class RequestTime {
-    // Since we expect localTimeAtStart != localTimeAtEnd, it's safe to have an empty request time.
-    public static final RequestTime EMPTY = new RequestTime(0L, 0L, 0L);
 
-    public final long localTimeAtStart;
-    public final long localTimeAtEnd;
-    public final long remoteSystemTime;
+import org.immutables.value.Value;
 
-    RequestTime(long localTimeAtStart, long localTimeAtEnd, long remoteSystemTime) {
-        this.localTimeAtStart = localTimeAtStart;
-        this.localTimeAtEnd = localTimeAtEnd;
-        this.remoteSystemTime = remoteSystemTime;
+@Value.Immutable
+public interface RequestTime {
+
+    long localTimeAtStart();
+
+    long localTimeAtEnd();
+
+    long remoteSystemTime();
+
+    default RequestTime progressLocalClock(long delta) {
+        return builder().from(this)
+                .localTimeAtStart(localTimeAtStart() + delta)
+                .localTimeAtEnd(localTimeAtEnd() + delta)
+                .build();
     }
 
-    public static class Builder {
-        private long localTimeAtStart;
-        private long localTimeAtEnd;
-        private long remoteSystemTime;
-
-        public Builder(RequestTime requestTime) {
-            localTimeAtStart = requestTime.localTimeAtStart;
-            localTimeAtEnd = requestTime.localTimeAtEnd;
-            remoteSystemTime = requestTime.remoteSystemTime;
-        }
-
-        public Builder progressLocalClock(long delta) {
-            localTimeAtStart += delta;
-            localTimeAtEnd += delta;
-            return this;
-        }
-
-        public Builder progressRemoteClock(long delta) {
-            remoteSystemTime += delta;
-            return this;
-        }
-
-        public RequestTime build() {
-            return new RequestTime(localTimeAtStart, localTimeAtEnd, remoteSystemTime);
-        }
+    default RequestTime progressRemoteClock(long delta) {
+        return builder().from(this)
+                .remoteSystemTime(remoteSystemTime() + delta)
+                .build();
     }
+
+
+    static ImmutableRequestTime.Builder builder() {
+        return ImmutableRequestTime.builder();
+    }
+
 }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/clock/ReversalDetectingClockService.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/clock/ReversalDetectingClockService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.clock;
+
+import javax.annotation.concurrent.GuardedBy;
+
+class ReversalDetectingClockService implements ClockService {
+
+    private final ClockSkewEvents events;
+    private final ClockService delegate;
+    private final String server;
+
+    @GuardedBy("this")
+    private long lastReturnedTime = Long.MIN_VALUE;
+
+    ReversalDetectingClockService(ClockService delegate, String server, ClockSkewEvents events) {
+        this.delegate = delegate;
+        this.server = server;
+        this.events = events;
+    }
+
+    @Override
+    public synchronized long getSystemTimeInNanos() {
+        long time = delegate.getSystemTimeInNanos();
+        if (time < lastReturnedTime) {
+            events.clockWentBackwards(server, Math.abs(lastReturnedTime - time));
+        }
+
+        lastReturnedTime = time;
+        return lastReturnedTime;
+    }
+}

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/clock/ReversalDetectingClockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/clock/ReversalDetectingClockServiceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class ReversalDetectingClockServiceTest {
+
+    private static final String SERVER_NAME = "foo";
+
+    private final ClockService delegate = mock(ClockService.class);
+    private final ClockSkewEvents events = mock(ClockSkewEvents.class);
+    private final ReversalDetectingClockService clock = new ReversalDetectingClockService(delegate, SERVER_NAME,
+            events);
+
+    @After
+    public void after() {
+        verifyNoMoreInteractions(events);
+    }
+
+    @Test
+    public void doesNotLogIfClockDoesNotGoBackwards() {
+        when(delegate.getSystemTimeInNanos())
+                .thenReturn(1L)
+                .thenReturn(2L)
+                .thenReturn(3L);
+
+        clock.getSystemTimeInNanos();
+    }
+
+    @Test
+    public void logsIfClockGoesBackwards() {
+        when(delegate.getSystemTimeInNanos())
+                .thenReturn(5L)
+                .thenReturn(2L);
+
+        clock.getSystemTimeInNanos();
+        clock.getSystemTimeInNanos();
+
+        verify(events).clockWentBackwards(SERVER_NAME, 3L);
+    }
+
+    @Test
+    public void returnsDelegateValueRegardlessOfWhetherClockGoesBackwards() {
+        when(delegate.getSystemTimeInNanos())
+                .thenReturn(1L)
+                .thenReturn(2L)
+                .thenReturn(1L)
+                .thenReturn(3L);
+
+        assertThat(clock.getSystemTimeInNanos()).isEqualTo(1);
+        assertThat(clock.getSystemTimeInNanos()).isEqualTo(2);
+        assertThat(clock.getSystemTimeInNanos()).isEqualTo(1);
+        assertThat(clock.getSystemTimeInNanos()).isEqualTo(3);
+
+        verify(events).clockWentBackwards(SERVER_NAME, 1L);
+    }
+
+}

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/clock/ReversalDetectingClockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/clock/ReversalDetectingClockServiceTest.java
@@ -47,6 +47,8 @@ public class ReversalDetectingClockServiceTest {
                 .thenReturn(3L);
 
         clock.getSystemTimeInNanos();
+        clock.getSystemTimeInNanos();
+        clock.getSystemTimeInNanos();
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Record if the clock ever goes backwards. Currently, we just throw an exception and would need to check the logs to see it.

**Implementation Description (bullets)**:
- Wrap all clock services in `ReversalDetectingClockService`
- Some drive-by refactors

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`ReversalDetectingClockService`

**Priority (whenever / two weeks / yesterday)**:
whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2243)
<!-- Reviewable:end -->
