### PR TITLE
[Startup Independence] Part 3: Fix for AwaitingLeadershipProxy, added ExceptionMapper, better Test

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
@@ -39,7 +39,12 @@ public interface AtlasDbFactory {
     KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig,
             boolean initializeAsync);
 
-    TimestampService createTimestampService(KeyValueService rawKvs);
+
+    default TimestampService createTimestampService(KeyValueService rawKvs) {
+        return createTimestampService(rawKvs, DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync);
 
     default TimestampStoreInvalidator createTimestampStoreInvalidator(KeyValueService rawKvs) {
         return () -> {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
@@ -39,7 +39,6 @@ public interface AtlasDbFactory {
     KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig,
             boolean initializeAsync);
 
-
     default TimestampService createTimestampService(KeyValueService rawKvs) {
         return createTimestampService(rawKvs, DEFAULT_INITIALIZE_ASYNC);
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -50,13 +50,14 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
     }
 
     @Override
-    public TimestampService createTimestampService(KeyValueService rawKvs) {
+    public TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync) {
         AtlasDbVersion.ensureVersionReported();
         Preconditions.checkArgument(rawKvs instanceof CassandraKeyValueService,
                 "TimestampService must be created from an instance of"
                 + " CassandraKeyValueService, found %s", rawKvs.getClass());
         return PersistentTimestampServiceImpl.create(
-                CassandraTimestampBoundStore.create((CassandraKeyValueService) rawKvs));
+                CassandraTimestampBoundStore.create((CassandraKeyValueService) rawKvs, initializeAsync),
+                initializeAsync);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -171,6 +171,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService
                     throw new NotInitializedException("CassandraKeyValueService");
                 }
             }
+            return delegateInternal();
+        }
+
+        private CassandraKeyValueService delegateInternal() {
             if (kvs.isInitialized()) {
                 return kvs;
             }
@@ -190,11 +194,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService
         @Override
         public void close() {
             if (status != Status.CLOSED) {
-                status = Status.OPEN;
                 try {
-                    delegate().close();
+                    delegateInternal().close();
                     status = Status.CLOSED;
                 } catch (NotInitializedException e) {
+                    // The wrapper is closed, but we still have to propagate this to the delegate, once it initializes.
                     status = Status.CLOSING;
                 }
             }

--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -150,7 +150,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,
@@ -584,7 +587,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -279,7 +279,8 @@
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:atlasdb-jdbc"
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -248,7 +248,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -995,7 +996,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -72,7 +72,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
                         SafeArg.of("failureCount", failureCount), e);
             } catch (NotInitializedException e) {
                 log.warn("Asynchronous initialization of resources is not complete. Retrying in 10 seconds.", e);
-                Uninterruptibles.sleepUninterruptibly(AsyncInitializer.sleepIntervalInSeconds, TimeUnit.SECONDS);
+                Uninterruptibles.sleepUninterruptibly(AsyncInitializer.millisUntilNextAttempt, TimeUnit.MILLISECONDS);
             } catch (RuntimeException e) {
                 log.warn("[{}] RuntimeException while processing transaction. {}", SafeArg.of("runId", runId), e);
                 throw e;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -74,7 +74,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
                 log.warn("Asynchronous initialization of resources is not complete. Retrying in 10 seconds.", e);
                 Uninterruptibles.sleepUninterruptibly(AsyncInitializer.millisUntilNextAttempt, TimeUnit.MILLISECONDS);
             } catch (RuntimeException e) {
-                log.warn("[{}] RuntimeException while processing transaction. {}", SafeArg.of("runId", runId), e);
+                log.warn("[{}] RuntimeException while processing transaction.", SafeArg.of("runId", runId), e);
                 throw e;
             }
             sleepForBackoff(failureCount);

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -35,7 +35,7 @@ import com.palantir.logsafe.SafeArg;
  */
 @ThreadSafe
 public interface AsyncInitializer {
-    int sleepIntervalInSeconds = 10; // in seconds
+    int millisUntilNextAttempt = 10_000;
     Logger log = LoggerFactory.getLogger(AsyncInitializer.class);
     int nThreads = 20;
     ScheduledExecutorService executorService = Executors.newScheduledThreadPool(
@@ -77,7 +77,11 @@ public interface AsyncInitializer {
                     scheduleInitialization();
                 }
             }
-        }, sleepIntervalInSeconds, TimeUnit.SECONDS);
+        }, millisUntilNextAttempt, TimeUnit.MILLISECONDS);
+    }
+
+    default int millisToNextAttempt() {
+        return millisUntilNextAttempt;
     }
 
     // TODO (JAVA9): Make this private.

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -25,7 +25,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.logsafe.SafeArg;
@@ -36,6 +35,7 @@ import com.palantir.logsafe.SafeArg;
  */
 @ThreadSafe
 public interface AsyncInitializer {
+    int sleepIntervalInSeconds = 10; // in seconds
     Logger log = LoggerFactory.getLogger(AsyncInitializer.class);
     int nThreads = 20;
     ScheduledExecutorService executorService = Executors.newScheduledThreadPool(
@@ -77,13 +77,7 @@ public interface AsyncInitializer {
                     scheduleInitialization();
                 }
             }
-        }, millisToNextAttempt(), TimeUnit.MILLISECONDS);
-    }
-
-    // TODO (JAVA9): Make this package private.
-    @VisibleForTesting
-    default int millisToNextAttempt() {
-        return 10_000;
+        }, sleepIntervalInSeconds, TimeUnit.SECONDS);
     }
 
     // TODO (JAVA9): Make this private.
