### PR TITLE
More hints for getRange() on Oracle

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -88,6 +88,11 @@ develop
            Developers may need to check your dependencies, but no other actions should be required.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2399>`__)
 
+    *    - |fixed|
+         - Adjusted optimizer hints for getRange() to prevent Oracle from picking a bad query plan.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2421>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
For some unknown reason, Oracle picks a very inefficient plan sometimes:

NESTED LOOPS
+-VIEW
| +-WINDOW NOSORT STOPKEY
|   +-SORT GROUP BY NOSORT
|     +-INDEX FULL SCAN
`- INDEX FAST FULL SCAN

Notice "FAST FULL SCAN" instead of "UNIQUE SCAN" or "RANGE SCAN".
Basically, Oracle decides to scan the whole index on every iteration
of the join loop, which is extremely slow.

We add more hints to discourage this behavior.

See PDS-56862

**Priority (whenever / two weeks / yesterday)**:
High

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2421)
<!-- Reviewable:end -->
