### PR TITLE
[Startup Independence]Part 6: Enable initialization with a quorum of nodes

### DIFF
--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
@@ -31,24 +31,19 @@ public class OneNodeDownTableManipulationTest {
     private static final TableReference NEW_TABLE2 = TableReference.createWithEmptyNamespace("new_table2");
 
     @Test
-    public void createTableThrows() {
+    public void canCreateTable() {
         assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).doesNotContain(NEW_TABLE);
-        assertThatThrownBy(
-                () -> OneNodeDownTestSuite.kvs.createTable(NEW_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA))
-                .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("At schema version UNREACHABLE");
+        OneNodeDownTestSuite.kvs.createTable(NEW_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
         // This documents and verifies the current behaviour, creating the table in spite of the exception
         // Seems to be inconsistent with the API
         assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).contains(NEW_TABLE);
     }
 
     @Test
-    public void createTablesThrows() {
+    public void canCreateTables() {
         assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).doesNotContain(NEW_TABLE2);
-        assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.createTables(
-                ImmutableMap.of(NEW_TABLE2, AtlasDbConstants.GENERIC_TABLE_METADATA)))
-                .isExactlyInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("At schema version UNREACHABLE");
+        OneNodeDownTestSuite.kvs.createTables(
+                ImmutableMap.of(NEW_TABLE2, AtlasDbConstants.GENERIC_TABLE_METADATA));
         // This documents and verifies the current behaviour, creating the table in spite of the exception
         // Seems to be inconsistent with the API
         assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).contains(NEW_TABLE2);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1723,7 +1723,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             CassandraKeyValueServices.waitForSchemaVersions(
                     client,
                     "(a call to createTables, filtered down to create: " + tableNamesToTableMetadata.keySet() + ")",
-                    configManager.getConfig().schemaMutationTimeoutMillis());
+                    configManager.getConfig().schemaMutationTimeoutMillis(), true);
             return null;
         });
     }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceEteTest.java
@@ -90,22 +90,15 @@ public class StartupIndependenceEteTest {
     }
 
     @Test
-    public void atlasStartsWithQuorumAndInitializesAfterAllNodesAreUp() throws InterruptedException, IOException {
+    public void atlasInitializesSynchronouslyIfQuorumOfNodesIsUp() throws InterruptedException, IOException {
         startCassandraNodes(QUORUM_OF_CASSANDRA_NODES);
         restartAtlasWithChecks();
-        assertNotInitializedExceptionIsThrownAndMappedCorrectly();
-        assertNotSatisfiedWithin(40, StartupIndependenceEteTest::canPerformTransaction);
-        startCassandraNodes(ALL_CASSANDRA_NODES);
-        assertSatisfiedWithin(180, StartupIndependenceEteTest::canPerformTransaction);
+        assertTrue(canPerformTransaction());
     }
 
     @Test
     public void atlasInitializesSynchronouslyIfCassandraIsInGoodState() throws InterruptedException, IOException {
         startCassandraNodes(ALL_CASSANDRA_NODES);
-        restartAtlasWithChecks();
-        assertTrue(canPerformTransaction());
-
-        killCassandraNodes(ONE_CASSANDRA_NODE);
         restartAtlasWithChecks();
         assertTrue(canPerformTransaction());
     }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceEteTest.java
@@ -90,6 +90,16 @@ public class StartupIndependenceEteTest {
     }
 
     @Test
+    public void atlasStartsWithQuorumAndInitializesAfterAllNodesAreUp() throws InterruptedException, IOException {
+        startCassandraNodes(QUORUM_OF_CASSANDRA_NODES);
+        restartAtlasWithChecks();
+        assertNotInitializedExceptionIsThrownAndMappedCorrectly();
+        assertNotSatisfiedWithin(40, StartupIndependenceEteTest::canPerformTransaction);
+        startCassandraNodes(ALL_CASSANDRA_NODES);
+        assertSatisfiedWithin(180, StartupIndependenceEteTest::canPerformTransaction);
+    }
+
+    @Test
     public void atlasInitializesSynchronouslyIfCassandraIsInGoodState() throws InterruptedException, IOException {
         startCassandraNodes(ALL_CASSANDRA_NODES);
         restartAtlasWithChecks();


### PR DESCRIPTION
**Goals (and why)**:
Enable initialization with a quorum of C* nodes

**Implementation Description (bullets)**:
We allowed tables (and keyspaces) to be created with a quorum of nodes

**Concerns (what feedback would you like?)**:
This should be safe, but @ashrayjain to double-check?

**Where should we start reviewing?**:
Small

**Priority (whenever / two weeks / yesterday)**:
Asap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2374)
<!-- Reviewable:end -->
