### PR TITLE
TimeLockAgent: Expose schema version accessors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         classpath 'gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.13.0'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.13.0'
         classpath 'com.palantir:jacoco-coverage:0.4.0'
-        classpath 'com.palantir.sls-packaging:gradle-sls-packaging:2.3.1'
+        classpath 'com.palantir.sls-packaging:gradle-sls-packaging:2.4.0'
         classpath "com.netflix.nebula:gradle-dependency-lock-plugin:4.3.2"
         classpath 'com.netflix.nebula:nebula-dependency-recommender:3.6.3'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:4.9.1'

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,6 +63,10 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2222>`__)
 
 
+    *    - |changed|
+         - Updated our dependency on ``sls-packaging`` from 2.3.1 to 2.4.0.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2xxx>`__)
+
 =======
 v0.53.0
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,7 +65,7 @@ develop
 
     *    - |changed|
          - Updated our dependency on ``sls-packaging`` from 2.3.1 to 2.4.0.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2xxx>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2268>`__)
 
 =======
 v0.53.0

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -92,7 +92,6 @@ public class TimeLockAgent {
     public long getSchemaVersion() {
         // So far there's only been one schema version. For future schema versions, we will have to persist the version
         // to disk somehow, so that we can check if var/data/paxos will have data in the expected format.
-        // TODO: is this the best place from which to look this up?
         return SCHEMA_VERSION;
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -38,6 +38,8 @@ import com.palantir.timelock.config.TimeLockRuntimeConfiguration;
 import io.reactivex.Observable;
 
 public class TimeLockAgent {
+    private static final Long SCHEMA_VERSION = 1L;
+
     private final TimeLockInstallConfiguration install;
     private final Observable<TimeLockRuntimeConfiguration> runtime;
     private final Consumer<Object> registrar;
@@ -84,6 +86,19 @@ public class TimeLockAgent {
                 runtime.map(conf -> conf.maxNumberOfClients()))));
 
         ClockSkewMonitorCreator.create(install, registrar).registerClockServices();
+    }
+
+    @SuppressWarnings("unused")
+    public long getSchemaVersion() {
+        // So far there's only been one schema version. For future schema versions, we will have to persist the version
+        // to disk somehow, so that we can check if var/data/paxos will have data in the expected format.
+        // TODO: is this the best place from which to look this up?
+        return SCHEMA_VERSION;
+    }
+
+    @SuppressWarnings("unused")
+    public long getLatestSchemaVersion() {
+        return SCHEMA_VERSION;
     }
 
     // No runtime configuration at the moment.


### PR DESCRIPTION
**Goals (and why)**: Expose methods to get actual and latest schema versions for `TimeLockAgent` to satisfy the [sls-spec](https://github.palantir.build/deployability/sls-spec/blob/develop/docs/schema-versions.md).

**Implementation Description (bullets)**:
* Add public methods `getSchemaVersion` and `getLatestSchemaVersion` to `TimeLockAgent`.
* So far, there's only been one schema version, so this PR does _not_ persist a schema version to the schema - it's just always V1.

**Concerns (what feedback would you like?)**:
* Is `TimeLockAgent` the right place from which to expose the schema version?
* I guess the underlying version is the formatting in `PaxosTimestampBoundStore`, but this class wasn't easily accessible - should we take immediate steps to rectify that? I've gone for simplicity so far (we might never actually change the format, so the schema version could always be 1) - is that the right call?

**Where should we start reviewing?**: TimelockAgent.java

**Priority (whenever / two weeks / yesterday)**: Today or Monday; an upcoming PR on our internal TimeLock project will depend on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2268)
<!-- Reviewable:end -->
