### PR TITLE
KVS Migration - Screen Sweep Tables from Validation (#2244)

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidator.java
@@ -84,8 +84,8 @@ public class KeyValueServiceValidator {
     }
 
     public void validate(boolean logOnly) {
-        Set<TableReference> tables = KeyValueServiceMigrators
-                .getMigratableTableNames(validationFromKvs, unmigratableTables);
+        Set<TableReference> tables = KeyValueServiceValidators.getValidatableTableNames(
+                validationFromKvs, unmigratableTables);
         try {
             validateTables(tables);
         } catch (Throwable t) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidators.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidators.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/KeyValueServiceValidators.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+public final class KeyValueServiceValidators {
+    private KeyValueServiceValidators() {
+        // utility
+    }
+
+    /**
+     * Returns tables that need to be validated.
+     * Generally speaking, this excludes tables that are modified outside of the transaction protocol
+     * (e.g. timestamp, transaction), and tables which are not required to be equal in the to- and from- KVSes
+     * (e.g. the sweep priority table).
+     *
+     * Clearly, the tables to be validated are a subset of that to be migrated.
+     */
+    public static Set<TableReference> getValidatableTableNames(
+            KeyValueService kvs,
+            Set<TableReference> unmigratableTables) {
+        Set<TableReference> tableNames = KeyValueServiceMigrators.getMigratableTableNames(kvs, unmigratableTables);
+        return removeSweepTableReferences(tableNames);
+    }
+
+    private static Set<TableReference> removeSweepTableReferences(Set<TableReference> tableNames) {
+        return tableNames.stream()
+                .filter(tableReference -> !isSweepTableReference(tableReference))
+                .collect(Collectors.toSet());
+    }
+
+    @VisibleForTesting
+    static boolean isSweepTableReference(TableReference tableReference) {
+        return tableReference.getNamespace().equals(SweepSchema.INSTANCE.getNamespace());
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/schema/KeyValueServiceValidatorsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/schema/KeyValueServiceValidatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/schema/KeyValueServiceValidatorsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/schema/KeyValueServiceValidatorsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.schema.generated.SweepPriorityTable;
+import com.palantir.atlasdb.schema.generated.SweepProgressTable;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+
+public class KeyValueServiceValidatorsTest {
+    private static final TableReference SWEEP_PRIORITY = TableReference.create(
+            SweepSchema.INSTANCE.getNamespace(), SweepPriorityTable.getRawTableName());
+    private static final TableReference SWEEP_PROGRESS = TableReference.create(
+            SweepSchema.INSTANCE.getNamespace(), SweepProgressTable.getRawTableName());
+    private static final TableReference OTHER_PRIORITY = TableReference.create(
+            Namespace.create("foo"), SweepPriorityTable.getRawTableName());
+
+    private final KeyValueService kvs = new InMemoryKeyValueService(true);
+
+    @Test
+    public void sweepPriorityTableIsASweepTable() {
+        assertThat(KeyValueServiceValidators.isSweepTableReference(SWEEP_PRIORITY)).isTrue();
+    }
+
+    @Test
+    public void sweepProgressTableIsASweepTable() {
+        assertThat(KeyValueServiceValidators.isSweepTableReference(SWEEP_PROGRESS)).isTrue();
+    }
+
+    @Test
+    public void otherPriorityTableIsNotASweepTable() {
+        assertThat(KeyValueServiceValidators.isSweepTableReference(OTHER_PRIORITY)).isFalse();
+    }
+
+    @Test
+    public void sweepPriorityTableNotValidated() {
+        kvs.createTable(SWEEP_PRIORITY, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of())).isEmpty();
+    }
+
+    @Test
+    public void sweepProgressTableNotValidated() {
+        kvs.createTable(SWEEP_PROGRESS, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of())).isEmpty();
+    }
+
+    @Test
+    public void transactionTableNotValidated() {
+        kvs.createTable(TransactionConstants.TRANSACTION_TABLE,
+                TransactionConstants.TRANSACTION_TABLE_METADATA.persistToBytes());
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of())).isEmpty();
+    }
+
+    @Test
+    public void otherPriorityTableIsValidated() {
+        kvs.createTable(OTHER_PRIORITY, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of()))
+                .containsExactly(OTHER_PRIORITY);
+    }
+
+    @Test
+    public void unmigratableTablesAreNotValidated() {
+        kvs.createTable(OTHER_PRIORITY, AtlasDbConstants.EMPTY_TABLE_METADATA);
+        assertThat(KeyValueServiceValidators.getValidatableTableNames(kvs, ImmutableSet.of(OTHER_PRIORITY))).isEmpty();
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,6 +42,12 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - KVS migrations will no longer verify equality between the from and to KVSes for the sweep priority and progress tables.
+           Note that these tables are still *migrated* across, as they provide heuristics for timely sweeping of tables.
+           However, these tables may change (e.g. the from-kvs could be swept).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2244>`__)
+
     *    - |improved|
          - Refactored ``AvailableTimestamps`` reducing overzealous synchronization. Giving out timestamps is no longer blocking on refreshing the timestamp bound if there are enough timestamps to give out with the current bound.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/1783>`__)


### PR DESCRIPTION
**Goals (and why)**: Backport validation fixes to 0.39.x. Exclude the sweep priority table from the tables to validate after a migration.

**Implementation Description (bullets)**: -

**Concerns (what feedback would you like?)**: -

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: -

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2278)
<!-- Reviewable:end -->
