### PR TITLE
Wait for non-default clients in TimeLock integ tests

### DIFF
--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -30,6 +31,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -47,6 +49,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     private static final String CLIENT_1 = "test";
     private static final String CLIENT_2 = "test2";
     private static final String CLIENT_3 = "test3";
+    private static final List<String> CLIENTS = ImmutableList.of(CLIENT_1, CLIENT_2, CLIENT_3);
 
     private static final TestableTimelockCluster CLUSTER = new TestableTimelockCluster(
             "https://localhost",
@@ -70,12 +73,12 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
 
     @BeforeClass
     public static void waitForClusterToStabilize() {
-        CLUSTER.waitUntilLeaderIsElected();
+        CLUSTER.waitUntilReadyToServeClients(CLIENTS);
     }
 
     @Before
     public void bringAllNodesOnline() {
-        CLUSTER.waitUntillAllSeversAreOnlineAndLeaderIsElected();
+        CLUSTER.waitUntilAllServersOnlineAndReadyToServeClients(CLIENTS);
     }
 
     @Test

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -81,7 +81,9 @@ public class PaxosTimeLockServerIntegrationTest {
     private static final String CLIENT_1 = "test";
     private static final String CLIENT_2 = "test2";
     private static final String CLIENT_3 = "test3";
-    private static final List<String> CLIENTS = ImmutableList.of(CLIENT_1, CLIENT_2, CLIENT_3);
+    private static final String LEARNER = "learner";
+    private static final String ACCEPTOR = "acceptor";
+    private static final List<String> CLIENTS = ImmutableList.of(CLIENT_1, CLIENT_2, CLIENT_3, LEARNER, ACCEPTOR);
     private static final String INVALID_CLIENT = "test2\b";
 
     private static final int MAX_SERVER_THREADS = 100;
@@ -133,8 +135,7 @@ public class PaxosTimeLockServerIntegrationTest {
                 .until(() -> {
                     try {
                         // Returns true only if this node is ready to serve timestamps and locks on all clients.
-                        CLIENTS.forEach(client -> getTimestampService(client).getFreshTimestamp());
-                        CLIENTS.forEach(client -> getLockService(client).currentTimeMillis());
+                        CLIENTS.forEach(client -> getTimelockService(client).getFreshTimestamp());
                         return leader.ping();
                     } catch (Throwable t) {
                         return false;
@@ -394,8 +395,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void supportsClientNamesMatchingPaxosRoles() throws InterruptedException {
-        getTimestampService("learner").getFreshTimestamp();
-        getTimestampService("acceptor").getFreshTimestamp();
+        getTimestampService(LEARNER).getFreshTimestamp();
+        getTimestampService(ACCEPTOR).getFreshTimestamp();
     }
 
     @Test

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -136,6 +136,7 @@ public class PaxosTimeLockServerIntegrationTest {
                     try {
                         // Returns true only if this node is ready to serve timestamps and locks on all clients.
                         CLIENTS.forEach(client -> getTimelockService(client).getFreshTimestamp());
+                        CLIENTS.forEach(client -> getTimelockService(client).currentTimeMillis());
                         return leader.ping();
                     } catch (Throwable t) {
                         return false;

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -75,15 +75,12 @@ public class TestableTimelockCluster {
     }
 
     public void waitUntilReadyToServeClients(List<String> clients) {
-        Set<TimelockService> timelockServices = clients.stream()
-                .map(this::timelockServiceForClient)
-                .collect(Collectors.toSet());
         Awaitility.await()
                 .atMost(30, TimeUnit.SECONDS)
                 .pollInterval(500, TimeUnit.MILLISECONDS)
                 .until(() -> {
                     try {
-                        timelockServices.forEach(TimelockService::getFreshTimestamp);
+                        clients.forEach(client -> timelockServiceForClient(client).getFreshTimestamp());
                         return true;
                     } catch (Throwable t) {
                         return false;

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.jayway.awaitility.Awaitility;
@@ -70,13 +71,19 @@ public class TestableTimelockCluster {
     }
 
     public void waitUntilLeaderIsElected() {
-        TimestampService timestampService = timestampService();
+        waitUntilReadyToServeClients(ImmutableList.of(defaultClient));
+    }
+
+    public void waitUntilReadyToServeClients(List<String> clients) {
+        Set<TimelockService> timelockServices = clients.stream()
+                .map(this::timelockServiceForClient)
+                .collect(Collectors.toSet());
         Awaitility.await()
                 .atMost(30, TimeUnit.SECONDS)
                 .pollInterval(500, TimeUnit.MILLISECONDS)
                 .until(() -> {
                     try {
-                        timestampService.getFreshTimestamp();
+                        timelockServices.forEach(TimelockService::getFreshTimestamp);
                         return true;
                     } catch (Throwable t) {
                         return false;
@@ -84,9 +91,9 @@ public class TestableTimelockCluster {
                 });
     }
 
-    public void waitUntillAllSeversAreOnlineAndLeaderIsElected() {
+    public void waitUntilAllServersOnlineAndReadyToServeClients(List<String> clients) {
         servers.forEach(TestableTimelockServer::start);
-        waitUntilLeaderIsElected();
+        waitUntilReadyToServeClients(clients);
     }
 
     public TestableTimelockServer currentLeader() {


### PR DESCRIPTION
**Goals (and why)**:
- Reduce the flakiness of the build.

Slack copypaste:
This is probably an offshoot of https://github.com/palantir/atlasdb/pull/2252, sometimes it takes a bit of time for the timelock leader to settle
(because previously we would start leader election for those namespaces on startup)
but now we only kick it off on the first time a client requests a timestamp

**Implementation Description (bullets)**:
- Wait for clients other than the default client and/or for the leader to be happy in TestableTimelockCluster
- Add `learner` and `acceptor` to be explicit clients we wait for before declaring that the cluster is ready

**Concerns (what feedback would you like?)**:
- Does this actually solve the problem / reduce the incidence of flakes?

**Where should we start reviewing?**: `TestableTimelockCluster`

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2350)
<!-- Reviewable:end -->
