### PR TITLE
Fix/compact warning for non ee oracle users

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Throwables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -253,7 +252,7 @@ public final class OracleDdlTable implements DbDdlTable {
                         + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
                         + " like more information. Underlying error was: {}", tableRef, e.getMessage());
             } catch (TableMappingNotFoundException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         } else {
             try {
@@ -264,7 +263,7 @@ public final class OracleDdlTable implements DbDdlTable {
                         tableRef,
                         oracleTableNameGetter.getInternalShortTableName(conns, tableRef));
             } catch (TableMappingNotFoundException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -256,10 +256,11 @@ public final class OracleDdlTable implements DbDdlTable {
             }
         } else {
             try {
-                log.warn("Tried to clean up table {}, but couldn't, because enterprise features are disabled. "
+                log.warn("Tried to clean up {} bloat after a sweep operation, but couldn't, because enterprise "
+                        + "features are disabled. "
                         + "This means that even if you are running sweep, you will need to manually clean up your "
-                        + "tables, otherwise disk usage will continually increase. To free up space, run the SHRINK "
-                        + "command on the underlying oracle table, {}.",
+                        + "tables, otherwise disk usage will continually increase. To free up space, run the "
+                        + "SHRINK SPACE command on the underlying oracle table, {}.",
                         tableRef,
                         oracleTableNameGetter.getInternalShortTableName(conns, tableRef));
             } catch (TableMappingNotFoundException e) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -255,6 +255,17 @@ public final class OracleDdlTable implements DbDdlTable {
             } catch (TableMappingNotFoundException e) {
                 throw Throwables.propagate(e);
             }
+        } else {
+            try {
+                log.warn("Tried to clean up table {}, but couldn't, because enterprise features are disabled. "
+                        + "This means that even if you are running sweep, you will need to manually clean up your "
+                        + "tables, otherwise disk usage will continually increase. To free up space, run the SHRINK "
+                        + "command on the underlying oracle table, {}.",
+                        tableRef,
+                        oracleTableNameGetter.getInternalShortTableName(conns, tableRef));
+            } catch (TableMappingNotFoundException e) {
+                throw Throwables.propagate(e);
+            }
         }
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -251,7 +251,7 @@ public final class OracleDdlTable implements DbDdlTable {
                         "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
                                 + " MOVE ONLINE");
             } catch (PalantirSqlException e) {
-                log.error(compactionFailureTemplate + "Underlying error was: {}",
+                log.error(compactionFailureTemplate + " Underlying error was: {}",
                         tableRef,
                         "(Enterprise Edition that requires this user to be able to perform DDL operations)",
                         e.getMessage());

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,6 +44,11 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - If ``enableOracleEnterpriseFeatures`` if configured to be false, you will now see warnings asking you to run Oracle compaction manually.
+           This will help make non-EE Oracle users aware of potential database bloat.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2277>`__)
+
     *    - |fixed|
          - Fixed a case where logging an expection suppressing itself would cause a stack overflow.
            See https://jira.qos.ch/browse/LOGBACK-1027.


### PR DESCRIPTION
**Goals (and why)**: Fixes #2276.

**Implementation Description (bullets)**: If enterprise features are disabled, log a warning when calling `compactInternally`.

**Concerns (what feedback would you like?)**: This warning is going to be logged _every time_ we delete some data as part of sweep, _forever_. Should we add an option to ignore it, or otherwise somehow suppress further occurrences in order to reduce logspam?

**Where should we start reviewing?**: The one file

**Priority (whenever / two weeks / yesterday)**: ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2277)
<!-- Reviewable:end -->
