### PR TITLE
use correct logging archiving preference

### DIFF
--- a/docs/source/cluster_management/sweep/background-sweep.rst
+++ b/docs/source/cluster_management/sweep/background-sweep.rst
@@ -52,7 +52,7 @@ By default, the background sweeper only logs errors. If you'd like to watch the 
     log4j.appender.sweepAppend.threshold=debug
     log4j.appender.sweepAppend.file=log/background-sweeper.log
     log4j.appender.sweepAppend.datePattern='.'yyyy-MM-dd
-    log4j.appender.sweepAppend.maxArchivesToKeep=90
+    log4j.appender.sweepAppend.MaxRollFileCount=90
 
 This will create a log file ``log/background-sweeper.log`` where sweep information will be logged.
 


### PR DESCRIPTION
The http://www.simonsite.org.uk/javadoc/timeandsize/uk/org/simonsite/log4j/appender/TimeAndSizeRollingAppender.html doesn't have a `maxArchivesToKeep` preference, it is actually `MaxRollFileCount`

**Goals (and why)**: The existing preference is ignored, and it defaults to keeping 10.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2282)
<!-- Reviewable:end -->
