### PR TITLE
Simplify getCandidateCellsForSweeping()

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CandidateCellForSweepingRequest.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CandidateCellForSweepingRequest.java
@@ -26,19 +26,6 @@ public interface CandidateCellForSweepingRequest {
     OptionalInt batchSizeHint();
 
     /**
-     * This can be used in the future when we implement the 'transaction table sweeping' feature.
-     * This should be set to the timestamp T such that all transactions with start timestamps less than T that
-     * appear in the given table are known to be committed. The number T can come from the previous run of sweep
-     * for the table.
-     *
-     * This enables in-database pre-filtering of cells that should be considered for sweeping.
-     * For example, if a cell has exactly one timestamp and this timestamp is known to belong to a committed
-     * transaction, then the cell doesn't need to be swept, and therefore we can avoid sending it over the network
-     * from the DB to the sweeper process.
-     */
-    long minUncommittedStartTimestamp();
-
-    /**
      *  Only start timestamps that are strictly below this number will be considered.
      */
     long sweepTimestamp();

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -450,30 +450,10 @@ public interface KeyValueService extends AutoCloseable {
 
     /**
      * For a given range of rows, returns all candidate cells for sweeping (and their timestamps).
-     * Here is the precise definition of a candidate cell:
-     * <blockquote>
-     *      Let {@code Ts} be {@code request.sweepTimestamp()}<br>
-     *      Let {@code Tu} be {@code request.minUncommittedTimestamp()}<br>
-     *      Let {@code V} be {@code request.shouldCheckIfLatestValueIsEmpty()}<br>
-     *      Let {@code Ti} be set of timestamps in {@code request.timestampsToIgnore()}<br>
-     *      <p>
-     *      Consider a cell {@code C}. Let {@code Tc} be the set of all timestamps for {@code C} that are strictly
-     *      less than {@code Ts}. Let {@code T} be {@code Tc \ Ti} (i.e. the cell timestamps minus the ignored
-     *      timestamps).
-     *      <p>
-     *      Then {@code C} is a candidate for sweeping if and only if at least one of
-     *      the following conditions is true:
-     *      <ol>
-     *          <li> The set {@code T} has more than one element
-     *          <li> The set {@code T} contains an element that is greater than or equal to {@code Tu}
-     *             (that is, there is a timestamp that can possibly come from an uncommitted or aborted transaction)
-     *          <li> The set {@code T} contains {@link Value#INVALID_VALUE_TIMESTAMP}
-     *             (that is, there is a sentinel we can possibly clean up)
-     *          <li> {@code V} is true and the cell value corresponding to the maximum element of {@code T} is empty
-     *             (that is, the latest sweepable value is a 'soft-delete' tombstone)
-     *      </ol>
-     *
-     * </blockquote>
+     * <p>
+     * A candidate cell is a cell that has at least one timestamp that is less than request.sweepTimestamp() and is
+     * not in the set specified by request.timestampsToIgnore().
+     * <p>
      * This method will scan the semi-open range of rows from the start row specified in the {@code request}
      * to the end of the table. If the given start row name is an empty byte array, the whole table will be
      * scanned.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/GetCandidateCellsForSweepingShim.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/GetCandidateCellsForSweepingShim.java
@@ -82,10 +82,9 @@ public class GetCandidateCellsForSweepingShim {
                         Cell cell = Cell.create(rr.getRowName(), colName);
                         boolean latestValEmpty = isLatestValueEmpty(cell, peekingValues);
                         numExamined.add(timestampArr.length);
-                        boolean candidate = isCandidate(timestampArr, latestValEmpty, request);
                         candidateBatch.add(ImmutableCandidateCellForSweeping.builder()
                                 .cell(cell)
-                                .sortedTimestamps(candidate ? timestampArr : EMPTY_LONG_ARRAY)
+                                .sortedTimestamps(timestampArr)
                                 .isLatestValueEmpty(latestValEmpty)
                                 .numCellsTsPairsExamined(numExamined.longValue())
                                 .build());
@@ -107,18 +106,6 @@ public class GetCandidateCellsForSweepingShim {
             c.release();
         }
         return closer;
-    }
-
-    private static boolean isCandidate(long[] timestamps,
-                                       boolean lastValEmpty,
-                                       CandidateCellForSweepingRequest request) {
-        return timestamps.length > 1
-            || (request.shouldCheckIfLatestValueIsEmpty() && lastValEmpty)
-            || (timestamps.length == 1 && timestampIsPotentiallySweepable(timestamps[0], request));
-    }
-
-    private static boolean timestampIsPotentiallySweepable(long ts, CandidateCellForSweepingRequest request) {
-        return ts == Value.INVALID_VALUE_TIMESTAMP || ts >= request.minUncommittedStartTimestamp();
     }
 
     private ClosableIterator<RowResult<Value>> getValues(TableReference tableRef,
@@ -175,5 +162,4 @@ public class GetCandidateCellsForSweepingShim {
         }
     }
 
-    private static final long[] EMPTY_LONG_ARRAY = new long[0];
 }

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -97,7 +97,8 @@ public final class DbkvsPostgresTestSuite {
                 kvs = ConnectionManagerAwareDbKvs.create(getKvsConfig());
                 return kvs.getConnectionManager().getConnection().isValid(5);
             } catch (Exception ex) {
-                if (ex.getMessage().contains("The connection attempt failed.")) {
+                if (ex.getMessage().contains("The connection attempt failed.")
+                        || ex.getMessage().contains("the database system is starting up")) {
                     return false;
                 } else {
                     throw ex;

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresGetCandidateCellsForSweepingTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresGetCandidateCellsForSweepingTest.java
@@ -16,113 +16,18 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.List;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
-import com.palantir.atlasdb.encoding.PtBytes;
-import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
-import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
-import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.DbkvsPostgresTestSuite;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionManagerAwareDbKvs;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.SqlConnectionSupplier;
-import com.palantir.atlasdb.keyvalue.dbkvs.impl.sweep.DbKvsGetCandidateCellsForSweeping;
 import com.palantir.atlasdb.keyvalue.impl.AbstractGetCandidateCellsForSweepingTest;
-import com.palantir.common.base.ClosableIterator;
 
 public class DbKvsPostgresGetCandidateCellsForSweepingTest extends AbstractGetCandidateCellsForSweepingTest {
 
-    private static DbKeyValueServiceConfig config;
-    private static SqlConnectionSupplier connectionSupplier;
-
     @Override
     protected KeyValueService createKeyValueService() {
-        config = DbkvsPostgresTestSuite.getKvsConfig();
-        ConnectionManagerAwareDbKvs kvs = ConnectionManagerAwareDbKvs.create(config);
-        connectionSupplier = kvs.getSqlConnectionSupplier();
-        return kvs;
-    }
-
-    @Test
-    public void singleCellSpanningSeveralPages() {
-        new TestDataBuilder()
-                .put(10, 1, 1000)
-                .put(10, 1, 1001)
-                .put(10, 1, 1002)
-                .put(10, 1, 1003)
-                .put(10, 1, 1004)
-                .store();
-        List<CandidateCellForSweeping> cells = getWithOverriddenLimit(
-                conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 2000L, Long.MIN_VALUE), 2);
-        assertEquals(ImmutableList.of(ImmutableCandidateCellForSweeping.builder()
-                .cell(cell(10, 1))
-                .isLatestValueEmpty(false)
-                .numCellsTsPairsExamined(5)
-                .sortedTimestamps(1000L, 1001L, 1002L, 1003L, 1004L)
-                .build()), cells);
-    }
-
-    @Test
-    public void returnFirstAndLastCellOfThePage() {
-        new TestDataBuilder()
-                .put(10, 1, 1000)
-                .put(10, 2, 400)
-                // The cell (20, 1) is not a candidate because the minimumUncommittedTimestamp is 750, which is greater
-                // than 500. However, we still need to return this cell since it's at the page boundary.
-                .put(20, 1, 500)
-                // <---- page boundary here ---->
-                // Again, this cell is not a candidate, but we need to return it
-                // since it's the first SQL row in the page.
-                .put(30, 1, 600)
-                .store();
-        List<CandidateCellForSweeping> cells = getWithOverriddenLimit(
-                conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 2000L, 750L), 3);
-        assertEquals(
-                ImmutableList.of(
-                    ImmutableCandidateCellForSweeping.builder()
-                        .cell(cell(10, 1))
-                        .isLatestValueEmpty(false)
-                        .numCellsTsPairsExamined(1)
-                        .sortedTimestamps(1000L)
-                        .build(),
-                    ImmutableCandidateCellForSweeping.builder()
-                        .cell(cell(20, 1))
-                        .isLatestValueEmpty(false)
-                        .numCellsTsPairsExamined(3)
-                        // No timestamps because the cell is not a real candidate
-                        .sortedTimestamps()
-                        .build(),
-                    ImmutableCandidateCellForSweeping.builder()
-                        .cell(cell(30, 1))
-                        .isLatestValueEmpty(false)
-                        .numCellsTsPairsExamined(4)
-                        // No timestamps because the cell is not a real candidate
-                        .sortedTimestamps()
-                        .build()),
-                cells);
-    }
-
-    private List<CandidateCellForSweeping> getWithOverriddenLimit(
-            CandidateCellForSweepingRequest request,
-            int sqlRowLimitOverride) {
-        try (ClosableIterator<List<CandidateCellForSweeping>> iter = createImpl(sqlRowLimitOverride)
-                    .getCandidateCellsForSweeping(TEST_TABLE, request, null)) {
-            return ImmutableList.copyOf(Iterators.concat(Iterators.transform(iter, List::iterator)));
-        }
-    }
-
-    private DbKvsGetCandidateCellsForSweeping createImpl(int sqlRowLimitOverride) {
-        return new PostgresGetCandidateCellsForSweeping(
-                new PostgresPrefixedTableNames(config.ddl()),
-                connectionSupplier,
-                x -> sqlRowLimitOverride);
+        DbKeyValueServiceConfig config = DbkvsPostgresTestSuite.getKvsConfig();
+        return ConnectionManagerAwareDbKvs.create(config);
     }
 
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -189,7 +189,7 @@ public final class DbKvs extends AbstractKeyValueService {
                 new ParallelTaskRunner(newFixedThreadPool(config.poolSize()), config.fetchBatchSize()),
                 (conns, tbl, ids) -> Collections.emptyMap(), // no overflow on postgres
                 new PostgresGetRange(prefixedTableNames, connections, tableMetadataCache),
-                PostgresGetCandidateCellsForSweeping.create(prefixedTableNames, connections));
+                new PostgresGetCandidateCellsForSweeping(prefixedTableNames, connections));
     }
 
     private static DbKvs createOracle(ExecutorService executor,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -156,8 +156,6 @@ public class SweepTaskRunner {
         CandidateCellForSweepingRequest request = ImmutableCandidateCellForSweepingRequest.builder()
                 .startRowInclusive(startRow)
                 .batchSizeHint(batchConfig.candidateBatchSize())
-                 // TODO(sberler): change once we figure out transaction table sweep
-                .minUncommittedStartTimestamp(Long.MIN_VALUE)
                 .sweepTimestamp(sweepTs)
                 .shouldCheckIfLatestValueIsEmpty(sweeper.shouldSweepLastCommitted())
                 .timestampsToIgnore(sweeper.getTimestampsToIgnore())

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetCandidateCellsForSweepingBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetCandidateCellsForSweepingBenchmarks.java
@@ -75,7 +75,6 @@ public class KvsGetCandidateCellsForSweepingBenchmarks {
         CandidateCellForSweepingRequest request = ImmutableCandidateCellForSweepingRequest.builder()
                     .startRowInclusive(PtBytes.EMPTY_BYTE_ARRAY)
                     .batchSizeHint(1000)
-                    .minUncommittedStartTimestamp(Long.MIN_VALUE)
                     .sweepTimestamp(Long.MAX_VALUE)
                     .shouldCheckIfLatestValueIsEmpty(thorough)
                     .timestampsToIgnore(thorough ? new long[] {} : new long[] { Value.INVALID_VALUE_TIMESTAMP })

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractGetCandidateCellsForSweepingTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractGetCandidateCellsForSweepingTest.java
@@ -68,50 +68,45 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
     }
 
     @Test
-    public void returnCandidateIfPossiblyUncommittedTimestamp() {
-        new TestDataBuilder().put(1, 1, 10L).store();
-        assertThat(getAllCandidates(conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 40L, 5L)))
-                .containsExactly(ImmutableCandidateCellForSweeping.builder()
+    public void singleCellSpanningSeveralPages() {
+        new TestDataBuilder()
+                .put(10, 1, 1000)
+                .put(10, 1, 1001)
+                .put(10, 1, 1002)
+                .put(10, 1, 1003)
+                .put(10, 1, 1004)
+                .store();
+        List<CandidateCellForSweeping> cells = getAllCandidates(
+                conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 2000L, 2));
+        assertEquals(ImmutableList.of(ImmutableCandidateCellForSweeping.builder()
+                .cell(cell(10, 1))
+                .isLatestValueEmpty(false)
+                .numCellsTsPairsExamined(5)
+                .sortedTimestamps(1000L, 1001L, 1002L, 1003L, 1004L)
+                .build()), cells);
+    }
+
+    @Test
+    public void reportLatestEmptyValue() {
+        new TestDataBuilder()
+                .putEmpty(1, 1, 10L)
+                .put(1, 1, 5L)
+                .put(2, 2, 9L)
+                .putEmpty(2, 2, 4L)
+                .store();
+        assertThat(getAllCandidates(thoroughRequest(PtBytes.EMPTY_BYTE_ARRAY, 40L)))
+                .containsExactly(
+                    ImmutableCandidateCellForSweeping.builder()
                         .cell(cell(1, 1))
-                        .sortedTimestamps(new long[] { 10L })
-                        .isLatestValueEmpty(false)
-                        .numCellsTsPairsExamined(1)
-                        .build());
-    }
-
-    @Test
-    public void doNotReturnCandidateIfOnlyCommittedTimestamp() {
-        new TestDataBuilder().put(1, 1, 10L).store();
-        assertThat(getAllCandidates(conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 40L, 30L))).isEmpty();
-    }
-
-    @Test
-    public void returnCandidateIfTwoCommittedTimestamps() {
-        new TestDataBuilder().put(1, 1, 10L).put(1, 1, 20L).store();
-        assertThat(getAllCandidates(conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 40L, 30L)))
-                .containsExactly(ImmutableCandidateCellForSweeping.builder()
-                        .cell(cell(1, 1))
-                        .sortedTimestamps(new long[] { 10L, 20L })
-                        .isLatestValueEmpty(false)
-                        .numCellsTsPairsExamined(2)
-                        .build());
-    }
-
-    @Test
-    public void doNotReturnCandidateWithCommitedEmptyValueIfConservative() {
-        new TestDataBuilder().putEmpty(1, 1, 10L).store();
-        assertThat(getAllCandidates(conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 40L, 30L))).isEmpty();
-    }
-
-    @Test
-    public void returnCandidateWithCommitedEmptyValueIfThorough() {
-        new TestDataBuilder().putEmpty(1, 1, 10L).store();
-        assertThat(getAllCandidates(thoroughRequest(PtBytes.EMPTY_BYTE_ARRAY, 40L, 30L)))
-                .containsExactly(ImmutableCandidateCellForSweeping.builder()
-                        .cell(cell(1, 1))
-                        .sortedTimestamps(new long[] { 10L })
+                        .sortedTimestamps(5L, 10L)
                         .isLatestValueEmpty(true)
-                        .numCellsTsPairsExamined(1)
+                        .numCellsTsPairsExamined(2)
+                        .build(),
+                    ImmutableCandidateCellForSweeping.builder()
+                        .cell(cell(2, 2))
+                        .sortedTimestamps(4L, 9L)
+                        .isLatestValueEmpty(false)
+                        .numCellsTsPairsExamined(4)
                         .build());
     }
 
@@ -125,7 +120,7 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
                 .putEmpty(3, 2, 10L)
                 .putEmpty(3, 3, 10L)
                 .store();
-        assertThat(getAllCandidates(conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 30L, 5L))
+        assertThat(getAllCandidates(conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 30L, 100))
                     .stream().map(CandidateCellForSweeping::cell).collect(Collectors.toList()))
                 .containsExactly(cell(1, 1), cell(1, 2), cell(2, 2), cell(3, 1), cell(3, 2), cell(3, 3));
     }
@@ -140,13 +135,22 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
                 .putEmpty(3, 1, 10L)
                 .putEmpty(3, 2, 10L)
                 .store();
-        assertThat(getAllCandidates(conservativeRequest(cell(2, 2).getRowName(), 30L, 5L))
+        assertThat(getAllCandidates(conservativeRequest(cell(2, 2).getRowName(), 30L, 100))
                 .stream().map(CandidateCellForSweeping::cell).collect(Collectors.toList()))
                 .containsExactly(cell(2, 1), cell(2, 2), cell(3, 1), cell(3, 2));
     }
 
     @Test
-    public void largerTableWithSmallBatchSizeReturnsCorrectResults() {
+    public void largerTableWithSmallBatchSizeReturnsCorrectResultsConservative() {
+        doTestLargerTable(false);
+    }
+
+    @Test
+    public void largerTableWithSmallBatchSizeReturnsCorrectResultsThorough() {
+        doTestLargerTable(true);
+    }
+
+    private void doTestLargerTable(boolean checkIfLatestValueIsEmpty) {
         TestDataBuilder builder = new TestDataBuilder();
         List<Cell> expectedCells = Lists.newArrayList();
         for (int rowNum = 1; rowNum <= 50; ++rowNum) {
@@ -161,13 +165,12 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
         builder.store();
         List<CandidateCellForSweeping> candidates = getAllCandidates(
                 ImmutableCandidateCellForSweepingRequest.builder()
-                    .startRowInclusive(PtBytes.EMPTY_BYTE_ARRAY)
-                    .sweepTimestamp(40L)
-                    .minUncommittedStartTimestamp(1L)
-                    .shouldCheckIfLatestValueIsEmpty(false)
-                    .timestampsToIgnore(Value.INVALID_VALUE_TIMESTAMP)
-                    .batchSizeHint(1)
-                    .build());
+                        .startRowInclusive(PtBytes.EMPTY_BYTE_ARRAY)
+                        .sweepTimestamp(40L)
+                        .shouldCheckIfLatestValueIsEmpty(checkIfLatestValueIsEmpty)
+                        .timestampsToIgnore(Value.INVALID_VALUE_TIMESTAMP)
+                        .batchSizeHint(1)
+                        .build());
         assertEquals(expectedCells,
                 candidates.stream().map(CandidateCellForSweeping::cell).collect(Collectors.toList()));
     }
@@ -184,23 +187,20 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
 
     protected static CandidateCellForSweepingRequest conservativeRequest(byte[] startRow,
                                                                          long sweepTs,
-                                                                         long minUncommittedTs) {
+                                                                         int batchSizeHint) {
         return ImmutableCandidateCellForSweepingRequest.builder()
                 .startRowInclusive(startRow)
                 .sweepTimestamp(sweepTs)
-                .minUncommittedStartTimestamp(minUncommittedTs)
                 .shouldCheckIfLatestValueIsEmpty(false)
                 .timestampsToIgnore(Value.INVALID_VALUE_TIMESTAMP)
+                .batchSizeHint(batchSizeHint)
                 .build();
     }
 
-    protected static CandidateCellForSweepingRequest thoroughRequest(byte[] startRow,
-                                                                     long sweepTs,
-                                                                     long minUncommittedTs) {
+    protected static CandidateCellForSweepingRequest thoroughRequest(byte[] startRow, long sweepTs) {
         return ImmutableCandidateCellForSweepingRequest.builder()
                 .startRowInclusive(startRow)
                 .sweepTimestamp(sweepTs)
-                .minUncommittedStartTimestamp(minUncommittedTs)
                 .shouldCheckIfLatestValueIsEmpty(true)
                 .timestampsToIgnore()
                 .build();

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractGetCandidateCellsForSweepingTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractGetCandidateCellsForSweepingTest.java
@@ -70,11 +70,11 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
     @Test
     public void singleCellSpanningSeveralPages() {
         new TestDataBuilder()
-                .put(10, 1, 1000)
-                .put(10, 1, 1001)
-                .put(10, 1, 1002)
-                .put(10, 1, 1003)
-                .put(10, 1, 1004)
+                .put(10, 1, 1000L)
+                .put(10, 1, 1001L)
+                .put(10, 1, 1002L)
+                .put(10, 1, 1003L)
+                .put(10, 1, 1004L)
                 .store();
         List<CandidateCellForSweeping> cells = getAllCandidates(
                 conservativeRequest(PtBytes.EMPTY_BYTE_ARRAY, 2000L, 2));


### PR DESCRIPTION
Initially I hoped to take advantage of in-database filtering if we get
to implement the "transaction table sweeping" feature. However, seems
like that wasn't a great decision on my part - unclear when (and if) we
get that feature done, and also how much of improvement we would
actually get. The extra logic makes the code significantly more complex,
so I think we need to back off and give up the idea.

This doesn't invalidate the sweep rewrite project. The new impls still
bring significant performance improvements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2439)
<!-- Reviewable:end -->
