### PR TITLE
Throw the cause of the invocationTargetException

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DynamicDecoratingProxy.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DynamicDecoratingProxy.java
@@ -58,9 +58,8 @@ public final class DynamicDecoratingProxy<T> extends AbstractInvocationHandler {
         } catch (InvocationTargetException e) {
             if (e.getTargetException() instanceof NotInitializedException) {
                 log.warn("Resource is not initialized yet!");
-                throw e.getTargetException();
             }
-            throw e;
+            throw e.getTargetException();
         }
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -97,6 +97,10 @@ develop
           ``AutoCloseable``, shutting down its internal executor service.
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2451>`__)
 
+    *   - |fixed|
+        - When using the TimeLock block and either the timestamp or the lock service threw an exception, we were throwing InvocationTargetException instead.
+          We now throw the actual cause for the invocation exception.
+          (`Pull Request <https://github.com/palantir/atlasdb/pull/2460>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
Title says it all. One more reason for us to use AutoDelegate instead of dynamic proxies.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2460)
<!-- Reviewable:end -->
