### PR TITLE
Sweep - Normalize case before decoding; base16 is case insensitive

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -285,6 +285,6 @@ public class SweepCommand extends SingleBackendCommand {
     }
 
     private byte[] decodeStartRow(String rowString) {
-        return BaseEncoding.base16().decode(rowString);
+        return BaseEncoding.base16().decode(rowString.toUpperCase());
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -153,11 +153,12 @@ public class SpecificTableSweeper {
                 saveSweepResults(tableToSweep, results);
             }
         } catch (RuntimeException e) {
-            // Error logged at a higher log level above.
+            // This error may be logged on some paths above, but I prefer to log defensively.
             log.info("Failed to sweep.",
                     LoggingArgs.tableRef("tableRef", tableRef),
                     UnsafeArg.of("startRow", startRowToHex(startRow)),
-                    SafeArg.of("batchConfig", batchConfig));
+                    SafeArg.of("batchConfig", batchConfig),
+                    e);
             throw e;
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImpl.java
@@ -110,7 +110,7 @@ public final class SweeperServiceImpl implements SweeperService {
         if (startRow == null) {
             return PtBytes.EMPTY_BYTE_ARRAY;
         }
-        return BaseEncoding.base16().decode(startRow);
+        return BaseEncoding.base16().decode(startRow.toUpperCase());
     }
 
     private void runSweepWithoutSavingResults(TableReference tableRef) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
@@ -40,6 +40,7 @@ public class SweeperServiceImplTest extends SweeperTestSetup {
 
     private static final String VALID_START_ROW = "0102030A";
     private static final String LOWERCASE_BUT_VALID_START_ROW = "abadcafe";
+    private static final String MIXED_CASE_START_ROW = "AaAaAaAaAa1111";
     private static final String INVALID_START_ROW = "xyz";
     SweeperService sweeperService;
 
@@ -100,6 +101,15 @@ public class SweeperServiceImplTest extends SweeperTestSetup {
         when(kvs.getAllTableNames()).thenReturn(ImmutableSet.of(TABLE_REF));
 
         sweeperService.sweepTableFromStartRow(TABLE_REF.getQualifiedName(), LOWERCASE_BUT_VALID_START_ROW);
+    }
+
+    @Test
+    public void sweepTableFromStartRowShouldAcceptMixedCaseBase16Encodings() {
+        setupTaskRunner(Mockito.mock(SweepResults.class));
+
+        when(kvs.getAllTableNames()).thenReturn(ImmutableSet.of(TABLE_REF));
+
+        sweeperService.sweepTableFromStartRow(TABLE_REF.getQualifiedName(), MIXED_CASE_START_ROW);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
@@ -38,7 +38,8 @@ import io.dropwizard.testing.junit.DropwizardClientRule;
 
 public class SweeperServiceImplTest extends SweeperTestSetup {
 
-    private static final String VALID_START_ROW = "010203";
+    private static final String VALID_START_ROW = "0102030A";
+    private static final String LOWERCASE_BUT_VALID_START_ROW = "abadcafe";
     private static final String INVALID_START_ROW = "xyz";
     SweeperService sweeperService;
 
@@ -90,6 +91,15 @@ public class SweeperServiceImplTest extends SweeperTestSetup {
         when(kvs.getAllTableNames()).thenReturn(ImmutableSet.of(TABLE_REF));
 
         sweeperService.sweepTableFromStartRow(TABLE_REF.getQualifiedName(), VALID_START_ROW);
+    }
+
+    @Test
+    public void sweepTableFromStartRowShouldAcceptLowercaseBase16Encodings() {
+        setupTaskRunner(Mockito.mock(SweepResults.class));
+
+        when(kvs.getAllTableNames()).thenReturn(ImmutableSet.of(TABLE_REF));
+
+        sweeperService.sweepTableFromStartRow(TABLE_REF.getQualifiedName(), LOWERCASE_BUT_VALID_START_ROW);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -82,6 +82,11 @@ develop
            Instead, the exception is logged once only, when we run out of retries.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2432>`__)
 
+    *    - |fixed|
+         - The Sweep endpoint and CLI now accept start rows regardless of the case these are presented in.
+           Previously, giving a start row with hex characters in lower case e.g. ``deadbeef`` would result in an ``IllegalArgumentException`` being thrown.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2468>`__)
+
     *    - |devbreak|
          - Removed the following unnecessary classes related to wrapping KVSes:
 


### PR DESCRIPTION
**Goals (and why)**: Fix #2463 and #2464.
These came out of internal issue PDS-57742.

**Implementation Description (bullets)**:
- Normalize the case of a base 16 string when decoding the start row.
- Also add the exception to the log.info when we failed to sweep.
- Added a test that lowercase strings can also be parsed

**Concerns (what feedback would you like?)**:
- Are there any pitfalls I missed?

**Where should we start reviewing?**: wherever, it's small

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2468)
<!-- Reviewable:end -->
