### PR TITLE
Add debugging endpoint for LockRefreshingLockService

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -166,4 +166,9 @@ public class LockRefreshingLockService extends ForwardingLockService {
         super.close();
         dispose();
     }
+
+    // visible for debugging clients at runtime
+    public Set<LockRefreshToken> getAllRefreshingTokens() {
+        return ImmutableSet.copyOf(toRefresh);
+    }
 }


### PR DESCRIPTION
**Goals (and why)**:
Open up a java endpoint for inspecting locks to refresh

**Implementation Description (bullets)**:
we assume we're getting a LockRefreshingLockServce, so we don't need it punched through to LockService itself

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
nothing pressing, but sooner is always nice.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2414)
<!-- Reviewable:end -->
