### PR TITLE
deprecate old executor usage; allow for specifying your own

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefresher.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Sets;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 
-public class LockRefresher implements AutoCloseable {
+public class LockRefresher {
 
     private final Logger log = LoggerFactory.getLogger(LockRefresher.class);
 
@@ -75,10 +75,5 @@ public class LockRefresher implements AutoCloseable {
 
     public void unregisterLocks(Collection<LockToken> tokens) {
         tokensToRefresh.removeAll(tokens);
-    }
-
-    @Override
-    public void close() throws Exception {
-        executor.shutdown();
     }
 }

--- a/lock-api/src/test/java/com/palantir/lock/client/LockRefreshingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockRefreshingTimelockServiceTest.java
@@ -52,7 +52,7 @@ public class LockRefreshingTimelockServiceTest {
 
     private final LockRefresher refresher = mock(LockRefresher.class);
     private final TimelockService delegate = mock(TimelockService.class);
-    private final TimelockService timelock = new LockRefreshingTimelockService(delegate, refresher);
+    private final TimelockService timelock = new LockRefreshingTimelockService(delegate, refresher, null);
 
     private static final long TIMEOUT = 10_000;
 


### PR DESCRIPTION
**Goals (and why)**: Move to supplying your own executor, per https://github.com/palantir/atlasdb/pull/2451#discussion_r143602445

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2457)
<!-- Reviewable:end -->
