### PR TITLE
[Startup Independence] AtlasDbConfig + Wrapping Consistency

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
@@ -27,7 +27,7 @@ import com.palantir.timestamp.TimestampStoreInvalidator;
 
 public interface AtlasDbFactory {
     long NO_OP_FAST_FORWARD_TIMESTAMP = Long.MIN_VALUE + 1; // Note: Long.MIN_VALUE itself is not allowed.
-    boolean DEFAULT_INITIALIZE_ASYNC = true;
+    boolean DEFAULT_INITIALIZE_ASYNC = false;
 
     String getType();
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
@@ -27,12 +27,13 @@ import com.palantir.timestamp.TimestampStoreInvalidator;
 
 public interface AtlasDbFactory {
     long NO_OP_FAST_FORWARD_TIMESTAMP = Long.MIN_VALUE + 1; // Note: Long.MIN_VALUE itself is not allowed.
+    boolean DEFAULT_INITIALIZE_ASYNC = true;
 
     String getType();
 
     default KeyValueService createRawKeyValueService(KeyValueServiceConfig config,
             Optional<LeaderConfig> leaderConfig) {
-        return createRawKeyValueService(config, leaderConfig, true);
+        return createRawKeyValueService(config, leaderConfig, DEFAULT_INITIALIZE_ASYNC);
     }
 
     KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig,

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -66,7 +66,7 @@ public class CassandraClientPoolIntegrationTest {
     private CassandraKeyValueService kv = CassandraKeyValueServiceImpl.create(
             CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
             CassandraContainer.LEADER_CONFIG);
-    private CassandraClientPool clientPool = kv.getClientPool();
+    private CassandraClientPoolImpl clientPool = (CassandraClientPoolImpl) kv.getClientPool();
 
     @Before
     public void setUp() {
@@ -83,7 +83,7 @@ public class CassandraClientPoolIntegrationTest {
     @Test
     public void testTokenMapping() {
         Map<Range<CassandraClientPoolImpl.LightweightOppToken>, List<InetSocketAddress>> mapOfRanges =
-                clientPool.getTokenMap().asMapOfRanges();
+                clientPool.tokenMap.asMapOfRanges();
 
         for (Entry<Range<CassandraClientPoolImpl.LightweightOppToken>, List<InetSocketAddress>> entry : mapOfRanges
                 .entrySet()) {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -66,7 +66,7 @@ public class CassandraClientPoolIntegrationTest {
     private CassandraKeyValueService kv = CassandraKeyValueServiceImpl.create(
             CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
             CassandraContainer.LEADER_CONFIG);
-    private CassandraClientPoolImpl clientPool = kv.getClientPool();
+    private CassandraClientPool clientPool = kv.getClientPool();
 
     @Before
     public void setUp() {
@@ -83,7 +83,7 @@ public class CassandraClientPoolIntegrationTest {
     @Test
     public void testTokenMapping() {
         Map<Range<CassandraClientPoolImpl.LightweightOppToken>, List<InetSocketAddress>> mapOfRanges =
-                clientPool.tokenMap.asMapOfRanges();
+                clientPool.getTokenMap().asMapOfRanges();
 
         for (Entry<Range<CassandraClientPoolImpl.LightweightOppToken>, List<InetSocketAddress>> entry : mapOfRanges
                 .entrySet()) {
@@ -164,15 +164,15 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testPoolGivenNoOptionTalksToBlacklistedHosts() {
-        clientPool.blacklistedHosts.putAll(
-                Maps.transformValues(clientPool.currentPools, clientPoolContainer -> Long.MAX_VALUE));
+        clientPool.getBlacklistedHosts().putAll(
+                Maps.transformValues(clientPool.getCurrentPools(), clientPoolContainer -> Long.MAX_VALUE));
         try {
             clientPool.run(describeRing);
         } catch (Exception e) {
             fail("Should have been allowed to attempt forward progress after blacklisting all hosts in pool.");
         }
 
-        clientPool.blacklistedHosts.clear();
+        clientPool.getBlacklistedHosts().clear();
     }
 
     private FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception> describeRing =

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraGetCandidateCellsForSweepingTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraGetCandidateCellsForSweepingTest.java
@@ -33,9 +33,9 @@ public class CassandraGetCandidateCellsForSweepingTest extends AbstractGetCandid
 
     @Override
     protected KeyValueService createKeyValueService() {
-        return new CassandraKeyValueServiceImpl.InitializeCheckingWrapper(CassandraKeyValueServiceImpl.create(
+        return CassandraKeyValueServiceImpl.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
                 CassandraContainer.LEADER_CONFIG,
-                Mockito.mock(Logger.class)));
+                Mockito.mock(Logger.class));
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -67,8 +67,6 @@ import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueServiceTest {
     private static final long LOCK_ID = 123456789;
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -136,7 +136,9 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         Preconditions.checkArgument(!allTables.contains(table3));
     }
 
+    // Suppressing Slf4j warnings for test
     @Test
+    @SuppressWarnings("Slf4jConstantLogMessage")
     public void testGcGraceSecondsUpgradeIsApplied() throws TException {
         Logger testLogger = mock(Logger.class);
         //nth startup
@@ -206,8 +208,9 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         return testTable.getQualifiedName().replaceFirst("\\.", "__");
     }
 
-    @SuppressFBWarnings("SLF4J_FORMAT_SHOULD_BE_CONST")
+    // Suppressing Slf4j warnings for test
     @Test
+    @SuppressWarnings("Slf4jConstantLogMessage")
     public void shouldNotErrorForTimestampTableWhenCreatingCassandraKvs() throws Exception {
         verify(logger, never()).error(startsWith("Found a table {} that did not have persisted"), anyString());
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -104,7 +104,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         return createKvs(getConfigWithGcGraceSeconds(FOUR_DAYS_IN_SECONDS), logger);
     }
 
-    private CassandraKeyValueServiceImpl createKvs(CassandraKeyValueServiceConfig config, Logger testLogger) {
+    private CassandraKeyValueService createKvs(CassandraKeyValueServiceConfig config, Logger testLogger) {
         return CassandraKeyValueServiceImpl.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(config),
                 CassandraContainer.LEADER_CONFIG,

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTablesIntegrationTest.java
@@ -58,7 +58,8 @@ public class SchemaMutationLockTablesIntegrationTest {
     public void setupKvs() throws TException, InterruptedException {
         config = ImmutableCassandraKeyValueServiceConfig.copyOf(CassandraContainer.KVS_CONFIG)
                 .withKeyspace(UUID.randomUUID().toString().replace('-', '_')); // Hyphens not allowed in C* schema
-        clientPool = CassandraClientPoolImpl.create(config);
+        clientPool = CassandraClientPoolImpl.createImplForTest(config,
+                CassandraClientPoolImpl.StartupChecks.RUN);
         clientPool.runOneTimeStartupChecks();
         lockTables = new SchemaMutationLockTables(clientPool, config);
     }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/CassandraSchemaLockTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/CassandraSchemaLockTest.java
@@ -50,6 +50,7 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -73,7 +74,7 @@ public class CassandraSchemaLockTest {
             CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
             for (int i = 0; i < THREAD_COUNT; i++) {
                 async(() -> {
-                    CassandraKeyValueServiceImpl keyValueService =
+                    CassandraKeyValueService keyValueService =
                             CassandraKeyValueServiceImpl.create(configManager, Optional.empty());
                     barrier.await();
                     keyValueService.createTable(table1, AtlasDbConstants.GENERIC_TABLE_METADATA);
@@ -85,7 +86,7 @@ public class CassandraSchemaLockTest {
             assertTrue(executorService.awaitTermination(4, TimeUnit.MINUTES));
         }
 
-        CassandraKeyValueServiceImpl kvs =
+        CassandraKeyValueService kvs =
                 CassandraKeyValueServiceImpl.create(configManager, Optional.empty());
         assertThat(kvs.getAllTableNames(), hasItem(table1));
 

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/NodesDownTestSetup.java
@@ -61,7 +61,7 @@ public abstract class NodesDownTestSetup {
     static final long OLD_TIMESTAMP = 1L;
     static final Value DEFAULT_VALUE = Value.create(DEFAULT_CONTENTS, DEFAULT_TIMESTAMP);
 
-    static CassandraKeyValueServiceImpl kvs;
+    static CassandraKeyValueService kvs;
 
     @ClassRule
     public static final Containers CONTAINERS = new Containers(NodesDownTestSetup.class)
@@ -92,7 +92,7 @@ public abstract class NodesDownTestSetup {
         setupDb.close();
     }
 
-    protected static CassandraKeyValueServiceImpl createCassandraKvs() {
+    protected static CassandraKeyValueService createCassandraKvs() {
         CassandraKeyValueServiceConfig config = ImmutableCassandraKeyValueServiceConfig
                 .copyOf(ThreeNodeCassandraCluster.KVS_CONFIG)
                 .withSchemaMutationTimeoutMillis(3_000);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -43,11 +43,10 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
         Preconditions.checkArgument(config instanceof CassandraKeyValueServiceConfig,
                 "CassandraAtlasDbFactory expects a configuration of type"
                 + " CassandraKeyValueServiceConfig, found %s", config.getClass());
-        return new CassandraKeyValueServiceImpl.InitializeCheckingWrapper(
-                createKv((CassandraKeyValueServiceConfig) config, leaderConfig, initializeAsync));
+        return createKv((CassandraKeyValueServiceConfig) config, leaderConfig, initializeAsync);
     }
 
-    private static CassandraKeyValueServiceImpl createKv(
+    private static CassandraKeyValueService createKv(
             CassandraKeyValueServiceConfig config,
             Optional<LeaderConfig> leaderConfig,
             boolean initializeAsync) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -17,12 +17,10 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.cassandra.thrift.Cassandra;
 
-import com.google.common.collect.RangeMap;
 import com.palantir.common.base.FunctionCheckedException;
 
 public interface CassandraClientPool {
@@ -35,9 +33,8 @@ public interface CassandraClientPool {
             FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
     InetSocketAddress getAddressForHost(String host) throws UnknownHostException;
     <V, K extends Exception> V runWithRetry(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
-    Map<InetSocketAddress, CassandraClientPoolingContainer> getCurrentPools();
     InetSocketAddress getRandomHostForKey(byte[] key);
-    RangeMap<CassandraClientPoolImpl.LightweightOppToken, List<InetSocketAddress>> getTokenMap();
+    Map<InetSocketAddress, CassandraClientPoolingContainer> getCurrentPools();
     Map<InetSocketAddress, Long> getBlacklistedHosts();
     void shutdown();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -17,12 +17,16 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.cassandra.thrift.Cassandra;
 
+import com.google.common.collect.RangeMap;
 import com.palantir.common.base.FunctionCheckedException;
 
 public interface CassandraClientPool {
+    FunctionCheckedException<Cassandra.Client, Void, Exception> getValidatePartitioner();
     <V, K extends Exception> V runOnHost(InetSocketAddress specifiedHost,
             FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
     <V, K extends Exception> V run(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
@@ -31,6 +35,9 @@ public interface CassandraClientPool {
             FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
     InetSocketAddress getAddressForHost(String host) throws UnknownHostException;
     <V, K extends Exception> V runWithRetry(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
+    Map<InetSocketAddress, CassandraClientPoolingContainer> getCurrentPools();
     InetSocketAddress getRandomHostForKey(byte[] key);
+    RangeMap<CassandraClientPoolImpl.LightweightOppToken, List<InetSocketAddress>> getTokenMap();
+    Map<InetSocketAddress, Long> getBlacklistedHosts();
     void shutdown();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -129,7 +129,6 @@ public final class CassandraClientPoolImpl implements CassandraClientPool, Async
     static final int MAX_TRIES_TOTAL = 6;
 
     private volatile RangeMap<LightweightOppToken, List<InetSocketAddress>> tokenMap = ImmutableRangeMap.of();
-
     private Map<InetSocketAddress, Long> blacklistedHosts = Maps.newConcurrentMap();
     private Map<InetSocketAddress, CassandraClientPoolingContainer> currentPools = Maps.newConcurrentMap();
     final CassandraKeyValueServiceConfig config;
@@ -143,7 +142,6 @@ public final class CassandraClientPoolImpl implements CassandraClientPool, Async
     private volatile boolean isInitialized = false;
 
     public static class LightweightOppToken implements Comparable<LightweightOppToken> {
-
         final byte[] bytes;
 
         public LightweightOppToken(byte[] bytes) {
@@ -176,11 +174,9 @@ public final class CassandraClientPoolImpl implements CassandraClientPool, Async
         public String toString() {
             return BaseEncoding.base16().encode(bytes);
         }
-
     }
 
     private class RequestMetrics {
-
         private final Meter totalRequests;
         private final Meter totalRequestExceptions;
         private final Meter totalRequestConnectionExceptions;
@@ -215,12 +211,11 @@ public final class CassandraClientPoolImpl implements CassandraClientPool, Async
         double getConnectionExceptionProportion() {
             return ((double) totalRequestConnectionExceptions.getCount()) / ((double) totalRequests.getCount());
         }
-
     }
 
     enum StartupChecks {
         RUN,
-        DO_NOT_RUN;
+        DO_NOT_RUN
     }
 
     public static CassandraClientPool create(CassandraKeyValueServiceConfig config) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
@@ -31,6 +31,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -47,30 +48,24 @@ import com.palantir.common.collect.Maps2;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class CassandraExpiringKeyValueService extends CassandraKeyValueServiceImpl implements ExpiringKeyValueService {
-
+public final class CassandraExpiringKeyValueService extends CassandraKeyValueServiceImpl
+        implements ExpiringKeyValueService {
     public static CassandraExpiringKeyValueService create(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<LeaderConfig> leaderConfig) {
-        return create(configManager, leaderConfig, true);
-    }
-
-    public static CassandraExpiringKeyValueService create(
-            CassandraKeyValueServiceConfigManager configManager,
-            Optional<LeaderConfig> leaderConfig,
-            boolean initializeAsync) {
         Preconditions.checkState(!configManager.getConfig().servers().isEmpty(), "address list was empty");
 
         Optional<CassandraJmxCompactionManager> compactionManager =
                 CassandraJmxCompaction.createJmxCompactionManager(configManager);
         CassandraExpiringKeyValueService kvs =
-                new CassandraExpiringKeyValueService(configManager, compactionManager, leaderConfig, initializeAsync);
-        kvs.initialize(initializeAsync);
+                new CassandraExpiringKeyValueService(configManager, compactionManager, leaderConfig,
+                        AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+        kvs.initialize(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
         return kvs;
     }
 
     @SuppressFBWarnings("SLF4J_ILLEGAL_PASSED_CLASS")
-    protected CassandraExpiringKeyValueService(
+    private CassandraExpiringKeyValueService(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<CassandraJmxCompactionManager> compactionManager,
             Optional<LeaderConfig> leaderConfig,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
@@ -46,8 +46,6 @@ import com.palantir.atlasdb.keyvalue.impl.KeyValueServices;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.collect.Maps2;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public final class CassandraExpiringKeyValueService extends CassandraKeyValueServiceImpl
         implements ExpiringKeyValueService {
     public static CassandraExpiringKeyValueService create(
@@ -64,7 +62,6 @@ public final class CassandraExpiringKeyValueService extends CassandraKeyValueSer
         return kvs;
     }
 
-    @SuppressFBWarnings("SLF4J_ILLEGAL_PASSED_CLASS")
     private CassandraExpiringKeyValueService(
             CassandraKeyValueServiceConfigManager configManager,
             Optional<CassandraJmxCompactionManager> compactionManager,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -23,7 +23,5 @@ public interface CassandraKeyValueService extends KeyValueService {
     CassandraTables getCassandraTables();
     TracingQueryRunner getTracingQueryRunner();
     void cleanUpSchemaMutationLockTablesState() throws Exception;
-    default boolean isInitialized() {
-        return true;
-    }
+    boolean isInitialized();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -19,7 +19,11 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 
 public interface CassandraKeyValueService extends KeyValueService {
-    CassandraClientPoolImpl getClientPool();
+    CassandraClientPool getClientPool();
     CassandraTables getCassandraTables();
     TracingQueryRunner getTracingQueryRunner();
+    void cleanUpSchemaMutationLockTablesState() throws Exception;
+    default boolean isInitialized() {
+        return true;
+    }
 }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/CleanCassLocksStateCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/CleanCassLocksStateCommand.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.cli.output.OutputPrinter;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 
@@ -39,9 +40,10 @@ public class CleanCassLocksStateCommand extends AbstractCommand {
         Preconditions.checkState(isOffline(), "This CLI can only be run offline");
 
         CassandraKeyValueServiceConfig config = getCassandraKvsConfig();
-        CassandraKeyValueServiceImpl ckvs = CassandraKeyValueServiceImpl.create(
+        CassandraKeyValueService ckvs = CassandraKeyValueServiceImpl.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(config),
-                Optional.empty());
+                Optional.empty(),
+                getAtlasDbConfig().initializeAsync());
 
         ckvs.cleanUpSchemaMutationLockTablesState();
         printer.info("Schema mutation lock cli completed successfully.");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
@@ -93,7 +94,7 @@ public class AtlasDbConstants {
     public static final long SCRUBBER_RETRY_DELAY_MILLIS = 500L;
     public static final char OLD_SCRUB_TABLE_SEPARATOR_CHAR = '\0';
 
-    public static final boolean DEFAULT_INITIALIZE_ASYNC = true;
+    public static final boolean DEFAULT_INITIALIZE_ASYNC = AtlasDbFactory.DEFAULT_INITIALIZE_ASYNC;
 
     public static final boolean DEFAULT_ENABLE_SWEEP = true;
     public static final long DEFAULT_SWEEP_PAUSE_MILLIS = 5 * 1000;

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
     compile group: 'io.dropwizard.metrics', name: 'metrics-core'
     compile group: 'net.jpountz.lz4', name: 'lz4'
+    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
 
     testCompile group: 'junit', name: 'junit'
     testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.logsafe.SafeArg;
 
 @ThreadSafe
 public interface AsyncInitializer {
@@ -46,7 +47,7 @@ public interface AsyncInitializer {
         } catch (Throwable th) {
             cleanUpOnInitFailure();
             log.warn("Failed to initialize {} in the first attempt, will initialize asynchronously.",
-                    this.getClass().getName(), th);
+                    SafeArg.of("className", this.getClass().getName()), th);
 
             Executors.newSingleThreadExecutor().execute(
                     () -> {
@@ -59,7 +60,7 @@ public interface AsyncInitializer {
                                 Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
                             }
                         }
-                        log.warn("Initialized {} asynchronously.",  this.getClass().getName());
+                        log.warn("Initialized {} asynchronously.", SafeArg.of("className", this.getClass().getName()));
                     }
             );
         }

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -45,8 +45,8 @@ public interface AsyncInitializer {
             tryInitialize();
         } catch (Throwable th) {
             cleanUpOnInitFailure();
-            log.warn("Failed to initialize " + this.getClass().getName()
-                    + " in the first attempt, will initialize asynchronously.", th);
+            log.warn("Failed to initialize {} in the first attempt, will initialize asynchronously.",
+                    this.getClass().getName(), th);
 
             Executors.newSingleThreadExecutor().execute(
                     () -> {
@@ -59,7 +59,7 @@ public interface AsyncInitializer {
                                 Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
                             }
                         }
-                        log.warn("Initialized " +  this.getClass().getName() + " asynchronously.");
+                        log.warn("Initialized {} asynchronously.",  this.getClass().getName());
                     }
             );
         }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
@@ -54,6 +55,11 @@ public class ServiceDiscoveringAtlasSupplier {
     private final Supplier<TimestampStoreInvalidator> timestampStoreInvalidator;
 
     public ServiceDiscoveringAtlasSupplier(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig) {
+        this(config, leaderConfig, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    public ServiceDiscoveringAtlasSupplier(KeyValueServiceConfig config,
+            Optional<LeaderConfig> leaderConfig, boolean initializeAsync) {
         this.config = config;
         this.leaderConfig = leaderConfig;
 
@@ -64,7 +70,8 @@ public class ServiceDiscoveringAtlasSupplier {
                         "No atlas provider for KeyValueService type " + config.type() + " could be found."
                         + " Have you annotated it with @AutoService(AtlasDbFactory.class)?"
                 ));
-        keyValueService = Suppliers.memoize(() -> atlasFactory.createRawKeyValueService(config, leaderConfig));
+        keyValueService = Suppliers
+                .memoize(() -> atlasFactory.createRawKeyValueService(config, leaderConfig, initializeAsync));
         timestampService = () -> atlasFactory.createTimestampService(getKeyValueService());
         timestampStoreInvalidator = () -> atlasFactory.createTimestampStoreInvalidator(getKeyValueService());
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.common.annotation.Idempotent;
 
 public final class TransactionManagersInitializer implements AsyncInitializer {
-    private static volatile boolean isInitialized = false;
+    private volatile boolean isInitialized = false;
 
     private KeyValueService keyValueService;
     private Set<Schema> schemas;

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
@@ -51,7 +52,8 @@ public class ServiceDiscoveringAtlasSupplierTest {
 
         assertThat(
                 atlasSupplier.getKeyValueService(),
-                is(delegate.createRawKeyValueService(kvsConfig, leaderConfig)));
+                is(delegate.createRawKeyValueService(kvsConfig,
+                        leaderConfig, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC)));
     }
 
     @Test

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -72,15 +72,12 @@ public class CassandraContainer extends Container {
     public String getDockerComposeFile() {
         return "/docker-compose-cassandra.yml";
     }
-    // TODO(gmaretic): for now kept synchronous initialization -- should revisit
+
     @Override
     public SuccessOrFailure isReady(DockerComposeRule rule) {
-        return SuccessOrFailure.onResultOf(() -> {
-            CassandraKeyValueServiceImpl cassandraKeyValueService = CassandraKeyValueServiceImpl.create(
-                    CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),
-                    LEADER_CONFIG,
-                    false);
-            return cassandraKeyValueService.isInitialized();
-        });
+        return SuccessOrFailure.onResultOf(() -> CassandraKeyValueServiceImpl.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),
+                LEADER_CONFIG)
+                .isInitialized());
     }
 }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -100,12 +100,11 @@ public class ThreeNodeCassandraCluster extends Container {
             }
         });
     }
-    // TODO(gmaretic): for now kept synchronous initialization -- should revisit
+
     private static boolean canCreateCassandraKeyValueService() {
-        CassandraKeyValueServiceImpl.create(
+        return CassandraKeyValueServiceImpl.create(
                 CassandraKeyValueServiceConfigManager.createSimpleManager(KVS_CONFIG),
-                LEADER_CONFIG,
-                false);
-        return true;
+                LEADER_CONFIG)
+                .isInitialized();
     }
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/KeyValueServiceModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/KeyValueServiceModule.java
@@ -50,7 +50,8 @@ public class KeyValueServiceModule {
     public KeyValueService provideWrappedKeyValueService(@Named("rawKvs") KeyValueService rawKvs,
                                                          TimestampService tss,
                                                          ServicesConfig config) {
-        KeyValueService kvs = NamespacedKeyValueServices.wrapWithStaticNamespaceMappingKvs(rawKvs);
+        KeyValueService kvs = NamespacedKeyValueServices.wrapWithStaticNamespaceMappingKvs(rawKvs,
+                config.atlasDbConfig().initializeAsync());
         kvs = ProfilingKeyValueService.create(kvs,
                 config.atlasDbConfig().getKvsSlowLogThresholdMillis());
         kvs = TracingKeyValueService.create(kvs);

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
@@ -34,7 +34,8 @@ public abstract class ServicesConfig {
 
     @Value.Derived
     public ServiceDiscoveringAtlasSupplier atlasDbSupplier() {
-        return new ServiceDiscoveringAtlasSupplier(atlasDbConfig().keyValueService(), atlasDbConfig().leader());
+        return new ServiceDiscoveringAtlasSupplier(atlasDbConfig().keyValueService(),
+                atlasDbConfig().leader(), atlasDbConfig().initializeAsync());
     }
 
     @Value.Default

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/SweeperModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/SweeperModule.java
@@ -39,14 +39,15 @@ public class SweeperModule {
                                                   @Named("kvs") KeyValueService kvs,
                                                   TransactionService transactionService,
                                                   SweepStrategyManager sweepStrategyManager,
-                                                  Follower follower) {
+                                                  Follower follower,
+                                                  ServicesConfig config) {
         return new SweepTaskRunner(
                 kvs,
                 txm::getUnreadableTimestamp,
                 txm::getImmutableTimestamp,
                 transactionService,
                 sweepStrategyManager,
-                new CellsSweeper(txm, kvs, ImmutableList.of(follower)));
+                new CellsSweeper(txm, kvs, ImmutableList.of(follower), config.atlasDbConfig().initializeAsync()));
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestSweeperModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestSweeperModule.java
@@ -24,6 +24,7 @@ import javax.inject.Singleton;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.services.ServicesConfig;
 import com.palantir.atlasdb.sweep.CellsSweeper;
 import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -63,7 +64,8 @@ public class TestSweeperModule {
                                                   @Named("kvs") KeyValueService kvs,
                                                   TransactionService transactionService,
                                                   SweepStrategyManager sweepStrategyManager,
-                                                  Follower follower) {
+                                                  Follower follower,
+                                                  ServicesConfig config) {
         LongSupplier unreadable = unreadableTs.orElse(txm::getUnreadableTimestamp);
         LongSupplier immutable = immutableTs.orElse(txm::getImmutableTimestamp);
         return new SweepTaskRunner(
@@ -72,7 +74,7 @@ public class TestSweeperModule {
                 immutable,
                 transactionService,
                 sweepStrategyManager,
-                new CellsSweeper(txm, kvs, ImmutableList.of(follower)));
+                new CellsSweeper(txm, kvs, ImmutableList.of(follower), config.atlasDbConfig().initializeAsync()));
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -106,8 +106,7 @@ public class DefaultCleanerBuilder {
     }
 
     private Puncher buildPuncher() {
-        PuncherStore keyValuePuncherStore = new KeyValueServicePuncherStore.InitializingWrapper(
-                KeyValueServicePuncherStore.create(keyValueService, initalizeAsync));
+        PuncherStore keyValuePuncherStore = KeyValueServicePuncherStore.create(keyValueService, initalizeAsync);
         PuncherStore cachingPuncherStore = CachingPuncherStore.create(
                 keyValuePuncherStore,
                 punchIntervalMillis * 3);
@@ -121,8 +120,7 @@ public class DefaultCleanerBuilder {
 
     private Scrubber buildScrubber(Supplier<Long> unreadableTimestampSupplier,
             Supplier<Long> immutableTimestampSupplier) {
-        ScrubberStore scrubberStore = new KeyValueServiceScrubberStore.InitializingWrapper(
-                KeyValueServiceScrubberStore.create(keyValueService, initalizeAsync));
+        ScrubberStore scrubberStore = KeyValueServiceScrubberStore.create(keyValueService, initalizeAsync);
         return Scrubber.create(
                 keyValueService,
                 scrubberStore,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
@@ -67,14 +67,14 @@ public final class KeyValueServicePuncherStore implements PuncherStore, AsyncIni
     private static final byte[] COLUMN = "t".getBytes(StandardCharsets.UTF_8);
     private volatile boolean isInitialized = false;
 
-    public static KeyValueServicePuncherStore create(KeyValueService keyValueService) {
-        return create(keyValueService, true);
+    public static PuncherStore create(KeyValueService keyValueService) {
+        return create(keyValueService, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static KeyValueServicePuncherStore create(KeyValueService keyValueService, boolean initializeAsync) {
+    public static PuncherStore create(KeyValueService keyValueService, boolean initializeAsync) {
         KeyValueServicePuncherStore puncherStore = new KeyValueServicePuncherStore(keyValueService);
         puncherStore.initialize(initializeAsync);
-        return puncherStore;
+        return puncherStore.isInitialized() ? puncherStore : new InitializingWrapper(puncherStore);
     }
 
     private final KeyValueService keyValueService;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
@@ -82,14 +82,14 @@ public final class KeyValueServiceScrubberStore implements ScrubberStore, AsyncI
     private volatile boolean isInitialized = false;
     private final KeyValueService keyValueService;
 
-    public static KeyValueServiceScrubberStore create(KeyValueService keyValueService) {
-        return create(keyValueService, true);
+    public static ScrubberStore create(KeyValueService keyValueService) {
+        return create(keyValueService, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static KeyValueServiceScrubberStore create(KeyValueService keyValueService, boolean initializeAsync) {
+    public static ScrubberStore create(KeyValueService keyValueService, boolean initializeAsync) {
         KeyValueServiceScrubberStore scrubberStore = new KeyValueServiceScrubberStore(keyValueService);
         scrubberStore.initialize(initializeAsync);
-        return scrubberStore;
+        return scrubberStore.isInitialized() ? scrubberStore : new InitializingWrapper(scrubberStore);
     }
 
     private KeyValueServiceScrubberStore(KeyValueService keyValueService) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespacedKeyValueServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/NamespacedKeyValueServices.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.keyvalue.impl;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.NamespacedKeyValueService;
 import com.palantir.atlasdb.keyvalue.TableMappingService;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -25,8 +26,12 @@ public final class NamespacedKeyValueServices {
     }
 
     public static KeyValueService wrapWithStaticNamespaceMappingKvs(KeyValueService keyValueService) {
-        TableMappingService tableMap = new StaticTableMappingService.InitializingWrapper(
-                StaticTableMappingService.create(keyValueService));
+        return wrapWithStaticNamespaceMappingKvs(keyValueService, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    public static KeyValueService wrapWithStaticNamespaceMappingKvs(KeyValueService keyValueService,
+            boolean initializeAsync) {
+        TableMappingService tableMap = StaticTableMappingService.create(keyValueService, initializeAsync);
         NamespacedKeyValueService namespacedKeyValueService = TableRemappingKeyValueService.create(
                 keyValueService,
                 tableMap);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/StaticTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/StaticTableMappingService.java
@@ -21,10 +21,12 @@ import java.util.stream.Collectors;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.AutoDelegate_TableMappingService;
 import com.palantir.atlasdb.keyvalue.TableMappingService;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.exception.NotInitializedException;
 import com.palantir.processors.AutoDelegate;
 
 @AutoDelegate(typeToExtend = TableMappingService.class)
@@ -39,21 +41,24 @@ public final class StaticTableMappingService extends AbstractTableMappingService
 
         @Override
         public TableMappingService delegate() {
-            return tableMappingService;
+            if (tableMappingService.isInitialized()) {
+                return tableMappingService;
+            }
+            throw new NotInitializedException("TableMappingService");
         }
     }
 
     private volatile boolean isInitialized = false;
     private final KeyValueService kv;
 
-    public static StaticTableMappingService create(KeyValueService kv) {
-        return create(kv, true);
+    public static TableMappingService create(KeyValueService kv) {
+        return create(kv, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static StaticTableMappingService create(KeyValueService kv, boolean initalizeAsync) {
-        StaticTableMappingService ret = new StaticTableMappingService(kv);
-        ret.initialize(initalizeAsync);
-        return ret;
+    public static TableMappingService create(KeyValueService kv, boolean initalizeAsync) {
+        StaticTableMappingService tableMappingService = new StaticTableMappingService(kv);
+        tableMappingService.initialize(initalizeAsync);
+        return tableMappingService.isInitialized() ? tableMappingService : new InitializingWrapper(tableMappingService);
     }
 
     private StaticTableMappingService(KeyValueService kv) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/StaticTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/StaticTableMappingService.java
@@ -55,9 +55,9 @@ public final class StaticTableMappingService extends AbstractTableMappingService
         return create(kv, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static TableMappingService create(KeyValueService kv, boolean initalizeAsync) {
+    public static TableMappingService create(KeyValueService kv, boolean initializeAsync) {
         StaticTableMappingService tableMappingService = new StaticTableMappingService(kv);
-        tableMappingService.initialize(initalizeAsync);
+        tableMappingService.initialize(initializeAsync);
         return tableMappingService.isInitialized() ? tableMappingService : new InitializingWrapper(tableMappingService);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -71,7 +71,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     public String getType() {
         return "memory";
     }
-    
+
     @Override
     public InMemoryKeyValueService createRawKeyValueService(
             KeyValueServiceConfig config,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -72,6 +72,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
         return "memory";
     }
 
+
     @Override
     public InMemoryKeyValueService createRawKeyValueService(
             KeyValueServiceConfig config,
@@ -155,6 +156,6 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     }
 
     private static TableMappingService getMapper(KeyValueService kv) {
-        return StaticTableMappingService.create(kv, false);
+        return StaticTableMappingService.create(kv);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -71,8 +71,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     public String getType() {
         return "memory";
     }
-
-
+    
     @Override
     public InMemoryKeyValueService createRawKeyValueService(
             KeyValueServiceConfig config,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockService.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.remoting2.servers.jersey.WebPreconditions;
@@ -35,7 +36,11 @@ public class KvsBackedPersistentLockService implements PersistentLockService {
     }
 
     public static PersistentLockService create(KeyValueService kvs) {
-        LockStore lockStore = new LockStoreImpl.InitializingWrapper(LockStoreImpl.create(kvs));
+        return create(kvs, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    public static PersistentLockService create(KeyValueService kvs, boolean initializeAsync) {
+        LockStore lockStore = LockStoreImpl.create(kvs, initializeAsync);
         return new KvsBackedPersistentLockService(lockStore);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockStoreImpl.java
@@ -91,15 +91,25 @@ public class LockStoreImpl implements LockStore, AsyncInitializer {
             .reason("Available")
             .build();
 
-    private LockStoreImpl(KeyValueService kvs) {
+    LockStoreImpl(KeyValueService kvs) {
         this.keyValueService = kvs;
     }
 
-    public static LockStoreImpl create(KeyValueService kvs) {
-        return create(kvs, true);
+    public static LockStore create(KeyValueService kvs) {
+        return create(kvs, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    public static LockStoreImpl create(KeyValueService kvs, boolean initializeAsync) {
+    public static LockStore create(KeyValueService kvs, boolean initializeAsync) {
+        LockStoreImpl lockStore = createImplForTest(kvs, initializeAsync);
+        return lockStore.isInitialized() ? lockStore : new InitializingWrapper(lockStore);
+    }
+
+    @VisibleForTesting
+    static LockStoreImpl createImplForTest(KeyValueService kvs) {
+        return createImplForTest(kvs, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    private static LockStoreImpl createImplForTest(KeyValueService kvs, boolean initializeAsync) {
         LockStoreImpl lockStore = new LockStoreImpl(kvs);
         lockStore.initialize(initializeAsync);
         return lockStore;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsSweeper.java
@@ -41,10 +41,10 @@ public class CellsSweeper {
     private final PersistentLockManager persistentLockManager;
 
     public CellsSweeper(
-            TransactionManager txManager,
-            KeyValueService keyValueService,
-            PersistentLockManager persistentLockManager,
-            Collection<Follower> followers) {
+                TransactionManager txManager,
+                KeyValueService keyValueService,
+                PersistentLockManager persistentLockManager,
+                Collection<Follower> followers) {
         this.txManager = txManager;
         this.keyValueService = keyValueService;
         this.followers = followers;
@@ -55,15 +55,23 @@ public class CellsSweeper {
             TransactionManager txManager,
             KeyValueService keyValueService,
             Collection<Follower> followers) {
+        this(txManager, keyValueService, followers, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    public CellsSweeper(
+            TransactionManager txManager,
+            KeyValueService keyValueService,
+            Collection<Follower> followers,
+            boolean initializeAsync) {
         this(txManager, keyValueService,
-                new PersistentLockManager(getPersistentLockService(keyValueService),
+                new PersistentLockManager(getPersistentLockService(keyValueService, initializeAsync),
                         AtlasDbConstants.DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS),
                 followers);
     }
 
-    private static PersistentLockService getPersistentLockService(KeyValueService kvs) {
+    private static PersistentLockService getPersistentLockService(KeyValueService kvs, boolean initializeAsync) {
         if (kvs.supportsCheckAndSet()) {
-            return KvsBackedPersistentLockService.create(kvs);
+            return KvsBackedPersistentLockService.create(kvs, initializeAsync);
         } else {
             log.warn("CellsSweeper is being set up without a persistent lock service. "
                     + "It will not be safe to run backups while sweep is running.");

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockServiceClientTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockServiceClientTest.java
@@ -36,7 +36,7 @@ import io.dropwizard.testing.junit.DropwizardClientRule;
 
 public class KvsBackedPersistentLockServiceClientTest {
     private static final String REASON = "some-reason";
-    private static final LockStoreImpl LOCK_STORE = LockStoreImpl.create(new InMemoryKeyValueService(true));
+    private static final LockStoreImpl LOCK_STORE = LockStoreImpl.createImplForTest(new InMemoryKeyValueService(true));
 
     @ClassRule
     public static final DropwizardClientRule DW = new DropwizardClientRule(

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/KvsBackedPersistentLockServiceTest.java
@@ -38,7 +38,7 @@ public class KvsBackedPersistentLockServiceTest {
     @Before
     public void setUp() {
         KeyValueService kvs = new InMemoryKeyValueService(false);
-        lockStore = spy(LockStoreImpl.create(kvs));
+        lockStore = spy(LockStoreImpl.createImplForTest(kvs));
         service = new KvsBackedPersistentLockService(lockStore);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/LockStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/LockStoreTest.java
@@ -47,7 +47,7 @@ public class LockStoreTest {
     @Before
     public void setUp() throws Exception {
         kvs = spy(new InMemoryKeyValueService(false));
-        lockStore = LockStoreImpl.create(kvs);
+        lockStore = LockStoreImpl.createImplForTest(kvs);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/PersistentLockServiceClientTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/persistentlock/PersistentLockServiceClientTest.java
@@ -36,7 +36,7 @@ import io.dropwizard.testing.junit.DropwizardClientRule;
 
 public class PersistentLockServiceClientTest {
     private static final String REASON = "some-reason";
-    private static final LockStoreImpl LOCK_STORE = LockStoreImpl.create(new InMemoryKeyValueService(true));
+    private static final LockStoreImpl LOCK_STORE = LockStoreImpl.createImplForTest(new InMemoryKeyValueService(true));
 
     @ClassRule
     public static final DropwizardClientRule DW = new DropwizardClientRule(

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/CassandraKeyValueServiceInstrumentation.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/CassandraKeyValueServiceInstrumentation.java
@@ -59,20 +59,15 @@ public class CassandraKeyValueServiceInstrumentation extends KeyValueServiceInst
 
     @Override
     public boolean canConnect(InetSocketAddress addr) {
-        try {
-            CassandraKeyValueServiceImpl.create(
+        return CassandraKeyValueServiceImpl.create(
                     CassandraKeyValueServiceConfigManager.createSimpleManager(
                             (CassandraKeyValueServiceConfig) getKeyValueServiceConfig(addr)),
                     Optional.of(ImmutableLeaderConfig.builder()
                             .quorumSize(1)
                             .localServer(addr.getHostString())
                             .leaders(ImmutableSet.of(addr.getHostString()))
-                            .build()));
-            return true;
-        } catch (Exception e) {
-            log.error("Unable to create Cassandra KVS", e);
-            return false;
-        }
+                            .build()))
+                .isInitialized();
     }
 
     @Override

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/PuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/PuncherTest.java
@@ -42,7 +42,7 @@ public class PuncherTest {
         InMemoryKeyValueService cachingKvsPuncherStoreKvs = new InMemoryKeyValueService(false);
 
         InMemoryPuncherStore inMemoryPuncherStore = InMemoryPuncherStore.create();
-        KeyValueServicePuncherStore keyValueServicePuncherStore =
+        PuncherStore puncherStore =
                 KeyValueServicePuncherStore.create(kvsPuncherStoreKvs);
         CachingPuncherStore cachingInMemoryPuncherStore =
                 CachingPuncherStore.create(InMemoryPuncherStore.create(), GRANULARITY_MILLIS);
@@ -50,7 +50,7 @@ public class PuncherTest {
                 KeyValueServicePuncherStore.create(cachingKvsPuncherStoreKvs),
                 GRANULARITY_MILLIS);
         Object[][] parameters = new Object[][] { { inMemoryPuncherStore, null },
-                { keyValueServicePuncherStore, kvsPuncherStoreKvs },
+                { puncherStore, kvsPuncherStoreKvs },
                 { cachingInMemoryPuncherStore, null },
                 { cachingKeyValueServicePuncherStore, cachingKvsPuncherStoreKvs } };
         return ImmutableList.copyOf(parameters);

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ test:
   override:
     - ./scripts/time-cmd.sh ./scripts/circle-ci/run-circle-tests.sh:
         parallel: true
-        timeout: 300
+        timeout: 600
   post:
     - ./scripts/time-cmd.sh ./scripts/circle-ci/ensure-repo-clean.sh
     - ./scripts/time-cmd.sh ./gradlew --profile jacocoFullReport -x classes:


### PR DESCRIPTION
**Goals (and why)**:
Propagating the AtlasDbConfig for startup ordering correctly, consistency in wrapping asynchronously initialized classes.

**Implementation Description (bullets)**:

- If synchronous initialization is successful, do not wrap the object, otherwise return the wrapper.
- Wherever we do not have acces to the AtlasDbConfig (mostly tests), sue the default setting for asynchronous initialization (currently set to true to get better signal from tests).

**Concerns (what feedback would you like?)**:
Are the dagger changes done correctly? Is there something I missed?

**Where should we start reviewing?**:
Maybe `CassandraKeyValueServiceImpl.java`

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2308)
<!-- Reviewable:end -->
