### PR TITLE
fix ordering ConcurrentStreams (#2337)

### DIFF
--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'org.inferred.processors'
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
@@ -10,6 +11,8 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
     compile group: 'io.dropwizard.metrics', name: 'metrics-core'
     compile group: 'net.jpountz.lz4', name: 'lz4'
+
+    processor group: 'org.immutables', name: 'value'
 
     testCompile group: 'junit', name: 'junit'
     testCompile group: 'org.assertj', name: 'assertj-core'

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,8 +44,22 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - The new concurrent version of `Transaction#getRanges` added in 0.56.0 did not correctly guarantee ordering of the results returned in its stream.
+           This will make sure the resulting ordering matches that of the input.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2337>`__)
+
+    *    - |devbreak| |improved|
+         - TimeLockAgent's constructor now accepts a Supplier instead of an RxJava Observable.
+           This reduces the size of the TimeLock Agent jar, and removes the need for a dependency on RxJava.
+           To convert an RxJava Observable to a Supplier that always returns the most recent value, consider the method `blockingMostRecent` as implemented `here <https://github.com/palantir/atlasdb/blob/0.56.0/timelock-agent/src/main/java/com/palantir/timelock/Observables.java#L39-L48>`__.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2339>`__)
+
+    *    - |userbreak| |fixed|
+         - AtlasDB no longer embeds Cassandra host names in its metrics.
+           Aggregate metrics are retained in both CassandraClientPool and CassandraClientPoolingContainer.
+           This was necessary for compatibility with an internal log-ingestion tool.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2324>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
* fix ordering ConcurrentStreams

* handle duplicates and update tests

* add more info in changelog

* address himangi comments

* use immutables for ConcurrentStreams.StreamElement

* Add new lines that help readability

* Resolve minor test comments

**Goals (and why)**: Cherry-pick of https://github.com/palantir/atlasdb/pull/2337 for 0.56.1. Will fix the release notes in a separate PR.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**: asap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2344)
<!-- Reviewable:end -->
