### PR TITLE
Fix/shrink oracle se

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -60,6 +60,11 @@ public abstract class OracleDdlConfig extends DdlConfig {
     }
 
     @Value.Default
+    public boolean enableShrinkOnOracleStandardEdition() {
+        return true;
+    }
+
+    @Value.Default
     @Override
     public String tablePrefix() {
         return "a_";

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -243,7 +243,7 @@ public final class OracleDdlTable implements DbDdlTable {
                 + " Since this can't be automated in your configuration,"
                 + " good practice would be do to occasional offline manual maintenance of rebuilding"
                 + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
-                + " like more information.";
+                + " like more information. Underlying error was: {}";
 
         if (config.enableOracleEnterpriseFeatures()) {
             try {
@@ -251,7 +251,7 @@ public final class OracleDdlTable implements DbDdlTable {
                         "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
                                 + " MOVE ONLINE");
             } catch (PalantirSqlException e) {
-                log.error(compactionFailureTemplate + " Underlying error was: {}",
+                log.error(compactionFailureTemplate,
                         tableRef,
                         "(Enterprise Edition that requires this user to be able to perform DDL operations)",
                         e.getMessage());
@@ -267,7 +267,7 @@ public final class OracleDdlTable implements DbDdlTable {
                         "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
                                 + " SHRINK SPACE");
             } catch (PalantirSqlException e) {
-                log.error(compactionFailureTemplate + " Underlying error was: {}",
+                log.error(compactionFailureTemplate,
                         tableRef,
                         "(If you are running against Enterprise Edition,"
                                 + " you can set enableOracleEnterpriseFeatures to true in the configuration.)",

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -258,7 +258,7 @@ public final class OracleDdlTable implements DbDdlTable {
             } catch (TableMappingNotFoundException e) {
                 throw new RuntimeException(e);
             }
-        } else {
+        } else if (config.enableShrinkOnOracleStandardEdition()) {
             try {
                 conns.get().executeUnregisteredQuery(
                         "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -15,10 +15,13 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Stopwatch;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -259,13 +262,22 @@ public final class OracleDdlTable implements DbDdlTable {
                 throw new RuntimeException(e);
             }
         } else if (config.enableShrinkOnOracleStandardEdition()) {
+            Stopwatch timer = Stopwatch.createStarted();
             try {
+                Stopwatch shrinkAndCompactTimer = Stopwatch.createStarted();
                 conns.get().executeUnregisteredQuery(
                         "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
                                 + " SHRINK SPACE COMPACT");
+                log.info("Call to SHRINK SPACE COMPACT on table {} took {} ms.",
+                        tableRef, shrinkAndCompactTimer.elapsed(TimeUnit.MILLISECONDS));
+
+                Stopwatch shrinkTimer = Stopwatch.createStarted();
                 conns.get().executeUnregisteredQuery(
                         "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
                                 + " SHRINK SPACE");
+                log.info("Call to SHRINK SPACE on table {} took {} ms."
+                                + " This implies that locks on the entire table were held for this period.",
+                        tableRef, shrinkTimer.elapsed(TimeUnit.MILLISECONDS));
             } catch (PalantirSqlException e) {
                 log.error(compactionFailureTemplate,
                         tableRef,
@@ -274,6 +286,9 @@ public final class OracleDdlTable implements DbDdlTable {
                         e.getMessage());
             } catch (TableMappingNotFoundException e) {
                 throw new RuntimeException(e);
+            } finally {
+                log.info("Call to KVS.compactInternally on table {} took {} ms.",
+                        tableRef, timer.elapsed(TimeUnit.MILLISECONDS));
             }
         }
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -259,10 +259,22 @@ public final class OracleDdlTable implements DbDdlTable {
                 throw new RuntimeException(e);
             }
         } else {
-            log.warn(compactionFailureTemplate,
-                    tableRef,
-                    "(If you are running against Enterprise Edition,"
-                    + " you can set enableOracleEnterpriseFeatures to true in the configuration.)");
+            try {
+                conns.get().executeUnregisteredQuery(
+                        "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
+                                + " SHRINK SPACE COMPACT");
+                conns.get().executeUnregisteredQuery(
+                        "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
+                                + " SHRINK SPACE");
+            } catch (PalantirSqlException e) {
+                log.error(compactionFailureTemplate + " Underlying error was: {}",
+                        tableRef,
+                        "(If you are running against Enterprise Edition,"
+                                + " you can set enableOracleEnterpriseFeatures to true in the configuration.)",
+                        e.getMessage());
+            } catch (TableMappingNotFoundException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,7 +45,8 @@ develop
          - Change
 
     *    - |new|
-         - Oracle SE will now automatically trigger shrinking table data files post sweeping a table.
+         - Oracle SE will now automatically trigger shrinking table data post sweeping a table to recover space.
+           You can disable the compaction by setting ``enableShrinkOnOracleStandardEdition`` to ``false`` in the Oracle DDL config.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2286>`__)
 
     *    - |userbreak|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,6 +44,10 @@ develop
     *    - Type
          - Change
 
+    *    - |new|
+         - Oracle SE will now automatically trigger shrinking table data files post sweeping a table.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2286>`__)
+
     *    - |userbreak|
          - If AtlasDB is used with TimeLock, and the TimeLock client name is different than either the Cassandra ``keyspace``, Postgres ``dbName``, or Oracle ``sid``, *AtlasDB will fail to start*.
            This was done to avoid risks of data corruption if these are accidentally changed independently.


### PR DESCRIPTION
**Goals (and why)**: Fix #2262.

**Implementation Description (bullets)**: If enterprise features are not enabled, use shrink space commands. Tested using the KVS and Sweeper tests on the internal oracle repo.

**Concerns (what feedback would you like?)**:
1. Should be warn users of the possible table lock when running `ALTER TABLE .. SHRINK SPACE` though we expect it to be short.
2. Should this be wrapped in a config flag - I think yes and it should be live reloadable?
3. When running shrink we should 
> disable any triggers based on rowid for table segments you want to shrink

This is beacuse rowids will be altered. Do we have any such triggers? - I think there are no such Atlas level triggers.

**Where should we start reviewing?**: OracleDdlTable

**Priority (whenever / two weeks / yesterday)**: one day.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2286)
<!-- Reviewable:end -->
