### PR TITLE
Remove expensive query from logs

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -113,11 +113,9 @@ public final class CassandraKeyValueServices {
                         + " or have schema 'UNKNOWN', which likely means they are down/unresponsive"
                         + " and examine their logs to determine the issue."
                         + " Fixing the underlying issue and restarting Cassandra should resolve the problem."
-                        + " You can quick-check this with 'nodetool describecluster'."
-                        + " For this node, the current keyspaces are: %s",
+                        + " You can quick-check this with 'nodetool describecluster'.",
                 tableName,
-                schemaVersions.toString(),
-                client.describe_keyspaces());
+                schemaVersions.toString());
         throw new IllegalStateException(errorMessage);
     }
 


### PR DESCRIPTION
**Goals (and why)**: `client.describe_keyspaces` will return all keyspaces in the current C* box we're querying. That's not very valuable, since we're still probably going to want to run `nodetool describe` on the cassandra cluster and on each cassandra node, potentially dangerous if we have too many tables on C* - will take time from C* to fetch this and memory from the service to log this - and not going to be safe, so we wont be able to see it in our current logging infrastructure.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2442)
<!-- Reviewable:end -->
