### PR TITLE
enableShrinkOnOracleStandardEdition-false-by-default

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -61,7 +61,7 @@ public abstract class OracleDdlConfig extends DdlConfig {
 
     @Value.Default
     public boolean enableShrinkOnOracleStandardEdition() {
-        return true;
+        return false;
     }
 
     @Value.Default

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,8 +44,11 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - Oracle auto-shrink is now not enabled by default. This is an experimental feature to allow Oracle non-EE users to compact automatically.
+           However, it has seen timeouts for large amounts of data. We are turning this off by default, until we figure out a better retry mechanism for
+           shrink failures.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
 
     *    - |new|
          - Can now specify ``hashRowComponents()`` in StreamStore definitions. This prevents hotspotting in Cassandra


### PR DESCRIPTION
**Goals (and why)**: enableShrinkOnOracleStandardEdition-false-by-default. There are issues seen in the field when running oracle shrink, as this times out on medium data scale, thus making sweep slower and spamming logs. Related to #2404.

**Implementation Description (bullets)**: change config flag.

**Concerns (what feedback would you like?)**: NA

**Where should we start reviewing?**: one file

**Priority (whenever / two weeks / yesterday)**: before next release

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2405)
<!-- Reviewable:end -->
