### PR TITLE
Actually log batch parameters in BackgroundSweeperImpl and friends

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -150,7 +150,9 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
                 SweepBatchConfig lastBatchConfig = getAdjustedBatchConfig();
                 log.warn("The background sweep job failed unexpectedly with batch config {}."
                                 + " Attempting to continue with a lower batch size...",
-                        SafeArg.of("cell batch size", lastBatchConfig),
+                        SafeArg.of("candidateBatchSize", lastBatchConfig.candidateBatchSize()),
+                        SafeArg.of("deleteBatchSize", lastBatchConfig.deleteBatchSize()),
+                        SafeArg.of("maxCellTsPairsToExamine", lastBatchConfig.maxCellTsPairsToExamine()),
                         e);
                 // Cut batch size in half, always sweep at least one row (we round down).
                 batchSizeMultiplier = Math.max(batchSizeMultiplier / 2, 1.5 / lastBatchConfig.candidateBatchSize());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -150,9 +150,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
                 SweepBatchConfig lastBatchConfig = getAdjustedBatchConfig();
                 log.warn("The background sweep job failed unexpectedly with batch config {}."
                                 + " Attempting to continue with a lower batch size...",
-                        SafeArg.of("candidateBatchSize", lastBatchConfig.candidateBatchSize()),
-                        SafeArg.of("deleteBatchSize", lastBatchConfig.deleteBatchSize()),
-                        SafeArg.of("maxCellTsPairsToExamine", lastBatchConfig.maxCellTsPairsToExamine()),
+                        SafeArg.of("sweepBatchConfig", lastBatchConfig.toString()),
                         e);
                 // Cut batch size in half, always sweep at least one row (we round down).
                 batchSizeMultiplier = Math.max(batchSizeMultiplier / 2, 1.5 / lastBatchConfig.candidateBatchSize());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -157,9 +157,7 @@ public class SpecificTableSweeper {
             log.info("Failed to sweep.",
                     LoggingArgs.tableRef("tableRef", tableRef),
                     UnsafeArg.of("startRow", startRowToHex(startRow)),
-                    SafeArg.of("candidateBatchSize", batchConfig.candidateBatchSize()),
-                    SafeArg.of("deleteBatchSize", batchConfig.deleteBatchSize()),
-                    SafeArg.of("maxCellTsPairsToExamine", batchConfig.maxCellTsPairsToExamine()));
+                    SafeArg.of("sweepBatchConfig", batchConfig.toString()));
             throw e;
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -157,7 +157,9 @@ public class SpecificTableSweeper {
             log.info("Failed to sweep.",
                     LoggingArgs.tableRef("tableRef", tableRef),
                     UnsafeArg.of("startRow", startRowToHex(startRow)),
-                    SafeArg.of("batchConfig", batchConfig));
+                    SafeArg.of("candidateBatchSize", batchConfig.candidateBatchSize()),
+                    SafeArg.of("deleteBatchSize", batchConfig.deleteBatchSize()),
+                    SafeArg.of("maxCellTsPairsToExamine", batchConfig.maxCellTsPairsToExamine()));
             throw e;
         }
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -72,6 +72,12 @@ develop
            This will help support large internal product's usage of the Timelock server.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2364>`__)
 
+    *    - |fixed|
+         - Sweep candidate batches are now logged correctly.
+           Previously, we would log a ``SafeArg`` for these batches that had no content.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2444>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
**Goals (and why)**:
- There's a VERY annoying issue where in sweep logs the batch is printed as `{}`. This fixes that and returns the three values (candidate batch size, delete batch size, max no. of cell-ts pairs to examine)

**Implementation Description (bullets)**:
- Log the values separately
- Release notes

**Concerns (what feedback would you like?)**:
- nothing in particular.

**Where should we start reviewing?**: BackgroundSweeperImpl

**Priority (whenever / two weeks / yesterday)**: soon, please - makes debugging sweep by sniffing its logs very hard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2444)
<!-- Reviewable:end -->
