### PR TITLE
Reimplement NamedColumnValueRenderer and NamedRowResultRenderer

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/NamedColumnValueRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/NamedColumnValueRenderer.java
@@ -19,164 +19,255 @@ import static com.palantir.atlasdb.table.description.render.ColumnRenderers.Type
 import static com.palantir.atlasdb.table.description.render.ColumnRenderers.long_name;
 import static com.palantir.atlasdb.table.description.render.ColumnRenderers.short_name;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.lang.model.element.Modifier;
+
+import com.google.common.base.MoreObjects;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.table.description.ColumnValueDescription;
 import com.palantir.atlasdb.table.description.NamedColumnDescription;
+import com.palantir.common.persist.Persistable;
+import com.squareup.javapoet.ArrayTypeName;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeSpec;
 
 public class NamedColumnValueRenderer extends Renderer {
+    private final String packageName;
     private final String tableName;
-    private final String Name;
+    private final ClassName tableType;
+    private final String columnName;
+    private final ClassName columnType;
     private final NamedColumnDescription col;
+    private final ClassName javaType;
 
-    public NamedColumnValueRenderer(Renderer parent, String tableName, NamedColumnDescription col) {
+    public NamedColumnValueRenderer(Renderer parent, String packageName, String tableName, NamedColumnDescription col) {
         super(parent);
+        this.packageName = packageName;
+
         this.tableName = tableName;
-        this.Name = Renderers.CamelCase(col.getLongName());
+        this.tableType = ClassName.get(packageName, tableName + "Table");
+
+        this.columnName = Renderers.CamelCase(col.getLongName());
+        this.columnType = tableType.nestedClass(this.columnName);
+
         this.col = col;
+        this.javaType = ClassName.get(col.getValue().getValueType().getTypeClass());
     }
 
     @Override
     protected void run() {
-        javaDoc();
-        line("public static final class ", Name, " implements ", tableName, "NamedColumnValue<", TypeName(col), "> {"); {
-            fields();
-            line();
-            staticFactories();
-            line();
-            constructors();
-            line();
-            getColumnName();
-            line();
-            getShortColumnName();
-            line();
-            getValue();
-            line();
-            persistValue();
-            line();
-            persistColumnName();
-            line();
-            bytesHydrator();
-            line();
-            renderToString();
-        } line("}");
+        TypeSpec.Builder columnClassBuilder = TypeSpec.classBuilder(this.columnName)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .addSuperinterface(ParameterizedTypeName.get(
+                        tableType.nestedClass(tableName + "NamedColumnValue"),
+                        javaType
+                ))
+                .addJavadoc(getJavaDoc());
+
+        for (FieldSpec field : getFields()) {
+            columnClassBuilder.addField(field);
+        }
+        for (MethodSpec staticFactory : getStaticFactories()) {
+            columnClassBuilder.addMethod(staticFactory);
+        }
+        for (MethodSpec constructor : getConstructors()) {
+            columnClassBuilder.addMethod(constructor);
+        }
+        for (MethodSpec method : getMethods()) {
+            columnClassBuilder.addMethod(method);
+        }
+
+        addBlock(columnClassBuilder.build().toString());
     }
 
-    private void javaDoc() {
-        line("/**");
-        line(" * <pre>");
-        line(" * Column value description {", "");
-        line(" *   type: ", TypeName(col), ";");
+    private String getJavaDoc() {
+        String javaDoc = "<pre> \n"
+                + "Column value description {\n"
+                + " type: " + TypeName(col) + ";\n";
         if (col.getValue().getProtoDescriptor() != null) {
             String protoDescription = col.getValue().getProtoDescriptor().toProto().toString();
             for (String line : protoDescription.split("\n")) {
-                line(" *   ", line, "");
+                javaDoc += "   " + line + "\n";
             }
         }
-        line(" * }", "");
-        line(" * </pre>");
-        line(" */");
+        javaDoc += "}\n"
+                + "</pre>";
+
+        return javaDoc;
     }
 
-    private void fields() {
-        line("private final ", TypeName(col), " value;");
+    private List<FieldSpec> getFields() {
+        ArrayList<FieldSpec> results = new ArrayList<>();
+        results.add(FieldSpec.builder(javaType, "value")
+                .addModifiers(Modifier.FINAL)
+                .build());
+        results.add(bytesHydrator());
+        return results;
     }
 
-    private void staticFactories() {
-        line("public static ", Name, " of(", TypeName(col), " value) {"); {
-            line("return new ", Name, "(value);");
-        } line("}");
+    private List<MethodSpec> getStaticFactories() {
+        ArrayList<MethodSpec> results = new ArrayList<>();
+        results.add(MethodSpec.methodBuilder("of")
+                .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
+                .addParameter(javaType, "value")
+                .returns(columnType)
+                .addStatement("return new $T(value)", columnType)
+                .build());
+        return results;
     }
 
-    private void constructors() {
-        line("private ", Name, "(", TypeName(col), " value) {"); {
-            line("this.value = value;");
-        } line("}");
+    private List<MethodSpec> getConstructors() {
+        ArrayList<MethodSpec> results = new ArrayList<>();
+        results.add(MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PRIVATE)
+                .addParameter(javaType, "value")
+                .addStatement("this.$N = $N", "value", "value")
+                .build());
+        return results;
     }
 
-    private void getColumnName() {
-        line("@Override");
-        line("public String getColumnName() {"); {
-            line("return ", long_name(col), ";");
-        } line("}");
+    private List<MethodSpec> getMethods() {
+        ArrayList<MethodSpec> results = new ArrayList<>();
+        results.add(getColumnName());
+        results.add(getShortColumnName());
+        results.add(getValue());
+        results.add(persistValue());
+        results.add(persistColumnName());
+        results.add(renderToString());
+        return results;
     }
 
-    private void getShortColumnName() {
-        line("@Override");
-        line("public String getShortColumnName() {"); {
-            line("return ", short_name(col), ";");
-        } line("}");
+    private MethodSpec getColumnName() {
+        return MethodSpec.methodBuilder("getColumnName")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(String.class)
+                .addStatement("return $N", long_name(col))
+                .build();
     }
 
-    private void getValue() {
-        line("@Override");
-        line("public ", TypeName(col), " getValue() {"); {
-            line("return value;");
-        } line("}");
+    private MethodSpec getShortColumnName() {
+        return MethodSpec.methodBuilder("getShortColumnName")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(String.class)
+                .addStatement("return $N", short_name(col))
+                .build();
     }
 
-    private void persistValue() {
-        line("@Override");
-        line("public byte[] persistValue() {"); {
-            switch (col.getValue().getFormat()) {
+    private MethodSpec getValue() {
+        return MethodSpec.methodBuilder("getValue")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(javaType)
+                .addStatement("return value")
+                .build();
+    }
+
+    private MethodSpec persistValue() {
+        String persistingToBytesCode;
+        switch (col.getValue().getFormat()) {
             case PERSISTABLE:
-                line("byte[] bytes = value.persistToBytes();");
+                persistingToBytesCode = "value.persistToBytes()";
                 break;
             case PROTO:
-                line("byte[] bytes = value.toByteArray();");
+                persistingToBytesCode = "value.toByteArray()";
                 break;
             case PERSISTER:
-                line("byte[] bytes = ", col.getValue().getPersistCode("value"), ";");
+                persistingToBytesCode = col.getValue().getPersistCode("value");
                 break;
             case VALUE_TYPE:
-                line("byte[] bytes = ", col.getValue().getValueType().getPersistCode("value"), ";");
+                persistingToBytesCode = col.getValue().getValueType().getPersistCode("value");
                 break;
             default:
                 throw new UnsupportedOperationException("Unsupported value type: " + col.getValue().getFormat());
-            }
-            line("return CompressionUtils.compress(bytes, Compression.", col.getValue().getCompression().name(), ");");
-        } line("}");
+        }
+
+        return MethodSpec.methodBuilder("persistValue")
+                 .addAnnotation(Override.class)
+                 .addModifiers(Modifier.PUBLIC)
+                 .returns(ArrayTypeName.of(byte.class))
+                 .addStatement("byte[] bytes = $N", persistingToBytesCode)
+                 .addStatement("return $T.compress(bytes, $T.$N)",
+                         CompressionUtils.class,
+                         ColumnValueDescription.Compression.class,
+                         col.getValue().getCompression().name())
+                 .build();
     }
 
-    private void persistColumnName() {
-        line("@Override");
-        line("public byte[] persistColumnName() {"); {
-            line("return PtBytes.toCachedBytes(", short_name(col), ");");
-        } line("}");
+    private MethodSpec persistColumnName() {
+        return MethodSpec.methodBuilder("persistColumnName")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ArrayTypeName.of(byte.class))
+                .addStatement("return $T.toCachedBytes($N)", PtBytes.class, short_name(col))
+                .build();
     }
 
-    private void bytesHydrator() {
-        line("public static final Hydrator<", Name, "> BYTES_HYDRATOR = new Hydrator<", Name, ">() {"); {
-            line("@Override");
-            line("public ", Name, " hydrateFromBytes(byte[] bytes) {"); {
-                line("bytes = CompressionUtils.decompress(bytes, Compression.", col.getValue().getCompression().name(), ");");
-                switch (col.getValue().getFormat()) {
-                case PERSISTABLE:
-                    line("return of(", TypeName(col), ".BYTES_HYDRATOR.hydrateFromBytes(bytes));");
-                    break;
-                case PROTO:
-                    line("try {"); {
-                        line("return of(", TypeName(col), ".parseFrom(bytes));");
-                    } line("} catch (InvalidProtocolBufferException e) {"); {
-                        line("throw Throwables.throwUncheckedException(e);");
-                    } line("}");
-                    break;
-                case PERSISTER:
-                    line("return of(", col.getValue().getHydrateCode("bytes"), ");");
-                    break;
-                case VALUE_TYPE:
-                    line("return of(", col.getValue().getValueType().getHydrateCode("bytes", "0"), ");");
-                    break;
-                default:
-                    throw new UnsupportedOperationException("Unsupported value type: " + col.getValue().getFormat());
-                }
-            } line("}");
-        } line("};");
+    private FieldSpec bytesHydrator() {
+        CodeBlock.Builder parsingFromBytes = CodeBlock.builder();
+        switch (col.getValue().getFormat()) {
+            case PERSISTABLE:
+                parsingFromBytes.add("return of(", TypeName(col), ".BYTES_HYDRATOR.hydrateFromBytes(bytes));");
+                break;
+            case PROTO:
+                parsingFromBytes.add("try {");
+                parsingFromBytes.add("  return of($T.parseFrom(bytes));", javaType);
+                parsingFromBytes.add("} catch (InvalidProtocolBufferException e) {");
+                parsingFromBytes.add("  throw Throwables.throwUncheckedException(e);");
+                parsingFromBytes.add("}");
+                break;
+            case PERSISTER:
+                parsingFromBytes.add("return of($N);", col.getValue().getHydrateCode("bytes"));
+                break;
+            case VALUE_TYPE:
+                parsingFromBytes.add("return of($N);",
+                        col.getValue().getValueType().getHydrateCode("bytes", "0"));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported value type: " + col.getValue().getFormat());
+        }
+
+        TypeSpec hydratorType = TypeSpec.anonymousClassBuilder("")
+                .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Persistable.Hydrator.class), columnType))
+                .addMethod(MethodSpec.methodBuilder("hydrateFromBytes")
+                        .addAnnotation(Override.class)
+                        .addModifiers(Modifier.PUBLIC)
+                        .addParameter(ArrayTypeName.of(byte.class), "bytes")
+                        .returns(columnType)
+                        .addStatement("bytes = $T.decompress(bytes, $T.$N)",
+                                CompressionUtils.class,
+                                ColumnValueDescription.Compression.class,
+                                col.getValue().getCompression().name()
+                        )
+                        .addCode(parsingFromBytes.build())
+                        .build())
+                .build();
+
+        return FieldSpec.builder(
+                ParameterizedTypeName.get(
+                        ClassName.get(Persistable.Hydrator.class),
+                        columnType),
+                "BYTES_HYDRATOR")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .initializer("$L", hydratorType)
+                .build();
     }
 
-    private void renderToString() {
-        line("@Override");
-        line("public String toString() {"); {
-            line("return MoreObjects.toStringHelper(getClass().getSimpleName())");
-            line("    .add(\"Value\", this.value)");
-            line("    .toString();");
-        } line("}");
+    private MethodSpec renderToString() {
+        return MethodSpec.methodBuilder("toString")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(String.class)
+                .addStatement("return $T.toStringHelper(getClass().getSimpleName())"
+                        + ".add(\"Value\", this.value).toString()", MoreObjects.class)
+                .build();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/Renderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/Renderer.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.table.description.render;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -84,5 +85,22 @@ public abstract class Renderer {
 
     protected byte[] getHash() {
         return Hashing.murmur3_128().hashUnencodedChars(s).asBytes();
+    }
+
+    protected void addBlock(String codeBlock) {
+        String[] lines = codeBlock.split("\\r?\\n");
+        for (String line : lines) {
+            s.append("\n");
+            for (int i = 0; i < indent.get(); i++) {
+                s.append("    ");
+            }
+            s.append(line);
+        }
+    }
+
+    protected void addBlocks(List<String> codeBlocks) {
+        for (String block : codeBlocks) {
+            addBlock(block);
+        }
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -300,7 +300,7 @@ public class TableRenderer {
             }
             renderTrigger();
             line();
-            new NamedRowResultRenderer(this, tableName, ColumnRenderers.namedColumns(table)).run();
+            new NamedRowResultRenderer(this, packageName, tableName, ColumnRenderers.namedColumns(table)).run();
             line();
             new NamedColumnRenderer(this, tableName, ColumnRenderers.namedColumns(table)).run();
             line();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -295,7 +295,7 @@ public class TableRenderer {
             line("public interface ", tableName, "NamedColumnValue<T> extends NamedColumnValue<T> { /* */ }");
             line();
             for (NamedColumnDescription col : ColumnRenderers.namedColumns(table)) {
-                new NamedColumnValueRenderer(this, tableName, col).run();
+                new NamedColumnValueRenderer(this, packageName, tableName, col).run();
                 line();
             }
             renderTrigger();

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
@@ -228,63 +228,59 @@ public final class CheckAndSetTable implements
     public interface CheckAndSetNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
 
     /**
-     * <pre>
+     * <pre> 
      * Column value description {
-     *   type: Long;
+     *  type: Long;
      * }
-     * </pre>
-     */
-    public static final class Value implements CheckAndSetNamedColumnValue<Long> {
-        private final Long value;
-
-        public static Value of(Long value) {
-            return new Value(value);
-        }
-
-        private Value(Long value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getColumnName() {
-            return "value";
-        }
-
-        @Override
-        public String getShortColumnName() {
-            return "v";
-        }
-
-        @Override
-        public Long getValue() {
-            return value;
-        }
-
-        @Override
-        public byte[] persistValue() {
-            byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
-            return CompressionUtils.compress(bytes, Compression.NONE);
-        }
-
-        @Override
-        public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("v");
-        }
-
-        public static final Hydrator<Value> BYTES_HYDRATOR = new Hydrator<Value>() {
-            @Override
-            public Value hydrateFromBytes(byte[] bytes) {
-                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));
-            }
-        };
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
-        }
+     * </pre> */
+    public static final class Value implements com.palantir.atlasdb.cas.generated.CheckAndSetTable.CheckAndSetNamedColumnValue<java.lang.Long> {
+      public static final com.palantir.common.persist.Persistable.Hydrator<com.palantir.atlasdb.cas.generated.CheckAndSetTable.Value> BYTES_HYDRATOR = new com.palantir.common.persist.Persistable.Hydrator<com.palantir.atlasdb.cas.generated.CheckAndSetTable.Value>() {
+        @java.lang.Override
+        public com.palantir.atlasdb.cas.generated.CheckAndSetTable.Value hydrateFromBytes(byte[] bytes) {
+          bytes = com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+          return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));}
+      };
+    
+      final java.lang.Long value;
+    
+      private Value(java.lang.Long value) {
+        this.value = value;
+      }
+    
+      public static com.palantir.atlasdb.cas.generated.CheckAndSetTable.Value of(java.lang.Long value) {
+        return new com.palantir.atlasdb.cas.generated.CheckAndSetTable.Value(value);
+      }
+    
+      @java.lang.Override
+      public java.lang.String getColumnName() {
+        return "value";
+      }
+    
+      @java.lang.Override
+      public java.lang.String getShortColumnName() {
+        return "v";
+      }
+    
+      @java.lang.Override
+      public java.lang.Long getValue() {
+        return value;
+      }
+    
+      @java.lang.Override
+      public byte[] persistValue() {
+        byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
+        return com.palantir.atlasdb.compress.CompressionUtils.compress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+      }
+    
+      @java.lang.Override
+      public byte[] persistColumnName() {
+        return com.palantir.atlasdb.encoding.PtBytes.toCachedBytes("v");
+      }
+    
+      @java.lang.Override
+      public java.lang.String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(getClass().getSimpleName()).add("Value", this.value).toString();
+      }
     }
 
     public interface CheckAndSetTrigger {
@@ -681,5 +677,5 @@ public final class CheckAndSetTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "pcyXr6MvNlvXZxaJAYYjfw==";
+    static String __CLASS_HASH = "ULfLx+E8NODixso/lu+zqg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -228,63 +228,59 @@ public final class DataTable implements
     public interface DataNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
 
     /**
-     * <pre>
+     * <pre> 
      * Column value description {
-     *   type: Long;
+     *  type: Long;
      * }
-     * </pre>
-     */
-    public static final class Value implements DataNamedColumnValue<Long> {
-        private final Long value;
-
-        public static Value of(Long value) {
-            return new Value(value);
-        }
-
-        private Value(Long value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getColumnName() {
-            return "value";
-        }
-
-        @Override
-        public String getShortColumnName() {
-            return "v";
-        }
-
-        @Override
-        public Long getValue() {
-            return value;
-        }
-
-        @Override
-        public byte[] persistValue() {
-            byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
-            return CompressionUtils.compress(bytes, Compression.NONE);
-        }
-
-        @Override
-        public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("v");
-        }
-
-        public static final Hydrator<Value> BYTES_HYDRATOR = new Hydrator<Value>() {
-            @Override
-            public Value hydrateFromBytes(byte[] bytes) {
-                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));
-            }
-        };
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
-        }
+     * </pre> */
+    public static final class Value implements com.palantir.atlasdb.schema.indexing.generated.DataTable.DataNamedColumnValue<java.lang.Long> {
+      public static final com.palantir.common.persist.Persistable.Hydrator<com.palantir.atlasdb.schema.indexing.generated.DataTable.Value> BYTES_HYDRATOR = new com.palantir.common.persist.Persistable.Hydrator<com.palantir.atlasdb.schema.indexing.generated.DataTable.Value>() {
+        @java.lang.Override
+        public com.palantir.atlasdb.schema.indexing.generated.DataTable.Value hydrateFromBytes(byte[] bytes) {
+          bytes = com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+          return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));}
+      };
+    
+      final java.lang.Long value;
+    
+      private Value(java.lang.Long value) {
+        this.value = value;
+      }
+    
+      public static com.palantir.atlasdb.schema.indexing.generated.DataTable.Value of(java.lang.Long value) {
+        return new com.palantir.atlasdb.schema.indexing.generated.DataTable.Value(value);
+      }
+    
+      @java.lang.Override
+      public java.lang.String getColumnName() {
+        return "value";
+      }
+    
+      @java.lang.Override
+      public java.lang.String getShortColumnName() {
+        return "v";
+      }
+    
+      @java.lang.Override
+      public java.lang.Long getValue() {
+        return value;
+      }
+    
+      @java.lang.Override
+      public byte[] persistValue() {
+        byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
+        return com.palantir.atlasdb.compress.CompressionUtils.compress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+      }
+    
+      @java.lang.Override
+      public byte[] persistColumnName() {
+        return com.palantir.atlasdb.encoding.PtBytes.toCachedBytes("v");
+      }
+    
+      @java.lang.Override
+      public java.lang.String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(getClass().getSimpleName()).add("Value", this.value).toString();
+      }
     }
 
     public interface DataTrigger {
@@ -3496,5 +3492,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/hrXL9YLBxZHFEbepfAK/A==";
+    static String __CLASS_HASH = "gAXfyJnl7T5X9IvPynEYQA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -228,123 +228,115 @@ public final class TwoColumnsTable implements
     public interface TwoColumnsNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
 
     /**
-     * <pre>
+     * <pre> 
      * Column value description {
-     *   type: Long;
+     *  type: Long;
      * }
-     * </pre>
-     */
-    public static final class Bar implements TwoColumnsNamedColumnValue<Long> {
-        private final Long value;
-
-        public static Bar of(Long value) {
-            return new Bar(value);
-        }
-
-        private Bar(Long value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getColumnName() {
-            return "bar";
-        }
-
-        @Override
-        public String getShortColumnName() {
-            return "b";
-        }
-
-        @Override
-        public Long getValue() {
-            return value;
-        }
-
-        @Override
-        public byte[] persistValue() {
-            byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
-            return CompressionUtils.compress(bytes, Compression.NONE);
-        }
-
-        @Override
-        public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("b");
-        }
-
-        public static final Hydrator<Bar> BYTES_HYDRATOR = new Hydrator<Bar>() {
-            @Override
-            public Bar hydrateFromBytes(byte[] bytes) {
-                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));
-            }
-        };
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
-        }
+     * </pre> */
+    public static final class Bar implements com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.TwoColumnsNamedColumnValue<java.lang.Long> {
+      public static final com.palantir.common.persist.Persistable.Hydrator<com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Bar> BYTES_HYDRATOR = new com.palantir.common.persist.Persistable.Hydrator<com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Bar>() {
+        @java.lang.Override
+        public com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Bar hydrateFromBytes(byte[] bytes) {
+          bytes = com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+          return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));}
+      };
+    
+      final java.lang.Long value;
+    
+      private Bar(java.lang.Long value) {
+        this.value = value;
+      }
+    
+      public static com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Bar of(java.lang.Long value) {
+        return new com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Bar(value);
+      }
+    
+      @java.lang.Override
+      public java.lang.String getColumnName() {
+        return "bar";
+      }
+    
+      @java.lang.Override
+      public java.lang.String getShortColumnName() {
+        return "b";
+      }
+    
+      @java.lang.Override
+      public java.lang.Long getValue() {
+        return value;
+      }
+    
+      @java.lang.Override
+      public byte[] persistValue() {
+        byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
+        return com.palantir.atlasdb.compress.CompressionUtils.compress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+      }
+    
+      @java.lang.Override
+      public byte[] persistColumnName() {
+        return com.palantir.atlasdb.encoding.PtBytes.toCachedBytes("b");
+      }
+    
+      @java.lang.Override
+      public java.lang.String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(getClass().getSimpleName()).add("Value", this.value).toString();
+      }
     }
 
     /**
-     * <pre>
+     * <pre> 
      * Column value description {
-     *   type: Long;
+     *  type: Long;
      * }
-     * </pre>
-     */
-    public static final class Foo implements TwoColumnsNamedColumnValue<Long> {
-        private final Long value;
-
-        public static Foo of(Long value) {
-            return new Foo(value);
-        }
-
-        private Foo(Long value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getColumnName() {
-            return "foo";
-        }
-
-        @Override
-        public String getShortColumnName() {
-            return "f";
-        }
-
-        @Override
-        public Long getValue() {
-            return value;
-        }
-
-        @Override
-        public byte[] persistValue() {
-            byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
-            return CompressionUtils.compress(bytes, Compression.NONE);
-        }
-
-        @Override
-        public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("f");
-        }
-
-        public static final Hydrator<Foo> BYTES_HYDRATOR = new Hydrator<Foo>() {
-            @Override
-            public Foo hydrateFromBytes(byte[] bytes) {
-                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));
-            }
-        };
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
-        }
+     * </pre> */
+    public static final class Foo implements com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.TwoColumnsNamedColumnValue<java.lang.Long> {
+      public static final com.palantir.common.persist.Persistable.Hydrator<com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Foo> BYTES_HYDRATOR = new com.palantir.common.persist.Persistable.Hydrator<com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Foo>() {
+        @java.lang.Override
+        public com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Foo hydrateFromBytes(byte[] bytes) {
+          bytes = com.palantir.atlasdb.compress.CompressionUtils.decompress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+          return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));}
+      };
+    
+      final java.lang.Long value;
+    
+      private Foo(java.lang.Long value) {
+        this.value = value;
+      }
+    
+      public static com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Foo of(java.lang.Long value) {
+        return new com.palantir.atlasdb.schema.indexing.generated.TwoColumnsTable.Foo(value);
+      }
+    
+      @java.lang.Override
+      public java.lang.String getColumnName() {
+        return "foo";
+      }
+    
+      @java.lang.Override
+      public java.lang.String getShortColumnName() {
+        return "f";
+      }
+    
+      @java.lang.Override
+      public java.lang.Long getValue() {
+        return value;
+      }
+    
+      @java.lang.Override
+      public byte[] persistValue() {
+        byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
+        return com.palantir.atlasdb.compress.CompressionUtils.compress(bytes, com.palantir.atlasdb.table.description.ColumnValueDescription.Compression.NONE);
+      }
+    
+      @java.lang.Override
+      public byte[] persistColumnName() {
+        return com.palantir.atlasdb.encoding.PtBytes.toCachedBytes("f");
+      }
+    
+      @java.lang.Override
+      public java.lang.String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(getClass().getSimpleName()).add("Value", this.value).toString();
+      }
     }
 
     public interface TwoColumnsTrigger {
@@ -2203,5 +2195,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "hyTbqBOunzYSF0DFQr0pSA==";
+    static String __CLASS_HASH = "8tIbe4cpqf34/728HQfGnA==";
 }


### PR DESCRIPTION
**Goals (and why)**:
This work is in preparation of a bigger update on TableRenderer. These subclasses are reimplemented by combining JavaPoet rendering with the old code gen. For now the gen code is a bit messy, as the imports are still being handled by the old code gen, so JavaPoet generates full Java class names.

**Where should we start reviewing?**:
Renderer.java, NamedColumnValueRenderer.java, NamedRowResultRenderer.java

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2294)
<!-- Reviewable:end -->
