### PR TITLE
Release notes 0.56

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,22 +62,31 @@ v0.56.0
     *    - Type
          - Change
 
-    *    - |devbreak| |new|
-         - TimelockServer now exposes the `LockService` instead of `RemoteLockService` if using the synchronous lock service.
+    *    - |new|
+         - TimelockServer now exposes the `LockService` instead of the `RemoteLockService` if using the synchronous lock service.
            This will provide a more comprehensive API which is required by the large internal products.
-           Any product which extends a TransactionManager will have to make changes to their class definition in order to support this update.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2284>`__)
-
-    *    - |devbreak| |new| |deprecated|
-         - Added two new methods to Transaction, getRangesLazy and a concurrent version of getRanges, which are also exposed in the Table API.
-           The existing getRanges method, which is now deprecated, would eagerly load the first page of all ranges, potentially concurrently. This often caused more data to be fetched than necessary or higher concurrency than expected.
-           If you expect to only use a small amount of the rows in the provided ranges, it is often advisable to use the new getRangesLazy method and serially iterate over the results.
-           Otherwise, you should use the new version of getRanges that allows explicitly operating on the resulting visitables in parallel.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2281>`__)
 
     *    - |userbreak| |new|
          - Timelock clients now report tritium metrics for the lock requests with the prefix ``LockService`` instead of ``RemoteLockService``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2284>`__)
+
+    *    - |devbreak|
+         - LockAwareTransactionManager now returns a `LockService` instead of a `RemoteLockService` in order to expose the new API.
+           Any products that extend this class will have to change their class definition.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2284>`__)
+
+    *    - |new|
+         - Added two new methods to Transaction, getRangesLazy and a concurrent version of getRanges, which are also exposed in the Table API.
+           If you expect to only use a small amount of the rows in the provided ranges, it is often advisable to use the new getRangesLazy method and serially iterate over the results.
+           Otherwise, you should use the new version of getRanges that allows explicitly operating on the resulting visitables in parallel.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2281>`__)
+
+    *    - |deprecated|
+         - The existing getRanges method has been deprecated as it would eagerly load the first page of all ranges, potentially concurrently.
+           This often caused more data to be fetched than necessary or higher concurrency than expected.
+           Recommended alternative is to use getRanges with a specified concurrency level, or getRangesLazy.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2281>`__)
 
     *    - |userbreak| |fixed|
          - AtlasDB no longer embeds user-agents in metric names.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,22 +44,40 @@ develop
     *    - Type
          - Change
 
-    *    - |userbreak|
+    *    -
+         -
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
+v0.56.0
+=======
+
+12 September 2017
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |devbreak| |new|
+         - TimelockServer now exposes the `LockService` instead of `RemoteLockService` if using the synchronous lock service.
+           This will provide a more comprehensive API which is required by the large internal products.
+           Any product which extends a TransactionManager will have to make changes to their class definition in order to support this update.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2284>`__)
+
+    *    - |devbreak| |new| |deprecated|
+         - Added two new methods to Transaction, getRangesLazy and a concurrent version of getRanges, which are also exposed in the Table API.
+           The existing getRanges method, which is now deprecated, would eagerly load the first page of all ranges, potentially concurrently. This often caused more data to be fetched than necessary or higher concurrency than expected.
+           If you expect to only use a small amount of the rows in the provided ranges, it is often advisable to use the new getRangesLazy method and serially iterate over the results.
+           Otherwise, you should use the new version of getRanges that allows explicitly operating on the resulting visitables in parallel.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2281>`__)
+
+    *    - |userbreak| |new|
          - Timelock clients now report tritium metrics for the lock requests with the prefix ``LockService`` instead of ``RemoteLockService``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2284>`__)
-
-    *    - |improved|
-         - LockServerOptions now provides a builder, which means constructing one should not require overriding methods.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2284>`__)
-
-    *    - |new|
-         - TimelockServer now exposes the `LockService` instead of `RemoteLockService` if using the synchronous lock service.
-           This will provide a more comprehensive API required by the large internal product.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2284>`__)
-
-    *    - |new|
-         - Oracle will now validate connections by running the test query when getting a new connection from the HikariPool.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2301>`__)
 
     *    - |userbreak| |fixed|
          - AtlasDB no longer embeds user-agents in metric names.
@@ -68,12 +86,13 @@ develop
            This was necessary for compatibility with an internal log-ingestion tool.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2322>`__)
 
-    *    - |devbreak|
-         - Added two new methods to Transaction, getRangesLazy and a concurrent version of getRanges. The old getRanges method would eagerly load the first page of all ranges, potentially
-           concurrently. This often caused more data to be fetched than necessary or higher concurrency than expected. If you expect to only use a small amount of the rows in the provided
-           ranges, it is often advisable to use the getRangesLazy method and serially iterate over the results. Otherwise, you should use the new version of getRanges that allows explicitly
-           operating on the resulting visitables in parallel.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2281>`__)
+    *    - |improved|
+         - LockServerOptions now provides a builder, which means constructing one should not require overriding methods.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2284>`__)
+
+    *    - |new|
+         - Oracle will now validate connections by running the test query when getting a new connection from the HikariPool.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2301>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**:
Cleaning up 0.56 release notes.

**Implementation Description (bullets)**:
- made 0.56.0 table
- cleaned up wording for notes in current release
- Changes in this release for reference:
04fb4c28a	Andreea Marzoca	2017-09-11	[no release notes] (#2330)
7a9e8096c	jnelson15	2017-09-11	Jeffn/expose get ranges concurrency (#2281)
b8d47a612	Jeremy Kong	2017-09-07	[Metrics Cardinality I] Eliminate user-agents (#2322)
190b11e34	Himangi Saraogi	2017-09-06	Fix/remotelock service to lockservice (#2284)
7307a6f8f	Jeremy Kong	2017-09-06	Mark some timelock parameters as safe [no release notes] (#2311)
5e5ba6ec2	Samuel Souza	2017-09-06	Fix docs regarding migration and sweep cli (#2320)
925379a5e	Samuel Souza	2017-09-06	Better release notes (#2310)
822ff0a47	Himangi Saraogi	2017-09-06	Validate connections from Hikari (#2301)
7df595ba4	Samuel Souza	2017-09-05	Add internal docs requirements.txt (#2317)
b858c7129	Tom Petracca	2017-09-05	Delete legacy and unused paxos/timelock code (#2306)

**Priority (whenever / two weeks / yesterday)**:
Today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2333)
<!-- Reviewable:end -->
