### PR TITLE
@Safe annotation for Jersey TimeLock Resources

### DIFF
--- a/atlasdb-api/versions.lock
+++ b/atlasdb-api/versions.lock
@@ -55,6 +55,12 @@
         "com.palantir.remoting-api:ssl-config": {
             "locked": "1.2.1"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",
             "transitive": [
@@ -144,6 +150,12 @@
         },
         "com.palantir.remoting-api:ssl-config": {
             "locked": "1.2.1"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",

--- a/atlasdb-cassandra/versions.lock
+++ b/atlasdb-cassandra/versions.lock
@@ -239,6 +239,7 @@
             "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -679,6 +680,7 @@
             "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -615,6 +615,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-cli/versions.lock
+++ b/atlasdb-cli/versions.lock
@@ -539,6 +539,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -1362,6 +1363,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-client/versions.lock
+++ b/atlasdb-client/versions.lock
@@ -160,7 +160,10 @@
             "locked": "3.2.1"
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.3"
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",
@@ -423,7 +426,10 @@
             "locked": "3.2.1"
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.3"
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "com.palantir.tritium:tritium-api": {
             "locked": "0.6.0",

--- a/atlasdb-config/versions.lock
+++ b/atlasdb-config/versions.lock
@@ -428,6 +428,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]
@@ -1021,6 +1022,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -604,6 +604,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-console/versions.lock
+++ b/atlasdb-console/versions.lock
@@ -467,6 +467,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]
@@ -1130,6 +1131,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]

--- a/atlasdb-container-test-utils/versions.lock
+++ b/atlasdb-container-test-utils/versions.lock
@@ -306,6 +306,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -876,6 +877,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-dagger/versions.lock
+++ b/atlasdb-dagger/versions.lock
@@ -470,6 +470,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]
@@ -1123,6 +1124,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -432,6 +432,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -1085,6 +1086,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -390,6 +390,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -946,6 +947,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-dropwizard-bundle/versions.lock
+++ b/atlasdb-dropwizard-bundle/versions.lock
@@ -570,6 +570,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -1843,6 +1844,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -595,6 +595,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -1972,6 +1973,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-feign/versions.lock
+++ b/atlasdb-feign/versions.lock
@@ -133,7 +133,8 @@
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.squareup.okhttp3:okhttp": {
@@ -318,7 +319,8 @@
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.squareup.okhttp3:okhttp": {

--- a/atlasdb-hikari/versions.lock
+++ b/atlasdb-hikari/versions.lock
@@ -213,6 +213,7 @@
             "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -548,6 +549,7 @@
             "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-impl-shared/versions.lock
+++ b/atlasdb-impl-shared/versions.lock
@@ -286,6 +286,7 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]
@@ -701,6 +702,7 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]

--- a/atlasdb-jdbc/versions.lock
+++ b/atlasdb-jdbc/versions.lock
@@ -202,6 +202,7 @@
             "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },
@@ -519,6 +520,7 @@
             "locked": "0.1.3",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl"
             ]
         },

--- a/atlasdb-jepsen-tests/versions.lock
+++ b/atlasdb-jepsen-tests/versions.lock
@@ -458,6 +458,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]
@@ -1098,6 +1099,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]

--- a/atlasdb-lock-api/versions.lock
+++ b/atlasdb-lock-api/versions.lock
@@ -81,7 +81,8 @@
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {
@@ -207,7 +208,8 @@
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -630,6 +630,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -1635,6 +1636,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-service-server/versions.lock
+++ b/atlasdb-service-server/versions.lock
@@ -486,6 +486,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]
@@ -1618,6 +1619,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/atlasdb-service/versions.lock
+++ b/atlasdb-service/versions.lock
@@ -458,6 +458,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]
@@ -1096,6 +1097,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]

--- a/atlasdb-tests-shared/versions.lock
+++ b/atlasdb-tests-shared/versions.lock
@@ -347,6 +347,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]
@@ -867,6 +868,7 @@
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
             ]

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,10 +54,15 @@ develop
          - KVS migration no longer fails when the old ``_scrub`` table is present.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2362>`__)
 
+    *    - |fixed|
+         - Path and query parameters for TimeLock endpoints have now been marked as safe.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/TODO>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
-0.57.0
+v0.57.0
 =======
 
 19 September 2017

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,8 +56,12 @@ develop
 
     *    - |fixed|
          - Path and query parameters for TimeLock endpoints have now been marked as safe.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/TODO>`__)
