### PR TITLE
Add TransactionManagerOptions for TM creation

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagerOptions.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagerOptions.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.atlasdb.factory;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.immutables.value.Value;
+
+import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
+import com.palantir.atlasdb.factory.TransactionManagers.Environment;
+import com.palantir.atlasdb.http.UserAgents;
+import com.palantir.atlasdb.table.description.Schema;
+import com.palantir.lock.LockServerOptions;
+
+@Value.Immutable
+public interface TransactionManagerOptions {
+    AtlasDbConfig config();
+
+    Supplier<Optional<AtlasDbRuntimeConfig>> runtimeConfigSupplier();
+
+    Set<Schema> schemas();
+
+    Environment env();
+
+    @Value.Default
+    default LockServerOptions lockServerOptions() {
+        return LockServerOptions.DEFAULT;
+    }
+
+    @Value.Default
+    default boolean allowHiddenTableAccess() {
+        return false;
+    }
+
+    Optional<Class<?>> callingClass();
+
+    Optional<String> userAgent();
+
+    // directly specified -> inferred from caller -> default
+    @Value.Derived
+    default String derivedUserAgent() {
+        return userAgent().orElse(callingClass().map(UserAgents::fromClass).orElse(UserAgents.DEFAULT_USER_AGENT));
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableTransactionManagerOptions.Builder {}
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagerOptions.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagerOptions.java
@@ -21,11 +21,17 @@ import com.palantir.lock.LockServerOptions;
 public interface TransactionManagerOptions {
     AtlasDbConfig config();
 
-    Supplier<Optional<AtlasDbRuntimeConfig>> runtimeConfigSupplier();
+    @Value.Default
+    default Supplier<Optional<AtlasDbRuntimeConfig>> runtimeConfigSupplier() {
+        return Optional::empty;
+    }
 
     Set<Schema> schemas();
 
-    Environment env();
+    @Value.Default
+    default Environment env() {
+        return resource -> { };
+    }
 
     @Value.Default
     default LockServerOptions lockServerOptions() {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -260,7 +260,6 @@ public class TransactionManagersTest {
         TransactionManagerOptions options = TransactionManagerOptions.builder()
                 .config(realConfig)
                 .env(environment)
-                .runtimeConfigSupplier(() -> Optional.empty())
                 .build();
         TransactionManagers.create(options);
 
@@ -300,7 +299,6 @@ public class TransactionManagersTest {
                 .build();
         TransactionManagerOptions options = TransactionManagerOptions.builder()
                 .config(realConfig)
-                .runtimeConfigSupplier(() -> Optional.empty())
                 .env(environment)
                 .build();
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -56,7 +56,6 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.jayway.awaitility.Awaitility;
 import com.palantir.atlasdb.config.AtlasDbConfig;
@@ -258,8 +257,12 @@ public class TransactionManagersTest {
                 .keyValueService(new InMemoryAtlasDbConfig())
                 .defaultLockTimeoutSeconds((int) expectedTimeout.getTime())
                 .build();
-        TransactionManagers.create(realConfig, Optional::empty,
-                ImmutableSet.of(), environment, false);
+        TransactionManagerOptions options = TransactionManagerOptions.builder()
+                .config(realConfig)
+                .env(environment)
+                .runtimeConfigSupplier(() -> Optional.empty())
+                .build();
+        TransactionManagers.create(options);
 
         assertEquals(expectedTimeout, LockRequest.getDefaultLockTimeout());
 
@@ -295,11 +298,15 @@ public class TransactionManagersTest {
                 .keyValueService(new InMemoryAtlasDbConfig())
                 .defaultLockTimeoutSeconds(120)
                 .build();
+        TransactionManagerOptions options = TransactionManagerOptions.builder()
+                .config(realConfig)
+                .runtimeConfigSupplier(() -> Optional.empty())
+                .env(environment)
+                .build();
 
         Runnable callback = mock(Runnable.class);
 
-        SerializableTransactionManager manager = TransactionManagers.create(
-                realConfig, Optional::empty, ImmutableSet.of(), environment, false);
+        SerializableTransactionManager manager = TransactionManagers.create(options);
         manager.registerClosingCallback(callback);
         manager.close();
         verify(callback, times(1)).run();

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -21,7 +21,6 @@ import com.palantir.atlasdb.api.AtlasDbService
 import com.palantir.atlasdb.api.TransactionToken
 import com.palantir.atlasdb.config.AtlasDbConfig
 import com.palantir.atlasdb.config.AtlasDbConfigs
-import com.palantir.atlasdb.config.AtlasDbRuntimeConfig
 import com.palantir.atlasdb.console.AtlasConsoleModule
 import com.palantir.atlasdb.console.AtlasConsoleService
 import com.palantir.atlasdb.console.AtlasConsoleServiceImpl
@@ -32,12 +31,10 @@ import com.palantir.atlasdb.factory.TransactionManagerOptions
 import com.palantir.atlasdb.impl.AtlasDbServiceImpl
 import com.palantir.atlasdb.impl.TableMetadataCache
 import com.palantir.atlasdb.jackson.AtlasJacksonModule
-import com.palantir.atlasdb.table.description.Schema
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager
 import groovy.json.JsonBuilder
 import groovy.json.JsonOutput
 import groovy.transform.CompileStatic
-import java.util.function.Supplier
 
 /**
  * Public methods that clients can call within AtlasConsole.
@@ -220,17 +217,6 @@ class AtlasCoreModule implements AtlasConsoleModule {
     private setupConnection(AtlasDbConfig config) {
         TransactionManagerOptions options = TransactionManagerOptions.builder()
                 .config(config)
-                .env(new com.palantir.atlasdb.factory.TransactionManagers.Environment() {
-                    @Override
-                    public void register(Object resource) {
-                    }
-                })
-                .runtimeConfigSupplier(new Supplier<Optional<AtlasDbRuntimeConfig>>() {
-                    @Override
-                    Optional<AtlasDbRuntimeConfig> get() {
-                        return Optional.empty()
-                    }
-                })
                 .allowHiddenTableAccess(true)
                 .build();
         SerializableTransactionManager tm = TransactionManagers.create(options);

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -83,7 +82,6 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
                         .config(config.getAtlasDbConfig())
                         .schemas(ETE_SCHEMAS)
                         .env(environment.jersey()::register)
-                        .runtimeConfigSupplier(() -> Optional.empty())
                         .build();
                 return TransactionManagers.create(options);
             } catch (RuntimeException e) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,7 +45,7 @@ develop
          - Change
 
     *    - |new|
-         - Added an immutable `TransactionManagerOptions` class that can be used as an argument when calling `TransactionManagers.create()` instead of passing in a long list of individual arguments.
+         - Added an immutable ``TransactionManagerOptions`` class that can be used as an argument when calling ``TransactionManagers.create()`` instead of passing in a long list of individual arguments.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2302>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,8 +44,9 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |new|
+         - Added an immutable `TransactionManagerOptions` class that can be used as an argument when calling `TransactionManagers.create()` instead of passing in a long list of individual arguments.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2302>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**: Resolves #2164 ; one of many steps to simplify and de-dupe `TransactionManagers.create` codepath.

**Implementation Description (bullets)**: Used an immutable class with sane defaults that has the same level of configurability as our combination of `TMs.create()` methods arguments.

**Concerns (what feedback would you like?)**: Meh, it's straightforward.

**Where should we start reviewing?**: TransactionManagerOptions.java

**Priority (whenever / two weeks / yesterday)**: Not high priority, but it's simple.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2302)
<!-- Reviewable:end -->
