### PR TITLE
[no release notes] Correct offending obsolete docs

### DIFF
--- a/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
@@ -19,7 +19,7 @@ Timelock
     Changing the TimeLock ``client`` will mean that one receives timestamps from a different timestamp service.
     This may result in **SEVERE DATA CORRUPTION** as the timestamp service's guarantees may be broken.
     Doing this safely requires a fast forward of the new client to at least the highest timestamp given out from the old client.
-    Please contact the AtlasDB team for assistance on such a operation.
+    Please contact the AtlasDB team for assistance on such an operation.
 
 Required parameters:
 
@@ -34,6 +34,9 @@ Required parameters:
          - The name of your client, generally the same as your application name.
            Note that if the top-level AtlasDB ``namespace`` configuration parameter is set, then this parameter need not be set.
            However, if it is, then this parameter MUST be equal to the AtlasDB ``namespace``, or AtlasDB will fail to start.
+
+           Note that client names must be non-empty and consist of only alphanumeric characters, dashes and
+           underscores (succinctly, ``[a-zA-Z0-9_-]+``) and for backwards compatibility cannot be the reserved word ``leader``.
 
     *    - serversList::servers
          - A list of all hosts. The hosts must be specified as addresses, i.e. ``https://host:port``.
@@ -61,7 +64,9 @@ Timelock Configuration Examples
 
 Here is an example of an AtlasDB configuration with the ``timelock`` block.
 
-You must ensure that you have migrated to the Timelock Server before adding a ``timelock`` block to the config.
+If you are using Cassandra, then automated migration will be performed when starting up your AtlasDB clients.
+If you are using another key-value-service, then you MUST ensure that you have migrated to the Timelock Server before
+adding a ``timelock`` block to the config.
 
 .. code-block:: yaml
 

--- a/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_server_config.rst
@@ -15,16 +15,11 @@ these may be configured in turn, as well as additional configuration parameters.
 Clients
 -------
 
-The ``clients`` block is a list of strings which corresponds to client namespaces that the server will respond to.
-Querying an endpoint for a client that does not exist will result in a 404.
-Note that client names must consist of only alphanumeric characters, dashes and
-underscores (succinctly, ``[a-zA-Z0-9_-]+``) and for backwards compatibility cannot be the reserved word ``leader``.
+.. note::
 
-   .. code:: yaml
-
-      clients:
-        - tom
-        - jerry
+   TimeLock previously required users to explicitly configure the namespaces that it would allow to be used,
+   returning 404s otherwise. From AtlasDB 0.54.0 onwards, though, TimeLock dynamically creates clients when a request
+   is made for that client for the first time.
 
 A single Timelock Server or cluster of Timelock Servers can support multiple AtlasDB clients. When querying a
 Timelock Server, clients must supply a namespace for which they are requesting timestamps or locks in the form of a
@@ -37,6 +32,9 @@ path variable. There are no guarantees of relationships between timestamps reque
 
 This is done for performance reasons: consider that if we maintained a global timestamp across all clients, then
 requests from each of these clients would need to all be synchronized.
+
+As far as the TimeLock Server is concerned, a client is created on the first request a user makes for the namespace
+in question.
 
 Cluster
 -------

--- a/docs/source/services/timelock_service/installation.rst
+++ b/docs/source/services/timelock_service/installation.rst
@@ -79,13 +79,12 @@ Add client(s) to Timelock
 
 9. Configure each client to use Timelock.
    Detailed documentation is :ref:`here <timelock-client-configuration>`.
-   You must remove any ``leader``, ``timestamp``, or ``lock`` blocks; the ``timelock`` block to add looks like this:
+   You must remove any ``leader``, ``timestamp``, or ``lock`` blocks; the ``timelock`` block to add looks like this.
 
 .. code-block:: yaml
 
    atlasdb:
       timelock:
-        client: tom
         serversList:
           servers:
             - palantir-1.com:8080
@@ -94,17 +93,14 @@ Add client(s) to Timelock
           sslConfiguration:
             trustStorePath: var/security/truststore.jks
 
-10. Configure Timelock to respond to your clients.
-    Add each client as a named entry in the ``clients`` block of your :ref:`timelock-server-configuration`.
+10. (Optional) For verification purposes, you may retrieve a timestamp from each client you are configuring to use TimeLock.
+    This can typically be performed with the Fetch Timestamp CLI or Dropwizard bundle. For example, using the Dropwizard bundle:
 
+.. code-block:: bash
 
-.. code-block:: yaml
+   ./service/bin/<service> atlasdb timestamp fetch
 
-   clients:
-      - tom
-      - jerry
-
-10. As a verification step, request a fresh timestamp from each client. We will use these values later to check that the migration is complete.
+    Note down the value of the timestamp returned; we will subsequently use these values to ensure that migration took place.
 
 11. Shut down each client that has been newly added.
 

--- a/docs/source/services/timelock_service/installation.rst
+++ b/docs/source/services/timelock_service/installation.rst
@@ -79,7 +79,7 @@ Add client(s) to Timelock
 
 9. Configure each client to use Timelock.
    Detailed documentation is :ref:`here <timelock-client-configuration>`.
-   You must remove any ``leader``, ``timestamp``, or ``lock`` blocks; the ``timelock`` block to add looks like this.
+   You must remove any ``leader``, ``timestamp``, or ``lock`` blocks; the ``timelock`` block to add looks like this:
 
 .. code-block:: yaml
 
@@ -114,5 +114,5 @@ Add client(s) to Timelock
 
 14. Restart each client.
 
-15. To verify that the migration worked correctly, get a fresh timestamp for each client from the Timelock server.
+15. (Optional) To verify that the migration worked correctly, get a fresh timestamp for each client from the Timelock server.
     For each client, the timestamp returned should be strictly greater than the corresponding timestamp obtained in step 10.


### PR DESCRIPTION
**Goals (and why)**: Fix #2245 

**Implementation Description (bullets)**:
- Update the docs to reflect that (1) automated migration exists, and (2) you don't have to configure the clients block yourself.

**Concerns (what feedback would you like?)**:
- Are there any errors? Nothing in particular

**Where should we start reviewing?**: Pick one of the 3 files, the diff is small

**Priority (whenever / two weeks / yesterday)**: whenever, maybe before timelock GAs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2325)
<!-- Reviewable:end -->
