### PR TITLE
Mark some timelock logging args as safe [no release notes]

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosAcceptorImpl.java
@@ -21,6 +21,8 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
+
 public class PaxosAcceptorImpl implements PaxosAcceptor {
     private static final Logger logger = LoggerFactory.getLogger(PaxosAcceptorImpl.class);
 
@@ -92,7 +94,7 @@ public class PaxosAcceptorImpl implements PaxosAcceptor {
         try {
             checkLogIfNeeded(seq);
         } catch (Exception e) {
-            logger.error("log read failed for request: {}", seq, e);
+            logger.error("Log read failed for request at sequence {}", SafeArg.of("sequence", seq), e);
             return new BooleanPaxosResponse(false); // nack
         }
 

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLearnerImpl.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.palantir.leader.PaxosKnowledgeEventRecorder;
+import com.palantir.logsafe.SafeArg;
 
 public class PaxosLearnerImpl implements PaxosLearner {
 
@@ -83,7 +84,8 @@ public class PaxosLearnerImpl implements PaxosLearner {
             }
             return state.get(seq);
         } catch (IOException e) {
-            logger.error("unable to get corrupt learned value", e);
+            logger.error("Unable to get corrupt learned value for sequence {}",
+                    SafeArg.of("sequence", seq), e);
             return null;
         }
     }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosProposerImpl.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 
 /**
  * Implementation of a paxos proposer than can be a designated proposer (leader) and designated
@@ -126,7 +128,10 @@ public class PaxosProposerImpl implements PaxosProposer {
                 try {
                     learner.learn(seq, finalValue);
                 } catch (Throwable e) {
-                    log.warn("failed to teach learner", e);
+                    log.warn("Failed to teach learner the value {} at sequence {}",
+                            UnsafeArg.of("value", bytes),
+                            SafeArg.of("sequence", seq),
+                            e);
                 }
             });
         }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogImpl.java
@@ -42,6 +42,8 @@ import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.persist.Persistable;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.paxos.persistence.generated.PaxosPersistence;
 import com.palantir.util.crypto.Sha256Hash;
 
@@ -257,8 +259,13 @@ public class PaxosStateLogImpl<V extends Persistable & Versionable> implements P
                     throw new CorruptLogFileException();
                 }
             } catch (FileNotFoundException e) {
+                // TODO (jkong): Check if this is intentional, or if the author intended FileNotFound to be a problem
+                // that should be treated in the same way as IOException.
             } catch (IOException e) {
-                log.error("problem reading paxos state");
+                // Note that the file name is a Paxos log entry - so it is the round number - and thus safe.
+                log.error("Problem reading paxos state, specifically when reading file {} (file-name {})",
+                        UnsafeArg.of("full path", file.getAbsolutePath()),
+                        SafeArg.of("file name", file.getName()));
                 throw Throwables.rewrap(e);
             } finally {
                 IOUtils.closeQuietly(fileIn);

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
@@ -20,6 +20,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.timelock.AsyncTimelockResource;
@@ -34,8 +37,11 @@ import com.palantir.atlasdb.timelock.util.AsyncOrLegacyTimelockService;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.JavaSuppliers;
 import com.palantir.lock.RemoteLockService;
+import com.palantir.logsafe.SafeArg;
 
 public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
+    private static final Logger log = LoggerFactory.getLogger(AsyncTimeLockServicesCreator.class);
+
     private final PaxosLeadershipCreator leadershipCreator;
     private final AsyncLockConfiguration asyncLockConfiguration;
 
@@ -50,6 +56,7 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
             String client,
             Supplier<ManagedTimestampService> rawTimestampServiceSupplier,
             Supplier<RemoteLockService> rawLockServiceSupplier) {
+        log.info("Creating async timelock services for client {}", SafeArg.of("client", client));
         AsyncOrLegacyTimelockService asyncOrLegacyTimelockService;
         AsyncTimelockService asyncTimelockService = instrumentInLeadershipProxy(
                 AsyncTimelockService.class,


### PR DESCRIPTION
**Goals (and why)**:
- Improve logging in Timelock/Paxos/Leader Election
- Deal with the second piece of #2274

**Implementation Description (bullets)**:
- Mark some logging arguments as safe
- Add some useful debugging information e.g. offending sequence numbers, file-names, (unsafe) values.
- Log on creation of async timelock services.

**Concerns (what feedback would you like?)**:
- Is anything I marked safe actually unsafe?

**Where should we start reviewing?**: anywhere

**Priority (whenever / two weeks / yesterday)**: whenever, preferably before timelock internally GAs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2311)
<!-- Reviewable:end -->