+           Several logging parameters in TimeLock (e.g. in ``PaxosTimestampBoundStore`` and ``PaxosSynchronizer`` have also been marked as safe).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2375>`__)
 
+    *    - |improved|
+         - The ``LockServiceImpl`` now, in addition to lock tokens and grants (which are unsafe for logging), also logs token and grant IDs (which are big-integer IDs) as safe.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2375>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,7 +56,7 @@ develop
 
     *    - |fixed|
          - Path and query parameters for TimeLock endpoints have now been marked as safe.
-           Several logging parameters in TimeLock (e.g. in ``PaxosTimestampBoundStore`` and ``PaxosSynchronizer`` have also been marked as safe).
+           Several logging parameters in TimeLock (e.g. in ``PaxosTimestampBoundStore`` and ``PaxosSynchronizer``) have also been marked as safe.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2375>`__)
 
     *    - |improved|

--- a/examples/profile-client/versions.lock
+++ b/examples/profile-client/versions.lock
@@ -189,7 +189,8 @@
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -489,7 +490,8 @@
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-client"
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "com.palantir.tritium:tritium-api": {

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.palantir.logsafe.Safe;
 import com.palantir.timestamp.TimestampRange;
 
 @Path("/timelock")
@@ -38,7 +39,7 @@ public interface TimelockService {
 
     @POST
     @Path("fresh-timestamps")
-    TimestampRange getFreshTimestamps(@QueryParam("number") int numTimestampsRequested);
+    TimestampRange getFreshTimestamps(@Safe @QueryParam("number") int numTimestampsRequested);
 
     @POST
     @Path("lock-immutable-timestamp")

--- a/lock-api/versions.lock
+++ b/lock-api/versions.lock
@@ -50,7 +50,10 @@
             "project": true
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.3"
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",
@@ -131,7 +134,10 @@
             "project": true
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.3"
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -848,7 +848,7 @@ public final class LockServiceImpl
                 "Converted from Grant, Missing Thread Name");
         if (log.isTraceEnabled()) {
             log.trace(".useGrant({}, {}) (grant ID {}) returns {} (token ID {})",
-                    UnsafeArg.of("client", client),
+                    SafeArg.of("client", client),
                     UnsafeArg.of("grant", grant),
                     SafeArg.of("grantId", grant.getGrantId()),
                     UnsafeArg.of("token", token),

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LockServiceImpl.java
@@ -278,7 +278,9 @@ public final class LockServiceImpl
             }
             log.error("Lock ID collision! "
                     + "Count of held tokens = {}"
-                    + "; random bit count = {}", heldLocksTokenMap.size(), RANDOM_BIT_COUNT);
+                    + "; random bit count = {}",
+                    SafeArg.of("heldTokenCount", heldLocksTokenMap.size()),
+                    SafeArg.of("randomBitCount", RANDOM_BIT_COUNT));
         }
     }
 
@@ -297,7 +299,9 @@ public final class LockServiceImpl
             }
             log.error("Lock ID collision! "
                     + "Count of held grants = {}"
-                    + "; random bit count = {}", heldLocksGrantMap.size(), RANDOM_BIT_COUNT);
+                    + "; random bit count = {}",
+                    SafeArg.of("heldTokenCount", heldLocksTokenMap.size()),
+                    SafeArg.of("randomBitCount", RANDOM_BIT_COUNT));
         }
     }
 
