### PR TITLE
Make fields final in CharacterLimitType enum

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/CharacterLimitType.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/CharacterLimitType.java
@@ -26,8 +26,8 @@ public enum CharacterLimitType {
     CASSANDRA("Cassandra", AtlasDbConstants.CASSANDRA_TABLE_NAME_CHAR_LIMIT),
     POSTGRES("Postgres", AtlasDbConstants.POSTGRES_TABLE_NAME_CHAR_LIMIT);
 
-    private String kvsName;
-    private int charLimit;
+    private final String kvsName;
+    private final int charLimit;
     CharacterLimitType(String name, int limit) {
         kvsName = name;
         charLimit = limit;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,7 +44,11 @@ develop
     *    - Type
          - Change
 
-    *    - 'fixed'
+    *    - |fixed|
+         - CharacterLimitType now has fields marked as final.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2259>`__)
+
+    *    - |fixed|
          - ``kvs-slow-log`` now uses ``logsafe`` to support sls-compatible logging.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2222>`__)
 


### PR DESCRIPTION
**Goals (and why)**:

Non-final fields in enum caused tests to break in latest release (0.53).


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2259)
<!-- Reviewable:end -->
