### PR TITLE
Do not log an error every time a metric is re-registered

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -29,7 +29,6 @@ import com.codahale.metrics.MetricRegistry;
 public class MetricsManager {
 
     private static final Logger log = LoggerFactory.getLogger(MetricsManager.class);
-    private static final Set<String> globalMetricsRegistry = new HashSet<>();
 
     private final MetricRegistry metricRegistry;
     private final Set<String> registeredMetrics;
@@ -61,9 +60,8 @@ public class MetricsManager {
 
     private synchronized void registerMetricWithFqn(String fullyQualifiedMetricName, Metric metric) {
         try {
-            if (!globalMetricsRegistry.contains(fullyQualifiedMetricName)) {
+            if (!metricRegistry.getNames().contains(fullyQualifiedMetricName)) {
                 metricRegistry.register(fullyQualifiedMetricName, metric);
-                globalMetricsRegistry.add(fullyQualifiedMetricName);
             }
             registeredMetrics.add(fullyQualifiedMetricName);
         } catch (Exception e) {
@@ -79,7 +77,6 @@ public class MetricsManager {
     private synchronized Meter registerMeter(String fullyQualifiedMeterName) {
         Meter meter = metricRegistry.meter(fullyQualifiedMeterName);
         registeredMetrics.add(fullyQualifiedMeterName);
-        globalMetricsRegistry.add(fullyQualifiedMeterName);
         return meter;
     }
 


### PR DESCRIPTION
**Goals (and why)**: Logging an error should be reserved for important metrics, not for logging when re-registering a metric. This fix will also prevent errors such as the re-registering of metrics due to the recent removal of hostnames of the metrics prefix.

**Implementation Description (bullets)**: Keep a global metric registry, to avoid re-registering a metric.

**Concerns (what feedback would you like?)**: Is this the best approach?

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: We probably want this before the next release, to avoid errors due to the re-registration of metrics being logged.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2395)
<!-- Reviewable:end -->
