### PR TITLE
KVS Migration - Screen Sweep Tables from Validation

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
@@ -84,8 +84,8 @@ public class KeyValueServiceValidator {
     }
 
     public void validate(boolean logOnly) {
-        Set<TableReference> tables = KeyValueServiceMigrators
-                .getMigratableTableNames(validationFromKvs, unmigratableTables);
+        Set<TableReference> tables = KeyValueServiceValidators.getValidatableTableNames(
+                validationFromKvs, unmigratableTables);
         try {
             validateTables(tables);
         } catch (Throwable t) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidators.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidators.java
@@ -30,8 +30,9 @@ public final class KeyValueServiceValidators {
 
     /**
      * Returns tables that need to be validated.
-     * Generally speaking, this excludes tables that are not controlled by the transaction table, as well as
-     * tables which are not  (e.g. the sweep priority table).
+     * Generally speaking, this excludes tables that are modified outside of the transaction protocol
+     * (e.g. timestamp, transaction), and tables which are not required to be equal in the to- and from- KVSes
+     * (e.g. the sweep priority table).
      *
      * Clearly, the tables to be validated are a subset of that to be migrated.
      */
@@ -42,9 +43,6 @@ public final class KeyValueServiceValidators {
         return removeSweepTableReferences(tableNames);
     }
 
-    /**
-     * Removes any table references that are part of Sweep, defined as being a part of the Sweep namespace.
-     */
     private static Set<TableReference> removeSweepTableReferences(Set<TableReference> tableNames) {
         return tableNames.stream()
                 .filter(tableReference -> !isSweepTableReference(tableReference))

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidators.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidators.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+public final class KeyValueServiceValidators {
+    private KeyValueServiceValidators() {
+        // utility
+    }
+
+    /**
+     * Returns tables that need to be validated.
+     * Generally speaking, this excludes tables that are not controlled by the transaction table, as well as
+     * tables which are not  (e.g. the sweep priority table).
+     *
+     * Clearly, the tables to be validated are a subset of that to be migrated.
+     */
+    public static Set<TableReference> getValidatableTableNames(
+            KeyValueService kvs,
+            Set<TableReference> unmigratableTables) {
+        Set<TableReference> tableNames = KeyValueServiceMigrators.getMigratableTableNames(kvs, unmigratableTables);
+        return removeSweepTableReferences(tableNames);
+    }
+
+    /**
+     * Removes any table references that are part of Sweep, defined as being a part of the Sweep namespace.
+     */
+    private static Set<TableReference> removeSweepTableReferences(Set<TableReference> tableNames) {
+        return tableNames.stream()
+                .filter(tableReference -> !isSweepTableReference(tableReference))
+                .collect(Collectors.toSet());
+    }
+
+    @VisibleForTesting
+    static boolean isSweepTableReference(TableReference tableReference) {
+        return tableReference.getNamespace().equals(SweepSchema.INSTANCE.getNamespace());
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/schema/KeyValueServiceValidatorsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/schema/KeyValueServiceValidatorsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+
+public class KeyValueServiceValidatorsTest {
+    private static final TableReference SWEEP_PRIORITY = TableReference.createFromFullyQualifiedName("sweep.priority");
+    private static final TableReference SWEEP_PROGRESS = TableReference.createFromFullyQualifiedName("sweep.progress");
+    private static final TableReference OTHER_PRIORITY = TableReference.createFromFullyQualifiedName("foo.priority");
+
+    private final KeyValueService kvs = new InMemoryKeyValueService(true);
+
+    @Test
+    public void sweepPriorityTableIsASweepTable() {
+        assertThat(KeyValueServiceValidators.isSweepTableReference(SWEEP_PRIORITY)).isTrue();
+    }
+
+    @Test
+    public void sweepProgressTableIsASweepTable() {
+        assertThat(KeyValueServiceValidators.isSweepTableReference(SWEEP_PROGRESS)).isTrue();
+    }
+
+    @Test
+    public void otherPriorityTableIsNotASweepTable() {
+        assertThat(KeyValueServiceValidators.isSweepTableReference(OTHER_PRIORITY)).isFalse();
+    }
+
+    @Test
+    public void sweepPriorityTableNotValidated() {
+        kvs.createTable(SWEEP_PRIORITY, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of())).isEmpty();
+    }
+
+    @Test
+    public void sweepProgressTableNotValidated() {
+        kvs.createTable(SWEEP_PROGRESS, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of())).isEmpty();
+    }
+
+    @Test
+    public void transactionTableNotValidated() {
+        kvs.createTable(TransactionConstants.TRANSACTION_TABLE,
+                TransactionConstants.TRANSACTION_TABLE_METADATA.persistToBytes());
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of())).isEmpty();
+    }
+
+    @Test
+    public void otherPriorityTableIsValidated() {
+        kvs.createTable(OTHER_PRIORITY, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of()))
+                .containsExactly(OTHER_PRIORITY);
+    }
+
+    @Test
+    public void unmigratableTablesAreNotValidated() {
+        kvs.createTable(OTHER_PRIORITY, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of(OTHER_PRIORITY))).isEmpty();
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/schema/KeyValueServiceValidatorsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/schema/KeyValueServiceValidatorsTest.java
@@ -23,14 +23,20 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.schema.generated.SweepPriorityTable;
+import com.palantir.atlasdb.schema.generated.SweepProgressTable;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
 public class KeyValueServiceValidatorsTest {
-    private static final TableReference SWEEP_PRIORITY = TableReference.createFromFullyQualifiedName("sweep.priority");
-    private static final TableReference SWEEP_PROGRESS = TableReference.createFromFullyQualifiedName("sweep.progress");
-    private static final TableReference OTHER_PRIORITY = TableReference.createFromFullyQualifiedName("foo.priority");
+    private static final TableReference SWEEP_PRIORITY = TableReference.create(
+            SweepSchema.INSTANCE.getNamespace(), SweepPriorityTable.getRawTableName());
+    private static final TableReference SWEEP_PROGRESS = TableReference.create(
+            SweepSchema.INSTANCE.getNamespace(), SweepProgressTable.getRawTableName());
+    private static final TableReference OTHER_PRIORITY = TableReference.create(
+            Namespace.create("foo"), SweepPriorityTable.getRawTableName());
 
     private final KeyValueService kvs = new InMemoryKeyValueService(true);
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -47,8 +47,8 @@ develop
     *    - |fixed|
          - KVS migrations will no longer verify equality between the from and to KVSes for the sweep priority and progress tables.
            Note that these tables are still *migrated* across, as they provide heuristics for timely sweeping of tables.
-           However, these tables are expected to change as the migration process performs writes to the to-KVS.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
+           However, these tables may change (e.g. the from-kvs could be swept).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2244>`__)
 
     *    - |devbreak|
          - IteratorUtils.forEach removed; it's not needed in a Java 8 codebase.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,8 +44,11 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - KVS migrations will no longer verify equality between the from and to KVSes for the sweep priority and progress tables.
+           Note that these tables are still *migrated* across, as they provide heuristics for timely sweeping of tables.
+           However, these tables are expected to change as the migration process performs writes to the to-KVS.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
 
 =======
 v0.52.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,7 +51,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/abcd>`__)
 
     *    - |devbreak|
-	       - IteratorUtils.forEach removed; it's not needed in a Java 8 codebase.
+         - IteratorUtils.forEach removed; it's not needed in a Java 8 codebase.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2207>`__)
 
 =======


### PR DESCRIPTION
**Goals (and why)**: Fix #2137 

**Implementation Description (bullets)**:
- Remove tables from the Sweep namespace from validation.
- Add a bunch of tests for the validator.

**Concerns (what feedback would you like?)**:
- Is the condition too strong? Should I be removing strictly priority and progress?
- Do we need to support unvalidatable tables?

**Where should we start reviewing?**: `KeyValueServiceValidators.java`

**Priority (whenever / two weeks / yesterday)**: whenever?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2244)
<!-- Reviewable:end -->
