### PR TITLE
Remove dropwizard-jackson

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -21,9 +21,9 @@ dependencies {
 
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk7'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
-    compile group: 'io.dropwizard', name: 'dropwizard-jackson'
     compile group: 'com.google.code.findbugs', name: 'annotations'
 
     // This is added so that AtlasDB clients can specify the javaAgent as a JVM argument to load jars needed for HTTP/2

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfigs.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.StdSubtypeResolver;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -37,8 +38,6 @@ import com.palantir.config.crypto.jackson.JsonNodeStringReplacer;
 import com.palantir.config.crypto.jackson.JsonNodeVisitors;
 import com.palantir.remoting.api.config.ssl.SslConfiguration;
 
-import io.dropwizard.jackson.DiscoverableSubtypeResolver;
-
 public final class AtlasDbConfigs {
     public static final String ATLASDB_CONFIG_OBJECT_PATH = "/atlasdb";
 
@@ -47,7 +46,7 @@ public final class AtlasDbConfigs {
             .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
 
     static {
-        OBJECT_MAPPER.setSubtypeResolver(new DiscoverableSubtypeResolver());
+        OBJECT_MAPPER.setSubtypeResolver(new StdSubtypeResolver());
         OBJECT_MAPPER.registerModule(new GuavaModule());
         OBJECT_MAPPER.registerModule(new Jdk7Module());
         OBJECT_MAPPER.registerModule(new Jdk8Module());

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/ExceptionMappersSerializationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/ExceptionMappersSerializationTest.java
@@ -26,14 +26,16 @@ import javax.ws.rs.core.Response;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.StdSubtypeResolver;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.remoting2.errors.SerializableError;
 
-import io.dropwizard.jackson.Jackson;
-
 public class ExceptionMappersSerializationTest {
-    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final StackTraceElement[] TRACES = { new StackTraceElement("class", "method", null, 1) };
     private static final ServiceNotAvailableException SERVICE_NOT_AVAILABLE_EXCEPTION =
@@ -45,7 +47,11 @@ public class ExceptionMappersSerializationTest {
             ExceptionMappersSerializationTest.class.getResource(JSON_RESOURCE_PATH).getPath());
 
     static {
+        MAPPER.registerModule(new GuavaModule());
+        MAPPER.registerModule(new AfterburnerModule());
+        MAPPER.registerModule(new Jdk7Module());
         MAPPER.registerModule(new Jdk8Module());
+        MAPPER.setSubtypeResolver(new StdSubtypeResolver());
         SERVICE_NOT_AVAILABLE_EXCEPTION.setStackTrace(TRACES);
     }
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/AbstractTimelockServerConfigDeserializationTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/config/AbstractTimelockServerConfigDeserializationTest.java
@@ -25,15 +25,17 @@ import java.nio.file.Paths;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.StdSubtypeResolver;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk7.Jdk7Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 import com.palantir.remoting.api.config.ssl.SslConfiguration;
 import com.palantir.timelock.config.TsBoundPersisterConfiguration;
-
-import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 
 public abstract class AbstractTimelockServerConfigDeserializationTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory()
@@ -41,10 +43,11 @@ public abstract class AbstractTimelockServerConfigDeserializationTest {
             .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
 
     static {
-        OBJECT_MAPPER.setSubtypeResolver(new DiscoverableSubtypeResolver());
+        OBJECT_MAPPER.setSubtypeResolver(new StdSubtypeResolver());
         OBJECT_MAPPER.registerModule(new GuavaModule());
         OBJECT_MAPPER.registerModule(new Jdk7Module());
         OBJECT_MAPPER.registerModule(new Jdk8Module());
+        OBJECT_MAPPER.registerSubtypes(CassandraKeyValueServiceConfig.class, InMemoryAtlasDbConfig.class);
     }
 
     protected AbstractTimelockServerConfigDeserializationTest() {}


### PR DESCRIPTION
- direct dependency on jackson-datatype-jdk7
- replace DiscoverableSubtypeResolver with standard Jackson StdSubtypeResolver

**Goals (and why)**:

Remove dropwizard-jackson dependency from atlasdb-config since it depends on an old version of dropwizard and makes it difficult to for clients to move to a newer version.

Discussed in https://github.com/palantir/atlasdb/issues/1106

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

@tpetracca this was the approach you mentioned in the issue, but I think it has the problem that atlasdb-config and atlasdb-{cassandra,dbkvs,jdbc} are in different packages, so I couldn't annotate the superclass in atlasdb with all the subclasses since the project dependencies go the opposite direction.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

Low

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2465)
<!-- Reviewable:end -->
