### PR TITLE
Double quotes

### DIFF
--- a/docs/source/cluster_management/backup-restore.rst
+++ b/docs/source/cluster_management/backup-restore.rst
@@ -77,7 +77,7 @@ For example (replace the serialised ``PersistentLockId`` with your own from step
 
 .. code:: bash
 
-   $ curl -X POST --header 'content-type: application/json' '<product-base-url>/persistent-lock/release-backup-lock' -d '9dbae91b-a35c-4938-82fe-58fb31772738'
+   $ curl -X POST --header 'content-type: application/json' '<product-base-url>/persistent-lock/release-backup-lock' -d '"9dbae91b-a35c-4938-82fe-58fb31772738"'
 
 
 Restoring from a Backup


### PR DESCRIPTION
[no release notes]

The data passed to the release request should be a json. This stems from a question from FDEs.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2261)
<!-- Reviewable:end -->