@@ -327,7 +331,8 @@ public final class LockServiceImpl
         long startTime = System.currentTimeMillis();
         if (requestLogger.isDebugEnabled()) {
             requestLogger.debug("LockServiceImpl processing lock request {} for requesting thread {}",
-                    request, request.getCreatingThreadName());
+                    UnsafeArg.of("lockRequest", request),
+                    SafeArg.of("requestingThread", request.getCreatingThreadName()));
         }
         Map<ClientAwareReadWriteLock, LockMode> locks = Maps.newLinkedHashMap();
         if (isShutDown.get()) {
@@ -618,7 +623,8 @@ public final class LockServiceImpl
         long heldDuration = System.currentTimeMillis() - token.getCreationDateMs();
         if (requestLogger.isDebugEnabled()) {
             requestLogger.debug("Releasing locks {} after holding for {} ms",
-                    heldLocks, heldDuration);
+                    UnsafeArg.of("heldLocks", heldLocks),
+                    SafeArg.of("heldDuration", heldDuration));
         }
         @Nullable LockClient client = heldLocks.realToken.getClient();
         if (client == null) {
@@ -767,7 +773,9 @@ public final class LockServiceImpl
         if (log.isInfoEnabled()) {
             long age = now - token.getCreationDateMs();
             if (age > maxNormalLockAge.toMillis()) {
-                log.debug("Token refreshed which is {} ms old: {}", age, description.get());
+                log.debug("Token refreshed which is {} ms old: {}",
+                        SafeArg.of("ageMillis", age),
+                        UnsafeArg.of("description", description.get()));
             }
         }
     }
@@ -782,13 +790,17 @@ public final class LockServiceImpl
         Preconditions.checkNotNull(token);
         @Nullable HeldLocks<HeldLocksToken> heldLocks = heldLocksTokenMap.remove(token);
         if (heldLocks == null) {
-            log.warn("Cannot convert to grant; invalid token: {}", token);
+            log.warn("Cannot convert to grant; invalid token: {} (token ID {})",
+                    UnsafeArg.of("token", token),
+                    SafeArg.of("tokenId", token.getTokenId()));
             throw new IllegalArgumentException("token is invalid: " + token);
         }
         if (isFrozen(heldLocks.locks.getKeys())) {
             heldLocksTokenMap.put(token, heldLocks);
             lockTokenReaperQueue.add(token);
-            log.warn("Cannot convert to grant because token is frozen: {}", token);
+            log.warn("Cannot convert to grant because token is frozen: {} (token ID {})",
+                    UnsafeArg.of("token", token),
+                    SafeArg.of("tokenId", token.getTokenId()));
             throw new IllegalArgumentException("token is frozen: " + token);
         }
         try {
@@ -797,7 +809,10 @@ public final class LockServiceImpl
         } catch (IllegalMonitorStateException e) {
             heldLocksTokenMap.put(token, heldLocks);
             lockTokenReaperQueue.add(token);
-            log.warn("Failure converting {} to grant", token, e);
+            log.warn("Failure converting {} (token ID {}) to grant",
+                    UnsafeArg.of("token", token),
+                    SafeArg.of("tokenId", token.getTokenId()),
+                    e);
             throw e;
         }
         lockClientMultimap.remove(heldLocks.realToken.getClient(), token);
@@ -805,7 +820,11 @@ public final class LockServiceImpl
                 heldLocks.locks, heldLocks.realToken.getLockTimeout(),
                 heldLocks.realToken.getVersionId());
         if (log.isTraceEnabled()) {
-            log.trace(".convertToGrant({}) returns {}", token, grant);
+            log.trace(".convertToGrant({}) (token ID {}) returns {} (grant ID {})",
+                    UnsafeArg.of("token", token),
+                    SafeArg.of("tokenId", token.getTokenId()),
+                    UnsafeArg.of("grant", grant),
+                    SafeArg.of("grantId", grant.getGrantId()));
         }
         return grant;
     }
@@ -817,7 +836,9 @@ public final class LockServiceImpl
         Preconditions.checkNotNull(grant);
         @Nullable HeldLocks<HeldLocksGrant> heldLocks = heldLocksGrantMap.remove(grant);
         if (heldLocks == null) {
-            log.warn("Tried to use invalid grant: {}", grant);
+            log.warn("Tried to use invalid grant: {} (grant ID {})",
+                    UnsafeArg.of("grant", grant),
+                    SafeArg.of("grantId", grant.getGrantId()));
             throw new IllegalArgumentException("grant is invalid: " + grant);
         }
         HeldLocksGrant realGrant = heldLocks.realToken;
@@ -826,7 +847,12 @@ public final class LockServiceImpl
                 heldLocks.locks, realGrant.getLockTimeout(), realGrant.getVersionId(),
                 "Converted from Grant, Missing Thread Name");
         if (log.isTraceEnabled()) {
-            log.trace(".useGrant({}, {}) returns {}", client, grant, token);
+            log.trace(".useGrant({}, {}) (grant ID {}) returns {} (token ID {})",
+                    UnsafeArg.of("client", client),
+                    UnsafeArg.of("grant", grant),
+                    SafeArg.of("grantId", grant.getGrantId()),
+                    UnsafeArg.of("token", token),
+                    SafeArg.of("tokenId", token.getTokenId()));
         }
         return token;
     }
