### PR TITLE
Oracle Sweep IMPL

### DIFF
--- a/atlasdb-dbkvs-tests/build.gradle
+++ b/atlasdb-dbkvs-tests/build.gradle
@@ -3,9 +3,27 @@ apply plugin: 'org.inferred.processors'
 
 apply from: "../gradle/shared.gradle"
 
+repositories {
+    mavenCentral()
+    mavenLocal()
+    maven {
+        url 'https://artifactory.palantir.build/artifactory/all-jar'
+    }
+    maven {
+        url 'https://artifactory.palantir.build/artifactory/internal-jar-snapshot'
+    }
+    maven {
+        url 'https://plugins.gradle.org/m2/'
+    }
+}
+
 dependencies {
   compile project(":atlasdb-dbkvs")
   compile project(":atlasdb-tests-shared")
+  compile (group: 'com.palantir.atlasdb', name: 'dbkvs-oracle-driver', version: '0.3.0-110-g80a53e7') {
+      exclude module:'commons-db'
+  }
+  compile group: 'com.oracle', name: 'ojdbc7', version: '12.1.0.2'
 
   testCompile group: 'org.mockito', name: 'mockito-core'
   testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4'

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/DbKvsOracleGetCandidateCellsForSweepingTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/DbKvsOracleGetCandidateCellsForSweepingTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
+import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
+import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweeping;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionManagerAwareDbKvs;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.SqlConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.sweep.DbKvsGetCandidateCellsForSweeping;
+import com.palantir.atlasdb.keyvalue.impl.AbstractGetCandidateCellsForSweepingTest;
+import com.palantir.common.base.ClosableIterator;
+
+public class DbKvsOracleGetCandidateCellsForSweepingTest extends AbstractGetCandidateCellsForSweepingTest {
+
+    private static DbKeyValueServiceConfig config;
+    private static SqlConnectionSupplier connectionSupplier;
+
+    @Override
+    protected KeyValueService createKeyValueService() {
+        config = DbkvsOracleTestSuite.getKvsConfig();
+        ConnectionManagerAwareDbKvs kvs = ConnectionManagerAwareDbKvs.create(config);
+        connectionSupplier = kvs.getSqlConnectionSupplier();
+        return kvs;
+    }
+
+    @Test
+    public void singleCellSpanningSeveralPages() {
+        new TestDataBuilder()
+                .put(10, 1, 1000)
+                .put(10, 1, 1001)
+                .put(10, 1, 1002)
+                .put(10, 1, 1003)
+                .put(10, 1, 1004)
+                .store();
+        List<CandidateCellForSweeping> cells = getWithOverriddenLimit(
+                conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 2000L, Long.MIN_VALUE), 2);
+        assertEquals(ImmutableList.of(ImmutableCandidateCellForSweeping.builder()
+                .cell(cell(10, 1))
+                .isLatestValueEmpty(false)
+                .numCellsTsPairsExamined(5)
+                .sortedTimestamps(1000L, 1001L, 1002L, 1003L, 1004L)
+                .build()), cells);
+    }
+
+    @Test
+    public void returnFirstAndLastCellOfThePage() {
+        new TestDataBuilder()
+                .put(10, 1, 1000)
+                .put(10, 2, 400)
+                // The cell (20, 1) is not a candidate because the minimumUncommittedTimestamp is 750, which is greater
+                // than 500. However, we still need to return this cell since it's at the page boundary.
+                .put(20, 1, 500)
+                // <---- page boundary here ---->
+                // Again, this cell is not a candidate, but we need to return it
+                // since it's the first SQL row in the page.
+                .put(30, 1, 600)
+                .store();
+        List<CandidateCellForSweeping> cells = getWithOverriddenLimit(
+                conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 2000L, 750L), 3);
+        assertEquals(
+                ImmutableList.of(
+                    ImmutableCandidateCellForSweeping.builder()
+                        .cell(cell(10, 1))
+                        .isLatestValueEmpty(false)
+                        .numCellsTsPairsExamined(1)
+                        .sortedTimestamps(1000L)
+                        .build(),
+                    ImmutableCandidateCellForSweeping.builder()
+                        .cell(cell(20, 1))
+                        .isLatestValueEmpty(false)
+                        .numCellsTsPairsExamined(3)
+                        // No timestamps because the cell is not a real candidate
+                        .sortedTimestamps()
+                        .build(),
+                    ImmutableCandidateCellForSweeping.builder()
+                        .cell(cell(30, 1))
+                        .isLatestValueEmpty(false)
+                        .numCellsTsPairsExamined(4)
+                        // No timestamps because the cell is not a real candidate
+                        .sortedTimestamps()
+                        .build()),
+                cells);
+    }
+
+    private List<CandidateCellForSweeping> getWithOverriddenLimit(
+            CandidateCellForSweepingRequest request,
+            int sqlRowLimitOverride) {
+        try (ClosableIterator<List<CandidateCellForSweeping>> iter = createImpl(sqlRowLimitOverride)
+                    .getCandidateCellsForSweeping(TEST_TABLE, request, null)) {
+            return ImmutableList.copyOf(Iterators.concat(Iterators.transform(iter, List::iterator)));
+        }
+    }
+
+    private DbKvsGetCandidateCellsForSweeping createImpl(int sqlRowLimitOverride) {
+        return new OracleGetCandidateCellsForSweeping(
+                new OraclePrefixedTableNames(new OracleTableNameGetter((OracleDdlConfig) config.ddl())),
+                connectionSupplier,
+                x -> sqlRowLimitOverride);
+    }
+
+}

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/DbkvsOracleTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/DbkvsOracleTestSuite.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
+
+import java.net.InetSocketAddress;
+import java.sql.Connection;
+import java.util.concurrent.Callable;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.Duration;
+import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.ImmutableDbKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.ImmutableOracleDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionManagerAwareDbKvs;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.SqlConnectionSupplier;
+import com.palantir.db.oracle.NativeOracleJdbcHandler;
+import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import com.palantir.docker.compose.connection.Container;
+import com.palantir.docker.compose.connection.DockerPort;
+import com.palantir.nexus.db.monitoring.timer.SqlTimer;
+import com.palantir.nexus.db.monitoring.timer.SqlTimers;
+import com.palantir.nexus.db.pool.ReentrantManagedConnectionSupplier;
+import com.palantir.nexus.db.pool.config.ConnectionConfig;
+import com.palantir.nexus.db.pool.config.ImmutableMaskedValue;
+import com.palantir.nexus.db.pool.config.ImmutableOracleConnectionConfig;
+import com.palantir.nexus.db.sql.ConnectionBackedSqlConnectionImpl;
+import com.palantir.nexus.db.sql.SQL;
+import com.palantir.nexus.db.sql.SqlConnection;
+import com.palantir.nexus.db.sql.SqlConnectionHelper;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses(DbKvsOracleGetCandidateCellsForSweepingTest.class)
+public final class DbkvsOracleTestSuite {
+    private static final int ORACLE_PORT_NUMBER = 1521;
+
+    private DbkvsOracleTestSuite() {
+        // Test suite
+    }
+
+    @ClassRule
+    public static final DockerComposeRule docker = DockerComposeRule.builder()
+            .file("/Users/hsaraogi/code/atlasdb/atlasdb-dbkvs-tests/src/test/resources/docker-compose.oracle.yml")
+            .waitingForService("oracle", Container::areAllPortsOpen)
+            .saveLogsTo("container-logs")
+            .shutdownStrategy(ShutdownStrategy.SKIP)
+            .build();
+
+    @BeforeClass
+    public static void waitUntilDbKvsIsUp() throws InterruptedException {
+        Awaitility.await()
+                .atMost(Duration.TEN_MINUTES)
+                .pollInterval(Duration.TEN_SECONDS)
+                .until(canCreateKeyValueService());
+    }
+
+    public static DbKeyValueServiceConfig getKvsConfig() {
+        DockerPort port = docker.containers()
+                .container("oracle")
+                .port(ORACLE_PORT_NUMBER);
+
+        InetSocketAddress oracleAddress = new InetSocketAddress(port.getIp(), port.getExternalPort());
+
+        ConnectionConfig connectionConfig = ImmutableOracleConnectionConfig.builder()
+                .dbLogin("palantir")
+                .dbPassword(ImmutableMaskedValue.of("palpal"))
+                .sid("palantir")
+                .host(oracleAddress.getHostName())
+                .port(oracleAddress.getPort())
+                .build();
+
+        return ImmutableDbKeyValueServiceConfig.builder()
+                .connection(connectionConfig)
+                .ddl(ImmutableOracleDdlConfig.builder()
+                        .overflowMigrationState(OverflowMigrationState.FINISHED)
+                        .jdbcHandler(new NativeOracleJdbcHandler())
+                        .build())
+                .build();
+    }
+
+    public static ConnectionSupplier getConnectionSupplier() {
+        ConnectionManagerAwareDbKvs kvs = ConnectionManagerAwareDbKvs.create(getKvsConfig());
+        ReentrantManagedConnectionSupplier connSupplier =
+                new ReentrantManagedConnectionSupplier(kvs.getConnectionManager());
+        return new ConnectionSupplier(getSimpleTimedSqlConnectionSupplier(connSupplier));
+    }
+
+    private static SqlConnectionSupplier getSimpleTimedSqlConnectionSupplier(
+            ReentrantManagedConnectionSupplier connectionSupplier) {
+        Supplier<Connection> supplier = () -> connectionSupplier.get();
+        SQL sql = new SQL() {
+            @Override
+            protected SqlConfig getSqlConfig() {
+                return new SqlConfig() {
+                    @Override
+                    public boolean isSqlCancellationDisabled() {
+                        return false;
+                    }
+
+                    protected Iterable<SqlTimer> getSqlTimers() {
+                        return ImmutableList.of(
+                                SqlTimers.createDurationSqlTimer(),
+                                SqlTimers.createSqlStatsSqlTimer());
+                    }
+
+                    @Override
+                    public SqlTimer getSqlTimer() {
+                        return SqlTimers.createCombinedSqlTimer(getSqlTimers());
+                    }
+                };
+            }
+        };
+
+        return new SqlConnectionSupplier() {
+            @Override
+            public SqlConnection get() {
+                return new ConnectionBackedSqlConnectionImpl(
+                        supplier.get(),
+                        () -> {
+                            throw new UnsupportedOperationException(
+                                    "This SQL connection does not provide reliable timestamp.");
+                        },
+                        new SqlConnectionHelper(sql));
+            }
+
+            @Override
+            public void close() {
+                connectionSupplier.close();
+            }
+        };
+    }
+
+    private static Callable<Boolean> canCreateKeyValueService() {
+        return () -> {
+            ConnectionManagerAwareDbKvs kvs = null;
+            try {
+                kvs = ConnectionManagerAwareDbKvs.create(getKvsConfig());
+                return kvs.getConnectionManager().getConnection().isValid(5);
+            } catch (Exception e) {
+                return false;
+            } finally {
+                if (kvs != null) {
+                    kvs.close();
+                }
+            }
+        };
+    }
+}

