### PR TITLE
Make AutoDelegate also handle exceptions

### DIFF
--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/ClassWithExceptions.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/ClassWithExceptions.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.processors;
+
+@AutoDelegate(typeToExtend = ClassWithExceptions.class,
+        exceptions = {IllegalStateException.class, RuntimeException.class})
+public class ClassWithExceptions {
+    public void methodThatThrowsExceptions() {};
+}

--- a/atlasdb-processors-tests/src/main/java/com/palantir/processors/InterfaceWithExceptions.java
+++ b/atlasdb-processors-tests/src/main/java/com/palantir/processors/InterfaceWithExceptions.java
@@ -16,21 +16,8 @@
 
 package com.palantir.processors;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.CLASS)
-public @interface AutoDelegate {
-    /**
-     * The type to be extended. Can be either a class or an interface.
-     */
-    Class typeToExtend();
-
-    /**
-     * The exceptions to be caught. The respective methods will be of name `handle_ExceptionName`.
-     */
-    Class[] exceptions() default void.class;
+@AutoDelegate(typeToExtend = InterfaceWithExceptions.class,
+        exceptions = {IllegalStateException.class, RuntimeException.class})
+public interface InterfaceWithExceptions {
+    public void methodThatThrowsExceptions();
 }

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/ClassWithExceptionsTest.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/ClassWithExceptionsTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.processors;
+
+public class ClassWithExceptionsTest {
+}

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/InterfaceWithExceptionsTest.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/InterfaceWithExceptionsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.processors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class InterfaceWithExceptionsTest {
+    final InterfaceWithExceptions delegateMock = mock(InterfaceWithExceptions.class);
+    boolean handleIllegalStateExceptionWasCalled = false;
+    boolean handleRuntimeExceptionWasCalled = false;
+
+    final AutoDelegate_InterfaceWithExceptions wrapper = new AutoDelegate_InterfaceWithExceptions() {
+        @Override
+        public InterfaceWithExceptions delegate() {
+            return delegateMock;
+        }
+
+        @Override
+        public void handleIllegalStateException(IllegalStateException exception) {
+            handleIllegalStateExceptionWasCalled = true;
+        }
+
+        @Override
+        public void handleRuntimeException(RuntimeException exception) {
+            handleRuntimeExceptionWasCalled = true;
+        }
+    };
+
+    @Before
+    public void setUp() {
+        handleIllegalStateExceptionWasCalled = false;
+        handleRuntimeExceptionWasCalled = false;
+    }
+
+    @Test
+    public void assertIllegalStateExceptionIsCaughtByHandler() {
+        doThrow(IllegalStateException.class).when(delegateMock).methodThatThrowsExceptions();
+        wrapper.methodThatThrowsExceptions();
+        assertTrue(handleIllegalStateExceptionWasCalled);
+        assertFalse(handleRuntimeExceptionWasCalled);
+    }
+
+    @Test
+    public void assertRuntimeExceptionIsCaughtByHandler() {
+        doThrow(RuntimeException.class).when(delegateMock).methodThatThrowsExceptions();
+        wrapper.methodThatThrowsExceptions();
+        assertFalse(handleIllegalStateExceptionWasCalled);
+        assertTrue(handleRuntimeExceptionWasCalled);
+    }
+}

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import javax.annotation.Generated;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.FilerException;
@@ -49,6 +50,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Sets;
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
@@ -217,6 +219,11 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
         }
 
         // Add modifiers
+        typeBuilder.addAnnotation(AnnotationSpec
+                .builder(Generated.class)
+                .addMember("value", "$S", this.getClass().getCanonicalName())
+                .addMember("value", "$S", typeToExtend.getSimpleName())
+                .build());
         TypeMirror typeMirror = typeToExtend.getType();
         if (typeToExtend.isPublic()) {
             typeBuilder.addModifiers(Modifier.PUBLIC);

--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -245,7 +245,7 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
                 .returns(TypeName.get(typeMirror));
         typeBuilder.addMethod(delegateMethod.build());
 
-        // Add exception messages
+        // Add exception methods
         List<TypeElement> exceptions = typeToExtend.getExceptions();
         for (TypeElement exception : exceptions) {
             MethodSpec.Builder exceptionMethod = MethodSpec
@@ -264,6 +264,7 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
             if (typeToExtend.isInterface()) {
                 method.addModifiers(Modifier.DEFAULT);
             }
+
             if (exceptions.size() > 0) {
                 method.beginControlFlow("try");
             }

--- a/atlasdb-processors/src/main/java/com/palantir/processors/TypeToExtend.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/TypeToExtend.java
@@ -29,6 +29,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 import com.google.common.collect.Sets;
@@ -38,8 +39,10 @@ final class TypeToExtend {
     private PackageElement typePackage;
     private Set<ExecutableElement> methods;
     private Set<ExecutableElement> constructors;
+    private List<TypeElement> exceptions;
 
     TypeToExtend(PackageElement typePackage,
+            List<TypeElement> exceptions,
             TypeElement typeToExtend,
             TypeElement... supertypes) {
 
@@ -60,6 +63,7 @@ final class TypeToExtend {
 
         methods = Sets.newHashSet(methodSignatureToMethod.values());
         constructors = extractConstructors(typeToExtend);
+        this.exceptions = exceptions;
     }
 
     private List<ExecutableElement> extractMethods(TypeElement typeToExtractMethodsFrom) {
@@ -137,5 +141,9 @@ final class TypeToExtend {
 
     Set<ExecutableElement> getConstructors() {
         return constructors;
+    }
+
+    List<TypeElement> getExceptions() {
+        return exceptions;
     }
 }


### PR DESCRIPTION
**Goals (and why)**: This is the first PR of a series that desires to remove all the proxies from our codebase.

**Implementation Description (bullets)**: Add a exceptions tag to the AutoDelegate annotation, that receives a varargs number of exceptions. All the extended methods are wrapped with `catch` blocks, catching the annotations in-order.

**Concerns (what feedback would you like?)**: Is the code readable enough? Are there any more tests needed?

**Where should we start reviewing?**: AutoDelegateProcessor.

**Priority (whenever / two weeks / yesterday)**: This is not high priority, so whenever people have time.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2292)
<!-- Reviewable:end -->
