### PR TITLE
[Startup Independence] Part 1: Asynchronous Initialization

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
@@ -30,7 +30,13 @@ public interface AtlasDbFactory {
 
     String getType();
 
-    KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig);
+    default KeyValueService createRawKeyValueService(KeyValueServiceConfig config,
+            Optional<LeaderConfig> leaderConfig) {
+        return createRawKeyValueService(config, leaderConfig, true);
+    }
+
+    KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync);
 
     TimestampService createTimestampService(KeyValueService rawKvs);
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -139,10 +139,8 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
     @Test
     public void testGcGraceSecondsUpgradeIsApplied() throws TException {
         Logger testLogger = mock(Logger.class);
+        //nth startup
         CassandraKeyValueService kvs = createKvs(getConfigWithGcGraceSeconds(FOUR_DAYS_IN_SECONDS), testLogger);
-        //first startup same as initial - no upgrade
-        verify(testLogger, times(1))
-                .info(startsWith("No tables are being upgraded on startup. No updated table-related settings found."));
         kvs.createTable(testTable, AtlasDbConstants.GENERIC_TABLE_METADATA);
         assertThatGcGraceSecondsIs(kvs, FOUR_DAYS_IN_SECONDS);
         kvs.close();
@@ -150,7 +148,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         CassandraKeyValueService kvs2 = createKvs(getConfigWithGcGraceSeconds(ONE_HOUR_IN_SECONDS), testLogger);
         assertThatGcGraceSecondsIs(kvs2, ONE_HOUR_IN_SECONDS);
         kvs2.close();
-        //startup with different GC grace seconds - should upgrade
+        //n+1th startup with different GC grace seconds - should upgrade
         verify(testLogger, times(1))
                 .info(startsWith("New table-related settings were applied on startup!!"));
 
@@ -230,7 +228,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
     @Test
     public void testLockTablesStateCleanUp() throws Exception {
-        CassandraKeyValueService ckvs = (CassandraKeyValueService) keyValueService;
+        CassandraKeyValueServiceImpl ckvs = (CassandraKeyValueServiceImpl) keyValueService;
         SchemaMutationLockTables lockTables = new SchemaMutationLockTables(
                 ckvs.getClientPool(),
                 CassandraContainer.KVS_CONFIG);

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
@@ -61,7 +61,7 @@ public abstract class NodesDownTestSetup {
     static final long OLD_TIMESTAMP = 1L;
     static final Value DEFAULT_VALUE = Value.create(DEFAULT_CONTENTS, DEFAULT_TIMESTAMP);
 
-    static CassandraKeyValueService kvs;
+    static CassandraKeyValueServiceImpl kvs;
 
     @ClassRule
     public static final Containers CONTAINERS = new Containers(NodesDownTestSetup.class)
@@ -92,7 +92,7 @@ public abstract class NodesDownTestSetup {
         setupDb.close();
     }
 
-    protected static CassandraKeyValueService createCassandraKvs() {
+    protected static CassandraKeyValueServiceImpl createCassandraKvs() {
         CassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig
                 .copyOf(ThreeNodeCassandraCluster.KVS_CONFIG)
                 .withSchemaMutationTimeoutMillis(3_000);

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   explicitShadow group: 'com.carrotsearch', name: 'hppc', version: '0.5.4'
 
   explicitShadow project(":atlasdb-client")
+  explicitShadow project(":atlasdb-processors")
   explicitShadow project(":atlasdb-api")
   explicitShadow project(":commons-api")
   explicitShadow project(':timestamp-impl')
@@ -52,6 +53,7 @@ dependencies {
 
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'
+  processor project(":atlasdb-processors")
 }
 
 shadowJar {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -37,20 +37,17 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
     @Override
     public KeyValueService createRawKeyValueService(
             KeyValueServiceConfig config,
-            Optional<LeaderConfig> leaderConfig) {
+            Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync) {
         AtlasDbVersion.ensureVersionReported();
         Preconditions.checkArgument(config instanceof CassandraKeyValueServiceConfig,
                 "CassandraAtlasDbFactory expects a configuration of type"
                 + " CassandraKeyValueServiceConfig, found %s", config.getClass());
-        return createKv((CassandraKeyValueServiceConfig) config, leaderConfig);
-    }
 
-    private static CassandraKeyValueService createKv(
-            CassandraKeyValueServiceConfig config,
-            Optional<LeaderConfig> leaderConfig) {
         return CassandraKeyValueServiceImpl.create(
-                CassandraKeyValueServiceConfigManager.createSimpleManager(config),
-                leaderConfig);
+                CassandraKeyValueServiceConfigManager.createSimpleManager((CassandraKeyValueServiceConfig) config),
+                leaderConfig,
+                initializeAsync);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -223,9 +223,9 @@ public final class CassandraClientPoolImpl implements CassandraClientPool, Async
         return create(config, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static CassandraClientPool create(CassandraKeyValueServiceConfig config, boolean initAsync) {
+    public static CassandraClientPool create(CassandraKeyValueServiceConfig config, boolean initializeAsync) {
         CassandraClientPoolImpl cassandraClientPool = new CassandraClientPoolImpl(config, StartupChecks.RUN);
-        cassandraClientPool.initialize(initAsync);
+        cassandraClientPool.initialize(initializeAsync);
         return cassandraClientPool.isInitialized() ? cassandraClientPool : new InitializingWrapper(cassandraClientPool);
     }
 
@@ -274,8 +274,6 @@ public final class CassandraClientPoolImpl implements CassandraClientPool, Async
         isInitialized = true;
     }
 
-    // TODO(gmaretic): if cleanup is necessary, initialization is not thread safe. It is an odd corner case,
-    // but making a note for now
     @Override
     public synchronized void cleanUpOnInitFailure() {
         metricsManager.deregisterMetrics();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -63,6 +64,7 @@ import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedBytes;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -71,6 +73,8 @@ import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.exception.NotInitializedException;
+import com.palantir.processors.AutoDelegate;
 import com.palantir.remoting2.tracing.Tracers;
 
 /**
@@ -90,7 +94,24 @@ import com.palantir.remoting2.tracing.Tracers;
  *   ... this is one of the reasons why there is a new system.
  **/
 @SuppressWarnings("VisibilityModifier")
-public class CassandraClientPoolImpl implements CassandraClientPool {
+@AutoDelegate(typeToExtend = CassandraClientPool.class)
+public final class CassandraClientPoolImpl implements CassandraClientPool, AsyncInitializer {
+    public static class InitializingWrapper implements AutoDelegate_CassandraClientPool {
+        private CassandraClientPoolImpl cassandraClientPool;
+
+        public InitializingWrapper(CassandraClientPoolImpl cassandraClientPool) {
+            this.cassandraClientPool = cassandraClientPool;
+        }
+
+        @Override
+        public CassandraClientPool delegate() {
+            if (cassandraClientPool.isInitialized()) {
+                return cassandraClientPool;
+            }
+            throw new NotInitializedException("CassandraClientPool");
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(CassandraClientPool.class);
     private static final String CONNECTION_FAILURE_MSG = "Tried to connect to cassandra {} times."
             + " Error writing to Cassandra socket."
@@ -110,11 +131,15 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
     Map<InetSocketAddress, Long> blacklistedHosts = Maps.newConcurrentMap();
     Map<InetSocketAddress, CassandraClientPoolingContainer> currentPools = Maps.newConcurrentMap();
     final CassandraKeyValueServiceConfig config;
+    private final StartupChecks startupChecks;
     final ScheduledExecutorService refreshDaemon;
+    private ScheduledFuture<?> refreshPoolFuture;
 
     private final MetricsManager metricsManager = new MetricsManager();
     private final RequestMetrics aggregateMetrics = new RequestMetrics(null);
     private final Map<InetSocketAddress, RequestMetrics> metricsByHost = new HashMap<>();
+
+    private volatile boolean isInitialized = false;
 
     public static class LightweightOppToken implements Comparable<LightweightOppToken> {
         final byte[] bytes;
@@ -193,28 +218,44 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         DO_NOT_RUN
     }
 
-    public static CassandraClientPool create(CassandraKeyValueServiceConfig config) {
-        return new CassandraClientPoolImpl(config, StartupChecks.RUN);
+    public static CassandraClientPoolImpl create(CassandraKeyValueServiceConfig config) {
+        return create(config, true);
+    }
+
+    public static CassandraClientPoolImpl create(CassandraKeyValueServiceConfig config, boolean initAsync) {
+        CassandraClientPoolImpl cassandraClientPool = new CassandraClientPoolImpl(config, StartupChecks.RUN);
+        cassandraClientPool.initialize(initAsync);
+        return cassandraClientPool;
     }
 
     @VisibleForTesting
     static CassandraClientPoolImpl createImplForTest(CassandraKeyValueServiceConfig config,
             StartupChecks startupChecks) {
-        return new CassandraClientPoolImpl(config, startupChecks);
-    }
-
-    public CassandraClientPoolImpl(CassandraKeyValueServiceConfig config) {
-        this(config, StartupChecks.RUN);
+        CassandraClientPoolImpl cassandraClientPool = new CassandraClientPoolImpl(config, startupChecks);
+        cassandraClientPool.tryInitialize();
+        return cassandraClientPool;
     }
 
     private CassandraClientPoolImpl(CassandraKeyValueServiceConfig config, StartupChecks startupChecks) {
         this.config = config;
-        config.servers().forEach(this::addPool);
-        refreshDaemon = Tracers.wrap(PTExecutors.newScheduledThreadPool(1, new ThreadFactoryBuilder()
+        this.startupChecks = startupChecks;
+        this.refreshDaemon = Tracers.wrap(PTExecutors.newScheduledThreadPool(1, new ThreadFactoryBuilder()
                 .setDaemon(true)
                 .setNameFormat("CassandraClientPoolRefresh-%d")
                 .build()));
-        refreshDaemon.scheduleWithFixedDelay(() -> {
+    }
+
+    @Override
+    public synchronized boolean isInitialized() {
+        return isInitialized;
+    }
+
+    @Override
+    public synchronized void tryInitialize() {
+        assertNotInitialized();
+
+        config.servers().forEach(this::addPool);
+        refreshPoolFuture = refreshDaemon.scheduleWithFixedDelay(() -> {
             try {
                 refreshPool();
             } catch (Throwable t) {
@@ -229,6 +270,18 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         }
         refreshPool(); // ensure we've initialized before returning
         registerAggregateMetrics();
+        isInitialized = true;
+    }
+
+    // TODO(gmaretic): if cleanup is necessary, initialization is not thread safe. It is an odd corner case,
+    // but making a note for now
+    @Override
+    public synchronized void cleanUpOnInitFailure() {
+        metricsManager.deregisterMetrics();
+        refreshPoolFuture.cancel(true);
+        currentPools.forEach((address, cassandraClientPoolingContainer) ->
+                cassandraClientPoolingContainer.shutdownPooling());
+        currentPools.clear();
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -65,6 +65,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedBytes;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -218,14 +219,14 @@ public final class CassandraClientPoolImpl implements CassandraClientPool, Async
         DO_NOT_RUN
     }
 
-    public static CassandraClientPoolImpl create(CassandraKeyValueServiceConfig config) {
-        return create(config, true);
+    public static CassandraClientPool create(CassandraKeyValueServiceConfig config) {
+        return create(config, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static CassandraClientPoolImpl create(CassandraKeyValueServiceConfig config, boolean initAsync) {
+    public static CassandraClientPool create(CassandraKeyValueServiceConfig config, boolean initAsync) {
         CassandraClientPoolImpl cassandraClientPool = new CassandraClientPoolImpl(config, StartupChecks.RUN);
         cassandraClientPool.initialize(initAsync);
-        return cassandraClientPool;
+        return cassandraClientPool.isInitialized() ? cassandraClientPool : new InitializingWrapper(cassandraClientPool);
     }
 
     @VisibleForTesting

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
@@ -52,13 +52,20 @@ public class CassandraExpiringKeyValueService extends CassandraKeyValueServiceIm
     public static CassandraExpiringKeyValueService create(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<LeaderConfig> leaderConfig) {
+        return create(configManager, leaderConfig, true);
+    }
+
+    public static CassandraExpiringKeyValueService create(
+            CassandraKeyValueServiceConfigManager configManager,
+            Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync) {
         Preconditions.checkState(!configManager.getConfig().servers().isEmpty(), "address list was empty");
 
         Optional<CassandraJmxCompactionManager> compactionManager =
                 CassandraJmxCompaction.createJmxCompactionManager(configManager);
         CassandraExpiringKeyValueService kvs =
-                new CassandraExpiringKeyValueService(configManager, compactionManager, leaderConfig);
-        kvs.init();
+                new CassandraExpiringKeyValueService(configManager, compactionManager, leaderConfig, initializeAsync);
+        kvs.initialize(initializeAsync);
         return kvs;
     }
 
@@ -66,8 +73,10 @@ public class CassandraExpiringKeyValueService extends CassandraKeyValueServiceIm
     protected CassandraExpiringKeyValueService(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<CassandraJmxCompactionManager> compactionManager,
-            Optional<LeaderConfig> leaderConfig) {
-        super(LoggerFactory.getLogger(CassandraKeyValueService.class), configManager, compactionManager, leaderConfig);
+            Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync) {
+        super(LoggerFactory.getLogger(CassandraKeyValueService.class), configManager, compactionManager, leaderConfig,
+                initializeAsync);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -202,10 +202,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService
     public static CassandraKeyValueServiceImpl create(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<LeaderConfig> leaderConfig) {
-        return create(configManager, leaderConfig, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+        return (CassandraKeyValueServiceImpl)
+                create(configManager, leaderConfig, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static CassandraKeyValueServiceImpl create(
+    public static CassandraKeyValueService create(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<LeaderConfig> leaderConfig,
             boolean initializeAsync) {
@@ -213,14 +214,15 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService
                 initializeAsync);
     }
 
-    public static CassandraKeyValueServiceImpl create(
+    @VisibleForTesting
+    static CassandraKeyValueService create(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<LeaderConfig> leaderConfig,
             Logger log) {
         return create(configManager, leaderConfig, log, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static CassandraKeyValueServiceImpl create(
+    private static CassandraKeyValueServiceImpl create(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<LeaderConfig> leaderConfig,
             Logger log,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -79,6 +79,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
 import com.google.common.primitives.UnsignedBytes;
+import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
@@ -125,8 +126,10 @@ import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.exception.PalantirRuntimeException;
+import com.palantir.exception.NotInitializedException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
+import com.palantir.processors.AutoDelegate;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -144,7 +147,31 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
  * if some nodes are down, and the change can be detected through active hosts,
  * and these inactive nodes will be removed afterwards.
  */
-public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implements CassandraKeyValueService {
+@AutoDelegate(typeToExtend = CassandraKeyValueService.class)
+public class CassandraKeyValueServiceImpl extends AbstractKeyValueService
+        implements AsyncInitializer, CassandraKeyValueService {
+
+    public static class InitializeCheckingWrapper implements AutoDelegate_CassandraKeyValueService {
+        private CassandraKeyValueServiceImpl kvs;
+
+        public InitializeCheckingWrapper(CassandraKeyValueServiceImpl kvs) {
+            this.kvs = kvs;
+        }
+
+        @Override
+        public CassandraKeyValueService delegate() {
+            if (kvs.isInitialized()) {
+                return kvs;
+            }
+            throw new NotInitializedException("CassandraKeyValueService");
+        }
+
+        @Override
+        public boolean supportsCheckAndSet() {
+            return kvs.supportsCheckAndSet();
+        }
+    }
+
     private final Logger log;
 
     private static final Function<Entry<Cell, Value>, Long> ENTRY_SIZING_FUNCTION = input ->
@@ -155,6 +182,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
     private final Optional<CassandraJmxCompactionManager> compactionManager;
     private final CassandraClientPool clientPool;
+
     private SchemaMutationLock schemaMutationLock;
     private final Optional<LeaderConfig> leaderConfig;
     private final HiddenTables hiddenTables;
@@ -169,36 +197,56 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private final TracingQueryRunner queryRunner;
     private final CassandraTables cassandraTables;
 
+    private volatile boolean isInitialized = false;
+
     public static CassandraKeyValueServiceImpl create(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<LeaderConfig> leaderConfig) {
-        return create(configManager, leaderConfig, LoggerFactory.getLogger(CassandraKeyValueService.class));
+        return create(configManager, leaderConfig, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    public static CassandraKeyValueServiceImpl create(
+            CassandraKeyValueServiceConfigManager configManager,
+            Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync) {
+        return create(configManager, leaderConfig, LoggerFactory.getLogger(CassandraKeyValueService.class),
+                initializeAsync);
     }
 
     public static CassandraKeyValueServiceImpl create(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<LeaderConfig> leaderConfig,
             Logger log) {
+        return create(configManager, leaderConfig, log, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    public static CassandraKeyValueServiceImpl create(
+            CassandraKeyValueServiceConfigManager configManager,
+            Optional<LeaderConfig> leaderConfig,
+            Logger log,
+            boolean initializeAsync) {
         Optional<CassandraJmxCompactionManager> compactionManager =
                 CassandraJmxCompaction.createJmxCompactionManager(configManager);
         CassandraKeyValueServiceImpl ret = new CassandraKeyValueServiceImpl(
                 log,
                 configManager,
                 compactionManager,
-                leaderConfig);
-        ret.init();
+                leaderConfig,
+                initializeAsync);
+        ret.initialize(initializeAsync);
         return ret;
     }
 
     protected CassandraKeyValueServiceImpl(Logger log,
                                        CassandraKeyValueServiceConfigManager configManager,
                                        Optional<CassandraJmxCompactionManager> compactionManager,
-                                       Optional<LeaderConfig> leaderConfig) {
+                                       Optional<LeaderConfig> leaderConfig,
+                                       boolean initializeAsync) {
         super(AbstractKeyValueService.createFixedThreadPool("Atlas Cassandra KVS",
                 configManager.getConfig().poolSize() * configManager.getConfig().servers().size()));
         this.log = log;
         this.configManager = configManager;
-        this.clientPool = CassandraClientPoolImpl.create(configManager.getConfig());
+        this.clientPool = CassandraClientPoolImpl.create(configManager.getConfig(), initializeAsync);
         this.compactionManager = compactionManager;
         this.leaderConfig = leaderConfig;
         this.hiddenTables = new HiddenTables();
@@ -216,7 +264,20 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 .orElse(LockLeader.I_AM_THE_LOCK_LEADER);
     }
 
-    protected void init() {
+    @Override
+    public synchronized void cleanUpOnInitFailure() {
+        // no-op
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return isInitialized;
+    }
+
+    @Override
+    public synchronized void tryInitialize() {
+        assertNotInitialized();
+
         boolean supportsCas = !configManager.getConfig().scyllaDb()
                 && clientPool.runWithRetry(CassandraVerifier.underlyingCassandraClusterSupportsCASOperations);
 
@@ -241,6 +302,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         CassandraKeyValueServices.warnUserInInitializationIfClusterAlreadyInInconsistentState(
                 clientPool,
                 configManager.getConfig());
+
+        isInitialized = true;
     }
 
     private void upgradeFromOlderInternalSchema() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -211,7 +211,8 @@ public final class CassandraVerifier {
         CassandraKeyValueServices.waitForSchemaVersions(
                 client,
                 "(adding the initial empty keyspace)",
-                config.schemaMutationTimeoutMillis());
+                config.schemaMutationTimeoutMillis(),
+                true);
     }
 
     private static boolean attemptedToCreateKeyspaceTwice(InvalidRequestException ex) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -148,7 +148,7 @@ public class CassandraClientPoolTest {
             hostList.add(new InetSocketAddress(i));
         }
 
-        CassandraClientPool cassandraClientPool = throwingClientPoolWithServersInCurrentPool(
+        CassandraClientPoolImpl cassandraClientPool = throwingClientPoolWithServersInCurrentPool(
                 ImmutableSet.copyOf(hostList), new SocketTimeoutException());
         runNoopOnHostWithRetryWithException(hostList.get(0), cassandraClientPool);
 
@@ -160,7 +160,7 @@ public class CassandraClientPoolTest {
 
     @Test
     public void shouldKeepRetryingIfNowhereToRedirectTo() {
-        CassandraClientPool cassandraClientPool = throwingClientPoolWithServersInCurrentPool(
+        CassandraClientPoolImpl cassandraClientPool = throwingClientPoolWithServersInCurrentPool(
                 ImmutableSet.of(HOST_1), new SocketTimeoutException());
 
         runNoopOnHostWithRetryWithException(HOST_1, cassandraClientPool);
@@ -186,7 +186,8 @@ public class CassandraClientPoolTest {
     }
 
     private void runTwoNoopsOnTwoHostsAndThrowFromSecondRunOnFirstHost(Exception exception) {
-        CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(HOST_1, HOST_2));
+        CassandraClientPoolImpl cassandraClientPool = clientPoolWithServersInCurrentPool(
+                ImmutableSet.of(HOST_1, HOST_2));
 
         runNoopOnHost(HOST_1, cassandraClientPool);
         runNoopOnHost(HOST_2, cassandraClientPool);
@@ -210,14 +211,14 @@ public class CassandraClientPoolTest {
     }
 
     private void verifyNumberOfAttemptsOnHost(InetSocketAddress host,
-                                              CassandraClientPool cassandraClientPool,
-                                              int numAttempts) {
+            CassandraClientPool cassandraClientPool,
+            int numAttempts) {
         Mockito.verify(cassandraClientPool.getCurrentPools().get(host), Mockito.times(numAttempts))
                 .runWithPooledResource(
                         Mockito.<FunctionCheckedException<Cassandra.Client, Object, RuntimeException>>any());
     }
 
-    private CassandraClientPool clientPoolWithServers(ImmutableSet<InetSocketAddress> servers) {
+    private CassandraClientPoolImpl clientPoolWithServers(ImmutableSet<InetSocketAddress> servers) {
         return clientPoolWith(servers, ImmutableSet.of(), Optional.empty());
     }
 
@@ -226,7 +227,7 @@ public class CassandraClientPoolTest {
     }
 
     private CassandraClientPoolImpl throwingClientPoolWithServersInCurrentPool(ImmutableSet<InetSocketAddress> servers,
-                                                                           Exception exception) {
+            Exception exception) {
         return clientPoolWith(ImmutableSet.of(), servers, Optional.of(exception));
     }
 
@@ -249,7 +250,7 @@ public class CassandraClientPoolTest {
     }
 
     private CassandraClientPoolingContainer getMockPoolingContainerForHost(InetSocketAddress address,
-                                                                           Optional<Exception> maybeFailureMode) {
+            Optional<Exception> maybeFailureMode) {
         CassandraClientPoolingContainer poolingContainer = mock(CassandraClientPoolingContainer.class);
         when(poolingContainer.getHost()).thenReturn(address);
         if (maybeFailureMode.isPresent()) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsWrapperTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsWrapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+public class CassandraKvsWrapperTest {
+    private static final CassandraKeyValueServiceImpl kvs = mock(CassandraKeyValueServiceImpl.class);
+    private static final KeyValueService kvsWrapper = new CassandraKeyValueServiceImpl.InitializeCheckingWrapper(kvs);
+
+    @Test
+    public void ifWrapperIsInitializedDelegateIsCalled() {
+        when(kvs.isInitialized()).thenReturn(true);
+        TableReference tableRef = TableReference.create(Namespace.DEFAULT_NAMESPACE, "test");
+        kvsWrapper.createTable(tableRef, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        verify(kvs).createTable(any(TableReference.class), any());
+    }
+
+    @Test
+    public void ifWrapperIsNotInitializedDelegateIsNotCalled() {
+        when(kvs.isInitialized()).thenReturn(false);
+        TableReference tableRef = TableReference.create(Namespace.DEFAULT_NAMESPACE, "test");
+        assertThatThrownBy(() -> kvsWrapper.createTable(tableRef, AtlasDbConstants.GENERIC_TABLE_METADATA))
+                .isInstanceOf(RuntimeException.class);
+        verify(kvs, never()).createTable(any(TableReference.class), any());
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsWrapperTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsWrapperTest.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.exception.NotInitializedException;
 
 public class CassandraKvsWrapperTest {
     private static final CassandraKeyValueServiceImpl kvs = mock(CassandraKeyValueServiceImpl.class);
@@ -47,7 +48,7 @@ public class CassandraKvsWrapperTest {
         when(kvs.isInitialized()).thenReturn(false);
         TableReference tableRef = TableReference.create(Namespace.DEFAULT_NAMESPACE, "test");
         assertThatThrownBy(() -> kvsWrapper.createTable(tableRef, AtlasDbConstants.GENERIC_TABLE_METADATA))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(NotInitializedException.class);
         verify(kvs, never()).createTable(any(TableReference.class), any());
     }
 }

--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -83,6 +83,7 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
@@ -109,6 +110,7 @@
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -165,6 +167,9 @@
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true
         },
         "com.palantir.atlasdb:commons-annotations": {
             "project": true,
@@ -257,6 +262,12 @@
             "locked": "0.6.0",
             "transitive": [
                 "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-codec:commons-codec": {
@@ -505,6 +516,7 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
@@ -531,6 +543,7 @@
                 "com.datastax.cassandra:cassandra-driver-core",
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
                 "com.palantir.tritium:tritium-core",
@@ -587,6 +600,9 @@
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true
         },
         "com.palantir.atlasdb:commons-annotations": {
             "project": true,
@@ -679,6 +695,12 @@
             "locked": "0.6.0",
             "transitive": [
                 "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-codec:commons-codec": {

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -161,6 +161,7 @@
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -199,6 +200,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -348,6 +350,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -567,6 +575,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "com.zaxxer:HikariCP": {

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/CleanCassLocksStateCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/CleanCassLocksStateCommand.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cli.output.OutputPrinter;
-import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
@@ -40,7 +39,7 @@ public class CleanCassLocksStateCommand extends AbstractCommand {
         Preconditions.checkState(isOffline(), "This CLI can only be run offline");
 
         CassandraKeyValueServiceConfig config = getCassandraKvsConfig();
-        CassandraKeyValueService ckvs = CassandraKeyValueServiceImpl.create(
+        CassandraKeyValueServiceImpl ckvs = CassandraKeyValueServiceImpl.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(config),
                 Optional.empty());
 

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -151,6 +151,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -190,6 +191,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -301,6 +303,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -502,6 +510,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-codec:commons-codec": {
@@ -886,6 +900,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -922,6 +937,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -1033,6 +1049,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -1234,6 +1256,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-codec:commons-codec": {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -93,6 +93,8 @@ public class AtlasDbConstants {
     public static final long SCRUBBER_RETRY_DELAY_MILLIS = 500L;
     public static final char OLD_SCRUB_TABLE_SEPARATOR_CHAR = '\0';
 
+    public static final boolean DEFAULT_INITIALIZE_ASYNC = false;
+
     public static final boolean DEFAULT_ENABLE_SWEEP = true;
     public static final long DEFAULT_SWEEP_PAUSE_MILLIS = 5 * 1000;
     public static final long DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS = 30_000L;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schemas.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schemas.java
@@ -83,6 +83,10 @@ public final class Schemas {
         return true;
     }
 
+    private Schemas() {
+        //
+    }
+
     /**
      * Creates tables/indexes for this schema.
      *

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schemas.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schemas.java
@@ -83,10 +83,6 @@ public final class Schemas {
         return true;
     }
 
-    private Schemas() {
-        //
-    }
-
     /**
      * Creates tables/indexes for this schema.
      *

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.concurrent.NamedThreadFactory;
 
 /**

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.async.initializer;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.palantir.common.annotation.Idempotent;
+import com.palantir.common.concurrent.NamedThreadFactory;
+
+/**
+ * Implements basic infrastructure to allow an object to be asynchronously initialized.
+ * In order to be ThreadSafe, the abstract methods of the inheriting class need to be synchronized.
+ */
+// TODO: Enforce that all methods from this interface are synchronized.
+@ThreadSafe
+public interface AsyncInitializer {
+    Logger log = LoggerFactory.getLogger(AsyncInitializer.class);
+    int nThreads = 20;
+    ScheduledExecutorService executorService = Executors.newScheduledThreadPool(
+            nThreads, new NamedThreadFactory("AsyncInitializer", true));
+
+    default void initialize(boolean initializeAsync) {
+        synchronized (this) {
+            initializeInternal(initializeAsync);
+        }
+    }
+
+    // TODO (JAVA9): Make this private.
+    default void initializeInternal(boolean initializeAsync) {
+        if (!initializeAsync) {
+            tryToInitializeIfNotInitialized();
+            return;
+        }
+
+        try {
+            tryToInitializeIfNotInitialized();
+        } catch (Throwable throwable) {
+            log.warn("Failed to initialize " + this.getClass().getName()
+                    + " in the first attempt, will initialize asynchronously.", throwable);
+            cleanUpOnInitFailure();
+            scheduleInitialization();
+        }
+    }
+
+    // TODO (JAVA9): Make this private.
+    default void scheduleInitialization() {
+        executorService.schedule(() -> {
+            try {
+                tryToInitializeIfNotInitialized();
+                log.warn("Initialized " +  this.getClass().getName() + " asynchronously.");
+            } catch (Throwable throwable) {
+                cleanUpOnInitFailure();
+                scheduleInitialization();
+            }
+        }, 10, TimeUnit.SECONDS);
+    }
+
+    // TODO (JAVA9): Make this private.
+    default void tryToInitializeIfNotInitialized() {
+        if (isInitialized()) {
+            log.warn(this.getClass().getName() + "was initialized underneath us.");
+        } else {
+            tryInitialize();
+        }
+    }
+
+    default void assertNotInitialized() {
+        Preconditions.checkState(!isInitialized(),
+                "Tried to initialize " + this.getClass().getName() + " , but was already initialized");
+    }
+
+    boolean isInitialized();
+
+    /**
+     * Tries to initialize the object synchronously.
+     * @throws IllegalStateException if object has already been initialized.
+     */
+    // TODO: Make this method protected abstract.
+    void tryInitialize();
+
+    void cleanUpOnInitFailure();
+}

--- a/atlasdb-commons/src/main/java/com/palantir/exception/NotInitializedException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/exception/NotInitializedException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.exception;
+
+public class NotInitializedException extends RuntimeException {
+    public NotInitializedException(String objectNotInitialized) {
+        super(String.format("The %s is not initialized yet", objectNotInitialized));
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -128,6 +128,18 @@ public abstract class AtlasDbConfig {
     }
 
     /**
+     * If false, the KVS and classes that depend on it will only try to initialize synchronously and will
+     * throw on failure, preventing AtlasDB from starting. This is consistent with the behaviour prior to
+     * implementing asynchronous initialization.
+     * If true, initialization will be attempted synchronously, but on failure we keep retrying asynchronously
+     * and start AtlasDB.
+     */
+    @Value.Default
+    public boolean initializeAsync() {
+        return AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC;
+    }
+
+    /**
      * If true, a background thread will periodically delete cells that
      * have been overwritten or deleted. This differs from scrubbing
      * because it is an untargeted cleaning process that scans all data

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -259,18 +259,18 @@ public final class TransactionManagers {
                 .setInitializeAsync(config.initializeAsync())
                 .buildCleaner();
 
-        SerializableTransactionManager transactionManager = new SerializableTransactionManager
-                .InitializeCheckingWrapper(
-                new SerializableTransactionManager(kvs,
-                        lockAndTimestampServices.timelock(),
-                        lockAndTimestampServices.lock(),
-                        transactionService,
-                        Suppliers.ofInstance(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS),
-                        conflictManager,
-                        sweepStrategyManager,
-                        cleaner,
-                        allowHiddenTableAccess,
-                        () -> runtimeConfigSupplier.get().transaction().getLockAcquireTimeoutMillis()));
+        SerializableTransactionManager transactionManager = SerializableTransactionManager.create(
+                kvs,
+                lockAndTimestampServices.timelock(),
+                lockAndTimestampServices.lock(),
+                transactionService,
+                Suppliers.ofInstance(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS),
+                conflictManager,
+                sweepStrategyManager,
+                cleaner,
+                allowHiddenTableAccess,
+                () -> runtimeConfigSupplier.get().transaction().getLockAcquireTimeoutMillis(),
+                config.initializeAsync());
 
         PersistentLockManager persistentLockManager = new PersistentLockManager(
                 persistentLockService,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.factory;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.logging.LoggingArgs;
+import com.palantir.atlasdb.schema.SweepSchema;
+import com.palantir.atlasdb.table.description.Schema;
+import com.palantir.atlasdb.table.description.Schemas;
+import com.palantir.atlasdb.transaction.impl.TransactionTables;
+
+public final class TransactionManagersInitializer implements AsyncInitializer {
+    private static volatile boolean isInitialized = false;
+
+    private KeyValueService keyValueService;
+    private Set<Schema> schemas;
+
+    public static void createInitialTables(KeyValueService keyValueService, Set<Schema> schemas,
+            boolean initializeAsync) {
+        new TransactionManagersInitializer(keyValueService, schemas).initialize(initializeAsync);
+    }
+
+    private TransactionManagersInitializer(KeyValueService keyValueService, Set<Schema> schemas) {
+        this.keyValueService = keyValueService;
+        this.schemas = schemas;
+    }
+
+    @Override
+    public synchronized boolean isInitialized() {
+        return isInitialized;
+    }
+
+    @Override
+    public synchronized void tryInitialize() {
+        assertNotInitialized();
+
+        TransactionTables.createTables(keyValueService);
+
+        Set<Schema> allSchemas = ImmutableSet.<Schema>builder()
+                .add(SweepSchema.INSTANCE.getLatestSchema())
+                .addAll(schemas)
+                .build();
+
+        for (Schema schema : allSchemas) {
+            Schemas.createTablesAndIndexes(schema, keyValueService);
+        }
+
+        LoggingArgs.hydrate(keyValueService.getMetadataForTables());
+
+        isInitialized = true;
+    }
+
+    @Override
+    public synchronized void cleanUpOnInitFailure() {
+        // no-op
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
@@ -44,7 +44,8 @@ public class AutoServiceAnnotatedAtlasDbFactory implements AtlasDbFactory {
     }
 
     @Override
-    public KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig) {
+    public KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync) {
         return keyValueService;
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -151,6 +151,8 @@ public class TransactionManagersTest {
         when(config.lock()).thenReturn(Optional.empty());
         when(config.timelock()).thenReturn(Optional.empty());
         when(config.keyValueService()).thenReturn(new InMemoryAtlasDbConfig());
+//        when(config.initializeAsync()).thenReturn();
+
 
         runtimeConfig = mock(AtlasDbRuntimeConfig.class);
         when(runtimeConfig.timestampClient()).thenReturn(ImmutableTimestampClientConfig.of(false));
@@ -325,6 +327,17 @@ public class TransactionManagersTest {
         manager.close();
         verify(callback, times(1)).run();
     }
+
+//    @Test
+//    public void newTest() {
+//        AtlasDbConfig realConfig = ImmutableAtlasDbConfig.builder()
+//                .keyValueService(new InMemoryAtlasDbConfig())
+//                .defaultLockTimeoutSeconds(120)
+//                .build();
+//        SerializableTransactionManager manager =
+//                TransactionManagers.create(realConfig, Optional::empty, ImmutableSet.of(), environment, false);
+//        manager.getKeyValueService().getAllTableNames();
+//    }
 
     private void verifyUserAgentOnRawTimestampAndLockRequests() {
         verifyUserAgentOnTimestampAndLockRequests(TIMESTAMP_PATH, LOCK_PATH);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -151,8 +151,7 @@ public class TransactionManagersTest {
         when(config.lock()).thenReturn(Optional.empty());
         when(config.timelock()).thenReturn(Optional.empty());
         when(config.keyValueService()).thenReturn(new InMemoryAtlasDbConfig());
-//        when(config.initializeAsync()).thenReturn();
-
+        when(config.initializeAsync()).thenReturn(false);
 
         runtimeConfig = mock(AtlasDbRuntimeConfig.class);
         when(runtimeConfig.timestampClient()).thenReturn(ImmutableTimestampClientConfig.of(false));
@@ -327,17 +326,6 @@ public class TransactionManagersTest {
         manager.close();
         verify(callback, times(1)).run();
     }
-
-//    @Test
-//    public void newTest() {
-//        AtlasDbConfig realConfig = ImmutableAtlasDbConfig.builder()
-//                .keyValueService(new InMemoryAtlasDbConfig())
-//                .defaultLockTimeoutSeconds(120)
-//                .build();
-//        SerializableTransactionManager manager =
-//                TransactionManagers.create(realConfig, Optional::empty, ImmutableSet.of(), environment, false);
-//        manager.getKeyValueService().getAllTableNames();
-//    }
 
     private void verifyUserAgentOnRawTimestampAndLockRequests() {
         verifyUserAgentOnTimestampAndLockRequests(TIMESTAMP_PATH, LOCK_PATH);

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -161,6 +161,7 @@
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -198,6 +199,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -337,6 +339,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -556,6 +564,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "com.zaxxer:HikariCP": {

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
@@ -75,11 +76,9 @@ public class CassandraContainer extends Container {
 
     @Override
     public SuccessOrFailure isReady(DockerComposeRule rule) {
-        return SuccessOrFailure.onResultOf(() -> {
-            CassandraKeyValueServiceImpl.create(
-                    CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),
-                    LEADER_CONFIG);
-            return true;
-        });
+        return SuccessOrFailure.onResultOf(() -> CassandraKeyValueServiceImpl.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),
+                LEADER_CONFIG)
+                .isInitialized());
     }
 }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableSet;
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
@@ -102,9 +103,9 @@ public class ThreeNodeCassandraCluster extends Container {
     }
 
     private static boolean canCreateCassandraKeyValueService() {
-        CassandraKeyValueServiceImpl.create(
+        return CassandraKeyValueServiceImpl.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),
-                LEADER_CONFIG);
-        return true;
+                LEADER_CONFIG)
+                .isInitialized();
     }
 }

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -108,6 +108,7 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
@@ -135,6 +136,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.docker.compose:docker-compose-rule-core",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
@@ -204,6 +206,12 @@
                 "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-annotations": {
@@ -321,6 +329,12 @@
             "locked": "0.6.0",
             "transitive": [
                 "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-codec:commons-codec": {
@@ -657,6 +671,7 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:commons-executors",
@@ -684,6 +699,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.docker.compose:docker-compose-rule-core",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
@@ -753,6 +769,12 @@
                 "com.palantir.atlasdb:commons-api",
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:commons-annotations": {
@@ -870,6 +892,12 @@
             "locked": "0.6.0",
             "transitive": [
                 "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-codec:commons-codec": {

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -72,6 +72,7 @@ public class TransactionManagerModule {
                 .setBackgroundScrubThreads(atlasDbConfig.getBackgroundScrubThreads())
                 .setPunchIntervalMillis(atlasDbConfig.getPunchIntervalMillis())
                 .setTransactionReadTimeout(atlasDbConfig.getTransactionReadTimeoutMillis())
+                .setInitializeAsync(atlasDbConfig.initializeAsync())
                 .buildCleaner();
     }
 

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -78,6 +78,7 @@ public class TestTransactionManagerModule {
                 .setBackgroundScrubThreads(atlasDbConfig.getBackgroundScrubThreads())
                 .setPunchIntervalMillis(atlasDbConfig.getPunchIntervalMillis())
                 .setTransactionReadTimeout(atlasDbConfig.getTransactionReadTimeoutMillis())
+                .setInitializeAsync(atlasDbConfig.initializeAsync())
                 .buildCleaner();
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -38,8 +38,10 @@ public class DbAtlasDbFactory implements AtlasDbFactory {
         return TYPE;
     }
 
+    // TODO(gmaretic): async initialization not implemented/propagated
     @Override
-    public KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig) {
+    public KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync) {
         Preconditions.checkArgument(config instanceof DbKeyValueServiceConfig,
                 "DbAtlasDbFactory expects a configuration of type DbKeyValueServiceConfiguration, found %s",
                 config.getClass());

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -181,6 +181,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -217,6 +218,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -341,6 +343,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -543,6 +551,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-cli:commons-cli": {
@@ -1373,6 +1387,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -1409,6 +1424,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -1533,6 +1549,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -1735,6 +1757,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-cli:commons-cli": {

--- a/atlasdb-ete-tests/docker-compose.multiple-cassandra.yml
+++ b/atlasdb-ete-tests/docker-compose.multiple-cassandra.yml
@@ -30,7 +30,7 @@ services:
 
   ete1:
     build: .
-    command: bash -c 'cp var/conf/atlasdb-ete.multiple-cassandra.yml var/conf/atlasdb-ete.yml && dockerize -timeout 120s -wait tcp://cassandra1:9160 -wait tcp://cassandra2:9160 -wait tcp://cassandra3:9160 && service/bin/init.sh console'
+    command: bash -c 'cp var/conf/atlasdb-ete.multiple-cassandra.yml var/conf/atlasdb-ete.yml && service/bin/init.sh start && tail -F var/log/atlasdb-ete-startup.log'
     environment:
       - ME=ete1
     ports:

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -17,13 +17,8 @@ package com.palantir.atlasdb;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cas.CheckAndSetClient;
 import com.palantir.atlasdb.cas.CheckAndSetSchema;
@@ -45,10 +40,6 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
-    private static final Logger log = LoggerFactory.getLogger(AtlasDbEteServer.class);
-
-    private static final long CREATE_TRANSACTION_MANAGER_MAX_WAIT_TIME_SECS = 60;
-    private static final long CREATE_TRANSACTION_MANAGER_POLL_INTERVAL_SECS = 5;
     private static final boolean DONT_SHOW_HIDDEN_TABLES = false;
     private static final Set<Schema> ETE_SCHEMAS = ImmutableSet.of(
             CheckAndSetSchema.getSchema(),
@@ -76,21 +67,12 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
 
     private TransactionManager createTransactionManager(AtlasDbEteConfiguration config, Environment environment)
             throws InterruptedException {
-        Stopwatch sw = Stopwatch.createStarted();
-        while (sw.elapsed(TimeUnit.SECONDS) < CREATE_TRANSACTION_MANAGER_MAX_WAIT_TIME_SECS) {
-            try {
-                return TransactionManagers.create(
-                        config.getAtlasDbConfig(),
-                        Optional::empty,
-                        ETE_SCHEMAS,
-                        environment.jersey()::register,
-                        DONT_SHOW_HIDDEN_TABLES);
-            } catch (RuntimeException e) {
-                log.warn("An error occurred while trying to create transaction manager. Retrying...", e);
-                Thread.sleep(CREATE_TRANSACTION_MANAGER_POLL_INTERVAL_SECS);
-            }
-        }
-        throw new IllegalStateException("Timed-out because we were unable to create transaction manager");
+        return TransactionManagers.create(
+                config.getAtlasDbConfig(),
+                Optional::empty,
+                ETE_SCHEMAS,
+                environment.jersey()::register,
+                DONT_SHOW_HIDDEN_TABLES);
     }
 
     private void enableEnvironmentVariablesInConfig(Bootstrap<AtlasDbEteConfiguration> bootstrap) {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -39,6 +39,8 @@ import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.configuration.ShutdownStrategy;
 import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.DockerMachine;
+import com.palantir.docker.compose.execution.DockerComposeExecArgument;
+import com.palantir.docker.compose.execution.DockerComposeExecOption;
 import com.palantir.docker.compose.execution.DockerComposeRunArgument;
 import com.palantir.docker.compose.execution.DockerComposeRunOption;
 import com.palantir.docker.compose.logging.LogDirectory;
@@ -109,6 +111,13 @@ public abstract class EteSetup {
                 DockerComposeRunOption.options("-T"),
                 "ete-cli",
                 DockerComposeRunArgument.arguments("bash", "-c", command));
+    }
+
+    static String execCliCommand(String command) throws IOException, InterruptedException {
+        return docker.exec(
+                DockerComposeExecOption.options("-T"),
+                "ete1",
+                DockerComposeExecArgument.arguments("bash", "-c", command));
     }
 
     static <T> T createClientToSingleNode(Class<T> clazz) {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraStartupOrderingEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraStartupOrderingEteTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.ete;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.core.ConditionTimeoutException;
+import com.palantir.atlasdb.http.errors.AtlasDbRemoteException;
+import com.palantir.atlasdb.todo.ImmutableTodo;
+import com.palantir.atlasdb.todo.Todo;
+import com.palantir.atlasdb.todo.TodoResource;
+import com.palantir.docker.compose.connection.DockerPort;
+
+@RunWith(Parameterized.class)
+public class MultiCassandraStartupOrderingEteTest {
+
+    private final List<String> cassandraNodesToStartOrStop;
+    private static final int CASSANDRA_PORT = 9160;
+
+    public MultiCassandraStartupOrderingEteTest(List<String> cassandraNodesToStartorStop) {
+        this.cassandraNodesToStartOrStop = cassandraNodesToStartorStop;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> testCases() {
+        Collection<Object[]> params = Lists.newArrayList();
+
+        params.add(new Object[] {ImmutableList.of("cassandra1")});
+        params.add(new Object[] {ImmutableList.of("cassandra1", "cassandra2")});
+        return params;
+    }
+
+    @Before
+    public void randomizeKeyspace() throws IOException, InterruptedException {
+        EteSetup.execCliCommand("sed -i 's/keyspace: .*/keyspace: " + UUID.randomUUID().toString().replace("-", "_")
+                + "/' var/conf/atlasdb-ete.yml");
+    }
+
+    @AfterClass
+    public static void resetKeyspace() throws IOException, InterruptedException {
+        EteSetup.execCliCommand("sed -i 's/keyspace: .*/keyspace: atlasete/' var/conf/atlasdb-ete.yml");
+        stopTheAtlasServer();
+        startTheAtlasServer();
+    }
+
+    @Test
+    public void shouldBeAbleToStartUpIfCassandraIsDownAndRunTransactionsWhenCassandraIsUp()
+            throws IOException, InterruptedException {
+        stopTheAtlasServer();
+
+        stopCassandraNodes();
+
+        startTheAtlasServer();
+
+        assertNotSatisfiedWithin(40, MultiCassandraStartupOrderingEteTest::canAddTodo);
+
+        startCassandraNodes();
+
+        assertSatisfiedWithin(150, MultiCassandraStartupOrderingEteTest::canAddTodo);
+
+        stopTheAtlasServer();
+
+        stopCassandraNodes();
+
+        startTheAtlasServer();
+
+        if (hasQuorum()) {
+            assertSatisfiedWithin(120, MultiCassandraStartupOrderingEteTest::canAddTodo);
+        } else {
+            assertNotSatisfiedWithin(40, MultiCassandraStartupOrderingEteTest::canAddTodo);
+        }
+    }
+
+    private static void stopTheAtlasServer() throws IOException, InterruptedException {
+        EteSetup.execCliCommand("service/bin/init.sh stop");
+        assertSatisfiedWithin(10, () -> !serverStarted());
+    }
+
+    private static void startTheAtlasServer() throws IOException, InterruptedException {
+        EteSetup.execCliCommand("service/bin/init.sh start");
+        assertSatisfiedWithin(120, MultiCassandraStartupOrderingEteTest::serverStarted);
+    }
+
+    private void stopCassandraNodes() throws InterruptedException {
+        runOnCassandraNodes(cassandraNodesToStartOrStop, MultiCassandraTestSuite::killCassandraContainer);
+        cassandraNodesToStartOrStop.forEach(node -> {
+            DockerPort containerPort = new DockerPort(node, CASSANDRA_PORT, CASSANDRA_PORT);
+            assertSatisfiedWithin(20, () -> !containerPort.isListeningNow());
+        });
+    }
+
+    private void startCassandraNodes() throws InterruptedException {
+        runOnCassandraNodes(cassandraNodesToStartOrStop, MultiCassandraTestSuite::startCassandraContainer);
+    }
+
+    private static void assertSatisfiedWithin(long time, Callable<Boolean> condition) {
+        Awaitility.waitAtMost(time, TimeUnit.SECONDS).pollInterval(2, TimeUnit.SECONDS).until(condition);
+    }
+
+    private static void assertNotSatisfiedWithin(long time, Callable<Boolean> condition) {
+        Assertions.assertThatThrownBy(
+                () -> Awaitility
+                        .waitAtMost(time, TimeUnit.SECONDS)
+                        .pollInterval(2, TimeUnit.SECONDS)
+                        .until(condition))
+                .isInstanceOf(ConditionTimeoutException.class);
+    }
+
+    private static boolean canAddTodo() {
+        try {
+            addATodo();
+            return true;
+        } catch (AtlasDbRemoteException e) {
+            return false;
+        }
+    }
+
+    private static boolean serverStarted() {
+        try {
+            canAddTodo();
+            return true;
+        } catch (AtlasDbRemoteException e) {
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean hasQuorum() {
+        return cassandraNodesToStartOrStop.size() < 2;
+    }
+
+    private static void addATodo() {
+        TodoResource todos = EteSetup.createClientToSingleNode(TodoResource.class);
+        Todo todo = getUniqueTodo();
+
+        todos.addTodo(todo);
+    }
+
+    private static Todo getUniqueTodo() {
+        return ImmutableTodo.of("some unique TODO item with UUID=" + UUID.randomUUID());
+    }
+
+    private void runOnCassandraNodes(List<String> nodes, CassandraContainerOperator operator)
+            throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(nodes.size());
+
+        executorService.invokeAll(nodes.stream()
+                .map(cassandraContainer -> Executors.callable(() -> operator.nodeOperation(cassandraContainer)))
+                .collect(Collectors.toList()));
+    }
+
+    interface CassandraContainerOperator {
+        void nodeOperation(String node);
+    }
+}

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraTestSuite.java
@@ -37,7 +37,8 @@ import com.palantir.docker.compose.connection.DockerPort;
         CommandLineEteTest.class,
         ServiceExposureEteTest.class,
         MultiCassandraSingleNodeDownEteTest.class,
-        MultiCassandraDoubleNodeDownEteTest.class
+        MultiCassandraDoubleNodeDownEteTest.class,
+        MultiCassandraStartupOrderingEteTest.class
         })
 public class MultiCassandraTestSuite extends EteSetup {
     private static final List<String> CLIENTS = ImmutableList.of("ete1");

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -184,6 +184,7 @@
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -220,6 +221,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -365,6 +367,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -568,6 +576,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "com.zaxxer:HikariCP": {
@@ -1426,6 +1440,7 @@
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -1464,6 +1479,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -1633,6 +1649,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -1853,6 +1875,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "com.zaxxer:HikariCP": {

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
   processor group: 'org.immutables', name: 'value'
   processor 'com.google.auto.service:auto-service:1.0-rc2'
+  processor project(":atlasdb-processors")
 
   testCompile group: 'com.palantir.remoting2', name: 'jaxrs-clients'
   testCompile group: 'io.dropwizard', name: 'dropwizard-testing'

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -43,6 +43,7 @@ public class DefaultCleanerBuilder {
     private int backgroundScrubReadThreads = AtlasDbConstants.DEFAULT_BACKGROUND_SCRUB_READ_THREADS;
     private long backgroundScrubFrequencyMillis = AtlasDbConstants.DEFAULT_BACKGROUND_SCRUB_FREQUENCY_MILLIS;
     private int backgroundScrubBatchSize = AtlasDbConstants.DEFAULT_BACKGROUND_SCRUB_BATCH_SIZE;
+    private boolean initalizeAsync = AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC;
 
     public DefaultCleanerBuilder(KeyValueService keyValueService,
             RemoteLockService lockService,
@@ -99,8 +100,14 @@ public class DefaultCleanerBuilder {
         return this;
     }
 
+    public DefaultCleanerBuilder setInitializeAsync(boolean initializeAsync) {
+        this.initalizeAsync = initializeAsync;
+        return this;
+    }
+
     private Puncher buildPuncher() {
-        KeyValueServicePuncherStore keyValuePuncherStore = KeyValueServicePuncherStore.create(keyValueService);
+        PuncherStore keyValuePuncherStore = new KeyValueServicePuncherStore.InitializingWrapper(
+                KeyValueServicePuncherStore.create(keyValueService, initalizeAsync));
         PuncherStore cachingPuncherStore = CachingPuncherStore.create(
                 keyValuePuncherStore,
                 punchIntervalMillis * 3);
@@ -113,8 +120,9 @@ public class DefaultCleanerBuilder {
     }
 
     private Scrubber buildScrubber(Supplier<Long> unreadableTimestampSupplier,
-                                   Supplier<Long> immutableTimestampSupplier) {
-        ScrubberStore scrubberStore = KeyValueServiceScrubberStore.create(keyValueService);
+            Supplier<Long> immutableTimestampSupplier) {
+        ScrubberStore scrubberStore = new KeyValueServiceScrubberStore.InitializingWrapper(
+                KeyValueServiceScrubberStore.create(keyValueService, initalizeAsync));
         return Scrubber.create(
                 keyValueService,
                 scrubberStore,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
@@ -68,7 +68,7 @@ public final class KeyValueServicePuncherStore implements PuncherStore, AsyncIni
     private volatile boolean isInitialized = false;
 
     public static KeyValueServicePuncherStore create(KeyValueService keyValueService) {
-        return create(keyValueService, true);
+        return create(keyValueService, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static KeyValueServicePuncherStore create(KeyValueService keyValueService, boolean initializeAsync) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.cleaner;
 
 import java.nio.charset.StandardCharsets;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.async.initializer.AsyncInitializer;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
@@ -17,8 +17,10 @@ package com.palantir.atlasdb.cleaner;
 
 import java.nio.charset.StandardCharsets;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -36,16 +38,61 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.common.base.ClosableIterator;
+import com.palantir.exception.NotInitializedException;
+import com.palantir.processors.AutoDelegate;
 
 /**
  * A PuncherStore implemented as a table in the KeyValueService.
  *
  * @author jweel
  */
-public final class KeyValueServicePuncherStore implements PuncherStore {
+@AutoDelegate(typeToExtend = PuncherStore.class)
+public final class KeyValueServicePuncherStore implements PuncherStore, AsyncInitializer {
+    public static class InitializingWrapper implements AutoDelegate_PuncherStore {
+        private KeyValueServicePuncherStore puncherStore;
+
+        public InitializingWrapper(KeyValueServicePuncherStore puncherStore) {
+            this.puncherStore = puncherStore;
+        }
+
+
+        @Override
+        public PuncherStore delegate() {
+            if (puncherStore.isInitialized()) {
+                return puncherStore;
+            }
+            throw new NotInitializedException("PuncherStore");
+        }
+    }
+
     private static final byte[] COLUMN = "t".getBytes(StandardCharsets.UTF_8);
+    private volatile boolean isInitialized = false;
 
     public static KeyValueServicePuncherStore create(KeyValueService keyValueService) {
+        return create(keyValueService, true);
+    }
+
+    public static KeyValueServicePuncherStore create(KeyValueService keyValueService, boolean initializeAsync) {
+        KeyValueServicePuncherStore puncherStore = new KeyValueServicePuncherStore(keyValueService);
+        puncherStore.initialize(initializeAsync);
+        return puncherStore;
+    }
+
+    private final KeyValueService keyValueService;
+
+    private KeyValueServicePuncherStore(KeyValueService keyValueService) {
+        this.keyValueService = keyValueService;
+    }
+
+    @Override
+    public synchronized boolean isInitialized() {
+        return isInitialized;
+    }
+
+    @Override
+    public synchronized void tryInitialize() {
+        assertNotInitialized();
+
         keyValueService.createTable(AtlasDbConstants.PUNCH_TABLE, new TableMetadata(
                 NameMetadataDescription.create(ImmutableList.of(
                         new NameComponentDescription.Builder()
@@ -55,14 +102,14 @@ public final class KeyValueServicePuncherStore implements PuncherStore {
                                 .build())),
                 new ColumnMetadataDescription(ImmutableList.of(
                         new NamedColumnDescription("t", "t", ColumnValueDescription.forType(ValueType.VAR_LONG)))),
-                        ConflictHandler.IGNORE_ALL).persistToBytes());
-        return new KeyValueServicePuncherStore(keyValueService);
+                ConflictHandler.IGNORE_ALL).persistToBytes());
+
+        isInitialized = true;
     }
 
-    private final KeyValueService keyValueService;
-
-    private KeyValueServicePuncherStore(KeyValueService keyValueService) {
-        this.keyValueService = keyValueService;
+    @Override
+    public synchronized void cleanUpOnInitFailure() {
+        // no-op
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
@@ -83,7 +83,7 @@ public final class KeyValueServiceScrubberStore implements ScrubberStore, AsyncI
     private final KeyValueService keyValueService;
 
     public static KeyValueServiceScrubberStore create(KeyValueService keyValueService) {
-        return create(keyValueService, true);
+        return create(keyValueService, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static KeyValueServiceScrubberStore create(KeyValueService keyValueService, boolean initializeAsync) {
@@ -130,6 +130,7 @@ public final class KeyValueServiceScrubberStore implements ScrubberStore, AsyncI
 
     @Override
     public synchronized void cleanUpOnInitFailure() {
+        // no-op
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
@@ -22,12 +22,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -48,6 +50,8 @@ import com.palantir.common.base.AbstractBatchingVisitable;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitableFromIterable;
 import com.palantir.common.base.ClosableIterator;
+import com.palantir.exception.NotInitializedException;
+import com.palantir.processors.AutoDelegate;
 
 /**
  *
@@ -56,35 +60,77 @@ import com.palantir.common.base.ClosableIterator;
  *
  * @author ejin
  */
-public final class KeyValueServiceScrubberStore implements ScrubberStore {
+@AutoDelegate(typeToExtend = ScrubberStore.class)
+public final class KeyValueServiceScrubberStore implements ScrubberStore, AsyncInitializer {
+    public static class InitializingWrapper implements AutoDelegate_ScrubberStore {
+        private KeyValueServiceScrubberStore scrubberStore;
+
+        public InitializingWrapper(KeyValueServiceScrubberStore scrubberStore) {
+            this.scrubberStore = scrubberStore;
+        }
+
+
+        @Override
+        public ScrubberStore delegate() {
+            if (scrubberStore.isInitialized()) {
+                return scrubberStore;
+            }
+            throw new NotInitializedException("ScrubberStore");
+        }
+    }
+
     private static final byte[] EMPTY_CONTENTS = new byte[] {1};
+    private volatile boolean isInitialized = false;
     private final KeyValueService keyValueService;
 
-    public static ScrubberStore create(KeyValueService keyValueService) {
-        TableMetadata scrubTableMeta = new TableMetadata(
-                NameMetadataDescription.create(ImmutableList.of(
-                        new NameComponentDescription.Builder()
-                            .componentName("row")
-                            .type(ValueType.BLOB)
-                            .build())),
-                new ColumnMetadataDescription(new DynamicColumnDescription(
-                        NameMetadataDescription.create(ImmutableList.of(
-                                new NameComponentDescription.Builder()
-                                    .componentName("table")
-                                    .type(ValueType.VAR_STRING)
-                                    .build(),
-                                new NameComponentDescription.Builder()
-                                    .componentName("col")
-                                    .type(ValueType.BLOB)
-                                    .build())),
-                        ColumnValueDescription.forType(ValueType.VAR_LONG))),
-                ConflictHandler.IGNORE_ALL);
-        keyValueService.createTable(AtlasDbConstants.SCRUB_TABLE, scrubTableMeta.persistToBytes());
-        return new KeyValueServiceScrubberStore(keyValueService);
+    public static KeyValueServiceScrubberStore create(KeyValueService keyValueService) {
+        return create(keyValueService, true);
+    }
+
+    public static KeyValueServiceScrubberStore create(KeyValueService keyValueService, boolean initializeAsync) {
+        KeyValueServiceScrubberStore scrubberStore = new KeyValueServiceScrubberStore(keyValueService);
+        scrubberStore.initialize(initializeAsync);
+        return scrubberStore;
     }
 
     private KeyValueServiceScrubberStore(KeyValueService keyValueService) {
         this.keyValueService = keyValueService;
+    }
+
+    @Override
+    public synchronized boolean isInitialized() {
+        return isInitialized;
+    }
+
+    @Override
+    public synchronized void tryInitialize() {
+        assertNotInitialized();
+
+        TableMetadata scrubTableMeta = new TableMetadata(
+                NameMetadataDescription.create(ImmutableList.of(
+                        new NameComponentDescription.Builder()
+                                .componentName("row")
+                                .type(ValueType.BLOB)
+                                .build())),
+                new ColumnMetadataDescription(new DynamicColumnDescription(
+                        NameMetadataDescription.create(ImmutableList.of(
+                                new NameComponentDescription.Builder()
+                                        .componentName("table")
+                                        .type(ValueType.VAR_STRING)
+                                        .build(),
+                                new NameComponentDescription.Builder()
+                                        .componentName("col")
+                                        .type(ValueType.BLOB)
+                                        .build())),
+                        ColumnValueDescription.forType(ValueType.VAR_LONG))),
+                ConflictHandler.IGNORE_ALL);
+        keyValueService.createTable(AtlasDbConstants.SCRUB_TABLE, scrubTableMeta.persistToBytes());
+
+        isInitialized = true;
+    }
+
+    @Override
+    public synchronized void cleanUpOnInitFailure() {
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespacedKeyValueServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespacedKeyValueServices.java
@@ -25,7 +25,8 @@ public final class NamespacedKeyValueServices {
     }
 
     public static KeyValueService wrapWithStaticNamespaceMappingKvs(KeyValueService keyValueService) {
-        TableMappingService tableMap = StaticTableMappingService.create(keyValueService);
+        TableMappingService tableMap = new StaticTableMappingService.InitializingWrapper(
+                StaticTableMappingService.create(keyValueService));
         NamespacedKeyValueService namespacedKeyValueService = TableRemappingKeyValueService.create(
                 keyValueService,
                 tableMap);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/StaticTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/StaticTableMappingService.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.AutoDelegate_TableMappingService;
 import com.palantir.atlasdb.keyvalue.TableMappingService;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -47,7 +48,7 @@ public final class StaticTableMappingService extends AbstractTableMappingService
     private final KeyValueService kv;
 
     public static StaticTableMappingService create(KeyValueService kv) {
-        return create(kv, true);
+        return create(kv, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
     public static StaticTableMappingService create(KeyValueService kv, boolean initalizeAsync) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/StaticTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/StaticTableMappingService.java
@@ -20,21 +20,60 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.keyvalue.AutoDelegate_TableMappingService;
 import com.palantir.atlasdb.keyvalue.TableMappingService;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.processors.AutoDelegate;
 
-public final class StaticTableMappingService extends AbstractTableMappingService {
+@AutoDelegate(typeToExtend = TableMappingService.class)
+public final class StaticTableMappingService extends AbstractTableMappingService implements AsyncInitializer {
+    public static class InitializingWrapper implements AutoDelegate_TableMappingService {
+
+        private StaticTableMappingService tableMappingService;
+
+        public InitializingWrapper(StaticTableMappingService tableMappingService) {
+            this.tableMappingService = tableMappingService;
+        }
+
+        @Override
+        public TableMappingService delegate() {
+            return tableMappingService;
+        }
+    }
+
+    private volatile boolean isInitialized = false;
     private final KeyValueService kv;
 
-    public static TableMappingService create(KeyValueService kv) {
+    public static StaticTableMappingService create(KeyValueService kv) {
+        return create(kv, true);
+    }
+
+    public static StaticTableMappingService create(KeyValueService kv, boolean initalizeAsync) {
         StaticTableMappingService ret = new StaticTableMappingService(kv);
-        ret.updateTableMap();
+        ret.initialize(initalizeAsync);
         return ret;
     }
 
     private StaticTableMappingService(KeyValueService kv) {
         this.kv = kv;
+    }
+
+    @Override
+    public synchronized boolean isInitialized() {
+        return isInitialized;
+    }
+
+    @Override
+    public synchronized void tryInitialize() {
+        assertNotInitialized();
+        updateTableMap();
+        isInitialized = true;
+    }
+
+    @Override
+    public synchronized void cleanUpOnInitFailure() {
     }
 
     @Override
@@ -64,5 +103,4 @@ public final class StaticTableMappingService extends AbstractTableMappingService
     protected void validateShortName(TableReference tableRef, TableReference shortName) {
         // any name is ok for the static mapper
     }
-
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -75,7 +75,8 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     @Override
     public InMemoryKeyValueService createRawKeyValueService(
             KeyValueServiceConfig config,
-            Optional<LeaderConfig> leaderConfig) {
+            Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync) {
         AtlasDbVersion.ensureVersionReported();
         return new InMemoryKeyValueService(false);
     }
@@ -154,6 +155,6 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     }
 
     private static TableMappingService getMapper(KeyValueService kv) {
-        return StaticTableMappingService.create(kv);
+        return StaticTableMappingService.create(kv, false);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -23,6 +23,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
@@ -155,6 +156,6 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     }
 
     private static TableMappingService getMapper(KeyValueService kv) {
-        return StaticTableMappingService.create(kv, false);
+        return StaticTableMappingService.create(kv, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockService.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.remoting2.servers.jersey.WebPreconditions;
@@ -35,7 +36,11 @@ public class KvsBackedPersistentLockService implements PersistentLockService {
     }
 
     public static PersistentLockService create(KeyValueService kvs) {
-        LockStore lockStore = LockStoreImpl.create(kvs);
+        return create(kvs, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    public static PersistentLockService create(KeyValueService kvs, boolean initializeAsync) {
+        LockStore lockStore = LockStoreImpl.create(kvs, initializeAsync);
         return new KvsBackedPersistentLockService(lockStore);
     }
 

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcAtlasDbFactory.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcAtlasDbFactory.java
@@ -35,7 +35,8 @@ public class JdbcAtlasDbFactory implements AtlasDbFactory {
     }
 
     @Override
-    public KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig) {
+    public KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig,
+            boolean initializeAsync) {
         AtlasDbVersion.ensureVersionReported();
         return JdbcKeyValueService.create((JdbcKeyValueConfiguration) config);
     }

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -167,6 +167,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -212,6 +213,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.docker.compose:docker-compose-rule-core",
@@ -355,6 +357,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -582,6 +590,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "com.zaxxer:HikariCP": {
@@ -1069,6 +1083,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -1114,6 +1129,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.docker.compose:docker-compose-rule-core",
@@ -1257,6 +1273,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -1484,6 +1506,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "com.zaxxer:HikariCP": {

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -1169,6 +1169,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-lock-api",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.atlasdb:atlasdb-service",
                 "com.palantir.atlasdb:commons-annotations",
                 "com.palantir.atlasdb:commons-api",
@@ -1204,6 +1205,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:atlasdb-processors",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
                 "com.palantir.remoting2:error-handling",
@@ -1312,6 +1314,12 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-impl-shared"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-processors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-cassandra"
             ]
         },
         "com.palantir.atlasdb:atlasdb-service": {
@@ -1510,6 +1518,12 @@
             "locked": "1.9.0",
             "transitive": [
                 "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-processors"
             ]
         },
         "commons-codec:commons-codec": {

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampServiceImpl.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampServiceImpl.java
@@ -27,11 +27,11 @@ public class PersistentTimestampServiceImpl implements PersistentTimestampServic
 
     private final PersistentTimestamp timestamp;
 
-    public static PersistentTimestampServiceImpl create(TimestampBoundStore store) {
+    public static PersistentTimestampService create(TimestampBoundStore store) {
         return create(new ErrorCheckingTimestampBoundStore(store));
     }
 
-    public static PersistentTimestampServiceImpl create(ErrorCheckingTimestampBoundStore store) {
+    public static PersistentTimestampService create(ErrorCheckingTimestampBoundStore store) {
         long latestTimestamp = store.getUpperLimit();
         PersistentUpperLimit upperLimit = new PersistentUpperLimit(store);
         PersistentTimestamp timestamp = new PersistentTimestamp(upperLimit, latestTimestamp);


### PR DESCRIPTION
**Goals (and why)**: Fix #930.

**Implementation Description (bullets)**: 
1. Create an initializingWrapper for things that need to be initialized on startup after extracting interfaces.
2. Test that TransactionManager.create passes through without the KVs being up and operations are successful once its up.

**Concerns (what feedback would you like?)**: 
1. Are the error messages sane?
2. Does the approach makes sense.

**Where should we start reviewing?**: TransactionManagers.create

**Priority (whenever / two weeks / yesterday)**: one week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2269)
<!-- Reviewable:end -->
