### PR TITLE
[Startup Independence] Part 4: AsyncInitializer thread-safety fix and unit tests

### DIFF
--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -16,4 +16,7 @@ dependencies {
     testCompile group: "org.jmock", name: "jmock", version: libVersions.jmock
     testCompile group: 'org.hamcrest', name: 'hamcrest-core'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library'
+    testCompile group: 'org.mockito', name: 'mockito-core'
+    testCompile group: 'org.assertj', name: 'assertj-core'
+    testCompile group: "com.jayway.awaitility", name: "awaitility"
 }

--- a/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.async.initializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.jayway.awaitility.Awaitility;
+
+public class AsyncInitializerTest {
+
+    public static final int WAIT_TIME_MILLIS = 100;
+    public static final int ASYNC_INIT_DELAY = WAIT_TIME_MILLIS / 10;
+
+    static class AlwaysFailingInitializer implements AsyncInitializer {
+        volatile int initializationAttempts = 0;
+
+        @Override
+        public int millisToNextAttempt() {
+            return ASYNC_INIT_DELAY;
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return false;
+        }
+
+        @Override
+        public void tryInitialize() {
+            ++initializationAttempts;
+            throw new RuntimeException("Failed initializing");
+        }
+
+        @Override
+        public void cleanUpOnInitFailure() {
+            // noop
+        }
+    }
+
+    @Test
+    public void synchronousInitializationPropagatesExceptionsAndDoesNotRetry() throws InterruptedException {
+        AlwaysFailingInitializer initializer = new AlwaysFailingInitializer();
+        assertThatThrownBy(() -> initializer.initialize(false))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Failed initializing");
+        Thread.sleep(WAIT_TIME_MILLIS);
+        assertThat(initializer.initializationAttempts).isEqualTo(1);
+    }
+
+    @Test
+    public void asyncInitializationCatchesExceptionAndRetries() {
+        AlwaysFailingInitializer initializer = new AlwaysFailingInitializer();
+        initializer.initialize(true);
+        Awaitility.await().pollInterval(ASYNC_INIT_DELAY, TimeUnit.MILLISECONDS)
+                .atMost(WAIT_TIME_MILLIS, TimeUnit.MILLISECONDS)
+                .until(() -> initializer.initializationAttempts == 5);
+    }
+
+    @Test
+    public void initializationIsNoopIfAlreadyInitialized() {
+        AlwaysFailingInitializer initializer = new AlwaysFailingInitializer() {
+            @Override
+            public boolean isInitialized() {
+                return true;
+            }
+        };
+        initializer.initialize(true);
+        assertThat(initializer.initializationAttempts).isEqualTo(0);
+        initializer.initialize(false);
+        assertThat(initializer.initializationAttempts).isEqualTo(0);
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
@@ -27,7 +27,7 @@ import com.jayway.awaitility.Awaitility;
 
 public class AsyncInitializerTest {
 
-    public static final int WAIT_TIME_MILLIS = 100;
+    public static final int WAIT_TIME_MILLIS = 500;
     public static final int ASYNC_INIT_DELAY = WAIT_TIME_MILLIS / 10;
 
     static class AlwaysFailingInitializer implements AsyncInitializer {


### PR DESCRIPTION
**Goals (and why)**:
Add unit tests and fix threadsafety issue where scheduled threads were not synchronized while initializing.

**Implementation Description (bullets)**:
Now the body of the task is synchronized, so it is impossible for two threads to simultaneously initialize. It is still possible for someone to manually call tryInitialize, but there is no reasonable way around that.
Added a method that controls the scheduler delay to make tests faster. Maybe it makes sense to have it in general to allow for more fine-grained control if desired.

**Concerns (what feedback would you like?)**:
Does the thread-safety make sense now?

**Where should we start reviewing?**:
It's small

**Priority (whenever / two weeks / yesterday)**:
Low priority

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2356)
<!-- Reviewable:end -->
