### PR TITLE
[Metrics Cardinality I] Eliminate user-agents

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
@@ -58,10 +58,10 @@ public class ServiceCreator<T> implements Function<ServerListConfig, T> {
         return AtlasDbHttpClients.createProxyWithFailover(sslSocketFactory, uris, serviceClass, userAgent);
     }
 
-    public static <T> T createInstrumentedService(T service, Class<T> serviceClass, String userAgent) {
+    public static <T> T createInstrumentedService(T service, Class<T> serviceClass) {
         return AtlasDbMetrics.instrument(
                 serviceClass,
                 service,
-                MetricRegistry.name(serviceClass, userAgent));
+                MetricRegistry.name(serviceClass));
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -239,8 +239,7 @@ public final class TransactionManagers {
         kvs = SweepStatsKeyValueService.create(kvs,
                 new TimelockTimestampServiceAdapter(lockAndTimestampServices.timelock()));
         kvs = TracingKeyValueService.create(kvs);
-        kvs = AtlasDbMetrics.instrument(KeyValueService.class, kvs,
-                MetricRegistry.name(KeyValueService.class, userAgent));
+        kvs = AtlasDbMetrics.instrument(KeyValueService.class, kvs, MetricRegistry.name(KeyValueService.class));
         kvs = ValidatingQueryRewritingKeyValueService.create(kvs);
 
         TransactionTables.createTables(kvs);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -436,8 +436,7 @@ public final class TransactionManagers {
                 createRawInstrumentedServices(config, env, lock, time, invalidator, userAgent);
         return withRequestBatchingTimestampService(
                 runtimeConfigSupplier,
-                withRefreshingLockService(lockAndTimestampServices),
-                userAgent);
+                withRefreshingLockService(lockAndTimestampServices));
     }
 
     private static LockAndTimestampServices withRefreshingLockService(
@@ -451,12 +450,11 @@ public final class TransactionManagers {
 
     private static LockAndTimestampServices withRequestBatchingTimestampService(
             java.util.function.Supplier<TimestampClientConfig> timestampClientConfigSupplier,
-            LockAndTimestampServices lockAndTimestampServices, String userAgent) {
+            LockAndTimestampServices lockAndTimestampServices) {
         TimelockService timelockServiceWithBatching = DecoratedTimelockServices
                 .createTimelockServiceWithTimestampBatching(
                         lockAndTimestampServices.timelock(),
-                        timestampClientConfigSupplier,
-                        userAgent);
+                        timestampClientConfigSupplier);
 
         return ImmutableLockAndTimestampServices.builder()
                 .from(lockAndTimestampServices)
@@ -480,7 +478,7 @@ public final class TransactionManagers {
         } else if (config.timelock().isPresent()) {
             return createRawServicesFromTimeLock(config, invalidator, userAgent);
         } else {
-            return createRawEmbeddedServices(env, lock, time, userAgent);
+            return createRawEmbeddedServices(env, lock, time);
         }
     }
 
@@ -531,12 +529,10 @@ public final class TransactionManagers {
         LeaderElectionService leader = localPaxosServices.leaderElectionService();
         LockService localLock = ServiceCreator.createInstrumentedService(
                 AwaitingLeadershipProxy.newProxyInstance(LockService.class, lock, leader),
-                LockService.class,
-                userAgent);
+                LockService.class);
         TimestampService localTime = ServiceCreator.createInstrumentedService(
                 AwaitingLeadershipProxy.newProxyInstance(TimestampService.class, time, leader),
-                TimestampService.class,
-                userAgent);
+                TimestampService.class);
         env.register(localLock);
         env.register(localTime);
 
@@ -624,14 +620,9 @@ public final class TransactionManagers {
     private static LockAndTimestampServices createRawEmbeddedServices(
             Environment env,
             Supplier<LockService> lock,
-            Supplier<TimestampService> time,
-            String userAgent) {
-        LockService lockService = ServiceCreator.createInstrumentedService(lock.get(),
-                LockService.class,
-                userAgent);
-        TimestampService timeService = ServiceCreator.createInstrumentedService(time.get(),
-                TimestampService.class,
-                userAgent);
+            Supplier<TimestampService> time) {
+        LockService lockService = ServiceCreator.createInstrumentedService(lock.get(), LockService.class);
+        TimestampService timeService = ServiceCreator.createInstrumentedService(time.get(), TimestampService.class);
 
         env.register(lockService);
         env.register(timeService);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timestamp/DecoratedTimelockServices.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timestamp/DecoratedTimelockServices.java
@@ -35,22 +35,19 @@ public final class DecoratedTimelockServices {
 
     public static TimelockService createTimelockServiceWithTimestampBatching(
             TimelockService timelockService,
-            Supplier<TimestampClientConfig> configSupplier,
-            String userAgent) {
+            Supplier<TimestampClientConfig> configSupplier) {
         return DynamicDecoratingProxy.newProxyInstance(
                 new TimestampDecoratingTimelockService(timelockService,
-                        createRequestBatchingTimestampService(timelockService, userAgent)),
+                        createRequestBatchingTimestampService(timelockService)),
                 timelockService,
                 JavaSuppliers.compose(TimestampClientConfig::enableTimestampBatching, configSupplier),
                 TimelockService.class);
     }
 
     private static TimestampService createRequestBatchingTimestampService(
-            TimelockService timelockService,
-            String userAgent) {
+            TimelockService timelockService) {
         return ServiceCreator.createInstrumentedService(
                 new RequestBatchingTimestampService(new TimelockTimestampServiceAdapter(timelockService)),
-                TimestampService.class,
-                userAgent);
+                TimestampService.class);
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/AtlasDbHttpClients.java
@@ -50,7 +50,7 @@ public final class AtlasDbHttpClients {
         return AtlasDbMetrics.instrument(
                 type,
                 AtlasDbFeignTargetFactory.createProxy(sslSocketFactory, uri, type, userAgent),
-                MetricRegistry.name(type, userAgent));
+                MetricRegistry.name(type));
     }
 
     /**
@@ -101,7 +101,7 @@ public final class AtlasDbHttpClients {
         return AtlasDbMetrics.instrument(
                 type,
                 AtlasDbFeignTargetFactory.createProxyWithFailover(sslSocketFactory, endpointUris, type, userAgent),
-                MetricRegistry.name(type, userAgent));
+                MetricRegistry.name(type));
     }
 
     @VisibleForTesting

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -93,13 +93,13 @@ public class TransactionManagersTest {
     private static final long EMBEDDED_BOUND = 3;
 
     private static final String TIMELOCK_SERVICE_FRESH_TIMESTAMP_METRIC =
-            MetricRegistry.name(TimelockService.class, USER_AGENT, "getFreshTimestamp");
+            MetricRegistry.name(TimelockService.class, "getFreshTimestamp");
     private static final String TIMELOCK_SERVICE_CURRENT_TIME_METRIC =
-            MetricRegistry.name(TimelockService.class, USER_AGENT, "currentTimeMillis");
+            MetricRegistry.name(TimelockService.class, "currentTimeMillis");
     private static final String LOCK_SERVICE_CURRENT_TIME_METRIC =
-            MetricRegistry.name(LockService.class, USER_AGENT, "currentTimeMillis");
+            MetricRegistry.name(LockService.class, "currentTimeMillis");
     private static final String TIMESTAMP_SERVICE_FRESH_TIMESTAMP_METRIC =
-            MetricRegistry.name(TimestampService.class, USER_AGENT, "getFreshTimestamp");
+            MetricRegistry.name(TimestampService.class, "getFreshTimestamp");
 
     private static final String LEADER_UUID_PATH = "/leader/uuid";
     private static final MappingBuilder LEADER_UUID_MAPPING = get(urlEqualTo(LEADER_UUID_PATH));

--- a/docs/source/miscellaneous/dropwizard-metrics.rst
+++ b/docs/source/miscellaneous/dropwizard-metrics.rst
@@ -8,14 +8,14 @@ AtlasDB makes use of the Dropwizard `Metrics library <http://metrics.dropwizard.
 expose a global ``MetricRegistry`` called ``AtlasDbRegistry``. Users of AtlasDB should use ``AtlasDbMetrics.setMetricRegistry``
 to inject their own ``MetricRegistry`` for their application prior to initializing the AtlasDB transaction manager.
 
-Each AtlasDB client will expose their own KeyValueService.<useragent> metrics, as well as CassandraClientPool metrics
+Each AtlasDB client will expose their own KeyValueService metrics, as well as CassandraClientPool metrics
 for every Cassandra host.
 We expose sweep metrics specific to every table that has been swept, as well as aggregate metrics.
 
 For more details on what information each type of metric provides, we recommend reading
 the Metrics `Getting Started Guide <http://metrics.dropwizard.io/3.1.0/getting-started/#>`__.
 
-The full list of metrics exposed by AtlasDB can be found below.
+A reasonably comprehensive list of metrics exposed by AtlasDB can be found below.
 
 **Gauges**
 
@@ -70,37 +70,37 @@ the following:
 
 **Timers**
 
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.addGarbageCollectionSentinelValues``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.checkAndSet``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.close``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.compactInternally``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.createTable``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.createTables``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.delete``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.deleteRange``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.dropTable``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.dropTables``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.get``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getAllTableNames``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getAllTimestamps``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getDelegates``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getFirstBatchForRanges``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getLatestTimestamps``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getMetadataForTable``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getMetadataForTables``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getRange``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getRangeOfTimestamps``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getRows``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.getRowsColumnRange``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.multiPut``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.put``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.putMetadataForTable``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.putMetadataForTables``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.putUnlessExists``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.putWithTimestamps``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.supportsCheckAndSet``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.truncateTable``
-- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.<useragent>.truncateTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.addGarbageCollectionSentinelValues``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.checkAndSet``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.close``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.compactInternally``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.createTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.createTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.delete``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.deleteRange``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.dropTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.dropTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.get``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getAllTableNames``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getAllTimestamps``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getDelegates``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getFirstBatchForRanges``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getLatestTimestamps``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getMetadataForTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getMetadataForTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getRange``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getRangeOfTimestamps``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getRows``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.getRowsColumnRange``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.multiPut``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.put``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.putMetadataForTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.putMetadataForTables``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.putUnlessExists``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.putWithTimestamps``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.supportsCheckAndSet``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.truncateTable``
+- ``com.palantir.atlasdb.keyvalue.api.KeyValueService.truncateTables``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitAcquireLocks``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitCheckingForConflicts``
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.commitPutCommitTs``

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,10 +63,10 @@ develop
 
     *    - |userbreak| |fixed|
          - AtlasDB no longer embeds user-agents in metric names.
-           All metrics are still available, but will no longer include the user-agent component.
+           All metrics are still available; however, metrics which previously included a user-agent component will no longer do so.
            For example, the timer ``com.palantir.timestamp.TimestampService.myUserAgent_version.getFreshTimestamp`` is now named ``com.palantir.timestamp.TimestampService.getFreshTimestamp``.
            This was necessary for compatibility with an internal log-ingestion tool.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/foo>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2322>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -61,6 +61,13 @@ develop
          - Oracle will now validate connections by running the test query when getting a new connection from the HikariPool.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2301>`__)
 
+    *    - |userbreak| |fixed|
+         - AtlasDB no longer embeds user-agents in metric names.
+           All metrics are still available, but will no longer include the user-agent component.
+           For example, the timer ``com.palantir.timestamp.TimestampService.myUserAgent_version.getFreshTimestamp`` is now named ``com.palantir.timestamp.TimestampService.getFreshTimestamp``.
+           This was necessary for compatibility with an internal log-ingestion tool.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/foo>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
**Goals (and why)**:
- Remove user-agents from metrics. This inflates the cardinality of our metric names, which is bad for internal metrics ingestion tool. It also makes visualisation unnecessarily awkward.

**Implementation Description (bullets)**:
- Remove the user agent from all metrics names
- Update the docs and tests accordingly

**Concerns (what feedback would you like?)**:
- Did I miss any references to user agents?
- Is any information lost? (Note that internal log tool is able to fill in the user agent)

**Where should we start reviewing?**: `ServiceCreator` / `TransactionManagers` are good starting points.

**Priority (whenever / two weeks / yesterday)**: this week ideally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2322)
<!-- Reviewable:end -->
