### PR TITLE
Best-effort client side timestamp validation, part 1: Server Killer

### DIFF
--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'
 
+  testCompile group: 'com.github.stefanbirkner', name: 'system-rules'
   testCompile group: 'com.palantir.remoting2', name: 'jaxrs-clients'
   testCompile group: 'io.dropwizard', name: 'dropwizard-testing'
   testCompile group: 'org.assertj', name: 'assertj-core'

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/safetycheck/ServerKiller.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/safetycheck/ServerKiller.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.safetycheck;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ServerKiller {
+    private static final Logger log = LoggerFactory.getLogger(ServerKiller.class);
+
+    private ServerKiller() {
+        // Utility Class
+    }
+
+    public static void kill(Throwable throwable) {
+        log.error(
+                "AtlasDB is in a bad state and we can't continue, so we're preemptively killing the server.",
+                throwable);
+        System.exit(1);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/safetycheck/ServerKiller.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/safetycheck/ServerKiller.java
@@ -16,8 +16,15 @@
 
 package com.palantir.atlasdb.safetycheck;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 
 public final class ServerKiller {
     private static final Logger log = LoggerFactory.getLogger(ServerKiller.class);
@@ -27,9 +34,17 @@ public final class ServerKiller {
     }
 
     public static void kill(Throwable throwable) {
+        kill(throwable, Optional.empty());
+    }
+
+    public static void kill(Throwable throwable, Optional<String> loggableMessage) {
+        List<Object> loggingObjects = Lists.newArrayList(UnsafeArg.of("cause", throwable));
+        if (loggableMessage.isPresent()) {
+            loggingObjects.add(SafeArg.of("message", loggableMessage));
+        }
         log.error(
                 "AtlasDB is in a bad state and we can't continue, so we're preemptively killing the server.",
-                throwable);
+                loggingObjects.toArray());
         System.exit(1);
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/safetycheck/ServerKillerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/safetycheck/ServerKillerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.safetycheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+public class ServerKillerTest {
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    @Test
+    public void killsTheServerWithExitCodeOfOne() {
+        exit.expectSystemExitWithStatus(1);
+        ServerKiller.kill(new RuntimeException());
+    }
+
+    @Test
+    public void logsTheRelevantExceptionMessage() {
+        TestAppender appender = new TestAppender();
+        registerAppender(appender);
+
+        String errorId = UUID.randomUUID().toString();
+        exit.expectSystemExitWithStatus(1);
+        ServerKiller.kill(new RuntimeException("Something bad happened - " + errorId));
+
+        Set<String> relevantMessages = appender.logBuffer.stream()
+                .filter(message -> message.contains(errorId))
+                .collect(Collectors.toSet());
+        assertThat(relevantMessages).isNotEmpty();
+    }
+
+    private static void registerAppender(TestAppender appender) {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        appender.setContext(context);
+        context.getLogger(ServerKiller.class).addAppender(appender);
+    }
+
+    private static class TestAppender extends AppenderBase<ILoggingEvent> {
+        List<String> logBuffer = Lists.newArrayList();
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            String logMessage = eventObject.getFormattedMessage();
+            logBuffer.add(logMessage);
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/safetycheck/ServerKillerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/safetycheck/ServerKillerTest.java
@@ -33,9 +33,12 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
+//CHECKSTYLE:OFF: checkstyle:illegalimport
+// We use Logback as part of the test fixtures, to register our test appender.
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
+//CHECKSTYLE:ON: checkstyle:illegalimport
 
 public class ServerKillerTest {
     @Rule


### PR DESCRIPTION
**Goals (and why)**:
- Build a piece of the infrastructure for #1505 which Nathan mentions on #2253. I'm addressing that with the namespace suggestion, but that wouldn't have caught some cases including some production ones e.g. PDS-55508.
- The plan is, on startup you'll also read the latest value / few values from the punch table, get a fresh timestamp from TimeLock, and compare. If the timestamp is lower than any of these values, we invoke the ServerKiller.
- Should we add a safety flag to override this?

**Implementation Description (bullets)**:
- Implement ServerKiller which nukes the server. It isn't used anywhere yet.
- Unit tests

**Concerns (what feedback would you like?)**:
- Are there any landmines we uncovered here?
- Is this approach for killing the server the right one to take? Most of this 'bad state' stuff should happen during startup, so I think this is fine, but unsure if it, say, might cause the Backup Lock to stick.

**Where should we start reviewing?**: `ServerKiller.java`. This is similar to the version in internal auth product, though I've added shiny safelog stuff to it.

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2264)
<!-- Reviewable:end -->
