### PR TITLE
Cassandra pool metrics should be different for each pool

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -288,7 +288,8 @@ public class CassandraClientPool {
         debugLogStateOfPool();
     }
 
-    private void addPool(InetSocketAddress server) {
+    @VisibleForTesting
+    void addPool(InetSocketAddress server) {
         int currentPoolNumber = cassandraHosts.indexOf(server) + 1;
         addPool(server, new CassandraClientPoolingContainer(server, config, currentPoolNumber));
     }
@@ -298,7 +299,8 @@ public class CassandraClientPool {
         currentPools.put(server, container);
     }
 
-    private void removePool(InetSocketAddress removedServerAddress) {
+    @VisibleForTesting
+    void removePool(InetSocketAddress removedServerAddress) {
         blacklistedHosts.remove(removedServerAddress);
         try {
             currentPools.get(removedServerAddress).shutdownPooling();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -281,7 +281,8 @@ public class CassandraClientPool {
     }
 
     private void addPool(InetSocketAddress server) {
-        addPool(server, new CassandraClientPoolingContainer(server, config));
+        int currentPoolNumber = currentPools.size() + 1;
+        addPool(server, new CassandraClientPoolingContainer(server, config, currentPoolNumber));
     }
 
     @VisibleForTesting

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -54,10 +54,13 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
     private final AtomicInteger openRequests = new AtomicInteger();
     private final GenericObjectPool<Client> clientPool;
 
-    public CassandraClientPoolingContainer(InetSocketAddress host, CassandraKeyValueServiceConfig config) {
+    public CassandraClientPoolingContainer(
+            InetSocketAddress host,
+            CassandraKeyValueServiceConfig config,
+            int poolNumber) {
         this.host = host;
         this.config = config;
-        this.clientPool = createClientPool();
+        this.clientPool = createClientPool(poolNumber);
     }
 
     public InetSocketAddress getHost() {
@@ -217,8 +220,9 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
      *    Discard any connections in this tenth of the pool that have been idle for more than 10 minutes,
      *       while still keeping a minimum number of idle connections around for fast borrows.
      *
+     * @param poolNumber
      */
-    private GenericObjectPool<Client> createClientPool() {
+    private GenericObjectPool<Client> createClientPool(int poolNumber) {
         CassandraClientFactory cassandraClientFactory = new CassandraClientFactory(host, config);
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
 
@@ -246,21 +250,25 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
 
         poolConfig.setJmxNamePrefix(host.getHostString());
         GenericObjectPool<Client> pool = new GenericObjectPool<>(cassandraClientFactory, poolConfig);
-        registerMetrics(pool);
+        registerMetrics(pool, poolNumber);
         return pool;
     }
 
-    private void registerMetrics(GenericObjectPool<Client> pool) {
-        registerMetric("meanActiveTimeMillis", pool::getMeanActiveTimeMillis);
-        registerMetric("meanIdleTimeMillis", pool::getMeanIdleTimeMillis);
-        registerMetric("meanBorrowWaitTimeMillis", pool::getMeanBorrowWaitTimeMillis);
-        registerMetric("numIdle", pool::getNumIdle);
-        registerMetric("numActive", pool::getNumActive);
-        registerMetric("approximatePoolSize", () -> pool.getNumIdle() + pool.getNumActive());
-        registerMetric("proportionDestroyedByEvictor",
+    private void registerMetrics(GenericObjectPool<Client> pool, int poolNumber) {
+        registerMetric(getMetricName("meanActiveTimeMillis", poolNumber), pool::getMeanActiveTimeMillis);
+        registerMetric(getMetricName("meanIdleTimeMillis", poolNumber), pool::getMeanIdleTimeMillis);
+        registerMetric(getMetricName("meanBorrowWaitTimeMillis", poolNumber), pool::getMeanBorrowWaitTimeMillis);
+        registerMetric(getMetricName("numIdle", poolNumber), pool::getNumIdle);
+        registerMetric(getMetricName("numActive", poolNumber), pool::getNumActive);
+        registerMetric(getMetricName("approximatePoolSize", poolNumber), () -> pool.getNumIdle() + pool.getNumActive());
+        registerMetric(getMetricName("proportionDestroyedByEvictor", poolNumber),
                 () -> ((double) pool.getDestroyedByEvictorCount()) / ((double) pool.getCreatedCount()));
-        registerMetric("proportionDestroyedByBorrower",
+        registerMetric(getMetricName("proportionDestroyedByBorrower", poolNumber),
                 () -> ((double) pool.getDestroyedByBorrowValidationCount()) / ((double) pool.getCreatedCount()));
+    }
+
+    private String getMetricName(String metric, int poolNumber) {
+        return "pool" + poolNumber + "." + metric;
     }
 
     private void registerMetric(String metricName, Gauge gauge) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -220,7 +220,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
      *    Discard any connections in this tenth of the pool that have been idle for more than 10 minutes,
      *       while still keeping a minimum number of idle connections around for fast borrows.
      *
-     * @param poolNumber
+     * @param poolNumber number of the pool for metric registration.
      */
     private GenericObjectPool<Client> createClientPool(int poolNumber) {
         CassandraClientFactory cassandraClientFactory = new CassandraClientFactory(host, config);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,6 +44,12 @@ develop
     *    - Type
          - Change
 
+    *    - |userbreak| |fixed|
+         - AtlasDB no longer tries to register Cassandra metrics for each pool with the same names.
+           We now add `poolN` to the metric name in CassandraClientPoolingContainer, where N is the pool number.
+           This will prevent spurious stacktraces in logs due to failure in registering metrics with the same name.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2415>`__)
+
     *    - |improved|
          - Timestamp batching has now been enabled by default.
            Please see :ref:`Timestamp Client Options <timestamp-client-config>` for details.


### PR DESCRIPTION
**Goals (and why)**: temporary Cassandra pool metrics, prevent unnecessary stacktraces due to registering metrics multiple times.

**Implementation Description (bullets)**: Add pool1, pool2, pool3 etc to the metric names in cassandra client pool.
Note these used to be hostNames before 0.57.0 causing carinality bloat for internal metric ingestion tool.
repro'd on develop with atlasdbEteSever and CCM. Saw the stacktraces disappear with the fix.

**Concerns (what feedback would you like?)**: N/A

**Where should we start reviewing?**: CCPC

**Priority (whenever / two weeks / yesterday)**: today

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2415)
<!-- Reviewable:end -->
