### PR TITLE
add logging to cql executor

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
@@ -122,15 +122,15 @@ public class CqlExecutor {
         return query.executeAndGetCells(row);
     }
 
-    private UnsafeArg<String> key(byte[] row) {
+    private Arg<String> key(byte[] row) {
         return UnsafeArg.of("key", CassandraKeyValueServices.encodeAsHex(row));
     }
-    
-    private UnsafeArg<String> column1(byte[] column) {
+
+    private Arg<String> column1(byte[] column) {
         return UnsafeArg.of("column1", CassandraKeyValueServices.encodeAsHex(column));
     }
 
-    private SafeArg<Long> column2(long invertedTimestamp) {
+    private Arg<Long> column2(long invertedTimestamp) {
         return SafeArg.of("column2", invertedTimestamp);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
@@ -35,9 +35,9 @@ import com.google.common.base.Stopwatch;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.atlasdb.logging.KvsProfilingLogger;
 import com.palantir.atlasdb.logging.LoggingArgs;
+import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
@@ -80,8 +80,8 @@ public class CqlExecutor {
      * @param column the column name
      * @param maxTimestampExclusive the maximum timestamp, exclusive
      * @param limit the maximum number of results to return.
-     * @return up to <code>limit</code> cells that exactly match the row and column name,
-     * and have a timestamp less than <code>maxTimestampExclusive</code>
+     * @return up to <code>limit</code> cells that exactly match the row and column name, and have a timestamp less than
+     * <code>maxTimestampExclusive</code>
      */
     List<CellWithTimestamp> getTimestampsForRowAndColumn(
             TableReference tableRef,
@@ -139,7 +139,7 @@ public class CqlExecutor {
     }
 
     private Arg<String> quotedTableName(TableReference tableRef) {
-        String tableNameWithQuotes = "\"" + CassandraKeyValueService.internalTableName(tableRef) + "\"";
+        String tableNameWithQuotes = "\"" + CassandraKeyValueServiceImpl.internalTableName(tableRef) + "\"";
         return LoggingArgs.customTableName(tableRef, tableNameWithQuotes);
     }
 
@@ -213,21 +213,21 @@ public class CqlExecutor {
 
         private CqlResult executeQueryOnHost(String query, InetSocketAddress host) {
             try {
-                return clientPool.runWithRetryOnHost(host, getCqlFunction(query));
+                return clientPool.runWithRetryOnHost(host, createCqlFunction(query));
             } catch (TException e) {
                 throw Throwables.throwUncheckedException(e);
             }
         }
-        
-        private FunctionCheckedException<Cassandra.Client, CqlResult, TException> getCqlFunction(String query) {
+
+        private FunctionCheckedException<Cassandra.Client, CqlResult, TException> createCqlFunction(String query) {
             ByteBuffer queryBytes = ByteBuffer.wrap(query.getBytes(StandardCharsets.UTF_8));
-            
+
             return new FunctionCheckedException<Cassandra.Client, CqlResult, TException>() {
                 @Override
                 public CqlResult apply(Cassandra.Client client) throws TException {
                     return client.execute_cql3_query(queryBytes, Compression.NONE, consistency);
                 }
-                
+
                 @Override
                 public String toString() {
                     return query;
@@ -235,5 +235,5 @@ public class CqlExecutor {
             };
         }
     }
-    
+
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.cassandra.thrift.CqlResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.logging.KvsProfilingLogger;
+
+public class CqlExecutorTest {
+
+    private final CqlExecutor.QueryExecutor queryExecutor = mock(CqlExecutor.QueryExecutor.class);
+    private final CqlExecutor executor = new CqlExecutor(queryExecutor);
+
+    private long queryDelayMillis = 0L;
+
+    private static final TableReference TABLE_REF = TableReference.create(Namespace.create("foo"), "bar");
+    private static final byte[] ROW = {0x01, 0x02};
+    private static final byte[] COLUMN = {0x03, 0x04};
+    private static final long TIMESTAMP = 123L;
+    private static final int LIMIT = 100;
+
+    @Before
+    public void before() {
+        CqlResult result = new CqlResult();
+        result.setRows(ImmutableList.of());
+        when(queryExecutor.execute(any(), any())).thenAnswer(invocation -> {
+            Uninterruptibles.sleepUninterruptibly(queryDelayMillis, TimeUnit.MILLISECONDS);
+            return result;
+        });
+    }
+
+    @Test
+    public void getColumnsForRow() {
+        String expected = "SELECT column1, column2 FROM \"foo__bar\" WHERE key = 0x0102 LIMIT 100;";
+
+        executor.getColumnsForRow(TABLE_REF, ROW, LIMIT);
+
+        verify(queryExecutor).execute(ROW, expected);
+    }
+
+    @Test
+    public void getTimestampsForRowAndColumn() {
+        String expected = "SELECT column1, column2 FROM \"foo__bar\" WHERE key = 0x0102 AND column1 = 0x0304 "
+                + "AND column2 > -124 LIMIT 100;";
+
+        executor.getTimestampsForRowAndColumn(TABLE_REF, ROW, COLUMN, TIMESTAMP, LIMIT);
+
+        verify(queryExecutor).execute(ROW, expected);
+    }
+
+    @Test
+    public void getNextColumnsForRow() {
+        String expected = "SELECT column1, column2 FROM \"foo__bar\" WHERE key = 0x0102 AND column1 > 0x0304 "
+                + "LIMIT 100;";
+
+        executor.getNextColumnsForRow(TABLE_REF, ROW, COLUMN, LIMIT);
+
+        verify(queryExecutor).execute(ROW, expected);
+    }
+
+    // this test just verifies that nothing blows up when logging a slow query, and the output can be verified manually
+    @Test
+    public void logsSlowResult() {
+        queryDelayMillis = 10;
+        KvsProfilingLogger.setSlowLogThresholdMillis(1);
+
+        executor.getColumnsForRow(TABLE_REF, ROW, LIMIT);
+        executor.getTimestampsForRowAndColumn(TABLE_REF, ROW, COLUMN, TIMESTAMP, LIMIT);
+        executor.getNextColumnsForRow(TABLE_REF, ROW, COLUMN, LIMIT);
+    }
+
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -20,16 +20,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -50,40 +46,37 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.KvsProfilingLogger;
+import com.palantir.atlasdb.logging.KvsProfilingLogger.LoggingFunction;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 
 public final class ProfilingKeyValueService implements KeyValueService {
-    @VisibleForTesting
-    static final String SLOW_LOGGER_NAME = "kvs-slow-log";
 
-    private static final Logger slowlogger = LoggerFactory.getLogger(SLOW_LOGGER_NAME);
     private static final Logger log = LoggerFactory.getLogger(ProfilingKeyValueService.class);
 
     private final KeyValueService delegate;
-    private final Predicate<Stopwatch> slowLogPredicate;
+
+    public static ProfilingKeyValueService create(KeyValueService delegate) {
+        return new ProfilingKeyValueService(delegate);
+    }
 
     /**
-     * @deprecated in favour of ProfilingKeyValueService#create(KeyValueService delegate, long slowLogThresholdMillis).
+     * @deprecated in favour of ProfilingKeyValueService#create(KeyValueService delegate). Use
+     * {@link KvsProfilingLogger#setSlowLogThresholdMillis(long)} to configure the slow logging threshold.
      * @param delegate the KeyValueService to be profiled
      * Defaults to using a 1 second slowlog.
      * @return ProfilingKeyValueService that profiles the delegate KeyValueService
      */
     @Deprecated
-    public static ProfilingKeyValueService create(KeyValueService delegate) {
-        return new ProfilingKeyValueService(delegate, 1000);
-    }
-
     public static ProfilingKeyValueService create(KeyValueService delegate, long slowLogThresholdMillis) {
-        return new ProfilingKeyValueService(delegate, slowLogThresholdMillis);
+        return create(delegate);
     }
 
-    @FunctionalInterface
-    interface LoggingFunction {
-        void log(String fmt, Object... args);
+    private ProfilingKeyValueService(KeyValueService delegate) {
+        this.delegate = delegate;
     }
-
 
     private static BiConsumer<LoggingFunction, Stopwatch> logCellsAndSize(String method,
             TableReference tableRef,
@@ -138,102 +131,6 @@ public final class ProfilingKeyValueService implements KeyValueService {
         };
     }
 
-
-    private void maybeLog(Runnable runnable, BiConsumer<LoggingFunction, Stopwatch> logger) {
-        maybeLog(() -> {
-            runnable.run();
-            return null;
-        }, logger);
-    }
-
-    private <T> T maybeLog(Supplier<T> action, BiConsumer<LoggingFunction, Stopwatch> logger) {
-        return maybeLog(action, logger, (loggingFunction, result) -> { });
-    }
-
-    private static class Monitor<R> {
-        private final Stopwatch stopwatch;
-        private final BiConsumer<LoggingFunction, Stopwatch> primaryLogger;
-        private final BiConsumer<LoggingFunction, R> additionalLoggerWithAccessToResult;
-        private final Predicate<Stopwatch> slowLogPredicate;
-
-        private R result;
-        private Exception exception;
-
-        private Monitor(Stopwatch stopwatch,
-                BiConsumer<LoggingFunction, Stopwatch> primaryLogger,
-                BiConsumer<LoggingFunction, R> additionalLoggerWithAccessToResult,
-                Predicate<Stopwatch> slowLogPredicate) {
-            this.stopwatch = stopwatch;
-            this.primaryLogger = primaryLogger;
-            this.additionalLoggerWithAccessToResult = additionalLoggerWithAccessToResult;
-            this.slowLogPredicate = slowLogPredicate;
-        }
-
-        static <V> Monitor<V> createMonitor(BiConsumer<LoggingFunction,
-                Stopwatch> primaryLogger,
-                BiConsumer<LoggingFunction, V> additionalLoggerWithAccessToResult,
-                Predicate<Stopwatch> slowLogPredicate) {
-            return new Monitor<>(Stopwatch.createStarted(),
-                    primaryLogger,
-                    additionalLoggerWithAccessToResult,
-                    slowLogPredicate);
-        }
-
-        void registerResult(R res) {
-            this.result = res;
-        }
-
-        void registerException(Exception ex) {
-            this.exception = ex;
-        }
-
-        void log() {
-            stopwatch.stop();
-            Consumer<LoggingFunction> logger = (loggingMethod) -> {
-                primaryLogger.accept(loggingMethod, stopwatch);
-                if (result != null) {
-                    additionalLoggerWithAccessToResult.accept(loggingMethod, result);
-                } else if (exception != null) {
-                    loggingMethod.log("This operation has thrown an exception {}", exception);
-                }
-            };
-
-            if (log.isTraceEnabled()) {
-                logger.accept(log::trace);
-            }
-            if (slowlogger.isWarnEnabled() && slowLogPredicate.test(stopwatch)) {
-                logger.accept(slowlogger::warn);
-            }
-        }
-    }
-
-    private <T> T maybeLog(Supplier<T> action, BiConsumer<LoggingFunction, Stopwatch> primaryLogger,
-            BiConsumer<LoggingFunction, T> additonalLoggerWithAccessToResult) {
-        if (log.isTraceEnabled() || slowlogger.isWarnEnabled()) {
-            Monitor<T> monitor = Monitor.createMonitor(
-                    primaryLogger,
-                    additonalLoggerWithAccessToResult,
-                    slowLogPredicate);
-            try {
-                T res = action.get();
-                monitor.registerResult(res);
-                return res;
-            } catch (Exception ex) {
-                monitor.registerException(ex);
-                throw ex;
-            } finally {
-                monitor.log();
-            }
-        } else {
-            return action.get();
-        }
-    }
-
-    private ProfilingKeyValueService(KeyValueService delegate, long slowLogThresholdMillis) {
-        this.delegate = delegate;
-        slowLogPredicate = stopwatch -> stopwatch.elapsed(TimeUnit.MILLISECONDS) > slowLogThresholdMillis;
-    }
-
     @Override
     public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
         maybeLog(() -> delegate.addGarbageCollectionSentinelValues(tableRef, cells),
@@ -283,7 +180,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
 
     @Override
     public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
-        return maybeLog(() -> delegate.get(tableRef, timestampByCell),
+        return KvsProfilingLogger.maybeLog(() -> delegate.get(tableRef, timestampByCell),
                 (logger, stopwatch) ->
                         logger.log("Call to KVS.get on table {}, requesting {} cells took {} ms ",
                                 LoggingArgs.tableRef(tableRef),
@@ -358,7 +255,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
     @Override
     public Map<Cell, Value> getRows(TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection,
             long timestamp) {
-        return maybeLog(() -> delegate.getRows(tableRef, rows, columnSelection, timestamp),
+        return KvsProfilingLogger.maybeLog(() -> delegate.getRows(tableRef, rows, columnSelection, timestamp),
                 (logger, stopwatch) ->
                         logger.log(
                                 "Call to KVS.getRows on table {} requesting {} columns from {} rows took {} ms ",
@@ -488,6 +385,14 @@ public final class ProfilingKeyValueService implements KeyValueService {
                         LoggingArgs.columnRangeSelection(tableRef, columnRangeSelection),
                         LoggingArgs.batchHint(cellBatchHint),
                         LoggingArgs.durationMillis(stopwatch)));
+    }
+
+    private  <T> T maybeLog(Supplier<T> action, BiConsumer<LoggingFunction, Stopwatch> logger) {
+        return KvsProfilingLogger.maybeLog(action, logger);
+    }
+
+    private void maybeLog(Runnable runnable, BiConsumer<LoggingFunction, Stopwatch> logger) {
+        KvsProfilingLogger.maybeLog(runnable, logger);
     }
 
     private static <T> long byteSize(Map<Cell, T> values) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -71,6 +71,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
      */
     @Deprecated
     public static ProfilingKeyValueService create(KeyValueService delegate, long slowLogThresholdMillis) {
+        KvsProfilingLogger.setSlowLogThresholdMillis(slowLogThresholdMillis);
         return create(delegate);
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/KvsProfilingLogger.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/KvsProfilingLogger.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.logging;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Stopwatch;
+
+public class KvsProfilingLogger {
+
+    public static final String SLOW_LOGGER_NAME = "kvs-slow-log";
+
+    private static final Logger slowlogger = LoggerFactory.getLogger(SLOW_LOGGER_NAME);
+    private static final Logger log = LoggerFactory.getLogger(KvsProfilingLogger.class);
+
+    public static final int DEFAULT_THRESHOLD_MILLIS = 1000;
+    private static volatile Predicate<Stopwatch> slowLogPredicate = createLogPredicateForThresholdMillis(
+            DEFAULT_THRESHOLD_MILLIS);
+
+    @FunctionalInterface
+    public interface LoggingFunction {
+        void log(String fmt, Object... args);
+    }
+
+    /**
+     * Sets the minimum duration in millis that a query must take in order to be logged. Defaults to 1000ms.
+     */
+    public static void setSlowLogThresholdMillis(long thresholdMillis) {
+        slowLogPredicate = createLogPredicateForThresholdMillis(thresholdMillis);
+    }
+
+    public static <T> T maybeLog(Supplier<T> action, BiConsumer<LoggingFunction, Stopwatch> logger) {
+        return maybeLog(action, logger, (loggingFunction, result) -> { });
+    }
+
+    public static void maybeLog(Runnable runnable, BiConsumer<LoggingFunction, Stopwatch> logger) {
+        maybeLog(() -> {
+            runnable.run();
+            return null;
+        }, logger);
+    }
+
+    public static  <T> T maybeLog(Supplier<T> action, BiConsumer<LoggingFunction, Stopwatch> primaryLogger,
+            BiConsumer<LoggingFunction, T> additonalLoggerWithAccessToResult) {
+        if (log.isTraceEnabled() || slowlogger.isWarnEnabled()) {
+            Monitor<T> monitor = Monitor.createMonitor(
+                    primaryLogger,
+                    additonalLoggerWithAccessToResult,
+                    slowLogPredicate);
+            try {
+                T res = action.get();
+                monitor.registerResult(res);
+                return res;
+            } catch (Exception ex) {
+                monitor.registerException(ex);
+                throw ex;
+            } finally {
+                monitor.log();
+            }
+        } else {
+            return action.get();
+        }
+    }
+
+    private static class Monitor<R> {
+        private final Stopwatch stopwatch;
+        private final BiConsumer<LoggingFunction, Stopwatch> primaryLogger;
+        private final BiConsumer<LoggingFunction, R> additionalLoggerWithAccessToResult;
+        private final Predicate<Stopwatch> slowLogPredicate;
+
+        private R result;
+        private Exception exception;
+
+        private Monitor(Stopwatch stopwatch,
+                BiConsumer<LoggingFunction, Stopwatch> primaryLogger,
+                BiConsumer<LoggingFunction, R> additionalLoggerWithAccessToResult,
+                Predicate<Stopwatch> slowLogPredicate) {
+            this.stopwatch = stopwatch;
+            this.primaryLogger = primaryLogger;
+            this.additionalLoggerWithAccessToResult = additionalLoggerWithAccessToResult;
+            this.slowLogPredicate = slowLogPredicate;
+        }
+
+        static <V> Monitor<V> createMonitor(BiConsumer<LoggingFunction,
+                Stopwatch> primaryLogger,
+                BiConsumer<LoggingFunction, V> additionalLoggerWithAccessToResult,
+                Predicate<Stopwatch> slowLogPredicate) {
+            return new Monitor<>(Stopwatch.createStarted(),
+                    primaryLogger,
+                    additionalLoggerWithAccessToResult,
+                    slowLogPredicate);
+        }
+
+        void registerResult(R res) {
+            this.result = res;
+        }
+
+        void registerException(Exception ex) {
+            this.exception = ex;
+        }
+
+        void log() {
+            stopwatch.stop();
+            Consumer<LoggingFunction> logger = (loggingMethod) -> {
+                primaryLogger.accept(loggingMethod, stopwatch);
+                if (result != null) {
+                    additionalLoggerWithAccessToResult.accept(loggingMethod, result);
+                } else if (exception != null) {
+                    loggingMethod.log("This operation has thrown an exception {}", exception);
+                }
+            };
+
+            if (log.isTraceEnabled()) {
+                logger.accept(log::trace);
+            }
+            if (slowlogger.isWarnEnabled() && slowLogPredicate.test(stopwatch)) {
+                logger.accept(slowlogger::warn);
+            }
+        }
+    }
+
+    private static Predicate<Stopwatch> createLogPredicateForThresholdMillis(long thresholdMillis) {
+        return stopwatch -> stopwatch.elapsed(TimeUnit.MILLISECONDS) > thresholdMillis;
+    }
+
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -64,6 +64,10 @@ public final class LoggingArgs {
         return getArg(argName, tableReference, logArbitrator.isTableReferenceSafe(tableReference));
     }
 
+    public static Arg<String> customTableName(TableReference tableReference, String tableName) {
+        return getArg("tableName", tableName, logArbitrator.isTableReferenceSafe(tableReference));
+    }
+
     public static Arg<String> rowComponent(String argName, TableReference tableReference, String rowComponentName) {
         return getArg(argName,
                 rowComponentName,

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueServiceTest.java
@@ -94,7 +94,7 @@ public class ProfilingKeyValueServiceTest {
     @Before
     public void before() throws Exception {
         delegate = mock(KeyValueService.class);
-        kvs = ProfilingKeyValueService.create(delegate, 1000);
+        kvs = ProfilingKeyValueService.create(delegate);
     }
 
     @After

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueServiceTest.java
@@ -40,6 +40,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.KvsProfilingLogger;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -66,7 +67,7 @@ public class ProfilingKeyValueServiceTest {
         @Override
         public boolean matches(final Object argument) {
             LoggingEvent ev = (LoggingEvent) argument;
-            return ev.getLoggerName() == ProfilingKeyValueService.SLOW_LOGGER_NAME
+            return ev.getLoggerName() == KvsProfilingLogger.SLOW_LOGGER_NAME
                     && ev.getLevel() == Level.WARN;
         }
     });
@@ -75,7 +76,7 @@ public class ProfilingKeyValueServiceTest {
         @Override
         public boolean matches(final Object argument) {
             LoggingEvent ev = (LoggingEvent) argument;
-            return ev.getLoggerName() == LoggerFactory.getLogger(ProfilingKeyValueService.class).getName()
+            return ev.getLoggerName() == LoggerFactory.getLogger(KvsProfilingLogger.class).getName()
                     && ev.getLevel() == Level.TRACE;
         }
     });

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -58,6 +58,8 @@ import com.palantir.atlasdb.keyvalue.impl.ProfilingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.ValidatingQueryRewritingKeyValueService;
+import com.palantir.atlasdb.logging.KvsProfilingLogger;
+import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 import com.palantir.atlasdb.persistentlock.CheckAndSetExceptionMapper;
 import com.palantir.atlasdb.persistentlock.KvsBackedPersistentLockService;
@@ -230,7 +232,10 @@ public final class TransactionManagers {
                 atlasFactory::getTimestampService,
                 atlasFactory.getTimestampStoreInvalidator(),
                 userAgent);
-        KeyValueService kvs = ProfilingKeyValueService.create(rawKvs, config.getKvsSlowLogThresholdMillis());
+
+        KvsProfilingLogger.setSlowLogThresholdMillis(config.getKvsSlowLogThresholdMillis());
+        KeyValueService kvs = ProfilingKeyValueService.create(rawKvs);
+
         kvs = SweepStatsKeyValueService.create(kvs,
                 new TimelockTimestampServiceAdapter(lockAndTimestampServices.timelock()));
         kvs = TracingKeyValueService.create(kvs);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -59,7 +59,6 @@ import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.ValidatingQueryRewritingKeyValueService;
 import com.palantir.atlasdb.logging.KvsProfilingLogger;
-import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 import com.palantir.atlasdb.persistentlock.CheckAndSetExceptionMapper;
 import com.palantir.atlasdb.persistentlock.KvsBackedPersistentLockService;

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/KeyValueServiceModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/KeyValueServiceModule.java
@@ -24,6 +24,7 @@ import com.palantir.atlasdb.keyvalue.impl.ProfilingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.ValidatingQueryRewritingKeyValueService;
+import com.palantir.atlasdb.logging.KvsProfilingLogger;
 import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.table.description.Schemas;
@@ -49,8 +50,9 @@ public class KeyValueServiceModule {
     public KeyValueService provideWrappedKeyValueService(@Named("rawKvs") KeyValueService rawKvs,
                                                          TimestampService tss,
                                                          ServicesConfig config) {
-        KeyValueService kvs = ProfilingKeyValueService.create(rawKvs,
-                config.atlasDbConfig().getKvsSlowLogThresholdMillis());
+        KvsProfilingLogger.setSlowLogThresholdMillis(config.atlasDbConfig().getKvsSlowLogThresholdMillis());
+        KeyValueService kvs = ProfilingKeyValueService.create(rawKvs);
+
         kvs = TracingKeyValueService.create(kvs);
         kvs = AtlasDbMetrics.instrument(KeyValueService.class, kvs);
         kvs = ValidatingQueryRewritingKeyValueService.create(kvs);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -204,6 +204,14 @@ v0.58.0
     *    - Type
          - Change
 
+    *    - |improved|
+         - AtlasDB now logs slow queries CQL queries (via ``kvs-slow-log``) used for sweep
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2363>`__)     
+         
+    *    - |devbreak| |fixed|
+         - AtlasDB now depends on okhttp 3.8.1. This is expected to fix an issue where connections would constantly throw "shutdown" exceptions, which was likely due to a documented bug in okhttp 3.4.1.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2343>`__)         
+
     *    - |devbreak| |improved|
          - Upgraded all uses of `http-remoting <https://github.com/palantir/http-remoting>`__ from remoting2 to remoting3, except for serialization of errors (preserved for backwards wire compatibility).
            Developers may need to check their dependencies, as well as update instantiation of their calls to ``TransactionManagers.create()`` to use the remoting3 API.


### PR DESCRIPTION
**Goals (and why)**:
Add logging to the CQL executor. This is useful for debugging sweep slow queries.

**Implementation Description (bullets)**:
- Refactor the `ProfilingKeyValueService` logic to a static `ProfilingLogger` class
- Call this class for all queries in `CqlExecutor`
- Refactor some internals of `CqlExectutor` for easier testing

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`CqlExecutor`

**Priority (whenever / two weeks / yesterday)**:
whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2363)
<!-- Reviewable:end -->
