### PR TITLE
Publish timelock agent

### DIFF
--- a/timelock-agent/build.gradle
+++ b/timelock-agent/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'org.inferred.processors'
 apply plugin: 'org.unbroken-dome.test-sets'
 
+apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 apply from: "../gradle/timelock.gradle"
 


### PR DESCRIPTION
Self explanatory. Needed to add this so that I could use a locally published version of the `feature/timelock-agent` branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2250)
<!-- Reviewable:end -->
