### PR TITLE
TableTasks diffExternal and diffCopy handle thread interruption #2453

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
@@ -92,8 +92,16 @@ public final class TableTasks {
                                     final CopyTask task) throws InterruptedException {
         BlockingWorkerPool pool = new BlockingWorkerPool(exec, threadCount);
         for (final MutableRange range : getRanges(threadCount, batchSize)) {
+            if (Thread.currentThread().isInterrupted()) {
+                log.info("Thread interrupted. Cancelling copy of range {}", range);
+                break;
+            }
             pool.submitTask(() -> {
                 do {
+                    if (Thread.currentThread().isInterrupted()) {
+                        log.info("Thread interrupted. Cancelling copy of range {}", range);
+                        break;
+                    }
                     final RangeRequest request = range.getRangeRequest();
                     try {
                         long startTime = System.currentTimeMillis();
@@ -209,8 +217,16 @@ public final class TableTasks {
                                      final DiffTask task) throws InterruptedException {
         BlockingWorkerPool pool = new BlockingWorkerPool(exec, threadCount);
         for (final MutableRange range : getRanges(threadCount, batchSize)) {
+            if (Thread.currentThread().isInterrupted()) {
+                log.info("Thread interrupted. Cancelling diff of range {}", range);
+                break;
+            }
             pool.submitTask(() -> {
                 do {
+                    if (Thread.currentThread().isInterrupted()) {
+                        log.info("Thread interrupted. Cancelling diff of range {}", range);
+                        break;
+                    }
                     final RangeRequest request = range.getRangeRequest();
                     try {
                         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
**Goals (and why)**:
Interrupting a thread running copyExternal or diffExternal should terminate

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
diffExternal

**Priority (whenever / two weeks / yesterday)**:
whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2454)
<!-- Reviewable:end -->
