### PR TITLE
reduce default getRanges concurrency

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -221,7 +221,7 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
 
     @Value.Default
     public int rangesConcurrency() {
-        return 64;
+        return 32;
     }
 
     @Value.Default

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -192,6 +192,11 @@ v0.56.0
          - Oracle will now validate connections by running the test query when getting a new connection from the HikariPool.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2301>`__)
 
+    *    - |improved|
+         - Cassandra range concurrency defaults lowered from 64x to 32x, to reflect default connection pool sizes
+           that have shrank over time, and to be more appropriate for fairly common smaller 3-node clusters.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2386>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
Many people have this overridden because it was too large by default for their 3-node clusters that see moderate load from other concurrent operations happening.

For reference, the overall pool size defaults for a typical 3-node cluster come out to:
MIN: 16 * 3 = 48 total connections
MAX: 100 * 3 = 300 total connections

With **rangesConcurrency** of previous default, 64:
pro:
- larger clusters with well-distributed data and well-distributed range queries can see see speed improvements from improved parallelisation / utilisation of all nodes
con:
 - in 3 node cluster, from idle the pool would have to block on spinning up new connections
 - in 3 node cluster, the 64/3 = ~20 per node is probably higher concurrency than necessary on relatively low IOPS and throughput EBS volumes
 - in 3 node cluster, we can only handle 4-5 well-distributed concurrent getRanges at max pool size
 - it's not too unlikely that the range requests passed in may be hotspotted to a single 3-node replica group, in which case all of the above cons also apply to larger clusters

I'd prefer to fix things to be better for the majority of our stacks, and let the bigger high-touch stacks be the ones who can edit this if they want.

There is another good option, to remove **rangesConcurrency** and make instead a **rangesConcurrencyPerNode** that scales with cluster size.
This is slightly more work to do / move existing people to, and has the same issues listed above on larger clusters if many of the queries are hotspotted onto a smaller number of nodes. I can change this PR to be per-node-scaling if you'd like, up to you.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2386)
<!-- Reviewable:end -->
