### PR TITLE
Metric Tags Part1: Metric utils for creating metric names with tags

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricNameUtils.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricNameUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Preconditions;
+
+public final class MetricNameUtils {
+
+    private static final int MAX_ALLOWED_TAGS = 100;
+
+    private MetricNameUtils() {
+        //utility class
+    }
+
+    public static final String DELIMITER = ";";
+    public static final String EQUALS = "=";
+
+    public static String getMetricName(String metricName, Map<String, String> tags) {
+        Preconditions.checkState(tags.size() < MAX_ALLOWED_TAGS, "Too many tags set on the metric %s. "
+                + "Maximum allowed number of tags is %d, found %s", metricName, MAX_ALLOWED_TAGS, tags.size());
+
+        return tags.entrySet().stream()
+                .map(e -> e.getKey() + EQUALS + e.getValue())
+                .collect(Collectors.joining(DELIMITER, metricName + DELIMITER, ""));
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricNameUtils.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricNameUtils.java
@@ -33,8 +33,8 @@ public final class MetricNameUtils {
     private static final String EQUALS = "=";
 
     public static String getMetricName(String metricName, Map<String, String> tags) {
-        Preconditions.checkState(tags.size() <= MAX_ALLOWED_TAGS, "Too many tags set on the metric %d. "
-                + "Maximum allowed number of tags is %d, found %s", metricName, MAX_ALLOWED_TAGS, tags.size());
+        Preconditions.checkArgument(tags.size() <= MAX_ALLOWED_TAGS, "Too many tags set on the metric %s. "
+                + "Maximum allowed number of tags is %s, found %s.", metricName, MAX_ALLOWED_TAGS, tags.size());
 
         validateMetricComponentName(metricName, "metric");
         validateMetricTagNames(tags);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricNameUtils.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricNameUtils.java
@@ -23,21 +23,43 @@ import com.google.common.base.Preconditions;
 
 public final class MetricNameUtils {
 
-    private static final int MAX_ALLOWED_TAGS = 100;
+    private static final int MAX_ALLOWED_TAGS = 10;
 
     private MetricNameUtils() {
         //utility class
     }
 
-    public static final String DELIMITER = ";";
-    public static final String EQUALS = "=";
+    private static final String DELIMITER = ";";
+    private static final String EQUALS = "=";
 
     public static String getMetricName(String metricName, Map<String, String> tags) {
-        Preconditions.checkState(tags.size() < MAX_ALLOWED_TAGS, "Too many tags set on the metric %s. "
+        Preconditions.checkState(tags.size() <= MAX_ALLOWED_TAGS, "Too many tags set on the metric %d. "
                 + "Maximum allowed number of tags is %d, found %s", metricName, MAX_ALLOWED_TAGS, tags.size());
+
+        validateMetricComponentName(metricName, "metric");
+        validateMetricTagNames(tags);
 
         return tags.entrySet().stream()
                 .map(e -> e.getKey() + EQUALS + e.getValue())
                 .collect(Collectors.joining(DELIMITER, metricName + DELIMITER, ""));
+    }
+
+
+    private static void validateMetricTagNames(Map<String, String> tags) {
+      tags.forEach((key, value) -> {
+          validateMetricComponentName(key, "tag key");
+          validateMetricComponentName(value, "tag value");
+      });
+    }
+
+    private static void validateMetricComponentName(String metricName, String type) {
+         if (metricName.contains(DELIMITER)) {
+             throw new IllegalArgumentException(
+                     String.format("The %s name: %s contains the forbidden character: %s", type, metricName, DELIMITER));
+         } else if (metricName.contains(EQUALS)){
+             throw new IllegalArgumentException(
+                     String.format("The %s name: %s contains the forbidden character: %s", type, metricName, EQUALS));
+
+         }
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricNameUtilsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricNameUtilsTest.java
@@ -44,8 +44,8 @@ public class MetricNameUtilsTest {
     @Test
     public void shouldReturnNameWithMultipleTags() throws Exception {
         String metricName = MetricNameUtils.getMetricName(METRIC_NAME,
-                ImmutableMap.of(TAG_KEY_1, TAG_VALUE_1, TAG_KEY_2, TAG_VALUE_2));
-        assertThat(metricName).isEqualTo("metricName;tag1=tagVal1;tag2=tagVal2");
+                ImmutableMap.of(TAG_KEY_2, TAG_VALUE_2, TAG_KEY_1, TAG_VALUE_1));
+        assertThat(metricName).isIn("metricName;tag1=tagVal1;tag2=tagVal2", "metricName;tag2=tagVal2;tag1=tagVal1");
     }
 
     @Test
@@ -119,7 +119,7 @@ public class MetricNameUtilsTest {
                 .boxed()
                 .collect(Collectors.toMap(i -> "tag" + i, i -> "tagVal" + i));
         assertThat(tags.size()).isEqualTo(10);
-        MetricNameUtils.getMetricName(METRIC_NAME, tags);
+        assertThat(MetricNameUtils.getMetricName(METRIC_NAME, tags)).contains(METRIC_NAME);
     }
 
     @Test

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricNameUtilsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricNameUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class MetricNameUtilsTest {
+
+    @Test
+    public void shouldReturnNameWithSingleTag() throws Exception {
+        String metricName = MetricNameUtils.getMetricName("metricName", ImmutableMap.of("tag1", "tagVal1"));
+        assertThat(metricName).isEqualTo("metricName;tag1=tagVal1");
+    }
+
+    @Test
+    public void shouldReturnNameWithMultipleTags() throws Exception {
+        String metricName = MetricNameUtils.getMetricName("metricName", ImmutableMap.of("tag1", "tagVal1", "tag2", "tagVal2"));
+        assertThat(metricName).isEqualTo("metricName;tag1=tagVal1;tag2=tagVal2");
+    }
+
+    @Test
+    public void shouldThrowIfSameTagIsAddedMultipleTimes() throws Exception {
+        assertThatThrownBy(() -> MetricNameUtils.getMetricName("metricName", ImmutableMap.of("tag1", "tagVal1", "tag1", "tagVal2")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**: Add a utility class that can create a concatenation of metric name and tags of the form `metricName;tag1=tagVal1;tag2=tagVal2`. A step to fix #2341.

**Concerns (what feedback would you like?)**: Should we have the parsing logic here and copy to the internal logging spec. Technically, the parsing logic is not required by atlasDB itself. 

**Where should we start reviewing?**: one file

**Priority (whenever / two weeks / yesterday)**: soon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2400)
<!-- Reviewable:end -->