@@ -111,4 +105,8 @@ public interface AsyncInitializer {
     void tryInitialize();
 
     void cleanUpOnInitFailure();
+
+    default void close() {
+        // you must implement this method if you are asynchronously initializing a closeable class
+    }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DynamicDecoratingProxy.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DynamicDecoratingProxy.java
@@ -16,16 +16,23 @@
 
 package com.palantir.atlasdb.factory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.reflect.AbstractInvocationHandler;
+import com.palantir.exception.NotInitializedException;
 
 public final class DynamicDecoratingProxy<T> extends AbstractInvocationHandler {
     private final T decoratedService;
     private final T defaultService;
     private final Supplier<Boolean> shouldDecorate;
+
+    private static final Logger log = LoggerFactory.getLogger(DynamicDecoratingProxy.class);
 
     private DynamicDecoratingProxy(T decoratedService, T defaultService, Supplier<Boolean> shouldDecorate) {
         this.decoratedService = decoratedService;
@@ -46,6 +53,14 @@ public final class DynamicDecoratingProxy<T> extends AbstractInvocationHandler {
     @Override
     protected Object handleInvocation(Object proxy, Method method, Object[] args) throws Throwable {
         Object target = shouldDecorate.get() ? decoratedService : defaultService;
-        return method.invoke(target, args);
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            if (e.getTargetException() instanceof NotInitializedException) {
+                log.warn("Resource is not initialized yet!");
+                throw e.getTargetException();
+            }
+            throw e;
+        }
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java
@@ -72,7 +72,7 @@ public class ServiceDiscoveringAtlasSupplier {
                 ));
         keyValueService = Suppliers
                 .memoize(() -> atlasFactory.createRawKeyValueService(config, leaderConfig, initializeAsync));
-        timestampService = () -> atlasFactory.createTimestampService(getKeyValueService());
+        timestampService = () -> atlasFactory.createTimestampService(getKeyValueService(), initializeAsync);
         timestampStoreInvalidator = () -> atlasFactory.createTimestampStoreInvalidator(getKeyValueService());
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -51,6 +51,7 @@ import com.palantir.atlasdb.factory.Leaders.LocalPaxosServices;
 import com.palantir.atlasdb.factory.startup.TimeLockMigrator;
 import com.palantir.atlasdb.factory.timestamp.DecoratedTimelockServices;
 import com.palantir.atlasdb.http.AtlasDbFeignTargetFactory;
+import com.palantir.atlasdb.http.NotInitializedExceptionMapper;
 import com.palantir.atlasdb.http.UserAgents;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.NamespacedKeyValueServices;
@@ -209,6 +210,10 @@ public final class TransactionManagers {
             boolean allowHiddenTableAccess,
             String userAgent) {
         checkInstallConfig(config);
+
+        if (config.initializeAsync()) {
+            env.register(new NotInitializedExceptionMapper());
+        }
 
         AtlasDbRuntimeConfig defaultRuntime = AtlasDbRuntimeConfig.defaultRuntimeConfig();
         java.util.function.Supplier<AtlasDbRuntimeConfig> runtimeConfigSupplier =

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotInitializedExceptionMapper.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotInitializedExceptionMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import com.palantir.exception.NotInitializedException;
+
+public class NotInitializedExceptionMapper implements ExceptionMapper<NotInitializedException> {
+
+    @Override
+    public Response toResponse(NotInitializedException exception) {
+        return ExceptionMappers.encode503ResponseWithoutRetryAfter(exception);
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
@@ -50,7 +50,7 @@ public class AutoServiceAnnotatedAtlasDbFactory implements AtlasDbFactory {
     }
 
     @Override
-    public TimestampService createTimestampService(KeyValueService rawKvs) {
+    public TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync) {
         return nextTimestampServices.remove(0);
     }
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jmock.Mockery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.Lists;
@@ -36,7 +38,7 @@ public class AutoServiceAnnotatedAtlasDbFactory implements AtlasDbFactory {
     private static final Mockery context = new Mockery();
     private static final KeyValueService keyValueService = context.mock(KeyValueService.class);
     private static List<TimestampService> nextTimestampServices = new ArrayList<>();
-
+    private static final Logger log = LoggerFactory.getLogger(AutoServiceAnnotatedAtlasDbFactory.class);
 
     @Override
     public String getType() {
@@ -46,6 +48,9 @@ public class AutoServiceAnnotatedAtlasDbFactory implements AtlasDbFactory {
     @Override
     public KeyValueService createRawKeyValueService(KeyValueServiceConfig config, Optional<LeaderConfig> leaderConfig,
             boolean initializeAsync) {
+        if (initializeAsync) {
+            log.warn("Asynchronous initialization not implemented, will initialize synchronousy.");
+        }
         return keyValueService;
     }
 

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -271,7 +271,8 @@
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:atlasdb-jdbc"
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -189,7 +189,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -753,7 +754,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-cassandra"
+                "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -179,7 +179,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-dbkvs",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -755,7 +756,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-dbkvs",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -55,8 +55,9 @@ public class DbAtlasDbFactory implements AtlasDbFactory {
         return ConnectionManagerAwareDbKvs.create((DbKeyValueServiceConfig) config);
     }
 
+    // TODO(gmaretic): async initialization not implemented/propagated
     @Override
-    public TimestampService createTimestampService(KeyValueService rawKvs) {
+    public TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync) {
         Preconditions.checkArgument(rawKvs instanceof ConnectionManagerAwareDbKvs,
                 "DbAtlasDbFactory expects a raw kvs of type ConnectionManagerAwareDbKvs, found %s", rawKvs.getClass());
         ConnectionManagerAwareDbKvs dbkvs = (ConnectionManagerAwareDbKvs) rawKvs;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -55,9 +55,12 @@ public class DbAtlasDbFactory implements AtlasDbFactory {
         return ConnectionManagerAwareDbKvs.create((DbKeyValueServiceConfig) config);
     }
 
-    // TODO(gmaretic): async initialization not implemented/propagated
     @Override
     public TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync) {
+        if (initializeAsync) {
+            log.warn("Asynchronous initialization not implemented, will initialize synchronousy.");
+        }
+
         Preconditions.checkArgument(rawKvs instanceof ConnectionManagerAwareDbKvs,
                 "DbAtlasDbFactory expects a raw kvs of type ConnectionManagerAwareDbKvs, found %s", rawKvs.getClass());
         ConnectionManagerAwareDbKvs dbkvs = (ConnectionManagerAwareDbKvs) rawKvs;

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -163,7 +163,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -642,7 +643,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -282,7 +282,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -1489,7 +1490,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceEteTest.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.ete;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.List;
@@ -166,6 +167,7 @@ public class StartupIndependenceEteTest {
     private void assertNotInitializedExceptionIsThrownAndMappedCorrectly() {
         try {
             addTodo();
+            fail();
         } catch (Exception e) {
             assertTrue(exceptionIsRetryableAndContainsMessage(e, "CassandraKeyValueService is not initialized yet"));
         }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceEteTest.java
@@ -85,8 +85,6 @@ public class StartupIndependenceEteTest {
         assertSatisfiedWithin(180, StartupIndependenceEteTest::canPerformTransaction);
     }
 
-
-
     @Test
     public void atlasInitializesSynchronouslyIfCassandraIsInGoodState() throws InterruptedException, IOException {
         startCassandraNodes(ALL_CASSANDRA_NODES);
@@ -167,7 +165,7 @@ public class StartupIndependenceEteTest {
     private void assertNotInitializedExceptionIsThrownAndMappedCorrectly() {
         try {
             addTodo();
-            fail();
+            fail("Expected to throw an exception");
         } catch (Exception e) {
             assertTrue(exceptionIsRetryableAndContainsMessage(e, "CassandraKeyValueService is not initialized yet"));
         }

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -290,7 +290,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:atlasdb-jdbc"
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -1563,7 +1564,8 @@
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
-                "com.palantir.atlasdb:atlasdb-jdbc"
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-hikari/versions.lock
+++ b/atlasdb-hikari/versions.lock
@@ -131,7 +131,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-jdbc"
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -455,7 +456,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-jdbc"
+                "com.palantir.atlasdb:atlasdb-jdbc",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -90,7 +90,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     }
 
     @Override
-    public TimestampService createTimestampService(KeyValueService rawKvs) {
+    public TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync) {
         AtlasDbVersion.ensureVersionReported();
         return new InMemoryTimestampService();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -91,6 +91,9 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
 
     @Override
     public TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync) {
+        if (initializeAsync) {
+            log.warn("Asynchronous initialization not implemented, will initialize synchronousy.");
+        }
         AtlasDbVersion.ensureVersionReported();
         return new InMemoryTimestampService();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -52,6 +52,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                     // TODO(ssouza): replace with KVS healthcheck status when that gets implemented.
                     manager.getKeyValueService().getClusterAvailabilityStatus();
                 } catch (NotInitializedException e) {
+                    log.warn("The KeyValueService is not initialized yet!");
                     throw e;
                 }
                 isInitialized = true;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -52,7 +52,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                     // TODO(ssouza): replace with KVS healthcheck status when that gets implemented.
                     manager.getKeyValueService().getClusterAvailabilityStatus();
                 } catch (NotInitializedException e) {
-                    log.warn("The KeyValueService is not initialized yet!");
+                    log.info("The KeyValueService is not initialized yet!");
                     throw e;
                 }
                 isInitialized = true;

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcAtlasDbFactory.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcAtlasDbFactory.java
@@ -51,6 +51,9 @@ public class JdbcAtlasDbFactory implements AtlasDbFactory {
 
     @Override
     public TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync) {
+        if (initializeAsync) {
+            log.warn("Asynchronous initialization not implemented, will initialize synchronousy.");
+        }
         AtlasDbVersion.ensureVersionReported();
         return PersistentTimestampServiceImpl.create(JdbcTimestampBoundStore.create((JdbcKeyValueService) rawKvs));
     }

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcAtlasDbFactory.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcAtlasDbFactory.java
@@ -50,7 +50,7 @@ public class JdbcAtlasDbFactory implements AtlasDbFactory {
     }
 
     @Override
-    public TimestampService createTimestampService(KeyValueService rawKvs) {
+    public TimestampService createTimestampService(KeyValueService rawKvs, boolean initializeAsync) {
         AtlasDbVersion.ensureVersionReported();
         return PersistentTimestampServiceImpl.create(JdbcTimestampBoundStore.create((JdbcKeyValueService) rawKvs));
     }

--- a/atlasdb-jdbc/versions.lock
+++ b/atlasdb-jdbc/versions.lock
@@ -127,7 +127,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,
@@ -433,7 +436,10 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-client": {
-            "project": true
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-impl"
+            ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
             "project": true,

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -292,7 +292,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -1209,7 +1210,8 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -1263,7 +1263,8 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/timelock-agent/versions.lock
+++ b/timelock-agent/versions.lock
@@ -172,7 +172,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -712,7 +713,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/timelock-impl/versions.lock
+++ b/timelock-impl/versions.lock
@@ -168,7 +168,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -678,7 +679,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/timelock-server-distribution/versions.lock
+++ b/timelock-server-distribution/versions.lock
@@ -257,7 +257,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -251,7 +251,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {
@@ -1352,7 +1353,8 @@
         "com.palantir.atlasdb:atlasdb-client": {
             "project": true,
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.atlasdb:timestamp-impl"
             ]
         },
         "com.palantir.atlasdb:atlasdb-client-protobufs": {

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -1,4 +1,5 @@
 import org.gradle.plugins.ide.eclipse.model.AccessRule
+apply plugin: 'org.inferred.processors'
 
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
@@ -7,9 +8,13 @@ dependencies {
   compile(project(":timestamp-api"))
   compile(project(":timestamp-client"))
   compile(project(":atlasdb-commons"))
+  compile(project(":atlasdb-client"))
 
   compile group: 'com.palantir.remoting2', name: 'tracing'
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
+
+  processor 'com.google.auto.service:auto-service:1.0-rc2'
+  processor project(":atlasdb-processors")
 
   testCompile project(":atlasdb-tests-shared")
   testCompile group: 'junit', name: 'junit'

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executors;
 
 import org.junit.Test;
 
-// Mock AvailableTimestamps to test PersistentTimestampService.
+// Mock AvailableTimestamps to test PersistentTimestampServiceImpl.
 // See also PersistentTimestampServiceTests for end-to-end style tests.
 public class PersistentTimestampServiceMockingTest {
 
@@ -41,7 +41,7 @@ public class PersistentTimestampServiceMockingTest {
 
     private PersistentTimestamp timestamp = mock(PersistentTimestamp.class);
     private ExecutorService executor = Executors.newSingleThreadExecutor();
-    private PersistentTimestampService timestampService = new PersistentTimestampServiceImpl(timestamp);
+    private PersistentTimestampServiceImpl timestampService = new PersistentTimestampServiceImpl(timestamp);
 
     @Test
     public void

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTests.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTests.java
@@ -26,7 +26,7 @@ import org.junit.rules.ExpectedException;
 import com.palantir.atlasdb.timestamp.AbstractTimestampServiceTests;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 
-// Test PersistentTimestampService by fully instantiating it with an InMemoryTimestampBoundStore.
+// Test PersistentTimestampServiceImpl by fully instantiating it with an InMemoryTimestampBoundStore.
 // See also PersistentTimestampServiceMockingTest that mocks AvailableTimestamps instead.
 public class PersistentTimestampServiceTests extends AbstractTimestampServiceTests {
     @Rule

--- a/timestamp-impl/versions.lock
+++ b/timestamp-impl/versions.lock
@@ -4,6 +4,7 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-client"
@@ -16,7 +17,8 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -26,14 +28,18 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.remoting2:jackson-support",
+                "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
             "locked": "2.6.7",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:tracing"
             ]
@@ -61,16 +67,25 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.atlasdb:timestamp-client"
+                "com.palantir.atlasdb:timestamp-client",
+                "com.palantir.tritium:tritium-api",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
             ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "1.3.9",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
         "com.google.guava:guava": {
@@ -78,12 +93,52 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:ssl-config",
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "2.6.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.json-simple:json-simple": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.googlecode.protobuf-java-format:protobuf-java-format": {
+            "locked": "1.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-client": {
+            "project": true
+        },
+        "com.palantir.atlasdb:atlasdb-client-protobufs": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.atlasdb:atlasdb-commons": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:timestamp-client"
             ]
         },
@@ -96,6 +151,7 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:timestamp-client"
             ]
         },
@@ -108,24 +164,84 @@
                 "com.palantir.remoting2:tracing"
             ]
         },
+        "com.palantir.remoting2:ssl-config": {
+            "locked": "2.3.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
         "com.palantir.remoting2:tracing": {
-            "locked": "2.3.0"
+            "locked": "2.3.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
         },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.palantir.tritium:tritium-api": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
+            ]
+        },
+        "com.palantir.tritium:tritium-core": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
+            ]
+        },
+        "com.palantir.tritium:tritium-lib": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.tritium:tritium-metrics": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-slf4j": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.tritium:tritium-metrics",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-api"
             ]
@@ -136,12 +252,41 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
+            "locked": "1.1.2",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
                 "io.dropwizard.metrics:metrics-core"
+            ]
+        },
+        "org.xerial.snappy:snappy-java": {
+            "locked": "1.1.1.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         }
     },
@@ -150,6 +295,7 @@
             "locked": "2.6.7",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-client"
@@ -162,7 +308,8 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-afterburner"
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -172,14 +319,18 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.remoting2:jackson-support",
+                "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
             "locked": "2.6.7",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:tracing"
             ]
@@ -207,16 +358,25 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-executors",
                 "com.palantir.atlasdb:timestamp-api",
-                "com.palantir.atlasdb:timestamp-client"
+                "com.palantir.atlasdb:timestamp-client",
+                "com.palantir.tritium:tritium-api",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
             ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "1.3.9",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
             ]
         },
         "com.google.guava:guava": {
@@ -224,12 +384,52 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-guava",
                 "com.palantir.atlasdb:atlasdb-commons",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:ssl-config",
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "2.6.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.json-simple:json-simple": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.googlecode.protobuf-java-format:protobuf-java-format": {
+            "locked": "1.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-client": {
+            "project": true
+        },
+        "com.palantir.atlasdb:atlasdb-client-protobufs": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "com.palantir.atlasdb:atlasdb-commons": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:timestamp-client"
             ]
         },
@@ -242,6 +442,7 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true,
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:timestamp-client"
             ]
         },
