### PR TITLE
dont register NotInitializedExceptionMapper by default

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -147,8 +147,9 @@ public abstract class AtlasDbConfig {
      * asynchronous initialization.
      * <p>
      * If true, initialization will be attempted synchronously, but on failure we keep retrying asynchronously to start
-     * AtlasDB. If a method is invoked on an not-yet-initialized {@link com.palantir.atlasdb.transaction.api.TransactionManager}
-     * or other object, a {@link com.palantir.exception.NotInitializedException} will be thrown. Clients can register a
+     * AtlasDB. If a method is invoked on an not-yet-initialized
+     * {@link com.palantir.atlasdb.transaction.api.TransactionManager} or other object, a
+     * {@link com.palantir.exception.NotInitializedException} will be thrown. Clients can register a
      * {@link com.palantir.atlasdb.http.NotInitializedExceptionMapper} if they wish to map this exception to a 503
      * status code.
      */

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -142,11 +142,15 @@ public abstract class AtlasDbConfig {
     }
 
     /**
-     * If false, the KVS and classes that depend on it will only try to initialize synchronously and will
-     * throw on failure, preventing AtlasDB from starting. This is consistent with the behaviour prior to
-     * implementing asynchronous initialization.
-     * If true, initialization will be attempted synchronously, but on failure we keep retrying asynchronously
-     * and start AtlasDB.
+     * If false, the KVS and classes that depend on it will only try to initialize synchronously and will throw on
+     * failure, preventing AtlasDB from starting. This is consistent with the behaviour prior to implementing
+     * asynchronous initialization.
+     * <p>
+     * If true, initialization will be attempted synchronously, but on failure we keep retrying asynchronously to start
+     * AtlasDB. If a method is invoked on an not-yet-initialized {@link com.palantir.atlasdb.transaction.api.TransactionManager}
+     * or other object, a {@link com.palantir.exception.NotInitializedException} will be thrown. Clients can register a
+     * {@link com.palantir.atlasdb.http.NotInitializedExceptionMapper} if they wish to map this exception to a 503
+     * status code.
      */
     @Value.Default
     public boolean initializeAsync() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -213,10 +213,6 @@ public final class TransactionManagers {
             String userAgent) {
         checkInstallConfig(config);
 
-        if (config.initializeAsync()) {
-            env.register(new NotInitializedExceptionMapper());
-        }
-
         AtlasDbRuntimeConfig defaultRuntime = AtlasDbRuntimeConfig.defaultRuntimeConfig();
         java.util.function.Supplier<AtlasDbRuntimeConfig> runtimeConfigSupplier =
                 () -> optionalRuntimeConfigSupplier.get().orElse(defaultRuntime);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -52,7 +52,6 @@ import com.palantir.atlasdb.factory.Leaders.LocalPaxosServices;
 import com.palantir.atlasdb.factory.startup.TimeLockMigrator;
 import com.palantir.atlasdb.factory.timestamp.DecoratedTimelockServices;
 import com.palantir.atlasdb.http.AtlasDbFeignTargetFactory;
-import com.palantir.atlasdb.http.NotInitializedExceptionMapper;
 import com.palantir.atlasdb.http.UserAgents;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.NamespacedKeyValueServices;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotInitializedExceptionMapper.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/http/NotInitializedExceptionMapper.java
@@ -21,6 +21,9 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 import com.palantir.exception.NotInitializedException;
 
+/**
+ * Maps a {@link NotInitializedException} to a 503 status code.
+ */
 public class NotInitializedExceptionMapper implements ExceptionMapper<NotInitializedException> {
 
     @Override

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -31,6 +31,7 @@ import com.palantir.atlasdb.cas.SimpleCheckAndSetResource;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.dropwizard.AtlasDbBundle;
 import com.palantir.atlasdb.factory.TransactionManagers;
+import com.palantir.atlasdb.http.NotInitializedExceptionMapper;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.todo.SimpleTodoResource;
 import com.palantir.atlasdb.todo.TodoClient;
@@ -73,6 +74,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         environment.jersey().register(new SimpleTodoResource(new TodoClient(transactionManager)));
         environment.jersey().register(new SimpleCheckAndSetResource(new CheckAndSetClient(transactionManager)));
         environment.jersey().register(HttpRemotingJerseyFeature.INSTANCE);
+        environment.jersey().register(new NotInitializedExceptionMapper());
     }
 
     private TransactionManager tryToCreateTransactionManager(AtlasDbEteConfiguration config, Environment environment)

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.0'
+    id 'com.palantir.circle.style' version '1.0.0'
     id 'com.palantir.configuration-resolver' version '0.2.0'
     id 'com.palantir.git-version' version '0.5.2'
     id 'org.inferred.processors' version '1.2.12'


### PR DESCRIPTION
**Goals (and why)**:
It feels slightly too opinionated to register a 503 exception mapper for `NotInitializedException` without any way to turn it off (though I do think returning 503 is a reasonable default behavior).

Instead we can provide the exception mapper, and clients can register it if they want to.

**Implementation Description (bullets)**:
- Don't register the exception mapper

**Concerns (what feedback would you like?)**:
- Would it actually be better to register it by default, and provide a way to turn it off?

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP, hoping to release async initialization early next week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2447)
<!-- Reviewable:end -->