@@ -961,7 +987,9 @@ public final class LockServiceImpl
                         - maxAllowedClockDrift.toMillis()) {
                     queue.add(realToken);
                 } else {
-                    log.warn("Lock token {} was not properly refreshed and is now being reaped.", realToken);
+                    // TODO (jkong): Make both types of lock tokens identifiable.
+                    log.warn("Lock token {} was not properly refreshed and is now being reaped.",
+                            UnsafeArg.of("token", realToken));
                     unlockInternal(realToken, heldLocksMap);
                 }
             } catch (Throwable t) {

--- a/lock-impl/versions.lock
+++ b/lock-impl/versions.lock
@@ -132,7 +132,8 @@
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {
@@ -303,7 +304,8 @@
         "com.palantir.safe-logging:safe-logging": {
             "locked": "0.1.3",
             "transitive": [
-                "com.palantir.atlasdb:lock-api"
+                "com.palantir.atlasdb:lock-api",
+                "com.palantir.atlasdb:timestamp-api"
             ]
         },
         "io.dropwizard.metrics:metrics-core": {

--- a/timelock-agent/versions.lock
+++ b/timelock-agent/versions.lock
@@ -447,6 +447,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timelock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -1064,6 +1065,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timelock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockResource.java
@@ -36,6 +36,7 @@ import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.logsafe.Safe;
 import com.palantir.timestamp.TimestampRange;
 
 @Path("/timelock")
@@ -57,7 +58,7 @@ public class AsyncTimelockResource {
 
     @POST
     @Path("fresh-timestamps")
-    public TimestampRange getFreshTimestamps(@QueryParam("number") int numTimestampsRequested) {
+    public TimestampRange getFreshTimestamps(@Safe @QueryParam("number") int numTimestampsRequested) {
         return timelock.getFreshTimestamps(numTimestampsRequested);
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -30,6 +30,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.lock.LockService;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampService;
@@ -50,22 +51,22 @@ public class TimeLockResource {
     }
 
     @Path("/lock")
-    public LockService getLockService(@PathParam("client") String client) {
+    public LockService getLockService(@Safe @PathParam("client") String client) {
         return getOrCreateServices(client).getLockService();
     }
 
     @Path("/timestamp")
-    public TimestampService getTimeService(@PathParam("client") String client) {
+    public TimestampService getTimeService(@Safe @PathParam("client") String client) {
         return getOrCreateServices(client).getTimestampService();
     }
 
     @Path("/timelock")
-    public Object getTimelockService(@PathParam("client") String client) {
+    public Object getTimelockService(@Safe @PathParam("client") String client) {
         return getOrCreateServices(client).getTimelockService().getPresentService();
     }
 
     @Path("/timestamp-management")
-    public TimestampManagementService getTimestampManagementService(@PathParam("client") String client) {
+    public TimestampManagementService getTimestampManagementService(@Safe @PathParam("client") String client) {
         return getOrCreateServices(client).getTimestampManagementService();
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/BlockingTimeLimitedLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/BlockingTimeLimitedLockService.java
@@ -193,7 +193,7 @@ public class BlockingTimeLimitedLockService implements CloseableLockService {
             // In this case, the thread was interrupted for some other reason, perhaps because we lost leadership.
             log.info("Lock service was interrupted when servicing {} for client \"{}\"; request was {}",
                     SafeArg.of("method", specification.method()),
-                    UnsafeArg.of("client", specification.client()),
+                    SafeArg.of("client", specification.client()),
                     UnsafeArg.of("lockRequest", specification.lockRequest()),
                     e);
             throw e;
@@ -212,7 +212,7 @@ public class BlockingTimeLimitedLockService implements CloseableLockService {
         log.info(logMessage,
                 SafeArg.of("timeoutDurationMillis", blockingTimeLimitMillis),
                 SafeArg.of("method", specification.method()),
-                UnsafeArg.of("client", specification.client()),
+                SafeArg.of("client", specification.client()),
                 UnsafeArg.of("lockRequest", specification.lockRequest()));
 
         String errorMessage = String.format(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/BlockingTimeLimitedLockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/BlockingTimeLimitedLockService.java
@@ -193,7 +193,7 @@ public class BlockingTimeLimitedLockService implements CloseableLockService {
             // In this case, the thread was interrupted for some other reason, perhaps because we lost leadership.
             log.info("Lock service was interrupted when servicing {} for client \"{}\"; request was {}",
                     SafeArg.of("method", specification.method()),
-                    SafeArg.of("client", specification.client()),
+                    UnsafeArg.of("client", specification.client()),
                     UnsafeArg.of("lockRequest", specification.lockRequest()),
                     e);
             throw e;
@@ -212,7 +212,7 @@ public class BlockingTimeLimitedLockService implements CloseableLockService {
         log.info(logMessage,
                 SafeArg.of("timeoutDurationMillis", blockingTimeLimitMillis),
                 SafeArg.of("method", specification.method()),
-                SafeArg.of("client", specification.client()),
+                UnsafeArg.of("client", specification.client()),
                 UnsafeArg.of("lockRequest", specification.lockRequest()));
 
         String errorMessage = String.format(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosSynchronizer.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosQuorumChecker;
 import com.palantir.paxos.PaxosResponse;
@@ -46,10 +47,12 @@ public final class PaxosSynchronizer {
         if (mostRecentValue.isPresent()) {
             PaxosValue paxosValue = mostRecentValue.get();
             if (paxosValue.equals(learnerToSynchronize.getGreatestLearnedValue())) {
-                log.info("Started up and found that our value {} is already the most recent.", paxosValue);
+                log.info("Started up and found that our value {} is already the most recent.",
+                        SafeArg.of("value", paxosValue));
             } else {
                 learnerToSynchronize.learn(paxosValue.getRound(), paxosValue);
-                log.info("Started up and learned the most recent value: {}.", paxosValue);
+                log.info("Started up and learned the most recent value: {}.",
+                        SafeArg.of("value", paxosValue));
             }
         } else {
             log.info("Started up, and no one I talked to knows anything yet.");

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.leader.NotCurrentLeaderException;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosLearner;
 import com.palantir.paxos.PaxosProposer;
@@ -73,8 +74,8 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
             long maximumWaitBeforeProposalMs) {
         DebugLogger.logger.info("Creating PaxosTimestampBoundStore. The UUID of my proposer is {}."
                 + " Currently, I believe the timestamp bound is {}.",
-                proposer.getUuid(),
-                knowledge.getGreatestLearnedValue());
+                SafeArg.of("proposerUuid", proposer.getUuid()),
+                SafeArg.of("timestampBound", knowledge.getGreatestLearnedValue()));
         this.proposer = proposer;
         this.knowledge = knowledge;
         this.acceptors = acceptors;
@@ -269,8 +270,8 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
                     log.warn("It appears we updated the timestamp limit to {}, which was less than our target {}."
                             + " This suggests we have another timestamp service running; possibly because we"
                             + " lost and regained leadership. For safety, we are now stopping this service.",
-                            newLimit,
-                            limit);
+                            SafeArg.of("newLimit", newLimit),
+                            SafeArg.of("target", limit));
                     throw new NotCurrentLeaderException(String.format(
                             "We updated the timestamp limit to %s, which was less than our target %s.",
                             newLimit,
@@ -309,9 +310,9 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
             throw new NotCurrentLeaderException(errorMsg);
         }
         DebugLogger.logger.info("Trying to store limit '{}' for sequence '{}' yielded consensus on the value '{}'.",
-                limit,
-                newSeq,
-                value);
+                SafeArg.of("limit", limit),
+                SafeArg.of("paxosSequenceNumber", newSeq),
+                SafeArg.of("paxosValue", value));
     }
 
     /**
@@ -326,7 +327,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
         long backoffTime = getRandomBackoffTime();
         log.info("Paxos proposal couldn't complete, because we could not connect to a quorum of nodes. We"
                 + " will retry in {} ms.",
-                backoffTime,
+                SafeArg.of("backoffTime", backoffTime),
                 paxosException);
         try {
             backoffAction.backoff(backoffTime);

--- a/timelock-impl/versions.lock
+++ b/timelock-impl/versions.lock
@@ -427,6 +427,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -1017,6 +1018,7 @@
                 "com.palantir.atlasdb:leader-election-impl",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/timelock-server-distribution/versions.lock
+++ b/timelock-server-distribution/versions.lock
@@ -539,6 +539,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timelock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -524,6 +524,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timelock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"
@@ -1690,6 +1691,7 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timelock-impl",
+                "com.palantir.atlasdb:timestamp-api",
                 "com.palantir.atlasdb:timestamp-impl",
                 "com.palantir.remoting-api:errors",
                 "com.palantir.remoting3:jersey-servers"

--- a/timestamp-api/build.gradle
+++ b/timestamp-api/build.gradle
@@ -4,6 +4,7 @@ apply from: "../gradle/shared.gradle"
 dependencies {
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
+    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
 
     testCompile group: 'org.assertj', name: 'assertj-core'
 }

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementService.java
@@ -48,7 +48,7 @@ public interface TimestampManagementService {
     @Path("fast-forward")
     @Produces(MediaType.APPLICATION_JSON)
     void fastForwardTimestamp(
-            @QueryParam("currentTimestamp") @DefaultValue(SENTINEL_TIMESTAMP_STRING) long currentTimestamp);
+            @Safe @QueryParam("currentTimestamp") @DefaultValue(SENTINEL_TIMESTAMP_STRING) long currentTimestamp);
 
     @GET
     @Path("ping")

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampManagementService.java
@@ -25,6 +25,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.palantir.logsafe.Safe;
+
 @Path("/timestamp-management")
 public interface TimestampManagementService {
     long SENTINEL_TIMESTAMP = Long.MIN_VALUE;

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -39,5 +39,5 @@ public interface TimestampService {
     @POST // This has to be POST because we can't allow caching.
     @Path("fresh-timestamps")
     @Produces(MediaType.APPLICATION_JSON)
-    TimestampRange getFreshTimestamps(@QueryParam("number") int numTimestampsRequested);
+    TimestampRange getFreshTimestamps(@Safe @QueryParam("number") int numTimestampsRequested);
 }

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -21,6 +21,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.palantir.logsafe.Safe;
+
 @Path("/timestamp")
 public interface TimestampService {
     /**

--- a/timestamp-api/versions.lock
+++ b/timestamp-api/versions.lock
@@ -6,6 +6,9 @@
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.3"
+        },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",
             "requested": "2.0.1"
@@ -17,6 +20,9 @@
         },
         "com.google.code.findbugs:annotations": {
             "locked": "2.0.3"
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.3"
         },
         "javax.ws.rs:javax.ws.rs-api": {
             "locked": "2.0.1",

--- a/timestamp-client/versions.lock
+++ b/timestamp-client/versions.lock
@@ -49,6 +49,12 @@
         "com.palantir.atlasdb:timestamp-api": {
             "project": true
         },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",
             "transitive": [
@@ -125,6 +131,12 @@
         },
         "com.palantir.atlasdb:timestamp-api": {
             "project": true
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",

--- a/timestamp-impl/versions.lock
+++ b/timestamp-impl/versions.lock
@@ -64,7 +64,10 @@
             "project": true
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.3"
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",
@@ -158,7 +161,10 @@
             "project": true
         },
         "com.palantir.safe-logging:safe-logging": {
-            "locked": "0.1.3"
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:timestamp-api"
+            ]
         },
         "io.dropwizard.metrics:metrics-core": {
             "locked": "3.1.2",


### PR DESCRIPTION
**Goals (and why)**:
Currently, all timelock logs in internal ram product are missing key parameters. This includes the namespace of the client and the number of timestamps requested in a batch `getFreshTimestamps` call. This makes it difficult to evaluate how much load we are averting by using RBTS (the metrics suggest we do to some extent, but they tend to be noisy).

**Implementation Description (bullets)**:
- Mark the following query and path parameters as safe:
  - Client names (`TimeLockResource`)
  - Number of timestamps (`AsyncTimelockResource`, `TimeLockService`, `TimestampService`)
  - Fast forward timestamp (`TimestampManagementService`)
- Drive by fix of the missing version number in 0.57.0.

**Concerns (what feedback would you like?)**:
Main worry is if anything I marked safe could be unsafe.

**Where should we start reviewing?**: anywhere but the version-lock files

**Priority (whenever / two weeks / yesterday)**: preferably before v0.58.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2375)
<!-- Reviewable:end -->
