### PR TITLE
BatchingVisitables: use the default batch size for immutableCopy and friends

### DIFF
--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -19,4 +19,5 @@ dependencies {
     testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock
     testCompile group: 'org.hamcrest', name: 'hamcrest-core'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library'
+    testCompile group: 'org.mockito', name: 'mockito-core'
 }

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitableView.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitableView.java
@@ -225,7 +225,7 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
     public ImmutableList<T> immutableCopy() {
         final ImmutableList.Builder<T> builder = ImmutableList.builder();
         delegate().batchAccept(
-                BatchingVisitables.KEEP_ALL_BATCH_SIZE,
+                BatchingVisitables.DEFAULT_BATCH_SIZE,
                 items -> {
                     builder.addAll(items);
                     return true;
@@ -241,7 +241,7 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
     public ImmutableSet<T> immutableSetCopy() {
         final ImmutableSet.Builder<T> builder = ImmutableSet.builder();
         delegate().batchAccept(
-                BatchingVisitables.KEEP_ALL_BATCH_SIZE,
+                BatchingVisitables.DEFAULT_BATCH_SIZE,
                 items -> {
                     builder.addAll(items);
                     return true;
@@ -258,7 +258,7 @@ public abstract class BatchingVisitableView<T> extends ForwardingObject implemen
     public <S extends Collection<? super T>> S copyInto(final S collection) {
         Preconditions.checkNotNull(collection, "Cannot copy the visitable into a null collection");
         delegate().batchAccept(
-                BatchingVisitables.KEEP_ALL_BATCH_SIZE,
+                BatchingVisitables.DEFAULT_BATCH_SIZE,
                 items -> {
                     collection.addAll(items);
                     return true;

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
@@ -281,7 +281,7 @@ public class BatchingVisitables {
             protected <K extends Exception> void batchAcceptSizeHint(int batchSizeHint,
                                                                      final ConsistentVisitor<T, K> v) throws K {
                 if (batchSizeHint > limit) {
-                    batchSizeHint = (int)limit;
+                    batchSizeHint = (int) limit;
                 }
                 visitable.batchAccept(batchSizeHint, new AbortingVisitor<List<T>, K>() {
                     long visited = 0;

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
@@ -40,6 +40,7 @@ public class BatchingVisitables {
     private BatchingVisitables() {/**/}
 
     public static final int DEFAULT_BATCH_SIZE = 1000;
+    @SuppressWarnings("unused") // Used in internal legacy code
     public static final int KEEP_ALL_BATCH_SIZE = 100000;
 
     public static <T> BatchingVisitableView<T> emptyBatchingVisitable() {

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/BatchingVisitables.java
@@ -436,7 +436,7 @@ public class BatchingVisitables {
      * <p>
      * This can be used to make the performance of batching visitables better.  One example of where this is useful
      * is if I just visit the results one at a time, but I know that I will visit 100 results, then I can save
-     * a lot of potential round trips my hinting a page size of 100.
+     * a lot of potential round trips by hinting a page size of 100.
      */
     public static <T> BatchingVisitableView<T> hintPageSize(final BatchingVisitable<T> bv, final int pageSize) {
         Preconditions.checkArgument(pageSize > 0);

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
@@ -48,28 +48,28 @@ public class BatchingVisitablesTest {
         BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L));
 
         TokenBackedBasicResultsPage<Long, Long> page = BatchingVisitables.getFirstPage(visitor, 0);
-        assertEquals("anonymous assert 6BC9FC", 0, page.getResults().size());
-        assertEquals("anonymous assert 7EBA34", true, page.moreResultsAvailable());
+        assertEquals("page results had wrong size!", 0, page.getResults().size());
+        assertEquals("page.moreResultsAvailable was wrong", true, page.moreResultsAvailable());
 
         page = BatchingVisitables.getFirstPage(visitor, 1);
-        assertEquals("anonymous assert 1B3BD6", 1, page.getResults().size());
-        assertEquals("anonymous assert BDAB68", Lists.newArrayList(0L), page.getResults());
-        assertEquals("anonymous assert F4E06A", true, page.moreResultsAvailable());
+        assertEquals("page results had wrong size!", 1, page.getResults().size());
+        assertEquals("page.getResults was wrong", Lists.newArrayList(0L), page.getResults());
+        assertEquals("page.moreResultsAvailable was wrong", true, page.moreResultsAvailable());
 
         page = BatchingVisitables.getFirstPage(visitor, 3);
-        assertEquals("anonymous assert 87CB3C", 3, page.getResults().size());
-        assertEquals("anonymous assert 0AB14A", Lists.newArrayList(0L, 1L, 2L), page.getResults());
-        assertEquals("anonymous assert 178C51", true, page.moreResultsAvailable());
+        assertEquals("page results had wrong size!", 3, page.getResults().size());
+        assertEquals("page.getResults was wrong", Lists.newArrayList(0L, 1L, 2L), page.getResults());
+        assertEquals("page.moreResultsAvailable was wrong", true, page.moreResultsAvailable());
 
         page = BatchingVisitables.getFirstPage(visitor, 4);
-        assertEquals("anonymous assert 6215D2", 4, page.getResults().size());
-        assertEquals("anonymous assert C1D8C0", Lists.newArrayList(0L, 1L, 2L, 3L), page.getResults());
-        assertEquals("anonymous assert 91F5FF", false, page.moreResultsAvailable());
+        assertEquals("page results had wrong size!", 4, page.getResults().size());
+        assertEquals("page.getResults was wrong", Lists.newArrayList(0L, 1L, 2L, 3L), page.getResults());
+        assertEquals("page.moreResultsAvailable was wrong", false, page.moreResultsAvailable());
 
         page = BatchingVisitables.getFirstPage(visitor, 7);
-        assertEquals("anonymous assert 77AABC", 4, page.getResults().size());
-        assertEquals("anonymous assert E250DA", Lists.newArrayList(0L, 1L, 2L, 3L), page.getResults());
-        assertEquals("anonymous assert 516AA9", false, page.moreResultsAvailable());
+        assertEquals("page results had wrong size!", 4, page.getResults().size());
+        assertEquals("page.getResults was wrong", Lists.newArrayList(0L, 1L, 2L, 3L), page.getResults());
+        assertEquals("page.moreResultsAvailable was wrong", false, page.moreResultsAvailable());
 
         try {
             BatchingVisitables.getFirstPage(visitor, -1);
@@ -83,8 +83,8 @@ public class BatchingVisitablesTest {
     public void testMinMax() {
         BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L));
 
-        assertEquals("anonymous assert 3C39F5", 0L, (long) BatchingVisitables.getMin(visitor));
-        assertEquals("anonymous assert CC2B13", 3L, (long) BatchingVisitables.getMax(visitor));
+        assertEquals("BatchingVisitables.getMin was wrong", 0L, (long) BatchingVisitables.getMin(visitor));
+        assertEquals("BatchingVisitables.getMax was wrong", 3L, (long) BatchingVisitables.getMax(visitor));
 
         BatchingVisitable<Pair<Long, Long>> pairedVisitable = ListVisitor.create(Lists.newArrayList(
                 Pair.create(0L, 0L),
@@ -93,23 +93,23 @@ public class BatchingVisitablesTest {
                 Pair.create(1L, 1L)));
 
         Ordering<Pair<Long, Long>> ordering = Pair.compareLhSide();
-        assertEquals("anonymous assert C849C7", Pair.create(0L, 0L),
+        assertEquals("BatchingVisitables.getMin was wrong", Pair.create(0L, 0L),
                 BatchingVisitables.getMin(pairedVisitable, ordering, null));
-        assertEquals("anonymous assert A7358D", Pair.create(1L, 0L),
+        assertEquals("BatchingVisitables.getMax was wrong", Pair.create(1L, 0L),
                 BatchingVisitables.getMax(pairedVisitable, ordering, null));
     }
 
     @Test
     public void testEmpty() {
-        assertTrue("anonymous assert 08BE89",
+        assertTrue("empty batching visitable should be empty!",
                 BatchingVisitables.isEmpty(BatchingVisitables.emptyBatchingVisitable()));
-        assertEquals("anonymous assert 3E0F41", 0,
+        assertEquals("empty batching visitable should be empty!", 0,
                 BatchingVisitables.count(BatchingVisitables.emptyBatchingVisitable()));
 
         BatchingVisitable<Long> bv = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L));
-        assertFalse("anonymous assert DDDE16", BatchingVisitables.isEmpty(bv));
-        assertEquals("anonymous assert 1832D8", 4, BatchingVisitables.count(bv));
-        assertTrue("anonymous assert C6A211",
+        assertFalse("non-empty batching visitable should not be empty!", BatchingVisitables.isEmpty(bv));
+        assertEquals("visitable had wrong size", 4, BatchingVisitables.count(bv));
+        assertTrue("empty visitable should always be true, even when told to visit an always-false place",
                 BatchingVisitables.emptyBatchingVisitable().batchAccept(1, AbortingVisitors.alwaysFalse()));
     }
 
@@ -117,30 +117,30 @@ public class BatchingVisitablesTest {
     public void testPageSize() {
         BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L));
         visitor.batchAccept(5, item -> {
-            assertEquals("anonymous assert 8A150B", 5, item.size());
+            assertEquals("batched item had wrong size", 5, item.size());
             return false;
         });
         visitor.batchAccept(1, item -> {
-            assertEquals("anonymous assert 49A3AF", 1, item.size());
+            assertEquals("batched item had wrong size", 1, item.size());
             return false;
         });
         visitor.batchAccept(2, item -> {
-            assertEquals("anonymous assert B07B27", 2, item.size());
+            assertEquals("batched item had wrong size", 2, item.size());
             return true;
         });
 
         visitor.batchAccept(4, item -> {
-            Preconditions.checkState(item.size() == 4);
+            Preconditions.checkState(item.size() == 4, "batched item had wrong size");
             return false;
         });
 
         visitor.batchAccept(4, item -> {
-            Preconditions.checkState(item.size() == 4 || item.size() == 2);
+            Preconditions.checkState(item.size() == 4 || item.size() == 2, "batched item had wrong size");
             return true;
         });
 
         visitor.batchAccept(20, item -> {
-            assertEquals("anonymous assert 0757C9", 6, item.size());
+            assertEquals("batched item had wrong size", 6, item.size());
             return true;
         });
     }
@@ -149,7 +149,7 @@ public class BatchingVisitablesTest {
     public void testBatchHints() {
         BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
         Function<List<Long>, List<String>> trans = (input) -> {
-            assertEquals("anonymous assert 110D40", 2, input.size());
+            assertEquals("batched item had wrong size", 2, input.size());
             return Lists.transform(input, Functions.toStringFunction());
         };
         BatchingVisitableView<String> visitable = BatchingVisitableView.of(visitor).transformBatch(trans)
@@ -157,10 +157,10 @@ public class BatchingVisitablesTest {
         final Mutable<Boolean> hasTripped = Mutables.newMutable();
         visitable.batchAccept(10000, item -> {
             hasTripped.set(true);
-            assertEquals("anonymous assert F13DE1", 8, item.size());
+            assertEquals("batched item had wrong size", 8, item.size());
             return false;
         });
-        assertTrue("anonymous assert 323FF5", hasTripped.get());
+        assertTrue("should have been tripped!", hasTripped.get());
     }
 
     @Test
@@ -169,13 +169,13 @@ public class BatchingVisitablesTest {
         final Mutable<Boolean> hasTripped = Mutables.newMutable();
         AbortingVisitor<List<Object>, RuntimeException> bv = item -> {
             hasTripped.set(true);
-            assertEquals("anonymous assert 626F1C", 8, item.size());
+            assertEquals("batched item had wrong size", 8, item.size());
             return false;
         };
         AbortingVisitor<List<Long>, RuntimeException> wrap = AbortingVisitors.wrapBatching(bv);
         BatchingVisitableView.of(visitor).batchAccept(1000, wrap);
 
-        assertTrue("anonymous assert 755B51", hasTripped.get());
+        assertTrue("should have been tripped!", hasTripped.get());
     }
 
     @Test
@@ -184,13 +184,13 @@ public class BatchingVisitablesTest {
         final Mutable<Boolean> hasTripped = Mutables.newMutable();
         AbortingVisitor<List<? extends Long>, RuntimeException> bv = item -> {
             hasTripped.set(true);
-            assertEquals("anonymous assert 2BC193", 8, item.size());
+            assertEquals("batched item had wrong size", 8, item.size());
             return false;
         };
         AbortingVisitor<List<Long>, RuntimeException> wrap = AbortingVisitors.wrapBatching(bv);
         BatchingVisitableView.of(visitor).batchAccept(1000, wrap);
 
-        assertTrue("anonymous assert 380CE5", hasTripped.get());
+        assertTrue("should have been tripped!", hasTripped.get());
     }
 
     @Test
@@ -198,7 +198,9 @@ public class BatchingVisitablesTest {
         BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(
                 0L, 1L, 1L, 2L, 2L, 2L, 3L, 4L, 5L, 5L, 6L, 7L, 7L));
         BatchingVisitableView<Long> bv = BatchingVisitableView.of(visitor);
-        assertEquals("anonymous assert 139904", ImmutableList.of(0L, 1L, 2L, 3L), bv.unique().limit(4).immutableCopy());
+        assertEquals("unexpected result for unique view",
+                ImmutableList.of(0L, 1L, 2L, 3L),
+                bv.unique().limit(4).immutableCopy());
     }
 
     @Test

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
@@ -19,6 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
@@ -161,6 +165,26 @@ public class BatchingVisitablesTest {
             return false;
         });
         assertTrue("should have been tripped!", hasTripped.get());
+    }
+
+    @Test
+    public void testImmutableCopyRespectsCustomBatchSize() throws Exception {
+        AbstractBatchingVisitable bv = mock(AbstractBatchingVisitable.class);
+
+        BatchingVisitableView bvv = BatchingVisitableView.of(bv);
+        bvv.hintBatchSize(2).immutableCopy();
+
+        verify(bv).batchAcceptSizeHint(eq(2), any());
+    }
+
+    @Test
+    public void testImmutableCopyWithDefaultBatchSize() throws Exception {
+        AbstractBatchingVisitable bv = mock(AbstractBatchingVisitable.class);
+
+        BatchingVisitableView bvv = BatchingVisitableView.of(bv);
+        bvv.immutableCopy();
+
+        verify(bv).batchAcceptSizeHint(eq(BatchingVisitables.DEFAULT_BATCH_SIZE), any());
     }
 
     @Test

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
@@ -115,50 +115,32 @@ public class BatchingVisitablesTest {
     @Test
     public void testPageSize() {
         BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L));
-        visitor.batchAccept(5, new AbortingVisitor<List<Long>, RuntimeException>() {
-            @Override
-            public boolean visit(List<Long> item) {
-                assertEquals("anonymous assert 8A150B", 5, item.size());
-                return false;
-            }
+        visitor.batchAccept(5, item -> {
+            assertEquals("anonymous assert 8A150B", 5, item.size());
+            return false;
         });
-        visitor.batchAccept(1, new AbortingVisitor<List<Long>, RuntimeException>() {
-            @Override
-            public boolean visit(List<Long> item) {
-                assertEquals("anonymous assert 49A3AF", 1, item.size());
-                return false;
-            }
+        visitor.batchAccept(1, item -> {
+            assertEquals("anonymous assert 49A3AF", 1, item.size());
+            return false;
         });
-        visitor.batchAccept(2, new AbortingVisitor<List<Long>, RuntimeException>() {
-            @Override
-            public boolean visit(List<Long> item) {
-                assertEquals("anonymous assert B07B27", 2, item.size());
-                return true;
-            }
+        visitor.batchAccept(2, item -> {
+            assertEquals("anonymous assert B07B27", 2, item.size());
+            return true;
         });
 
-        visitor.batchAccept(4, new AbortingVisitor<List<Long>, RuntimeException>() {
-            @Override
-            public boolean visit(List<Long> item) {
-                Preconditions.checkState(item.size() == 4);
-                return false;
-            }
+        visitor.batchAccept(4, item -> {
+            Preconditions.checkState(item.size() == 4);
+            return false;
         });
 
-        visitor.batchAccept(4, new AbortingVisitor<List<Long>, RuntimeException>() {
-            @Override
-            public boolean visit(List<Long> item) {
-                Preconditions.checkState(item.size() == 4 || item.size() == 2);
-                return true;
-            }
+        visitor.batchAccept(4, item -> {
+            Preconditions.checkState(item.size() == 4 || item.size() == 2);
+            return true;
         });
 
-        visitor.batchAccept(20, new AbortingVisitor<List<Long>, RuntimeException>() {
-            @Override
-            public boolean visit(List<Long> item) {
-                assertEquals("anonymous assert 0757C9", 6, item.size());
-                return true;
-            }
+        visitor.batchAccept(20, item -> {
+            assertEquals("anonymous assert 0757C9", 6, item.size());
+            return true;
         });
     }
 
@@ -172,13 +154,10 @@ public class BatchingVisitablesTest {
         BatchingVisitableView<String> visitable = BatchingVisitableView.of(visitor).transformBatch(trans)
                 .hintBatchSize(2);
         final Mutable<Boolean> hasTripped = Mutables.newMutable();
-        visitable.batchAccept(10000, new AbortingVisitor<List<String>, RuntimeException>() {
-            @Override
-            public boolean visit(List<String> item) throws RuntimeException {
-                hasTripped.set(true);
-                assertEquals("anonymous assert F13DE1", 8, item.size());
-                return false;
-            }
+        visitable.batchAccept(10000, item -> {
+            hasTripped.set(true);
+            assertEquals("anonymous assert F13DE1", 8, item.size());
+            return false;
         });
         assertTrue("anonymous assert 323FF5", hasTripped.get());
     }
@@ -187,13 +166,10 @@ public class BatchingVisitablesTest {
     public void testBatchWrap() {
         BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
         final Mutable<Boolean> hasTripped = Mutables.newMutable();
-        AbortingVisitor<List<Object>, RuntimeException> bv = new AbortingVisitor<List<Object>, RuntimeException>() {
-            @Override
-            public boolean visit(List<Object> item) throws RuntimeException {
-                hasTripped.set(true);
-                assertEquals("anonymous assert 626F1C", 8, item.size());
-                return false;
-            }
+        AbortingVisitor<List<Object>, RuntimeException> bv = item -> {
+            hasTripped.set(true);
+            assertEquals("anonymous assert 626F1C", 8, item.size());
+            return false;
         };
         AbortingVisitor<List<Long>, RuntimeException> wrap = AbortingVisitors.wrapBatching(bv);
         BatchingVisitableView.of(visitor).batchAccept(1000, wrap);

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
@@ -41,6 +41,7 @@ import com.palantir.util.Mutables;
 import com.palantir.util.Pair;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
+@SuppressWarnings("Guava") // BatchingVisitables uses Guava.
 public class BatchingVisitablesTest {
     @Test
     public void testGetFirstPage() {
@@ -216,7 +217,7 @@ public class BatchingVisitablesTest {
         assertTrue("anonymous assert 33212B", limited.batchAccept(2, AbortingVisitors.alwaysTrue()));
         assertTrue("anonymous assert 8EF750", limited.batchAccept(3, AbortingVisitors.alwaysTrue()));
 
-        CountingVisitor<Long> cv = new CountingVisitor<Long>();
+        CountingVisitor<Long> cv = new CountingVisitor<>();
         assertTrue("anonymous assert F935C9", limited.batchAccept(2, AbortingVisitors.batching(cv)));
         assertEquals("anonymous assert 24BD1B", 3, cv.count);
         assertTrue("anonymous assert 15643D", limited.batchAccept(3, AbortingVisitors.batching(cv)));
@@ -248,7 +249,7 @@ public class BatchingVisitablesTest {
         BatchingVisitableView<Long> limited = BatchingVisitableView.of(visitor).limit(3);
         BatchingVisitableView<Long> concat = BatchingVisitables.concat(limited, visitor);
         assertTrue("anonymous assert CED0ED", concat.batchAccept(2, AbortingVisitors
-                .batching(AbortingVisitors.<Long>alwaysTrue())));
+                .batching(AbortingVisitors.alwaysTrue())));
     }
 
     static class CountingVisitor<T> implements AbortingVisitor<T, RuntimeException> {
@@ -272,10 +273,7 @@ public class BatchingVisitablesTest {
         @Override
         public boolean visit(T item) throws RuntimeException {
             count++;
-            if (count >= limit) {
-                return false;
-            }
-            return true;
+            return count < limit;
         }
     }
 
@@ -305,11 +303,11 @@ public class BatchingVisitablesTest {
     public void testHintPageSize() {
         InfiniteVisitable infinite = new InfiniteVisitable();
         BatchingVisitableView<Long> bv = BatchingVisitableView.of(infinite);
-        long first = bv.filter(new TakeEvery<Long>(100)).getFirst();
+        long first = bv.filter(new TakeEvery<>(100)).getFirst();
         assertEquals("anonymous assert A16A34", 99L, first);
         assertEquals("anonymous assert 55EE6D", 100L, infinite.count);
 
-        first = bv.filter(new TakeEvery<Long>(100)).hintBatchSize(100).getFirst();
+        first = bv.filter(new TakeEvery<>(100)).hintBatchSize(100).getFirst();
         assertEquals("anonymous assert 709532", 199L, first);
         assertEquals("anonymous assert D4A406", 200L, infinite.count);
     }
@@ -354,7 +352,7 @@ public class BatchingVisitablesTest {
         }
 
         public static <T> BatchingVisitable<T> create(List<T> list) {
-            return new ListVisitor<T>(list);
+            return new ListVisitor<>(list);
         }
 
         @Override

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.base;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.junit.Test;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.UnmodifiableIterator;
+import com.palantir.util.Mutable;
+import com.palantir.util.Mutables;
+import com.palantir.util.Pair;
+import com.palantir.util.paging.TokenBackedBasicResultsPage;
+
+public class BatchingVisitablesTest {
+    @Test
+    public void testGetFirstPage() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L));
+
+        TokenBackedBasicResultsPage<Long, Long> page = BatchingVisitables.getFirstPage(visitor, 0);
+        assertEquals("anonymous assert 6BC9FC", 0, page.getResults().size());
+        assertEquals("anonymous assert 7EBA34", true, page.moreResultsAvailable());
+
+        page = BatchingVisitables.getFirstPage(visitor, 1);
+        assertEquals("anonymous assert 1B3BD6", 1, page.getResults().size());
+        assertEquals("anonymous assert BDAB68", Lists.newArrayList(0L), page.getResults());
+        assertEquals("anonymous assert F4E06A", true, page.moreResultsAvailable());
+
+        page = BatchingVisitables.getFirstPage(visitor, 3);
+        assertEquals("anonymous assert 87CB3C", 3, page.getResults().size());
+        assertEquals("anonymous assert 0AB14A", Lists.newArrayList(0L, 1L, 2L), page.getResults());
+        assertEquals("anonymous assert 178C51", true, page.moreResultsAvailable());
+
+        page = BatchingVisitables.getFirstPage(visitor, 4);
+        assertEquals("anonymous assert 6215D2", 4, page.getResults().size());
+        assertEquals("anonymous assert C1D8C0", Lists.newArrayList(0L, 1L, 2L, 3L), page.getResults());
+        assertEquals("anonymous assert 91F5FF", false, page.moreResultsAvailable());
+
+        page = BatchingVisitables.getFirstPage(visitor, 7);
+        assertEquals("anonymous assert 77AABC", 4, page.getResults().size());
+        assertEquals("anonymous assert E250DA", Lists.newArrayList(0L, 1L, 2L, 3L), page.getResults());
+        assertEquals("anonymous assert 516AA9", false, page.moreResultsAvailable());
+
+        try {
+            BatchingVisitables.getFirstPage(visitor, -1);
+            fail("Should not allow visiting -1 elements.");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testMinMax() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L));
+
+        assertEquals("anonymous assert 3C39F5", 0L, (long) BatchingVisitables.getMin(visitor));
+        assertEquals("anonymous assert CC2B13", 3L, (long) BatchingVisitables.getMax(visitor));
+
+        BatchingVisitable<Pair<Long, Long>> v = ListVisitor.create(Lists.newArrayList(Pair.create(0L, 0L), Pair.create(1L, 0L), Pair.create(0L, 1L), Pair.create(1L, 1L)));
+
+        Ordering<Pair<Long, Long>> o = Pair.compareLhSide();
+        assertEquals("anonymous assert C849C7", Pair.create(0L, 0L), BatchingVisitables.getMin(v, o, null));
+        assertEquals("anonymous assert A7358D", Pair.create(1L, 0L), BatchingVisitables.getMax(v, o, null));
+    }
+
+    @Test
+    public void testEmpty() {
+        assertTrue("anonymous assert 08BE89", BatchingVisitables.isEmpty(BatchingVisitables.emptyBatchingVisitable()));
+        assertEquals("anonymous assert 3E0F41", 0, BatchingVisitables.count(BatchingVisitables.emptyBatchingVisitable()));
+
+        BatchingVisitable<Long> v = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L));
+        assertFalse("anonymous assert DDDE16", BatchingVisitables.isEmpty(v));
+        assertEquals("anonymous assert 1832D8", 4, BatchingVisitables.count(v));
+        assertTrue("anonymous assert C6A211", BatchingVisitables.emptyBatchingVisitable().batchAccept(1, AbortingVisitors.alwaysFalse()));
+    }
+
+    @Test
+    public void testPageSize() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L));
+        visitor.batchAccept(5, new AbortingVisitor<List<Long>, RuntimeException>() {
+            @Override
+            public boolean visit(List<Long> item) {
+                assertEquals("anonymous assert 8A150B", 5, item.size());
+                return false;
+            }
+        });
+        visitor.batchAccept(1, new AbortingVisitor<List<Long>, RuntimeException>() {
+            @Override
+            public boolean visit(List<Long> item) {
+                assertEquals("anonymous assert 49A3AF", 1, item.size());
+                return false;
+            }
+        });
+        visitor.batchAccept(2, new AbortingVisitor<List<Long>, RuntimeException>() {
+            @Override
+            public boolean visit(List<Long> item) {
+                assertEquals("anonymous assert B07B27", 2, item.size());
+                return true;
+            }
+        });
+
+        visitor.batchAccept(4, new AbortingVisitor<List<Long>, RuntimeException>() {
+            @Override
+            public boolean visit(List<Long> item) {
+                Preconditions.checkState(item.size() == 4);
+                return false;
+            }
+        });
+
+        visitor.batchAccept(4, new AbortingVisitor<List<Long>, RuntimeException>() {
+            @Override
+            public boolean visit(List<Long> item) {
+                Preconditions.checkState(item.size() == 4 || item.size() == 2);
+                return true;
+            }
+        });
+
+        visitor.batchAccept(20, new AbortingVisitor<List<Long>, RuntimeException>() {
+            @Override
+            public boolean visit(List<Long> item) {
+                assertEquals("anonymous assert 0757C9", 6, item.size());
+                return true;
+            }
+        });
+    }
+
+    @Test
+    public void testBatchHints() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
+        Function<List<Long>, List<String>> trans = (input) -> {
+            assertEquals("anonymous assert 110D40", 2, input.size());
+            return Lists.transform(input, Functions.toStringFunction());
+        };
+        BatchingVisitableView<String> visitable = BatchingVisitableView.of(visitor).transformBatch(trans).hintBatchSize(2);
+        final Mutable<Boolean> hasTripped = Mutables.newMutable();
+        visitable.batchAccept(10000, new AbortingVisitor<List<String>, RuntimeException>() {
+            @Override
+            public boolean visit(List<String> item) throws RuntimeException {
+                hasTripped.set(true);
+                assertEquals("anonymous assert F13DE1", 8, item.size());
+                return false;
+            }
+        });
+        assertTrue("anonymous assert 323FF5", hasTripped.get());
+    }
+
+    @Test
+    public void testBatchWrap() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
+        final Mutable<Boolean> hasTripped = Mutables.newMutable();
+        AbortingVisitor<List<Object>, RuntimeException> v = new AbortingVisitor<List<Object>, RuntimeException>() {
+            @Override
+            public boolean visit(List<Object> item) throws RuntimeException {
+                hasTripped.set(true);
+                assertEquals("anonymous assert 626F1C", 8, item.size());
+                return false;
+            }
+        };
+        AbortingVisitor<List<Long>, RuntimeException> wrap = AbortingVisitors.wrapBatching(v);
+        BatchingVisitableView.of(visitor).batchAccept(1000, wrap);
+
+        assertTrue("anonymous assert 755B51", hasTripped.get());
+    }
+
+    @Test
+    public void testBatchWrap2() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
+        final Mutable<Boolean> hasTripped = Mutables.newMutable();
+        AbortingVisitor<List<? extends Long>, RuntimeException> v = new AbortingVisitor<List<? extends Long>, RuntimeException>() {
+            @Override
+            public boolean visit(List<? extends Long> item) throws RuntimeException {
+                hasTripped.set(true);
+                assertEquals("anonymous assert 2BC193", 8, item.size());
+                return false;
+            }
+        };
+        AbortingVisitor<List<Long>, RuntimeException> wrap = AbortingVisitors.wrapBatching(v);
+        BatchingVisitableView.of(visitor).batchAccept(1000, wrap);
+
+        assertTrue("anonymous assert 380CE5", hasTripped.get());
+    }
+
+    @Test
+    public void testUnique() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 1L, 2L, 2L, 2L, 3L, 4L, 5L, 5L, 6L, 7L, 7L));
+        BatchingVisitableView<Long> v = BatchingVisitableView.of(visitor);
+        assertEquals("anonymous assert 139904", ImmutableList.of(0L, 1L, 2L, 3L), v.unique().limit(4).immutableCopy());
+    }
+
+    @Test
+    public void testLimit() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
+        BatchingVisitableView<Long> limited = BatchingVisitableView.of(visitor).limit(3);
+        ImmutableList<Long> copy = limited.immutableCopy();
+        assertEquals("anonymous assert 939C77", ImmutableList.of(0L, 1L, 2L), copy);
+        copy = BatchingVisitableView.of(visitor).limit(3).immutableCopy();
+        assertEquals("anonymous assert 67B112", ImmutableList.of(0L, 1L, 2L), copy);
+        copy = limited.immutableCopy();
+        assertEquals("anonymous assert BE4BE6", ImmutableList.of(0L, 1L, 2L), copy);
+        assertFalse("anonymous assert 38D61C", limited.batchAccept(1, AbortingVisitors.alwaysFalse()));
+        assertTrue("anonymous assert 70A3FC", limited.batchAccept(1, AbortingVisitors.alwaysTrue()));
+
+        assertTrue("anonymous assert 33212B", limited.batchAccept(2, AbortingVisitors.alwaysTrue()));
+        assertTrue("anonymous assert 8EF750", limited.batchAccept(3, AbortingVisitors.alwaysTrue()));
+
+        CountingVisitor<Long> c = new CountingVisitor<Long>();
+        assertTrue("anonymous assert F935C9", limited.batchAccept(2, AbortingVisitors.batching(c)));
+        assertEquals("anonymous assert 24BD1B", 3, c.count);
+        assertTrue("anonymous assert 15643D", limited.batchAccept(3, AbortingVisitors.batching(c)));
+        assertEquals("anonymous assert 97E616", 6, c.count);
+        assertTrue("anonymous assert 93B081", limited.batchAccept(4, AbortingVisitors.batching(c)));
+        assertEquals("anonymous assert 53317E", 9, c.count);
+        assertTrue("anonymous assert C44EC3", limited.skip(3).batchAccept(1, AbortingVisitors.alwaysFalse()));
+        LimitVisitor<Long> l = new LimitVisitor<Long>(3);
+        assertFalse("anonymous assert 94391F", limited.batchAccept(1, AbortingVisitors.batching(l)));
+        l = new LimitVisitor<Long>(4);
+        assertTrue("anonymous assert 1830FC", limited.batchAccept(1, AbortingVisitors.batching(l)));
+        l = new LimitVisitor<Long>(2);
+        assertFalse("anonymous assert 52C831", limited.batchAccept(1, AbortingVisitors.batching(l)));
+
+        assertFalse("anonymous assert 21BD70", limited.hintBatchSize(10).batchAccept(1, AbortingVisitors.alwaysFalse()));
+        assertTrue("anonymous assert 530244", limited.hintBatchSize(10).skip(3).batchAccept(1, AbortingVisitors.alwaysFalse()));
+
+        assertEquals("anonymous assert 22261C", 2, limited.limit(2).limit(4).size());
+        assertEquals("anonymous assert 860268", 2, limited.limit(4).limit(2).size());
+        assertEquals("anonymous assert 56B69B", 3, limited.limit(4).size());
+    }
+
+    @Test
+    public void testConcat() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
+        BatchingVisitableView<Long> limited = BatchingVisitableView.of(visitor).limit(3);
+        BatchingVisitableView<Long> concat = BatchingVisitables.concat(limited, visitor);
+        assertTrue("anonymous assert CED0ED", concat.batchAccept(2, AbortingVisitors.batching(AbortingVisitors.<Long>alwaysTrue())));
+    }
+
+    static class CountingVisitor<T> implements AbortingVisitor<T, RuntimeException> {
+        long count = 0;
+        @Override
+        public boolean visit(T item) throws RuntimeException {
+            count++;
+            return true;
+        }
+    }
+
+    static class LimitVisitor<T> implements AbortingVisitor<T, RuntimeException> {
+        final long limit;
+        long count = 0;
+
+        public LimitVisitor(long limit) {
+            this.limit = limit;
+        }
+
+        @Override
+        public boolean visit(T item) throws RuntimeException {
+            count++;
+            if (count >= limit) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    @Test
+    public void testAny() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
+        BatchingVisitableView<Long> v = BatchingVisitableView.of(visitor);
+        assertTrue("anonymous assert 447C52", v.any(Predicates.alwaysTrue()));
+        assertTrue("anonymous assert 6A41BA", v.all(Predicates.alwaysTrue()));
+
+        assertFalse("anonymous assert 8F527C", v.any(Predicates.alwaysFalse()));
+        assertFalse("anonymous assert 28FD17", v.all(Predicates.alwaysFalse()));
+    }
+
+    @Test
+    public void testAll() {
+        BatchingVisitable<Long> visitor = BatchingVisitables.emptyBatchingVisitable();
+        BatchingVisitableView<Long> v = BatchingVisitableView.of(visitor);
+        assertFalse("anonymous assert 94F1C3", v.any(Predicates.alwaysTrue()));
+        assertTrue("anonymous assert ED0ED7", v.all(Predicates.alwaysTrue()));
+
+        assertFalse("anonymous assert FDEDF7", v.any(Predicates.alwaysFalse()));
+        assertTrue("anonymous assert 01080C", v.all(Predicates.alwaysFalse()));
+    }
+
+    @Test
+    public void testHintPageSize() {
+        InfinateVisitable infinate = new InfinateVisitable();
+        BatchingVisitableView<Long> v = BatchingVisitableView.of(infinate);
+        long first = v.filter(new TakeEvery<Long>(100)).getFirst();
+        assertEquals("anonymous assert A16A34", 99L, first);
+        assertEquals("anonymous assert 55EE6D", 100L, infinate.count);
+
+        first = v.filter(new TakeEvery<Long>(100)).hintBatchSize(100).getFirst();
+        assertEquals("anonymous assert 709532", 199L, first);
+        assertEquals("anonymous assert D4A406", 200L, infinate.count);
+    }
+
+    static class InfinateVisitable extends AbstractBatchingVisitable<Long> {
+        long count = 0;
+        @Override
+        protected <K extends Exception> void batchAcceptSizeHint(int batchSizeHint,
+                ConsistentVisitor<Long, K> v)
+                throws K {
+            while (v.visitOne(count++)) { /* */ }
+        }
+    }
+
+    static class TakeEvery<T> implements Predicate<T> {
+        final long numToSkip;
+        long count = 0;
+
+        public TakeEvery(long numToSkip) {
+            this.numToSkip = numToSkip;
+        }
+
+        @Override
+        public boolean apply(@Nullable T input) {
+            return ++count % numToSkip == 0;
+        }
+    }
+
+    @Test
+    public void testSkip() {
+        BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
+        ImmutableList<Long> copy = BatchingVisitableView.of(visitor).skip(5).immutableCopy();
+        assertEquals("anonymous assert 82C94E", ImmutableList.of(5L, 6L, 7L), copy);
+    }
+
+    static class ListVisitor<T> extends AbstractBatchingVisitable<T> {
+        private final List<T> listToVisit;
+
+        public ListVisitor(List<T> list) {
+            this.listToVisit = list;
+        }
+
+        public static <T> BatchingVisitable<T> create(List<T> list) {
+            return new ListVisitor<T>(list);
+        }
+
+        @Override
+        protected <K extends Exception> void batchAcceptSizeHint(
+                int batchSize,
+                ConsistentVisitor<T, K> v) throws K {
+            int actualBatchSize = Math.max(2, batchSize/2);
+
+            for (List<T> subList : Lists.partition(listToVisit, actualBatchSize)) {
+                boolean moreToVisit = v.visit(subList);
+
+                if (!moreToVisit) {
+                    return;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testVisitWhile() {
+        List<Long> longList = Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L);
+        BatchingVisitable<Long> visitable = ListVisitor.create(longList);
+        BatchingVisitableView<Long> view = BatchingVisitables.visitWhile(
+                BatchingVisitableView.of(visitable), (input) -> input.longValue() < 5L);
+        assertEquals("anonymous assert 7B93D7", 5L, view.size());
+        assertEquals("anonymous assert 5FCD36", 0L, view.getFirst().longValue());
+        assertEquals("anonymous assert 0280B1", 4L, view.getLast().longValue());
+        assertTrue("anonymous assert 03417A", view.immutableCopy().containsAll(ImmutableSet.of(0L, 1L, 2L, 3L, 4L)));
+
+        visitable = ListVisitor.create(Lists.reverse(longList));
+        view = BatchingVisitables.visitWhile(
+                BatchingVisitableView.of(visitable), (input) -> input.longValue() >= 5L);
+        assertEquals("anonymous assert FFBC60", 5L, view.size());
+        assertEquals("anonymous assert E46C52", 9L, view.getFirst().longValue());
+        assertEquals("anonymous assert 8D6CA6", 5L, view.getLast().longValue());
+        assertTrue("anonymous assert 165D8C", view.immutableCopy().containsAll(ImmutableSet.of(5L, 6L, 7L, 8L, 9L)));
+    }
+
+    @Test
+    public void testFlatten() {
+        List<String> firstChars = Lists.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            firstChars.add("" + (char) ('a' + i));
+        }
+        BatchingVisitable<String> outerVisitable = BatchingVisitableFromIterable.create(firstChars);
+        BatchingVisitableView<BatchingVisitable<String>> v = BatchingVisitables.transform(outerVisitable,
+                (prefix) -> {
+                    List<String> innerChars = Lists.newArrayList();
+                    for (int i = 0; i < 10; i++) {
+                        innerChars.add(prefix + (char) ('0' + i));
+                    }
+                    return BatchingVisitableFromIterable.create(innerChars);
+                });
+        UnmodifiableIterator<String> iter = BatchingVisitables.flatten(7, v).immutableCopy().iterator();
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+                assertEquals("anonymous assert E5D518", "" + (char) ('a' + i) + (char) ('0' + j), iter.next());
+            }
+        }
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
@@ -209,10 +209,7 @@ public class BatchingVisitablesTest {
         BatchingVisitableView<Long> limited = BatchingVisitableView.of(visitor).limit(3);
         ImmutableList<Long> copy = limited.immutableCopy();
         assertEquals("anonymous assert 939C77", ImmutableList.of(0L, 1L, 2L), copy);
-        copy = BatchingVisitableView.of(visitor).limit(3).immutableCopy();
-        assertEquals("anonymous assert 67B112", ImmutableList.of(0L, 1L, 2L), copy);
-        copy = limited.immutableCopy();
-        assertEquals("anonymous assert BE4BE6", ImmutableList.of(0L, 1L, 2L), copy);
+
         assertFalse("anonymous assert 38D61C", limited.batchAccept(1, AbortingVisitors.alwaysFalse()));
         assertTrue("anonymous assert 70A3FC", limited.batchAccept(1, AbortingVisitors.alwaysTrue()));
 

--- a/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/base/BatchingVisitablesTest.java
@@ -277,7 +277,7 @@ public class BatchingVisitablesTest {
     }
 
     @Test
-    public void testAny() {
+    public void testAnyAndAllForNonEmptyLists() {
         BatchingVisitable<Long> visitor = ListVisitor.create(Lists.newArrayList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L));
         BatchingVisitableView<Long> bv = BatchingVisitableView.of(visitor);
         assertTrue("anonymous assert 447C52", bv.any(Predicates.alwaysTrue()));
@@ -288,7 +288,7 @@ public class BatchingVisitablesTest {
     }
 
     @Test
-    public void testAll() {
+    public void testAnyAndAllForEmptyLists() {
         BatchingVisitable<Long> visitor = BatchingVisitables.emptyBatchingVisitable();
         BatchingVisitableView<Long> bv = BatchingVisitableView.of(visitor);
         assertFalse("anonymous assert 94F1C3", bv.any(Predicates.alwaysTrue()));

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,6 +62,12 @@ develop
            This was necessary for compatibility with an internal log-ingestion tool.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2324>`__)
 
+    *    - |improved|
+         - ``BatchingVisitableView`` methods ``immutableCopy``, ``immutableSetCopy``, and ``copyInto`` use the default batch hint of 1000, instead of a batch hint of 100,000.
+           We previously defaulted to the higher value because the result set was assumed to be small; however, in practice this has turned out not to be the case, leading to timeouts and OOMs in the field.
+           To override the batch hint, wrap the copy call with ``hintPageSize``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2347>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,7 +65,8 @@ develop
     *    - |improved|
          - ``BatchingVisitableView`` methods ``immutableCopy``, ``immutableSetCopy``, and ``copyInto`` use the default batch hint of 1000, instead of a batch hint of 100,000.
            We previously defaulted to the higher value because the result set was assumed to be small; however, in practice this has turned out not to be the case, leading to timeouts and OOMs in the field.
-           To override the batch hint, wrap the copy call with ``hintPageSize``.
+           To use a custom batch hint, set the ``batchHint`` property for your ``RangeRequest``.
+           Alternatively, call ``BatchingVisitableView.hintBatchSize(int)`` before making a copy.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2347>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>


### PR DESCRIPTION
**Goals (and why)**: Fixes #2321.

**Implementation Description (bullets)**:
* Ported tests over from our large internal product
* Used `DEFAULT_BATCH_SIZE` instead of `KEEP_ALL_BATCH_SIZE`

**Concerns (what feedback would you like?)**:
* The release note recommends to use `hintPageSize` to override the batch hint, assuming that [Jeff's comment](https://github.com/palantir/atlasdb/issues/2321#issuecomment-327594997) was accurate. Do we need to document how to do this?
* The tests I ported over leave a lot to be desired - should we clean these up now?

**Where should we start reviewing?**: BatchingVisitablesView

**Priority (whenever / two weeks / yesterday)**: This week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2347)
<!-- Reviewable:end -->