--- a/atlasdb-dbkvs-tests/src/test/resources/docker-compose.oracle.yml
+++ b/atlasdb-dbkvs-tests/src/test/resources/docker-compose.oracle.yml
@@ -1,0 +1,19 @@
+version: '2'
+
+services:
+  oracle:
+    image: docker.palantir.build/pg/oracle-hydration-se-11.2.0.4:281a5862eb7af0c45c73c9e70481e2bd75bdb1de
+    environment:
+      SQLPLUS_INIT_00: startup nomount
+      SQLPLUS_INIT_01: alter system set processes=1000 scope=spfile
+      SQLPLUS_INIT_02: alter system set open_cursors=1000 scope=spfile
+      SQLPLUS_INIT_03: alter system set sessions=1000 scope=spfile
+      SQLPLUS_INIT_04: alter system set max_shared_servers=4000 scope=spfile
+      SQLPLUS_INIT_05: alter system set sga_max_size=1000M scope=spfile
+      SQLPLUS_INIT_06: alter system set sga_target=1000M scope=spfile
+      SQLPLUS_INIT_08: alter system set pga_aggregate_target=160M scope=spfile
+      SQLPLUS_INIT_09: shutdown immediate
+      SQLPLUS_INIT_10: startup
+    ports:
+      - "2080"
+      - "1521"

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -209,7 +209,7 @@ public final class DbKvs extends AbstractKeyValueService {
                 new ImmediateSingleBatchTaskRunner(),
                 overflowValueLoader,
                 getRange,
-                new OracleGetCandidateCellsForSweeping());
+                OracleGetCandidateCellsForSweeping.create(prefixedTableNames, connections));
     }
 
     private DbKvs(ExecutorService executor,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleGetCandidateCellsForSweeping.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleGetCandidateCellsForSweeping.java
@@ -16,23 +16,290 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.IntToLongFunction;
 
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.primitives.Longs;
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.FullQuery;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OraclePrefixedTableNames;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.SqlConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres.CandidatePageJoiningIterator;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ranges.RangeBoundPredicates;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.sweep.DbKvsGetCandidateCellsForSweeping;
-import com.palantir.atlasdb.keyvalue.impl.GetCandidateCellsForSweepingShim;
 import com.palantir.common.base.ClosableIterator;
+import com.palantir.common.base.ClosableIterators;
+import com.palantir.exception.PalantirSqlException;
+import com.palantir.nexus.db.sql.AgnosticLightResultRow;
+import com.palantir.nexus.db.sql.AgnosticLightResultSet;
+
+import gnu.trove.list.TLongList;
+import gnu.trove.list.array.TLongArrayList;
 
 public class OracleGetCandidateCellsForSweeping implements DbKvsGetCandidateCellsForSweeping {
+
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(OracleTableInitializer.class);
+
+    private final OraclePrefixedTableNames prefixedTableNames;
+    private final SqlConnectionSupplier connectionPool;
+
+    private final IntToLongFunction sqlRowLimitProvider;
+    private final long[] emptyLongArray = new long[] {};
+    private static final int DEFAULT_BATCH_SIZE = 1000;
+
+    public static OracleGetCandidateCellsForSweeping create(
+            OraclePrefixedTableNames prefixedTableNames,
+            SqlConnectionSupplier connectionPool) {
+        return new OracleGetCandidateCellsForSweeping(
+                prefixedTableNames,
+                connectionPool,
+                // Since in our SQL query we limit the number of examined cells rather than the number of
+                // returned candidates, we set the limit higher than the requested batch size.
+                batchHint -> 4 * batchHint);
+    }
+
+    @VisibleForTesting
+    /* package */ OracleGetCandidateCellsForSweeping(
+            OraclePrefixedTableNames prefixedTableNames,
+            SqlConnectionSupplier connectionPool,
+            IntToLongFunction sqlRowLimitProvider) {
+        this.prefixedTableNames = prefixedTableNames;
+        this.connectionPool = connectionPool;
+        this.sqlRowLimitProvider = sqlRowLimitProvider;
+    }
+
     @Override
     public ClosableIterator<List<CandidateCellForSweeping>> getCandidateCellsForSweeping(
             TableReference tableRef,
             CandidateCellForSweepingRequest request,
             KeyValueService kvs) {
-        // TODO(gbonik): actual impl
-        return new GetCandidateCellsForSweepingShim(kvs).getCandidateCellsForSweeping(tableRef, request);
+        String tableName = DbKvs.internalTableName(tableRef);
+        PageIterator rawIterator = new PageIterator(
+                request,
+                (int) sqlRowLimitProvider.applyAsLong(request.batchSizeHint().orElse(DEFAULT_BATCH_SIZE)),
+                tableName,
+                prefixedTableNames.get(tableRef, new ConnectionSupplier(connectionPool)),
+                request.startRowInclusive());
+        return ClosableIterators.wrap(
+                // Pages returned from rawIterator can be small or even empty,
+                // so we need to re-partition them
+                new CandidatePageJoiningIterator(rawIterator, request.batchSizeHint().orElse(DEFAULT_BATCH_SIZE)));
     }
+
+    private class PageIterator extends AbstractIterator<List<CandidateCellForSweeping>> {
+        private final CandidateCellForSweepingRequest request;
+        private final int sqlRowLimit;
+        private final String prefixedTableName;
+
+        private byte[] currentRowName;
+        private byte[] currentColName = PtBytes.EMPTY_BYTE_ARRAY;
+        private Long firstCellStartTimestampInclusive = null;
+        private boolean endOfResults = false;
+        private final TLongList currentCellTimestamps = new TLongArrayList();
+        private boolean currentIsLatestValueEmpty = false;
+        private long cellTsPairsExaminedTotal = 0;
+        private long cellTsPairsExaminedCurrentBatch = 0;
+
+        PageIterator(CandidateCellForSweepingRequest request, int sqlRowLimit, String tableName,
+                String prefixedTableName, byte[] currentRowName) {
+            this.request = request;
+            this.sqlRowLimit = sqlRowLimit;
+            this.prefixedTableName = prefixedTableName;
+            this.currentRowName = currentRowName;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        protected List<CandidateCellForSweeping> computeNext() {
+            if (endOfResults) {
+                return endOfData();
+            } else {
+                try (ConnectionSupplier conns = new ConnectionSupplier(connectionPool);
+                        ClosableIterator<AgnosticLightResultRow> iter = selectNextPage(conns)) {
+                    List<CandidateCellForSweeping> results = new ArrayList<>();
+                    boolean noResults = true;
+                    cellTsPairsExaminedCurrentBatch = 0;
+                    while (iter.hasNext()) {
+                        noResults = false;
+                        AgnosticLightResultRow sqlRow = iter.next();
+                        byte[] rowName = sqlRow.getBytes("row_name");
+                        byte[] colName = sqlRow.getBytes("col_name");
+                        if (!isCurrentCell(rowName, colName)) {
+                            getCurrentCandidate().ifPresent(results::add);
+                            currentCellTimestamps.clear();
+                            currentRowName = rowName;
+                            currentColName = colName;
+                        }
+                        BigDecimal[] timestamps = (BigDecimal[]) sqlRow.getArray("timestamps");
+                        for (BigDecimal ts : timestamps) {
+                            currentCellTimestamps.add(ts.longValue());
+                        }
+                        cellTsPairsExaminedCurrentBatch = sqlRow.getLong("max_row_number");
+                        if (request.shouldCheckIfLatestValueIsEmpty()) {
+                            currentIsLatestValueEmpty = sqlRow.getBoolean("latest_val_empty");
+                        }
+                    }
+                    if (noResults || cellTsPairsExaminedCurrentBatch < sqlRowLimit) {
+                        getCurrentCandidate().ifPresent(results::add);
+                        endOfResults = true;
+                    } else {
+                        computeNextStartPosition();
+                    }
+                    cellTsPairsExaminedTotal += cellTsPairsExaminedCurrentBatch;
+                    return results;
+                }
+            }
+        }
+
+        private boolean isCurrentCell(byte[] rowName, byte[] colName) {
+            return Arrays.equals(currentRowName, rowName) && Arrays.equals(currentColName, colName);
+        }
+
+        private void computeNextStartPosition() {
+            long lastTs = currentCellTimestamps.get(currentCellTimestamps.size() - 1);
+            // This can never happen because we request 'WHERE ts < ?', where '?' is some 'long' value.
+            // So if the timestamp is strictly less than another 'long', it can not be Long.MAX_VALUE.
+            // But we check anyway for general paranoia reasons.
+            Preconditions.checkState(lastTs != Long.MAX_VALUE);
+            firstCellStartTimestampInclusive = lastTs + 1;
+        }
+
+        private Optional<CandidateCellForSweeping> getCurrentCandidate() {
+            if (currentCellTimestamps.isEmpty()) {
+                return Optional.empty();
+            } else {
+                return Optional.of(ImmutableCandidateCellForSweeping.builder()
+                        .cell(Cell.create(currentRowName, currentColName))
+                        .sortedTimestamps(getSortedTimestamps())
+                        .isLatestValueEmpty(currentIsLatestValueEmpty)
+                        .numCellsTsPairsExamined(cellTsPairsExaminedTotal + cellTsPairsExaminedCurrentBatch)
+                        .build());
+            }
+        }
+
+        private long[] getSortedTimestamps() {
+            if (isCandidate()) {
+                long[] sortedTimestamps = currentCellTimestamps.toArray();
+                Arrays.sort(sortedTimestamps);
+                return sortedTimestamps;
+            } else {
+                return emptyLongArray;
+            }
+        }
+
+        private boolean isCandidate() {
+            return currentCellTimestamps.size() > 1
+                    || currentCellTimestamps.get(currentCellTimestamps.size() - 1)
+                    >= request.minUncommittedStartTimestamp()
+                    || currentCellTimestamps.contains(Value.INVALID_VALUE_TIMESTAMP)
+                    || currentIsLatestValueEmpty;
+        }
+
+        private ClosableIterator<AgnosticLightResultRow> selectNextPage(ConnectionSupplier conns) {
+            executeIgnoringError(conns, "CREATE TYPE num_list AS TABLE OF NUMBER(20)", "ORA-00955");
+
+            FullQuery query = getQuery();
+            AgnosticLightResultSet rs = conns.get().selectLightResultSetUnregisteredQuery(
+                    query.getQuery(), query.getArgs());
+            return ClosableIterators.wrap(rs.iterator(), rs);
+        }
+
+        private FullQuery getQuery() {
+            RangeBoundPredicates bounds = RangeBoundPredicates.builder(false)
+                    .startCellTsInclusiveOracle(currentRowName, currentColName, firstCellStartTimestampInclusive)
+                    .build();
+            boolean ignoreSentinels = areSentinelsIgnored();
+            String query =  "SELECT cells.row_name, cells.col_name, cells.timestamps, cells.max_rn AS max_row_number"
+                    +    (request.shouldCheckIfLatestValueIsEmpty() ? ", length(v.val) = 0 AS latest_val_empty" : "")
+                    + "  FROM ("
+                    + "    SELECT"
+                    + "      row_name,"
+                    + "      col_name,"
+                    + "      MIN(rn) AS min_rn,"
+                    + "      MAX(rn) AS max_rn,"
+                    + "      MIN(ts) AS min_ts,"
+                    + "      MAX(ts) AS max_ts,"
+                    +        (ignoreSentinels
+                    ? ""
+                    : " MAX((ts=" + Value.INVALID_VALUE_TIMESTAMP + ")::int) AS have_sentinel,")
+                    + "      CAST(COLLECT(ts) AS num_list) timestamps"
+                    + "    FROM ("
+                    + "      SELECT row_name, col_name, ts, ROW_NUMBER() OVER (ORDER BY row_name, col_name, ts) AS rn"
+                    + "      FROM " + prefixedTableName
+                    + "      WHERE ts < ? " + bounds.predicates + getIgnoredTimestampPredicate()
+                    + "      ORDER BY row_name, col_name, ts"
+//                    + "      LIMIT " + sqlRowLimit
+                    + "    ) sub"
+                    + "    GROUP BY row_name, col_name"
+                    + "    ORDER BY row_name, col_name"
+                    + "  ) cells"
+                    +    (request.shouldCheckIfLatestValueIsEmpty()
+                    ? "  JOIN " + prefixedTableName + " v"
+                    + "  ON cells.row_name = v.row_name"
+                    + "  AND cells.col_name = v.col_name"
+                    + "  AND cells.max_ts = v.ts"
+                    : "")
+                    + "  WHERE"
+                    // See KVS.getCandidateCellsForSweeping() docs for the definition of a candidate cell:
+                    // (1) The set T has more than one element
+                    + "    min_ts <> max_ts"
+                    // (2) The set T contains an element that is greater than or equal to Tu
+                    + "    OR max_ts >= ?"
+                    // (3) The set T contains Value.INVALID_VALUE_TIMESTAMP
+                    +      (ignoreSentinels ? "" : " OR have_sentinel = 1")
+                    // (4) V is true and the cell value corresponding to the maximum element of T is empty
+                    +      (request.shouldCheckIfLatestValueIsEmpty() ? " OR length(v.val) = 0" : "")
+                    // Also, always get the first cell, as well as the last one if the limit was reached
+                    + "    OR min_rn = 1 OR max_rn = " + sqlRowLimit
+                    + "  ORDER BY cells.row_name, cells.col_name";
+            return new FullQuery(query)
+                    .withArg(request.sweepTimestamp()) // "WHERE ts < ?"
+                    .withArgs(bounds.args)
+                    .withArg(request.minUncommittedStartTimestamp()); // "OR max_ts >= ?"
+        }
+
+        private boolean areSentinelsIgnored() {
+            return Longs.contains(request.timestampsToIgnore(), Value.INVALID_VALUE_TIMESTAMP);
+        }
+
+        private String getIgnoredTimestampPredicate() {
+            StringBuilder ret = new StringBuilder();
+            for (long ts : request.timestampsToIgnore()) {
+                // In practice this will always be -1, so we don't bother with binds
+                ret.append(" AND ts <> ").append(ts);
+            }
+            return ret.toString();
+        }
+    }
+
+    private void executeIgnoringError(ConnectionSupplier conns, String sql, String errorToIgnore) {
+        try {
+            conns.get().executeUnregisteredQuery(sql);
+        } catch (PalantirSqlException e) {
+            if (!e.getMessage().contains(errorToIgnore)) {
+                log.error("Error occurred trying to execute the query {}", sql, e);
+                throw e;
+            }
+        }
+    }
+
+
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/RangeBoundPredicates.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/ranges/RangeBoundPredicates.java
@@ -109,5 +109,23 @@ public final class RangeBoundPredicates {
         public RangeBoundPredicates build() {
             return new RangeBoundPredicates(predicates.toString(), args);
         }
+
+        public Builder startCellTsInclusiveOracle(byte[] startRowInclusive, byte[] startColumnInclusive,
+                Long startTsInclusive) {
+            if (startTsInclusive != null) {
+                Preconditions.checkArgument(startRowInclusive.length > 0);
+                Preconditions.checkArgument(startColumnInclusive.length > 0);
+                // Warning: this syntax is not supported by Oracle
+                predicates.append(reverse
+                        ? " AND row_name <= ? AND col_name <= ? AND ts <= ? "
+                        : " AND row_name >= ? AND col_name >= ? AND ts >= ? ");
+                args.add(startRowInclusive);
+                args.add(startColumnInclusive);
+                args.add(startTsInclusive);
+            } else {
+                startCellInclusive(startRowInclusive, startColumnInclusive);
+            }
+            return this;
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
         url 'https://dl.bintray.com/palantir/releases/'

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -14,6 +14,7 @@ version = rootProject.version
 group = rootProject.group
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
         url 'http://dl.bintray.com/palantir/releases/'


### PR DESCRIPTION
**Goals (and why)**:  Oracle sweep should respect sweep batching parameters. Sweep should be efficient/faster.

**Implementation Description (bullets)**:
1. tests for Postgres Sweep extended on Oracle (these should ultimately live in dbkvs-oracle-driver, exist here for faster iteration)
2. Basic candidate batch selection queries for oracle.

**Concerns (what feedback would you like?)**: 
1. Queries are not efficient/compatible
2. One test is failing

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2435)
<!-- Reviewable:end -->
