### PR TITLE
[Metrics Cardinality II] Cassandra Client Pools and Sweep

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -246,24 +246,24 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
 
         poolConfig.setJmxNamePrefix(host.getHostString());
         GenericObjectPool<Client> pool = new GenericObjectPool<>(cassandraClientFactory, poolConfig);
-        registerMetrics(pool, host.getHostString());
+        registerMetrics(pool);
         return pool;
     }
 
-    private void registerMetrics(GenericObjectPool<Client> pool, String metricPrefix) {
-        registerMetric(metricPrefix, "meanActiveTimeMillis", pool::getMeanActiveTimeMillis);
-        registerMetric(metricPrefix, "meanIdleTimeMillis", pool::getMeanIdleTimeMillis);
-        registerMetric(metricPrefix, "meanBorrowWaitTimeMillis", pool::getMeanBorrowWaitTimeMillis);
-        registerMetric(metricPrefix, "numIdle", pool::getNumIdle);
-        registerMetric(metricPrefix, "numActive", pool::getNumActive);
-        registerMetric(metricPrefix, "approximatePoolSize", () -> pool.getNumIdle() + pool.getNumActive());
-        registerMetric(metricPrefix, "proportionDestroyedByEvictor",
+    private void registerMetrics(GenericObjectPool<Client> pool) {
+        registerMetric("meanActiveTimeMillis", pool::getMeanActiveTimeMillis);
+        registerMetric("meanIdleTimeMillis", pool::getMeanIdleTimeMillis);
+        registerMetric("meanBorrowWaitTimeMillis", pool::getMeanBorrowWaitTimeMillis);
+        registerMetric("numIdle", pool::getNumIdle);
+        registerMetric("numActive", pool::getNumActive);
+        registerMetric("approximatePoolSize", () -> pool.getNumIdle() + pool.getNumActive());
+        registerMetric("proportionDestroyedByEvictor",
                 () -> ((double) pool.getDestroyedByEvictorCount()) / ((double) pool.getCreatedCount()));
-        registerMetric(metricPrefix, "proportionDestroyedByBorrower",
+        registerMetric("proportionDestroyedByBorrower",
                 () -> ((double) pool.getDestroyedByBorrowValidationCount()) / ((double) pool.getCreatedCount()));
     }
 
-    private void registerMetric(String metricPrefix, String metricName, Gauge gauge) {
-        metricsManager.registerMetric(CassandraClientPoolingContainer.class, metricPrefix, metricName, gauge);
+    private void registerMetric(String metricName, Gauge gauge) {
+        metricsManager.registerMetric(CassandraClientPoolingContainer.class, metricName, gauge);
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -170,8 +170,6 @@ public class CassandraClientPoolTest {
         runTwoNoopsOnTwoHostsAndThrowFromSecondRunOnFirstHost(
                 new SocketTimeoutException("test_socket_timeout_exception"));
         verifyAggregateFailureMetrics(0.25, 0.25);
-        verifyFailureMetricsOnHost(HOST_1, 0.5, 0.5);
-        verifyFailureMetricsOnHost(HOST_2, 0.0, 0.0);
     }
 
     @Test
@@ -179,8 +177,6 @@ public class CassandraClientPoolTest {
         runTwoNoopsOnTwoHostsAndThrowFromSecondRunOnFirstHost(
                 new NoSuchElementException("test_non_connection_exception"));
         verifyAggregateFailureMetrics(0.25, 0.0);
-        verifyFailureMetricsOnHost(HOST_1, 0.5, 0.0);
-        verifyFailureMetricsOnHost(HOST_2, 0.0, 0.0);
     }
 
     private void runTwoNoopsOnTwoHostsAndThrowFromSecondRunOnFirstHost(Exception exception) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -264,7 +264,7 @@ public class SpecificTableSweeper {
             return null;
         });
 
-        sweepMetrics.examinedCells(tableToSweep.getTableRef(), sweepResults.getCellTsPairsExamined());
-        sweepMetrics.deletedCells(tableToSweep.getTableRef(), sweepResults.getStaleValuesDeleted());
+        sweepMetrics.examinedCells(sweepResults.getCellTsPairsExamined());
+        sweepMetrics.deletedCells(sweepResults.getStaleValuesDeleted());
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepMetrics.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.sweep;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.util.MetricsManager;
 
 @SuppressWarnings("checkstyle:FinalClass")
@@ -40,18 +39,12 @@ public class SweepMetrics {
             this.name = name;
         }
 
-        void update(TableReference tableRef, long value) {
-            /* Lazily generate histogram since we need table-specific metrics */
-            metricsManager.getRegistry().histogram(getTableSpecificName(tableRef)).update(value);
+        void update(long value) {
             metricsManager.getRegistry().histogram(aggregateMetric()).update(value);
         }
 
         private String aggregateMetric() {
             return MetricRegistry.name(SweepMetrics.class, name);
-        }
-
-        private String getTableSpecificName(TableReference tableRef) {
-            return MetricRegistry.name(SweepMetrics.class, name, tableRef.getQualifiedName());
         }
     }
 
@@ -67,13 +60,13 @@ public class SweepMetrics {
         }
     }
 
-    void examinedCells(TableReference tableRef, long numExamined) {
-        cellsSweptHistogram.update(tableRef, numExamined);
+    void examinedCells(long numExamined) {
+        cellsSweptHistogram.update(numExamined);
         cellsSweptMeter.update(numExamined);
     }
 
-    void deletedCells(TableReference tableRef, long numDeleted) {
-        cellsDeletedHistogram.update(tableRef, numDeleted);
+    void deletedCells(long numDeleted) {
+        cellsDeletedHistogram.update(numDeleted);
         cellsDeletedMeter.update(numDeleted);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
@@ -146,8 +146,8 @@ public class BackgroundSweeperFastTest extends SweeperTestSetup {
                 .sweptTimestamp(12345L)
                 .build());
         backgroundSweeper.runOnce();
-        Mockito.verify(sweepMetrics).examinedCells(TABLE_REF, 21);
-        Mockito.verify(sweepMetrics).deletedCells(TABLE_REF, 5);
+        Mockito.verify(sweepMetrics).examinedCells(21);
+        Mockito.verify(sweepMetrics).deletedCells(5);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepMetricsTest.java
@@ -55,19 +55,19 @@ public class SweepMetricsTest {
 
     @Test
     public void cellsDeletedAreRecorded() {
-        sweepMetrics.examinedCells(TABLE, EXAMINED);
-        sweepMetrics.deletedCells(TABLE, DELETED);
+        sweepMetrics.examinedCells(EXAMINED);
+        sweepMetrics.deletedCells(DELETED);
 
         assertCellsDeleted(TABLE, DELETED);
     }
 
     @Test
     public void cellsDeletedAreRecordedSeparatelyAndAggregated() {
-        sweepMetrics.examinedCells(TABLE, EXAMINED);
-        sweepMetrics.deletedCells(TABLE, DELETED);
+        sweepMetrics.examinedCells(EXAMINED);
+        sweepMetrics.deletedCells(DELETED);
 
-        sweepMetrics.examinedCells(OTHER_TABLE, OTHER_EXAMINED);
-        sweepMetrics.deletedCells(OTHER_TABLE, OTHER_DELETED);
+        sweepMetrics.examinedCells(OTHER_EXAMINED);
+        sweepMetrics.deletedCells(OTHER_DELETED);
 
         assertCellsDeleted(TABLE, DELETED);
         assertCellsDeleted(OTHER_TABLE, OTHER_DELETED);
@@ -76,18 +76,18 @@ public class SweepMetricsTest {
 
     @Test
     public void cellsExaminedAreRecorded() {
-        sweepMetrics.examinedCells(TABLE, EXAMINED);
-        sweepMetrics.deletedCells(TABLE, DELETED);
+        sweepMetrics.examinedCells(EXAMINED);
+        sweepMetrics.deletedCells(DELETED);
         assertCellsExamined(TABLE, EXAMINED);
     }
 
     @Test
     public void cellsExaminedAreRecordedSeparatelyAndAggregated() {
-        sweepMetrics.examinedCells(TABLE, EXAMINED);
-        sweepMetrics.deletedCells(TABLE, DELETED);
+        sweepMetrics.examinedCells(EXAMINED);
+        sweepMetrics.deletedCells(DELETED);
 
-        sweepMetrics.examinedCells(OTHER_TABLE, OTHER_EXAMINED);
-        sweepMetrics.deletedCells(OTHER_TABLE, OTHER_DELETED);
+        sweepMetrics.examinedCells(OTHER_EXAMINED);
+        sweepMetrics.deletedCells(OTHER_DELETED);
 
         assertCellsExamined(TABLE, EXAMINED);
         assertCellsExamined(OTHER_TABLE, OTHER_EXAMINED);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepMetricsTest.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.sweep;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 
 import org.junit.After;
@@ -26,13 +25,9 @@ import org.junit.Test;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.primitives.Longs;
-import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 
 public class SweepMetricsTest {
-    private static final TableReference TABLE = TableReference.createFromFullyQualifiedName("test.table");
-    private static final TableReference OTHER_TABLE = TableReference.createFromFullyQualifiedName("test.other_table");
-
     private static final long DELETED = 10L;
     private static final long EXAMINED = 15L;
 
@@ -58,19 +53,17 @@ public class SweepMetricsTest {
         sweepMetrics.examinedCells(EXAMINED);
         sweepMetrics.deletedCells(DELETED);
 
-        assertCellsDeleted(TABLE, DELETED);
+        assertValuesRecorded("staleValuesDeleted", DELETED);
     }
 
     @Test
-    public void cellsDeletedAreRecordedSeparatelyAndAggregated() {
+    public void cellsDeletedAreAggregated() {
         sweepMetrics.examinedCells(EXAMINED);
         sweepMetrics.deletedCells(DELETED);
 
         sweepMetrics.examinedCells(OTHER_EXAMINED);
         sweepMetrics.deletedCells(OTHER_DELETED);
 
-        assertCellsDeleted(TABLE, DELETED);
-        assertCellsDeleted(OTHER_TABLE, OTHER_DELETED);
         assertValuesRecorded("staleValuesDeleted", DELETED, OTHER_DELETED);
     }
 
@@ -78,36 +71,23 @@ public class SweepMetricsTest {
     public void cellsExaminedAreRecorded() {
         sweepMetrics.examinedCells(EXAMINED);
         sweepMetrics.deletedCells(DELETED);
-        assertCellsExamined(TABLE, EXAMINED);
+
+        assertValuesRecorded("cellTimestampPairsExamined", EXAMINED);
     }
 
     @Test
-    public void cellsExaminedAreRecordedSeparatelyAndAggregated() {
+    public void cellsExaminedAreAggregated() {
         sweepMetrics.examinedCells(EXAMINED);
         sweepMetrics.deletedCells(DELETED);
 
         sweepMetrics.examinedCells(OTHER_EXAMINED);
         sweepMetrics.deletedCells(OTHER_DELETED);
 
-        assertCellsExamined(TABLE, EXAMINED);
-        assertCellsExamined(OTHER_TABLE, OTHER_EXAMINED);
         assertValuesRecorded("cellTimestampPairsExamined", EXAMINED, OTHER_EXAMINED);
     }
 
     private void assertValuesRecorded(String aggregateMetric, Long... values) {
         Histogram histogram = METRIC_REGISTRY.histogram(MetricRegistry.name(SweepMetrics.class, aggregateMetric));
         assertThat(Longs.asList(histogram.getSnapshot().getValues()), containsInAnyOrder(values));
-    }
-
-    private void assertCellsDeleted(TableReference table, long deleted) {
-        Histogram deleteMetric = METRIC_REGISTRY.histogram(MetricRegistry.name(
-                SweepMetrics.class, "staleValuesDeleted", table.getQualifiedName()));
-        assertArrayEquals(new long[] { deleted }, deleteMetric.getSnapshot().getValues());
-    }
-
-    private void assertCellsExamined(TableReference table, long examined) {
-        Histogram examinedMetric = METRIC_REGISTRY.histogram(MetricRegistry.name(
-                SweepMetrics.class, "cellTimestampPairsExamined", table.getQualifiedName()));
-        assertArrayEquals(new long[] { examined }, examinedMetric.getSnapshot().getValues());
     }
 }

--- a/docs/source/cluster_management/sweep/background-sweep.rst
+++ b/docs/source/cluster_management/sweep/background-sweep.rst
@@ -70,3 +70,9 @@ You can also query ``sweep.priority`` to get a breakdown per table of:
 - ``cells_deleted`` - The numbers of stale values deleted last time this table was swept.
 
 - ``cells_examined`` - The number of cell-timestamp pairs in the table total the last time this table was swept.
+
+.. note::
+
+   If one investigates the ``sweep.priority`` table, one *may* find information regarding the number of cell-timestamp
+   pairs examined or deleted on earlier runs as well. However, the ``sweep.priority`` table itself can be swept, thus
+   the table *may* not contain information concerning all historical runs of sweep.

--- a/docs/source/cluster_management/sweep/sweep-endpoints.rst
+++ b/docs/source/cluster_management/sweep/sweep-endpoints.rst
@@ -25,3 +25,4 @@ If you ever need to force a particular table to be swept immediately, you can ru
  |                                          | ``deleteBatchSize``: cells to delete per batch  |                                                                                                  |
  +------------------------------------------+-------------------------------------------------+--------------------------------------------------------------------------------------------------+
 
+Note that using the sweep endpoints to manually kick off sweep will *not* update the Background Sweeper's sweep priority table.

--- a/docs/source/miscellaneous/dropwizard-metrics.rst
+++ b/docs/source/miscellaneous/dropwizard-metrics.rst
@@ -20,18 +20,16 @@ A reasonably comprehensive list of metrics exposed by AtlasDB can be found below
 **Gauges**
 
  - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.numBlacklistedHosts``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requestConnectionExceptionProportion``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requestFailureProportion``
  - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestConnectionExceptionProportion``
  - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestFailureProportion``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.approximatePoolSize``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.meanActiveTimeMillis``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.meanBorrowWaitTimeMillis``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.meanIdleTimeMillis``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.numIdle``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.numActive``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.proportionDestroyedByBorrower``
- - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.<host>.proportionDestroyedByEvictor``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.approximatePoolSize``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.meanActiveTimeMillis``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.meanBorrowWaitTimeMillis``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.meanIdleTimeMillis``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.numIdle``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.numActive``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.proportionDestroyedByBorrower``
+ - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer.proportionDestroyedByEvictor``
  - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.estimated.size``
  - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.eviction.count``
  - ``com.palantir.atlasdb.cache.TimestampCache.startToCommitTimestamp.cache.hit.count``
@@ -48,14 +46,9 @@ A reasonably comprehensive list of metrics exposed by AtlasDB can be found below
 - ``com.palantir.atlasdb.transaction.impl.SnapshotTransaction.byteSizeTx``
 - ``com.palantir.atlasdb.sweep.SweepMetrics.cellTimestampPairsExamined``
 - ``com.palantir.atlasdb.sweep.SweepMetrics.staleValuesDeleted``
-- ``com.palantir.atlasdb.sweep.SweepMetrics.cellTimestampPairsExamined.<table>``
-- ``com.palantir.atlasdb.sweep.SweepMetrics.staleValuesDeleted.<table>``
 
 **Meters**
 
-- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requestConnectionExceptions``
-- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requestExceptions``
-- ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.<host>.requests``
 - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestConnectionExceptions``
 - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requestExceptions``
 - ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool.requests``

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,10 +63,24 @@ develop
 
     *    - |userbreak| |fixed|
          - AtlasDB no longer embeds user-agents in metric names.
+           This affects both AtlasDB clients as well as TimeLock Server.
            All metrics are still available; however, metrics which previously included a user-agent component will no longer do so.
            For example, the timer ``com.palantir.timestamp.TimestampService.myUserAgent_version.getFreshTimestamp`` is now named ``com.palantir.timestamp.TimestampService.getFreshTimestamp``.
            This was necessary for compatibility with an internal log-ingestion tool.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2322>`__)
+
+    *    - |userbreak| |fixed|
+         - AtlasDB no longer embeds Cassandra host names in its metrics.
+           Aggregate metrics are retained in both CassandraClientPool and CassandraClientPoolingContainer.
+           This was necessary for compatibility with an internal log-ingestion tool.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/foo>`__)
+
+    *    - |userbreak| |fixed|
+         - AtlasDB no longer embeds table names in Sweep metrics.
+           Sweep aggregate metrics continue to be reported.
+           This was necessary for compatibility with an internal log-ingestion tool.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/foo>`__)
+
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
- [ ] Detailed Metrics Service (separate PR to merge into this)
- [ ] Document how to read the Sweep Progress table

**Goals (and why)**:
- Continue prior work on #2314 
- Needed for compatibility with internal metrics tooling.

**Implementation Description (bullets)**:
- Remove Cassandra host names from CassandraClientPool and CassandraClientPoolingContainer, thereby *reducing the granularity of available metrics*.
- Remove table names from Sweep Metrics, thereby *reducing the granularity of available metrics*.

**Concerns (what feedback would you like?)**:
- **We are losing granularity of information.** Is this okay? I guess some metrics are better than no metrics, but will this affect deployments not using the internal metrics tooling?
- Are metrics like meanActiveTimeMillis across object pools useful at all?

**Where should we start reviewing?**:
- `dropwizard-metrics.rst` probably gives the best overview of what I've done.

**Priority (whenever / two weeks / yesterday)**: early next week?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2324)
<!-- Reviewable:end -->