@@ -254,24 +455,84 @@
                 "com.palantir.remoting2:tracing"
             ]
         },
+        "com.palantir.remoting2:ssl-config": {
+            "locked": "2.3.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
         "com.palantir.remoting2:tracing": {
-            "locked": "2.3.0"
+            "locked": "2.3.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
         },
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.palantir.tritium:tritium-api": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
+            ]
+        },
+        "com.palantir.tritium:tritium-core": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j"
+            ]
+        },
+        "com.palantir.tritium:tritium-lib": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.tritium:tritium-metrics": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-slf4j": {
+            "locked": "0.6.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-commons"
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.tritium:tritium-metrics",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
             ]
         },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:timestamp-api"
             ]
@@ -282,12 +543,41 @@
                 "com.palantir.atlasdb:atlasdb-commons"
             ]
         },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.9",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics",
+                "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir"
+            ]
+        },
+        "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
+            "locked": "1.1.2",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.5",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
                 "io.dropwizard.metrics:metrics-core"
+            ]
+        },
+        "org.xerial.snappy:snappy-java": {
+            "locked": "1.1.1.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         }
     }


### PR DESCRIPTION
**Goals (and why)**:
AwaitingLeadrshipProxy was unhappy because we weren't asynchronously initialising the TimestampBoundStore, furthermore, AbstractTransactionManager.runTaskWithRetry was constantly retrying when it hit a NotInitializedException.

**Implementation Description (bullets)**:

- Made sure that the NotInitializedException is correctly propagated and added an ExceptionMapper for it
- Added asynchronous initialization for CassandraTimestampBoundStore and PersistentTimestampService

**Concerns (what feedback would you like?)**:
Just sanity checking, check that tests make sense, are things in right locations?

**Where should we start reviewing?**:
Probably start with the tests?

**Priority (whenever / two weeks / yesterday)**:
asap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2346)
<!-- Reviewable:end -->
