### PR TITLE
Fix negative timestamp in Lock server logging

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -97,6 +97,10 @@ develop
           ``AutoCloseable``, shutting down its internal executor service.
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2451>`__)
 
+    *    - |fixed|
+         - Lock state logging will dump ``expiresIn`` of refreshed token, instead of original, which was negative after refreshing.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2469>`__)
+
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -115,7 +115,7 @@ public class LockServiceStateLogger {
 
     private Map<String, Object> generateHeldLocks(ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap) {
         Map<String, Object> mappedLocksToToken = Maps.newHashMap();
-        heldLocksTokenMap.forEach((token, locks) -> mappedLocksToToken.putAll(getDescriptorToTokenMap(token, locks)));
+        heldLocksTokenMap.values().forEach(locks -> mappedLocksToToken.putAll(getDescriptorToTokenMap(locks.getRealToken())));
 
         return nameObjectForYamlConvertion(HELD_LOCKS_TITLE, mappedLocksToToken);
     }
@@ -134,14 +134,13 @@ public class LockServiceStateLogger {
                 .collect(Collectors.toList());
     }
 
-    private Map<String, Object> getDescriptorToTokenMap(HeldLocksToken heldLocksToken,
-            LockServiceImpl.HeldLocks<HeldLocksToken> heldLocks) {
+    private Map<String, Object> getDescriptorToTokenMap(HeldLocksToken realToken) {
         Map<String, Object> lockToLockInfo = Maps.newHashMap();
 
-        heldLocks.getRealToken().getLocks().forEach(
+        realToken.getLocks().forEach(
                 lock -> lockToLockInfo.put(
                             this.lockDescriptorMapper.getDescriptorMapping(lock.getLockDescriptor()),
-                            SimpleTokenInfo.of(heldLocksToken, lock.getLockMode()))
+                            SimpleTokenInfo.of(realToken, lock.getLockMode()))
         );
         return lockToLockInfo;
     }

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -45,10 +46,14 @@ import com.palantir.lock.impl.LockServiceImpl;
 public class LockServiceStateLogger {
     private static Logger log = LoggerFactory.getLogger(LockServiceStateLogger.class);
 
+    @VisibleForTesting
     static final String LOCKSTATE_FILE_PREFIX = "lockstate-";
+    @VisibleForTesting
     static final String DESCRIPTORS_FILE_PREFIX = "descriptors-";
 
+    @VisibleForTesting
     static final String OUTSTANDING_LOCK_REQUESTS_TITLE = "OutstandingLockRequests";
+    @VisibleForTesting
     static final String HELD_LOCKS_TITLE = "HeldLocks";
 
     private static final String WARNING_LOCK_DESCRIPTORS = "WARNING: Lock descriptors may contain sensitive information";

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceStateLogger.java
@@ -45,16 +45,16 @@ import com.palantir.lock.impl.LockServiceImpl;
 public class LockServiceStateLogger {
     private static Logger log = LoggerFactory.getLogger(LockServiceStateLogger.class);
 
-    private static final String LOCKSTATE_FILE_PREFIX = "lockstate-";
-    private static final String DESCRIPTORS_FILE_PREFIX = "descriptors-";
+    static final String LOCKSTATE_FILE_PREFIX = "lockstate-";
+    static final String DESCRIPTORS_FILE_PREFIX = "descriptors-";
+
+    static final String OUTSTANDING_LOCK_REQUESTS_TITLE = "OutstandingLockRequests";
+    static final String HELD_LOCKS_TITLE = "HeldLocks";
+
     private static final String WARNING_LOCK_DESCRIPTORS = "WARNING: Lock descriptors may contain sensitive information";
     private static final String FILE_NOT_CREATED_LOG_ERROR = "Destination file [{}] either already exists"
             + "or can't be created. This is a very unlikely scenario."
             + "Retrigger logging or check if process has permitions on the folder";
-
-
-    private static final String OUTSTANDING_LOCK_REQUESTS_TITLE = "OutstandingLockRequests";
-    private static final String HELD_LOCKS_TITLE = "HeldLocks";
 
     private final LockDescriptorMapper lockDescriptorMapper = new LockDescriptorMapper();
     private final long startTimestamp = System.currentTimeMillis();

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceTestUtils.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceTestUtils.java
@@ -18,10 +18,12 @@ package com.palantir.lock.logger;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Lists;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockCollections;
@@ -41,6 +43,11 @@ public class LockServiceTestUtils {
             }
         }
         rootDir.delete();
+    }
+
+    static List<File> logStateDirFiles() {
+        File rootDir = new File(TEST_LOG_STATE_DIR);
+        return Lists.newArrayList(rootDir.listFiles());
     }
 
     public static HeldLocksToken getFakeHeldLocksToken(String clientName, String requestingThread, BigInteger tokenId,

--- a/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceTestUtils.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/LockServiceTestUtils.java
@@ -18,7 +18,6 @@ package com.palantir.lock.logger;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
@@ -22,24 +22,18 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Collection;
-import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSortedMap;

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
@@ -15,20 +15,38 @@
  */
 package com.palantir.lock.logger;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Collection;
+import java.util.IllegalFormatException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import com.palantir.lock.HeldLocksToken;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockCollections;
@@ -36,19 +54,22 @@ import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.SortedLockCollection;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.impl.LockServiceImpl;
 
 public class LockServiceStateLoggerTest {
 
-    private final ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap =
+    private static final ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap =
             new MapMaker().makeMap();
 
-    private final SetMultimap<LockClient, LockRequest> outstandingLockRequestMultimap =
+    private static final SetMultimap<LockClient, LockRequest> outstandingLockRequestMultimap =
             Multimaps.synchronizedSetMultimap(HashMultimap.<LockClient, LockRequest>create());
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
+        LockServiceTestUtils.cleanUpLogStateDir();
+
         LockClient clientA = LockClient.of("Client A");
         LockClient clientB = LockClient.of("Client B");
 
@@ -77,10 +98,7 @@ public class LockServiceStateLoggerTest {
 
         heldLocksTokenMap.putIfAbsent(token, LockServiceImpl.HeldLocks.of(token, LockCollections.of()));
         heldLocksTokenMap.putIfAbsent(token2, LockServiceImpl.HeldLocks.of(token2, LockCollections.of()));
-    }
 
-    @Test
-    public void testLocksLogging() throws Exception {
         LockServiceStateLogger logger = new LockServiceStateLogger(
                 heldLocksTokenMap,
                 outstandingLockRequestMultimap,
@@ -88,8 +106,91 @@ public class LockServiceStateLoggerTest {
         logger.logLocks();
     }
 
-    @After
-    public void after() throws IOException {
+    @Test
+    public void testFilesExist() throws Exception {
+        List<File> files = LockServiceTestUtils.logStateDirFiles();
+
+        assertEquals("Unexpected number of descriptor files", files.stream()
+                .filter(file -> file.getName().startsWith(LockServiceStateLogger.DESCRIPTORS_FILE_PREFIX))
+                .count(), 1);
+
+        assertEquals("Unexpected number of lock state files", files.stream()
+                .filter(file -> file.getName().startsWith(LockServiceStateLogger.LOCKSTATE_FILE_PREFIX))
+                .count(), 1);
+    }
+
+    @Test
+    public void testDescriptors() throws Exception {
+        List<File> files = LockServiceTestUtils.logStateDirFiles();
+
+        Optional<File> descriptorsFile = files.stream().filter(
+                file -> file.getName().startsWith(LockServiceStateLogger.DESCRIPTORS_FILE_PREFIX)).findFirst();
+
+        Map<String, String> descriptorsMap = new Yaml().loadAs(new FileInputStream(descriptorsFile.get()), Map.class);
+
+        Set<LockDescriptor> allDescriptors = getAllDescriptors();
+
+        for (LockDescriptor descriptor : allDescriptors) {
+            assertTrue("Existing descriptor can't be found in dumped descriptors",
+                    descriptorsMap.values().stream().anyMatch(descriptorFromFile -> descriptorFromFile.equals(descriptor.toString())));
+        }
+    }
+
+    @Test
+    public void testLockState() throws Exception {
+        List<File> files = LockServiceTestUtils.logStateDirFiles();
+
+        Optional<File> lockStateFile = files.stream().filter(
+                file -> file.getName().startsWith(LockServiceStateLogger.LOCKSTATE_FILE_PREFIX)).findFirst();
+
+        Iterable<Object> lockState = new Yaml().loadAll(new FileInputStream(lockStateFile.get()));
+
+        for (Object ymlMap : lockState) {
+            assertTrue("Lock state contains unrecognizable object", ymlMap instanceof Map);
+            Map map = (Map) ymlMap;
+            if (map.containsKey(LockServiceStateLogger.OUTSTANDING_LOCK_REQUESTS_TITLE)) {
+                Object arrayObj = map.get(LockServiceStateLogger.OUTSTANDING_LOCK_REQUESTS_TITLE);
+                assertTrue("Outstanding lock requests is not a list", arrayObj instanceof List);
+
+                assertEquals(getOutstandingDescriptors().size(), ((List) arrayObj).size());
+            } else if (map.containsKey(LockServiceStateLogger.HELD_LOCKS_TITLE)) {
+                Object mapObj = map.get(LockServiceStateLogger.HELD_LOCKS_TITLE);
+                assertTrue("Held locks is not a list", mapObj instanceof Map);
+
+                assertEquals(getHeldDescriptors().size(), ((Map) mapObj).size());
+            } else {
+                throw new IllegalStateException("Map found in YAML document without an expected key");
+            }
+        }
+
+    }
+
+    @AfterClass
+    public static void afterClass() throws IOException {
         LockServiceTestUtils.cleanUpLogStateDir();
+    }
+
+    private Set<LockDescriptor> getAllDescriptors() {
+        Set<LockDescriptor> allDescriptors = Sets.newHashSet();
+
+        allDescriptors.addAll(getOutstandingDescriptors());
+        allDescriptors.addAll(getHeldDescriptors());
+
+        return allDescriptors;
+    }
+
+    private Set<LockDescriptor> getHeldDescriptors() {
+        return heldLocksTokenMap.values().stream()
+                    .map(LockServiceImpl.HeldLocks::getRealToken)
+                    .map(HeldLocksToken::getLockDescriptors)
+                    .flatMap(SortedLockCollection::stream)
+                    .collect(Collectors.toSet());
+    }
+
+    private Set<LockDescriptor> getOutstandingDescriptors() {
+        return outstandingLockRequestMultimap.values().stream()
+                .map(LockRequest::getLockDescriptors)
+                .flatMap(SortedLockCollection::stream)
+                .collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
Lock state logging had a bug since very beginning, it was logging negative expiresIn.
We were using original expiration TS instead of refreshed one.

**Implementation Description (bullets)**:
Use real token, instead of original one

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
This week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2469)
<!-- Reviewable:end -->
