### PR TITLE
Create Timelock Clients Dynamically

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,13 @@ develop
     *    - |devbreak|
          - IteratorUtils.forEach removed; it's not needed in a Java 8 codebase.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2207>`__)
+           
+    *    - |improved|
+         - Timelock now creates client namespaces the first time they are requested, rather than requiring them to be specified in config.
+           This means that specifying a list of clients in Timelock configuration will no longer have any effect. Further, a new configuration property called ``max-number-of-clients`` has been introduced in ``TimeLockRuntimeConfiguration``. This can be used to limit the number of clients that will be created dynamically, since each distinct client has some memory, disk space, and CPU overhead.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2220>`__)
+           
+https://github.com/palantir/atlasdb/pull/2252
 
 =======
 v0.52.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,9 +60,8 @@ develop
     *    - |improved|
          - Timelock now creates client namespaces the first time they are requested, rather than requiring them to be specified in config.
            This means that specifying a list of clients in Timelock configuration will no longer have any effect. Further, a new configuration property called ``max-number-of-clients`` has been introduced in ``TimeLockRuntimeConfiguration``. This can be used to limit the number of clients that will be created dynamically, since each distinct client has some memory, disk space, and CPU overhead.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2220>`__)
-           
-https://github.com/palantir/atlasdb/pull/2252
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2252>`__)
+
 
 =======
 v0.52.0

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -47,6 +47,5 @@ public abstract class TimeLockRuntimeConfiguration {
     public void check() {
         Preconditions.checkState(slowLockLogTriggerMillis() >= 0,
                 "Slow lock log trigger threshold must be nonnegative, but found %s", slowLockLogTriggerMillis());
-
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -5,7 +5,6 @@
 package com.palantir.timelock.config;
 
 import java.util.Optional;
-import java.util.Set;
 
 import org.immutables.value.Value;
 
@@ -13,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
-import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 
 /**
  * Dynamic (live-reloaded) portions of TimeLock's configuration.
@@ -22,11 +20,18 @@ import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 @JsonSerialize(as = ImmutableTimeLockRuntimeConfiguration.class)
 @Value.Immutable
 public abstract class TimeLockRuntimeConfiguration {
-    private static final String CLIENT_NAME_REGEX = "[a-zA-Z0-9_-]+";
 
     public abstract Optional<PaxosRuntimeConfiguration> algorithm();
 
-    public abstract Set<String> clients();
+    /**
+     * The maximum number of client namespaces to allow. Each distinct client consumes some amount of memory and disk
+     * space.
+     */
+    @JsonProperty("max-number-of-clients")
+    @Value.Default
+    public Integer maxNumberOfClients() {
+        return 100;
+    }
 
     /**
      * Log at INFO if a lock request receives a response after given duration in milliseconds.
@@ -42,12 +47,6 @@ public abstract class TimeLockRuntimeConfiguration {
     public void check() {
         Preconditions.checkState(slowLockLogTriggerMillis() >= 0,
                 "Slow lock log trigger threshold must be nonnegative, but found %s", slowLockLogTriggerMillis());
-        clients().forEach(client -> Preconditions.checkState(
-                client.matches(CLIENT_NAME_REGEX),
-                "Client names must consist of alphanumeric characters, underscores, or dashes. Illegal name: %s",
-                client));
-        Preconditions.checkState(!clients().contains(PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE),
-                "The client name '%s' is reserved for the leader election service, and may not be used.",
-                PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE);
+
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/LockCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/LockCreator.java
@@ -52,9 +52,13 @@ public class LockCreator {
         }
 
         int availableThreads = deprecated.availableThreads();
-        int numClients = timeLockRuntimeConfiguration.clients().size();
-        int localThreadPoolSize = (availableThreads / numClients) / 2;
-        int sharedThreadPoolSize = availableThreads - localThreadPoolSize * numClients;
+        // TODO(nziebart): Since the number of clients can grow dynamically, we can't compute a correct and useful
+        // value for the local threadpool size at this point. Given that async lock service exists, and doesn't need
+        // a thread pool, it's likely we won't fix this and will eventually remove the thread pooled lock service.
+        // However, for the time being, it's still useful to have global limiting for services that need to use the
+        // legacy lock service.
+        int localThreadPoolSize = -1;
+        int sharedThreadPoolSize = availableThreads;
 
         synchronized (this) {
             if (sharedThreadPool.availablePermits() == -1) {

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosTimestampCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosTimestampCreator.java
@@ -65,8 +65,6 @@ public class PaxosTimestampCreator {
     }
 
     public Supplier<ManagedTimestampService> createPaxosBackedTimestampService(String client) {
-        paxosResource.addInstrumentedClient(client);
-
         ExecutorService executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
                 .setNameFormat("atlas-consensus-" + client + "-%d")
                 .setDaemon(true)

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockRuntimeConfigurationTest.java
@@ -18,66 +18,12 @@ package com.palantir.timelock.config;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.List;
-
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 
 public class TimeLockRuntimeConfigurationTest {
     @Test
     public void canCreateWithZeroClients() {
         ImmutableTimeLockRuntimeConfiguration.builder().build();
-    }
-
-    @Test
-    public void canCreateWithClientsMatchingRegex() {
-        String client1 = "test12345";
-        String client2 = "-_-";
-        String client3 = "___---___";
-
-        List<String> clients = ImmutableList.of(client1, client2, client3);
-        clients.forEach(this::assertClientNameAcceptable);
-    }
-
-    @Test
-    public void cannotCreateWithEmptyStringClient() {
-        assertClientNameUnacceptable("");
-    }
-
-    @Test
-    public void cannotCreateWithClientsFailingRegex() {
-        String client1 = "/";
-        String client2 = "123?";
-        String client3 = "/hello";
-
-        List<String> clients = ImmutableList.of(client1, client2, client3);
-        clients.forEach(this::assertClientNameUnacceptable);
-    }
-
-    @Test
-    public void throwsIfAnyClientFailsRegex() {
-        assertThatThrownBy(() -> ImmutableTimeLockRuntimeConfiguration.builder()
-                .addClients("okay")
-                .addClients("!@#$%^&*()_")
-                .build()).isInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
-    public void cannotCreateClientMatchingLeaderElectionNamespace() {
-        assertClientNameUnacceptable(PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE);
-    }
-
-    @Test
-    public void canCreateClientsMatchingPaxosNamespaces() {
-        assertClientNameAcceptable(PaxosTimeLockConstants.CLIENT_PAXOS_NAMESPACE);
-        assertClientNameAcceptable(PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE);
-    }
-
-    @Test
-    public void cannotCreateClientMatchingInternalNamespace() {
-        assertClientNameUnacceptable(PaxosTimeLockConstants.INTERNAL_NAMESPACE);
     }
 
     @Test
@@ -94,16 +40,4 @@ public class TimeLockRuntimeConfigurationTest {
                 .build()).isInstanceOf(IllegalStateException.class);
     }
 
-    public void assertClientNameAcceptable(String client) {
-        ImmutableTimeLockRuntimeConfiguration.builder()
-                .addClients(client)
-                .build(); // this passing means we passed validation
-    }
-
-    public void assertClientNameUnacceptable(String client) {
-        assertThatThrownBy(() -> ImmutableTimeLockRuntimeConfiguration.builder()
-                .addClients(client)
-                .build())
-                .isInstanceOf(IllegalStateException.class);
-    }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -42,7 +42,9 @@ public class TimeLockResource {
     private final ConcurrentMap<String, TimeLockServices> servicesByClient = Maps.newConcurrentMap();
     private final Supplier<Integer> maxNumberOfClients;
 
-    public TimeLockResource(Function<String, TimeLockServices> clientServicesFactory, Supplier<Integer> maxNumberOfClients) {
+    public TimeLockResource(
+            Function<String, TimeLockServices> clientServicesFactory,
+            Supplier<Integer> maxNumberOfClients) {
         this.clientServicesFactory = clientServicesFactory;
         this.maxNumberOfClients = maxNumberOfClients;
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -15,54 +15,78 @@
  */
 package com.palantir.atlasdb.timelock;
 
-import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
 
 @Path("/{client: [a-zA-Z0-9_-]+}")
 public class TimeLockResource {
-    private final Supplier<Map<String, TimeLockServices>> clientToServices;
+    private final Logger log = LoggerFactory.getLogger(TimeLockResource.class);
 
-    public TimeLockResource(Map<String, TimeLockServices> clientToServices) {
-        this.clientToServices = () -> clientToServices;
-    }
+    private final Function<String, TimeLockServices>  clientServicesFactory;
+    private final ConcurrentMap<String, TimeLockServices> servicesByClient = Maps.newConcurrentMap();
+    private final Supplier<Integer> maxNumberOfClients;
 
-    public TimeLockResource(Supplier<Map<String, TimeLockServices>> clientToServices) {
-        this.clientToServices = clientToServices;
+    public TimeLockResource(Function<String, TimeLockServices> clientServicesFactory, Supplier<Integer> maxNumberOfClients) {
+        this.clientServicesFactory = clientServicesFactory;
+        this.maxNumberOfClients = maxNumberOfClients;
     }
 
     @Path("/lock")
     public RemoteLockService getLockService(@PathParam("client") String client) {
-        return getTimeLockServicesForClient(client).getLockService();
+        return getOrCreateServices(client).getLockService();
     }
 
     @Path("/timestamp")
     public TimestampService getTimeService(@PathParam("client") String client) {
-        return getTimeLockServicesForClient(client).getTimestampService();
+        return getOrCreateServices(client).getTimestampService();
     }
 
     @Path("/timelock")
     public Object getTimelockService(@PathParam("client") String client) {
-        return getTimeLockServicesForClient(client).getTimelockService().getPresentService();
+        return getOrCreateServices(client).getTimelockService().getPresentService();
     }
 
     @Path("/timestamp-management")
     public TimestampManagementService getTimestampManagementService(@PathParam("client") String client) {
-        return getTimeLockServicesForClient(client).getTimestampManagementService();
+        return getOrCreateServices(client).getTimestampManagementService();
     }
 
-    private TimeLockServices getTimeLockServicesForClient(String client) {
-        TimeLockServices services = clientToServices.get().get(client);
-        if (services == null) {
-            throw new NotFoundException("Client doesn't exist");
+    @VisibleForTesting
+    TimeLockServices getOrCreateServices(String client) {
+        return servicesByClient.computeIfAbsent(client, this::createNewClient);
+    }
+
+    private TimeLockServices createNewClient(String client) {
+        Preconditions.checkArgument(!client.equals(PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE),
+                "The client name '%s' is reserved for the leader election service, and may not be "
+                        + "used.",
+                PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE);
+
+        if (servicesByClient.size() >= maxNumberOfClients.get()) {
+            log.error(
+                    "Unable to create timelock services for client {}, as it would exceed the maximum number of "
+                            + "allowed clients ({}).",
+                    SafeArg.of("client", client),
+                    SafeArg.of("maxNumberOfClients", maxNumberOfClients));
+            throw new IllegalStateException("Maximum number of clients exceeded");
         }
-        return services;
+
+        return clientServicesFactory.apply(client);
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -82,7 +82,7 @@ public class TimeLockResource {
             log.error(
                     "Unable to create timelock services for client {}, as it would exceed the maximum number of "
                             + "allowed clients ({}). If this is intentional, the maximum number of clients can be "
-                            + "increased via the maximum-number-of-clients config property.",
+                            + "increased via the maximum-number-of-clients runtime config property.",
                     SafeArg.of("client", client),
                     SafeArg.of("maxNumberOfClients", maxNumberOfClients));
             throw new IllegalStateException("Maximum number of clients exceeded");

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -81,7 +81,8 @@ public class TimeLockResource {
         if (servicesByClient.size() >= maxNumberOfClients.get()) {
             log.error(
                     "Unable to create timelock services for client {}, as it would exceed the maximum number of "
-                            + "allowed clients ({}).",
+                            + "allowed clients ({}). If this is intentional, the maximum number of clients can be "
+                            + "increased via the maximum-number-of-clients config property.",
                     SafeArg.of("client", client),
                     SafeArg.of("maxNumberOfClients", maxNumberOfClients));
             throw new IllegalStateException("Maximum number of clients exceeded");

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
@@ -37,8 +37,8 @@ public class TimeLockResourceTest {
 
     private static final int DEFAULT_MAX_NUMBER_OF_CLIENTS = 5;
 
-    private final TimeLockServices SERVICES_A = mock(TimeLockServices.class);
-    private final TimeLockServices SERVICES_B = mock(TimeLockServices.class);
+    private final TimeLockServices servicesA = mock(TimeLockServices.class);
+    private final TimeLockServices servicesB = mock(TimeLockServices.class);
 
     private final Function<String, TimeLockServices> serviceFactory = mock(Function.class);
     private final Supplier<Integer> maxNumberOfClientsSupplier = mock(Supplier.class);
@@ -50,16 +50,16 @@ public class TimeLockResourceTest {
     @Before
     public void before() {
         when(serviceFactory.apply(any())).thenReturn(mock(TimeLockServices.class));
-        when(serviceFactory.apply(CLIENT_A)).thenReturn(SERVICES_A);
-        when(serviceFactory.apply(CLIENT_B)).thenReturn(SERVICES_B);
+        when(serviceFactory.apply(CLIENT_A)).thenReturn(servicesA);
+        when(serviceFactory.apply(CLIENT_B)).thenReturn(servicesB);
 
         when(maxNumberOfClientsSupplier.get()).thenReturn(DEFAULT_MAX_NUMBER_OF_CLIENTS);
     }
 
     @Test
     public void returnsProperServiceForEachClient() {
-        assertThat(resource.getOrCreateServices(CLIENT_A)).isEqualTo(SERVICES_A);
-        assertThat(resource.getOrCreateServices(CLIENT_B)).isEqualTo(SERVICES_B);
+        assertThat(resource.getOrCreateServices(CLIENT_A)).isEqualTo(servicesA);
+        assertThat(resource.getOrCreateServices(CLIENT_B)).isEqualTo(servicesB);
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
@@ -15,54 +15,89 @@
  */
 package com.palantir.atlasdb.timelock;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
-import javax.ws.rs.NotFoundException;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
+import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.timelock.util.AsyncOrLegacyTimelockService;
-import com.palantir.lock.LockService;
-import com.palantir.timestamp.TimestampManagementService;
-import com.palantir.timestamp.TimestampService;
-
 public class TimeLockResourceTest {
-    private static final String EXISTING_CLIENT = "existing-client";
-    private static final String NON_EXISTING_CLIENT = "non-existing-client";
+    private static final String CLIENT_A = "a-client";
+    private static final String CLIENT_B = "b-client";
 
-    private static final LockService LOCK_SERVICE = mock(LockService.class);
-    private static final TimestampService TIMESTAMP_SERVICE = mock(TimestampService.class);
-    private static final TimestampManagementService TIMESTAMP_MANAGEMENT_SERVICE =
-            mock(TimestampManagementService.class);
-    private static final AsyncTimelockResource TIMELOCK_SERVICE =
-            mock(AsyncTimelockResource.class);
-    private static final TimeLockServices TIME_LOCK_SERVICES = TimeLockServices.create(
-            TIMESTAMP_SERVICE,
-            LOCK_SERVICE,
-            AsyncOrLegacyTimelockService.createFromAsyncTimelock(TIMELOCK_SERVICE),
-            TIMESTAMP_MANAGEMENT_SERVICE);
+    private static final int DEFAULT_MAX_NUMBER_OF_CLIENTS = 5;
 
-    private static final TimeLockResource RESOURCE = new TimeLockResource(
-            ImmutableMap.of(EXISTING_CLIENT, TIME_LOCK_SERVICES));
+    private final TimeLockServices SERVICES_A = mock(TimeLockServices.class);
+    private final TimeLockServices SERVICES_B = mock(TimeLockServices.class);
 
-    @Test
-    public void canGetExistingTimeService() {
-        RESOURCE.getTimeService(EXISTING_CLIENT);
-    }
+    private final Function<String, TimeLockServices> serviceFactory = mock(Function.class);
+    private final Supplier<Integer> maxNumberOfClientsSupplier = mock(Supplier.class);
+    private final TimeLockResource resource = new TimeLockResource(
+            serviceFactory,
+            maxNumberOfClientsSupplier);
 
-    @Test(expected = NotFoundException.class)
-    public void throwWhenTimeServiceDoesntExist() {
-        RESOURCE.getTimeService(NON_EXISTING_CLIENT);
+
+    @Before
+    public void before() {
+        when(serviceFactory.apply(any())).thenReturn(mock(TimeLockServices.class));
+        when(serviceFactory.apply(CLIENT_A)).thenReturn(SERVICES_A);
+        when(serviceFactory.apply(CLIENT_B)).thenReturn(SERVICES_B);
+
+        when(maxNumberOfClientsSupplier.get()).thenReturn(DEFAULT_MAX_NUMBER_OF_CLIENTS);
     }
 
     @Test
-    public void canGetExistingLockService() {
-        RESOURCE.getLockService(EXISTING_CLIENT);
+    public void returnsProperServiceForEachClient() {
+        assertThat(resource.getOrCreateServices(CLIENT_A)).isEqualTo(SERVICES_A);
+        assertThat(resource.getOrCreateServices(CLIENT_B)).isEqualTo(SERVICES_B);
     }
 
-    @Test(expected = NotFoundException.class)
-    public void throwWhenLockServiceDoesntExist() {
-        RESOURCE.getLockService(NON_EXISTING_CLIENT);
+    @Test
+    public void servicesAreOnlyCreatedOncePerClient() {
+        resource.getTimeService(CLIENT_A);
+        resource.getTimeService(CLIENT_A);
+
+        verify(serviceFactory, times(1)).apply(any());
     }
+
+    @Test
+    public void doesNotCreateNewClientsAfterMaximumNumberHasBeenReached() {
+        createMaximumNumberOfClients();
+
+        assertThatThrownBy(() -> resource.getTimeService(uniqueClient()))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(serviceFactory, times(DEFAULT_MAX_NUMBER_OF_CLIENTS)).apply(any());
+        verifyNoMoreInteractions(serviceFactory);
+    }
+
+    @Test
+    public void canDynamicallyIncreaseMaxAllowedClients() {
+        createMaximumNumberOfClients();
+
+        when(maxNumberOfClientsSupplier.get()).thenReturn(DEFAULT_MAX_NUMBER_OF_CLIENTS + 1);
+
+        resource.getTimeService(uniqueClient());
+    }
+
+    private void createMaximumNumberOfClients() {
+        for (int i = 0; i < DEFAULT_MAX_NUMBER_OF_CLIENTS; i++) {
+            resource.getTimeService(uniqueClient());
+        }
+    }
+
+    private String uniqueClient() {
+        return UUID.randomUUID().toString();
+    }
+
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourceTest.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.timelock.paxos;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,8 +57,7 @@ public class PaxosResourceTest {
     }
 
     @Test
-    public void canAddClients() {
-        paxosResource.addInstrumentedClient(CLIENT_1);
+    public void newClientCanBeCreated() {
         PaxosLearner learner = paxosResource.getPaxosLearner(CLIENT_1);
         learner.learn(PAXOS_ROUND_ONE, PAXOS_VALUE);
         assertThat(learner.getGreatestLearnedValue()).isNotNull();
@@ -73,7 +71,6 @@ public class PaxosResourceTest {
 
     @Test
     public void addsClientsInSubdirectory() {
-        paxosResource.addInstrumentedClient(CLIENT_1);
         File expectedAcceptorLogDir =
                 Paths.get(logDirectory.getPath(), CLIENT_1, PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH).toFile();
         assertThat(expectedAcceptorLogDir.exists()).isTrue();
@@ -82,17 +79,4 @@ public class PaxosResourceTest {
         assertThat(expectedLearnerLogDir.exists()).isTrue();
     }
 
-    @Test
-    public void throwsIfTryingToAddClientTwice() {
-        paxosResource.addInstrumentedClient(CLIENT_1);
-        assertThatThrownBy(() -> paxosResource.addInstrumentedClient(CLIENT_1))
-                .isInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
-    public void returnsNullIfClientNotAdded() {
-        paxosResource.addInstrumentedClient(CLIENT_1);
-        assertThat(paxosResource.getPaxosLearner(CLIENT_2)).isNull();
-        assertThat(paxosResource.getPaxosAcceptor(CLIENT_2)).isNull();
-    }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosResourceTest.java
@@ -71,6 +71,7 @@ public class PaxosResourceTest {
 
     @Test
     public void addsClientsInSubdirectory() {
+        paxosResource.getPaxosLearner(CLIENT_1);
         File expectedAcceptorLogDir =
                 Paths.get(logDirectory.getPath(), CLIENT_1, PaxosTimeLockConstants.ACCEPTOR_SUBDIRECTORY_PATH).toFile();
         assertThat(expectedAcceptorLogDir.exists()).isTrue();

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -40,6 +41,7 @@ import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
 
 public class MultiNodePaxosTimeLockServerIntegrationTest {
     private static final String CLIENT_1 = "test";
@@ -193,6 +195,18 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
             assertThat(CLUSTER.unlock(token)).isFalse();
             token = CLUSTER.lock(LockRequest.of(LOCKS, DEFAULT_LOCK_TIMEOUT_MS)).getToken();
+        }
+    }
+
+    @Test
+    public void canCreateNewClientsDynamically() {
+        for (int i = 0; i < 5; i++) {
+            String client = UUID.randomUUID().toString();
+            TimelockService timelock = CLUSTER.timelockServiceForClient(client);
+
+            timelock.getFreshTimestamp();
+            LockToken token = timelock.lock(LockRequest.of(LOCKS, DEFAULT_LOCK_TIMEOUT_MS)).getToken();
+            CLUSTER.unlock(token);
         }
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -231,7 +231,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
                     .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
         });
 
-        long ts1 = CLUSTER.currentLeader().timelockServiceForClient(client).getFreshTimestamp();
+        long ts1 = CLUSTER.timelockServiceForClient(client).getFreshTimestamp();
 
         CLUSTER.failoverToNewLeader();
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -211,6 +211,19 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
+    public void clientsCreatedDynamicallyOnNonLeadersAreFunctionalAfterFailover() {
+        String client = UUID.randomUUID().toString();
+        CLUSTER.nonLeaders().forEach(server -> {
+            assertThatThrownBy(() -> server.timelockServiceForClient(client).getFreshTimestamp())
+                    .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
+        });
+
+        CLUSTER.failoverToNewLeader();
+
+        CLUSTER.getFreshTimestamp();
+    }
+
+    @Test
     public void clockSkewMetricsSmokeTest() {
         Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -200,6 +200,10 @@ public class TestableTimelockCluster {
         return proxies.failoverForClient(defaultClient, TimelockService.class);
     }
 
+    public TimelockService timelockServiceForClient(String client) {
+        return proxies.failoverForClient(client, TimelockService.class);
+    }
+
     public RuleChain getRuleChain() {
         RuleChain ruleChain = RuleChain.outerRule(temporaryFolder);
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockServer.java
@@ -89,7 +89,11 @@ public class TestableTimelockServer {
     }
 
     public TimelockService timelockService() {
-        return proxies.singleNodeForClient(defaultClient, serverHolder, TimelockService.class);
+        return timelockServiceForClient(defaultClient);
+    }
+
+    public TimelockService timelockServiceForClient(String client) {
+        return proxies.singleNodeForClient(client, serverHolder, TimelockService.class);
     }
 
     public MetricsOutput getMetricsOutput() {

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockConfigMigrator.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/config/TimeLockConfigMigrator.java
@@ -50,7 +50,6 @@ public final class TimeLockConfigMigrator {
                         .maximumWaitBeforeProposalMs(paxos.maximumWaitBeforeProposalMs())
                         .pingRateMs(paxos.pingRateMs())
                         .build())
-                .clients(config.clients())
                 .slowLockLogTriggerMillis(config.slowLockLogTriggerMillis())
                 .build();
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimeLockServer.java
@@ -341,7 +341,6 @@ public class PaxosTimeLockServer implements TimeLockServer {
     }
 
     private Supplier<ManagedTimestampService> createRawPaxosBackedTimestampServiceSupplier(String client) {
-        paxosResource.addInstrumentedClient(client);
 
         ExecutorService executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
                 .setNameFormat("atlas-consensus-" + client + "-%d")


### PR DESCRIPTION
**Goals (and why)**:
Currently the clients block in timelock config must be specified at runtime. This is annoying because any service that wants to use timelock must advertise a client role, plus it introduces a startup ordering dependency.

This eliminates both the need to advertise the role and the startup dependency.

**Implementation Description (bullets)**:
- Dynamically create the client services the first time they are requested
- Add a configurable limit for the maximum number of clients, as a dumb safeguard against blowing up the server by requesting many different client services

**Concerns (what feedback would you like?)**:
- I removed the local threadpool for the thread pooled lock service. Given that we're pushing services toward async lock, is this OK? Is it OK for large internal product? (Note the global threadpool is still in place)
- Are there any edge cases with Paxos that I'm overlooking?

**Where should we start reviewing?**:
`PaxosResource` and `TimelockResource`

**Priority (whenever / two weeks / yesterday)**:
before 1.0 of timelock

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2252)
<!-- Reviewable:end -->
