### PR TITLE
Feature/serialisable tm initialise check

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -682,7 +682,7 @@ public interface KeyValueService extends AutoCloseable {
     ClusterAvailabilityStatus getClusterAvailabilityStatus();
 
     /**
-     * @return true iff the KeyValueService has been initialized and is ready to use.
+     * @return true iff the KeyValueService has been initialized and is ready to use
      *         Note that this check ignores the cluster's availability - use {@link #getClusterAvailabilityStatus()} if
      *         you wish to verify that we can talk to the backing store.
      */

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -680,4 +680,13 @@ public interface KeyValueService extends AutoCloseable {
     @Path("node-availability-status")
     @Consumes(MediaType.APPLICATION_JSON)
     ClusterAvailabilityStatus getClusterAvailabilityStatus();
+
+    /**
+     * @return true iff the KeyValueService has been initialized and is ready to use.
+     *         Note that this check ignores the cluster's availability - use {@link #getClusterAvailabilityStatus()} if
+     *         you wish to verify that we can talk to the backing store.
+     */
+    default boolean isInitialized() {
+        return true;
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -17,7 +17,13 @@ package com.palantir.atlasdb.transaction.api;
 
 public interface TransactionManager extends AutoCloseable {
     /**
-     * Used for TransactionManagers that can be initialized asynchronously (i.e. those extending
+     * Whether this transaction manager has established a connection to the backing store and timestamp/lock services,
+     * and is ready to service transactions.
+     *
+     * If an attempt is made to execute a transaction when this method returns {@code false}, a
+     * {@link com.palantir.exception.NotInitializedException} will be thrown.
+     *
+     * This method is used for TransactionManagers that can be initialized asynchronously (i.e. those extending
      * {@link com.palantir.async.initializer.AsyncInitializer}; other TransactionManagers can keep the default
      * implementation, and return true (they're trivially fully initialized).
      *

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -17,6 +17,17 @@ package com.palantir.atlasdb.transaction.api;
 
 public interface TransactionManager extends AutoCloseable {
     /**
+     * Used for TransactionManagers that can be initialized asynchronously (i.e. those extending
+     * {@link com.palantir.async.initializer.AsyncInitializer}; other TransactionManagers can keep the default
+     * implementation, and return true (they're trivially fully initialized).
+     *
+     * @return true if and only if the TransactionManager has been fully initialized
+     */
+    default boolean isInitialized() {
+        return true;
+    }
+
+    /**
      * Runs the given {@link TransactionTask}. If the task completes successfully
      * and does not call {@link Transaction#commit()} or {@link Transaction#abort()},
      * {@link Transaction#commit()} is called automatically.

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -265,6 +265,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         this.cassandraTables = new CassandraTables(clientPool, configManager);
     }
 
+    @Override
     public boolean isInitialized() {
         return wrapper.isInitialized();
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -252,6 +252,11 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
+    public boolean isInitialized() {
+        return delegate1.isInitialized() && delegate2.isInitialized();
+    }
+
+    @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(TableReference tableRef,
             Iterable<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
@@ -147,6 +147,11 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     }
 
     @Override
+    public boolean isInitialized() {
+        return delegate().isInitialized();
+    }
+
+    @Override
     public void put(TableReference tableRef, Map<Cell, byte[]> values, long timestamp) {
         delegate().put(tableRef, values, timestamp);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -460,6 +460,12 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public boolean isInitialized() {
+        return maybeLog(delegate::isInitialized,
+                logTime("isInitialized"));
+    }
+
+    @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(TableReference tableRef, Iterable<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection, long timestamp) {
         return maybeLog(() -> delegate.getRowsColumnRange(tableRef, rows,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -115,6 +115,11 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
+    public boolean isInitialized() {
+        return delegate().isInitialized();
+    }
+
+    @Override
     public void createTable(TableReference tableRef, byte[] tableMetadata) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTrace trace = startLocalTrace("createTable({})", tableRef)) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManager.java
@@ -25,6 +25,11 @@ public abstract class ForwardingTransactionManager extends ForwardingObject impl
     protected abstract TransactionManager delegate();
 
     @Override
+    public boolean isInitialized() {
+        return delegate().isInitialized();
+    }
+
+    @Override
     public <T, E extends Exception> T runTaskWithRetry(TransactionTask<T, E> task)
             throws E {
         return delegate().runTaskWithRetry(task);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueServiceTest.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.keyvalue.impl;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doAnswer;
@@ -99,6 +101,16 @@ public class ProfilingKeyValueServiceTest {
     @After
     public void after() throws Exception {
         kvs.close();
+    }
+
+    @Test
+    public void delegatesInitializationCheck() {
+        when(delegate.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(kvs.isInitialized());
+        assertTrue(kvs.isInitialized());
     }
 
     @Test

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/SweepStatsKeyValueServiceTest.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.impl;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 
@@ -33,13 +34,24 @@ public class SweepStatsKeyValueServiceTest {
     private static final byte[] ROW = "row".getBytes(StandardCharsets.UTF_8);
     private static final TableReference TABLE = TableReference.createWithEmptyNamespace("table");
 
+    private KeyValueService delegate = mock(KeyValueService.class);
+
     private SweepStatsKeyValueService kvs;
 
     @Before
     public void before() {
-        KeyValueService delegate = mock(KeyValueService.class);
         TimestampService timestampService = mock(TimestampService.class);
         kvs = SweepStatsKeyValueService.create(delegate, timestampService);
+    }
+
+    @Test
+    public void delegatesInitializationCheck() {
+        when(delegate.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(kvs.isInitialized());
+        assertTrue(kvs.isInitialized());
     }
 
     @Test

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueServiceTest.java
@@ -18,7 +18,9 @@ package com.palantir.atlasdb.keyvalue.impl;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -101,6 +103,16 @@ public class TracingKeyValueServiceTest {
     @Test(expected = NullPointerException.class)
     public void createNullThrows() throws Exception {
         TracingKeyValueService.create(null);
+    }
+
+    @Test
+    public void delegatesInitializationCheck() {
+        when(delegate.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(kvs.isInitialized());
+        assertTrue(kvs.isInitialized());
     }
 
     @Test

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -240,7 +240,8 @@ public final class TransactionManagers {
         kvs = AtlasDbMetrics.instrument(KeyValueService.class, kvs, MetricRegistry.name(KeyValueService.class));
         kvs = ValidatingQueryRewritingKeyValueService.create(kvs);
 
-        TransactionManagersInitializer.createInitialTables(kvs, schemas, config.initializeAsync());
+        TransactionManagersInitializer initializer = TransactionManagersInitializer.createInitialTables(kvs, schemas,
+                config.initializeAsync());
         PersistentLockService persistentLockService = createAndRegisterPersistentLockService(kvs, env,
                 config.initializeAsync());
 
@@ -273,6 +274,7 @@ public final class TransactionManagers {
                 conflictManager,
                 sweepStrategyManager,
                 cleaner,
+                initializer,
                 allowHiddenTableAccess,
                 () -> runtimeConfigSupplier.get().transaction().getLockAcquireTimeoutMillis(),
                 config.keyValueService().concurrentGetRangesThreadPoolSize(),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
@@ -32,10 +32,13 @@ public final class TransactionManagersInitializer extends AsyncInitializer {
     private KeyValueService keyValueService;
     private Set<Schema> schemas;
 
-    public static void createInitialTables(KeyValueService keyValueService, Set<Schema> schemas,
+    public static TransactionManagersInitializer createInitialTables(KeyValueService keyValueService,
+            Set<Schema> schemas,
             boolean initializeAsync) {
-        new TransactionManagersInitializer(keyValueService, schemas)
-                .initialize(initializeAsync);
+        TransactionManagersInitializer initializer = new TransactionManagersInitializer(
+                keyValueService, schemas);
+        initializer.initialize(initializeAsync);
+        return initializer;
     }
 
     private TransactionManagersInitializer(KeyValueService keyValueService, Set<Schema> schemas) {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceUtils.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceUtils.java
@@ -93,7 +93,7 @@ public final class StartupIndependenceUtils {
             addTodo();
             fail("Expected to throw an exception");
         } catch (Exception e) {
-            assertTrue(exceptionIsRetryableAndContainsMessage(e, "CassandraKeyValueService is not initialized yet"));
+            assertTrue(exceptionIsRetryableAndContainsMessage(e, "TransactionManager is not initialized yet"));
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
@@ -66,6 +66,11 @@ public final class AsyncPuncher implements Puncher {
     }
 
     @Override
+    public boolean isInitialized() {
+        return delegate.isInitialized();
+    }
+
+    @Override
     public void punch(long timestamp) {
         lastTimestamp.set(timestamp);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/CachingPuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/CachingPuncherStore.java
@@ -55,6 +55,11 @@ public final class CachingPuncherStore implements PuncherStore {
     }
 
     @Override
+    public boolean isInitialized() {
+        return puncherStore.isInitialized();
+    }
+
+    @Override
     public void put(long timestamp, long timeMillis) {
         puncherStore.put(timestamp, timeMillis);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Cleaner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Cleaner.java
@@ -30,6 +30,12 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
  * @author jweel
  */
 public interface Cleaner extends Closeable {
+
+    /**
+     * @return true if and only if the Cleaner has been fully initialized.
+     */
+    boolean isInitialized();
+
     /**
      * @param cellToTableRefs Cells that were touched as part of the hard delete transaction
      * @param scrubTimestamp The start timestamp of the hard delete transaction whose

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Cleaner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Cleaner.java
@@ -34,7 +34,9 @@ public interface Cleaner extends Closeable {
     /**
      * @return true if and only if the Cleaner has been fully initialized.
      */
-    boolean isInitialized();
+    default boolean isInitialized() {
+        return true;
+    }
 
     /**
      * @param cellToTableRefs Cells that were touched as part of the hard delete transaction

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Cleaner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Cleaner.java
@@ -32,7 +32,11 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 public interface Cleaner extends Closeable {
 
     /**
-     * @return true if and only if the Cleaner has been fully initialized.
+     * Used for Cleaners that can be initialized asynchronously (i.e. those extending
+     * {@link com.palantir.async.initializer.AsyncInitializer}; other Cleaners can keep the default implementation,
+     * and return true (they're trivially fully initialized).
+     *
+     * @return true if and only if the Cleaner has been fully initialized
      */
     default boolean isInitialized() {
         return true;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/InMemoryPuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/InMemoryPuncherStore.java
@@ -45,6 +45,11 @@ final class InMemoryPuncherStore implements PuncherStore {
     }
 
     @Override
+    public boolean isInitialized() {
+        return true;
+    }
+
+    @Override
     public void put(long timestamp, long timeMillis) {
         map.put(timeMillis, timestamp);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
@@ -97,6 +97,11 @@ public final class KeyValueServicePuncherStore implements PuncherStore {
     }
 
     @Override
+    public boolean isInitialized() {
+        return wrapper.isInitialized();
+    }
+
+    @Override
     public void put(long timestamp, long timeMillis) {
         byte[] row = EncodingUtils.encodeUnsignedVarLong(timeMillis);
         EncodingUtils.flipAllBitsInPlace(row);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServiceScrubberStore.java
@@ -117,6 +117,11 @@ public final class KeyValueServiceScrubberStore implements ScrubberStore {
     }
 
     @Override
+    public boolean isInitialized() {
+        return wrapper.isInitialized();
+    }
+
+    @Override
     public void queueCellsForScrubbing(
             Multimap<Cell, TableReference> cellToTableRefs,
             long scrubTimestamp,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/NoOpCleaner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/NoOpCleaner.java
@@ -24,6 +24,11 @@ public final class NoOpCleaner implements Cleaner {
     public static final NoOpCleaner INSTANCE = new NoOpCleaner();
 
     @Override
+    public boolean isInitialized() {
+        return true;
+    }
+
+    @Override
     public void queueCellsForScrubbing(Multimap<Cell, TableReference> cellToTableRefs,
                                        long scrubTimestamp) {
         throw new UnsupportedOperationException("This cleaner does not support scrubbing");

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Puncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Puncher.java
@@ -18,6 +18,12 @@ package com.palantir.atlasdb.cleaner;
 import com.google.common.base.Supplier;
 
 public interface Puncher {
+
+    /**
+     * @return true if and only if the Puncher has been initialized.
+     */
+    boolean isInitialized();
+
     /**
      * Indicate the given timestamp has just been created.
      */

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Puncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Puncher.java
@@ -20,7 +20,11 @@ import com.google.common.base.Supplier;
 public interface Puncher {
 
     /**
-     * @return true if and only if the Puncher has been initialized.
+     * Used for Punchers that can be initialized asynchronously (i.e. those extending
+     * {@link com.palantir.async.initializer.AsyncInitializer}; other Punchers can keep the default implementation,
+     * and return true (they're trivially fully initialized).
+     *
+     * @return true if and only if the Puncher has been initialized
      */
     default boolean isInitialized() {
         return true;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Puncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Puncher.java
@@ -22,7 +22,9 @@ public interface Puncher {
     /**
      * @return true if and only if the Puncher has been initialized.
      */
-    boolean isInitialized();
+    default boolean isInitialized() {
+        return true;
+    }
 
     /**
      * Indicate the given timestamp has just been created.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
@@ -25,7 +25,9 @@ public interface PuncherStore {
     /**
      * @return true if and only if the PuncherStore has been initialized.
      */
-    boolean isInitialized();
+    default boolean isInitialized() {
+        return true;
+    }
 
     /**
      * Declare that timestamp was acquired at time timeMillis.  Note

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
@@ -23,6 +23,11 @@ package com.palantir.atlasdb.cleaner;
  */
 public interface PuncherStore {
     /**
+     * @return true if and only if the PuncherStore has been initialized.
+     */
+    boolean isInitialized();
+
+    /**
      * Declare that timestamp was acquired at time timeMillis.  Note
      * that timestamp corresponds to "start timestamps" in the AtlasDB
      * transaction protocol.

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/PuncherStore.java
@@ -23,7 +23,11 @@ package com.palantir.atlasdb.cleaner;
  */
 public interface PuncherStore {
     /**
-     * @return true if and only if the PuncherStore has been initialized.
+     * Used for PuncherStores that can be initialized asynchronously (i.e. those extending
+     * {@link com.palantir.async.initializer.AsyncInitializer}; other PuncherStores can keep the default implementation,
+     * and return true (they're trivially fully initialized).
+
+     * @return true if and only if the PuncherStore has been initialized
      */
     default boolean isInitialized() {
         return true;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -179,7 +179,8 @@ public final class Scrubber {
 
     public boolean isInitialized() {
         try {
-            // We don't care about the return value here - just that we can do this without encountering NotInitializedException
+            // We don't care about the return value here;
+            // just that we can do this without encountering NotInitializedException
             keyValueService.getClusterAvailabilityStatus();
             return scrubberStore.isInitialized();
         } catch (NotInitializedException ex) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -72,7 +72,6 @@ import com.palantir.common.collect.Maps2;
 import com.palantir.common.concurrent.ExecutorInheritableThreadLocal;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.exception.NotInitializedException;
 import com.palantir.remoting3.tracing.Tracers;
 
 /**
@@ -178,14 +177,7 @@ public final class Scrubber {
     }
 
     public boolean isInitialized() {
-        try {
-            // We don't care about the return value here;
-            // just that we can do this without encountering NotInitializedException
-            keyValueService.getClusterAvailabilityStatus();
-            return scrubberStore.isInitialized();
-        } catch (NotInitializedException ex) {
-            return false;
-        }
+        return keyValueService.isInitialized() && scrubberStore.isInitialized();
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -72,6 +72,7 @@ import com.palantir.common.collect.Maps2;
 import com.palantir.common.concurrent.ExecutorInheritableThreadLocal;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.exception.NotInitializedException;
 import com.palantir.remoting3.tracing.Tracers;
 
 /**
@@ -174,6 +175,16 @@ public final class Scrubber {
         NamedThreadFactory threadFactory = new NamedThreadFactory(SCRUBBER_THREAD_PREFIX, true);
         this.readerExec = Tracers.wrap(PTExecutors.newFixedThreadPool(readThreadCount, threadFactory));
         this.exec = Tracers.wrap(PTExecutors.newFixedThreadPool(threadCount, threadFactory));
+    }
+
+    public boolean isInitialized() {
+        try {
+            // We don't care about the return value here - just that we can do this without encountering NotInitializedException
+            keyValueService.getClusterAvailabilityStatus();
+            return scrubberStore.isInitialized();
+        } catch (NotInitializedException ex) {
+            return false;
+        }
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/Scrubber.java
@@ -82,7 +82,8 @@ import com.palantir.remoting3.tracing.Tracers;
  *
  * @author jweel
  */
-public final class Scrubber {
+@SuppressWarnings("checkstyle:FinalClass") // non-final for mocking
+public class Scrubber {
     private static final Logger log = LoggerFactory.getLogger(Scrubber.class);
     private static final int MAX_RETRY_ATTEMPTS = 100;
     private static final int RETRY_SLEEP_INTERVAL_IN_MILLIS = 1000;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
@@ -30,6 +30,8 @@ import com.palantir.common.base.BatchingVisitable;
  * @author ejin
  */
 public interface ScrubberStore {
+    boolean isInitialized();
+
     void queueCellsForScrubbing(Multimap<Cell, TableReference> cellToTableRefs, long scrubTimestamp, int batchSize);
 
     void markCellsAsScrubbed(Map<TableReference, Multimap<Cell, Long>> cellToScrubTimestamp, int batchSize);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/ScrubberStore.java
@@ -30,7 +30,9 @@ import com.palantir.common.base.BatchingVisitable;
  * @author ejin
  */
 public interface ScrubberStore {
-    boolean isInitialized();
+    default boolean isInitialized() {
+        return true;
+    }
 
     void queueCellsForScrubbing(Multimap<Cell, TableReference> cellToTableRefs, long scrubTimestamp, int batchSize);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/SimpleCleaner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/SimpleCleaner.java
@@ -45,6 +45,11 @@ public class SimpleCleaner implements Cleaner {
     }
 
     @Override
+    public boolean isInitialized() {
+        return scrubber.isInitialized() && puncher.isInitialized();
+    }
+
+    @Override
     public void queueCellsForScrubbing(Multimap<Cell, TableReference> cellToTableRefs,
                                        long scrubTimestamp) {
         scrubber.queueCellsForScrubbing(cellToTableRefs, scrubTimestamp);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/SimplePuncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/SimplePuncher.java
@@ -43,6 +43,11 @@ public final class SimplePuncher implements Puncher {
     }
 
     @Override
+    public boolean isInitialized() {
+        return puncherStore.isInitialized();
+    }
+
+    @Override
     public void punch(long timestamp) {
         puncherStore.put(timestamp, clock.getTimeMillis());
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/persistentlock/LockStoreImpl.java
@@ -102,16 +102,16 @@ public class LockStoreImpl implements LockStore {
     }
 
     public static LockStore create(KeyValueService kvs, boolean initializeAsync) {
-        LockStoreImpl lockStore = createImplForTest(kvs, initializeAsync);
+        LockStoreImpl lockStore = createImpl(kvs, initializeAsync);
         return lockStore.wrapper.isInitialized() ? lockStore : lockStore.wrapper;
     }
 
     @VisibleForTesting
     static LockStoreImpl createImplForTest(KeyValueService kvs) {
-        return createImplForTest(kvs, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+        return createImpl(kvs, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
     }
 
-    private static LockStoreImpl createImplForTest(KeyValueService kvs, boolean initializeAsync) {
+    private static LockStoreImpl createImpl(KeyValueService kvs, boolean initializeAsync) {
         LockStoreImpl lockStore = new LockStoreImpl(kvs);
         lockStore.wrapper.initialize(initializeAsync);
         return lockStore;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -47,17 +47,14 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
         @Override
         public SerializableTransactionManager delegate() {
             if (!isInitialized) {
-                try {
-                    // Verify that the various dependent services have been initialized
-                    if (manager.getKeyValueService().isInitialized()
-                            && manager.getTimelockService().isInitialized()
-                            && manager.getTimestampService().isInitialized()
-                            && manager.getCleaner().isInitialized()) {
-                        isInitialized = true;
-                    }
-                } catch (NotInitializedException e) {
-                    log.info("The KeyValueService is not initialized yet!");
-                    throw e;
+                // Verify that the various dependent services have been initialized
+                if (manager.getKeyValueService().isInitialized()
+                        && manager.getTimelockService().isInitialized()
+                        && manager.getTimestampService().isInitialized()
+                        && manager.getCleaner().isInitialized()) {
+                    isInitialized = true;
+                } else {
+                    throw new NotInitializedException("TransactionManager");
                 }
             }
             return manager;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -53,17 +53,22 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
         public SerializableTransactionManager delegate() {
             if (!isInitialized) {
                 // Verify that the various dependent services have been initialized
-                if (manager.getKeyValueService().isInitialized()
-                        && manager.getTimelockService().isInitialized()
-                        && manager.getTimestampService().isInitialized()
-                        && manager.getCleaner().isInitialized()
-                        && prerequisite.isInitialized()) {
+                if (isInitialized()) {
                     isInitialized = true;
                 } else {
                     throw new NotInitializedException("TransactionManager");
                 }
             }
             return manager;
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return manager.getKeyValueService().isInitialized()
+                    && manager.getTimelockService().isInitialized()
+                    && manager.getTimestampService().isInitialized()
+                    && manager.getCleaner().isInitialized()
+                    && prerequisite.isInitialized();
         }
 
         @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -50,7 +50,9 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 try {
                     // SerializableTransactionManager should throw until the underlying KVS is initialized.
                     // TODO(ssouza): replace with KVS healthcheck status when that gets implemented.
+                    // Perform smoke tests on KVS and TimestampService
                     manager.getKeyValueService().getClusterAvailabilityStatus();
+                    manager.getTimestampService().getFreshTimestamp();
                 } catch (NotInitializedException e) {
                     log.info("The KeyValueService is not initialized yet!");
                     throw e;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -58,6 +58,10 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
 
         @Override
         public boolean isInitialized() {
+            // Note that the PersistentLockService is also initialized asynchronously as part of
+            // TransactionManagers.create; however, this is not required for the TransactionManager to fulfil
+            // requests (note that it is not accessible from any TransactionManager implementation), so we omit
+            // checking here whether it is initialized.
             return manager.getKeyValueService().isInitialized()
                     && manager.getTimelockService().isInitialized()
                     && manager.getTimestampService().isInitialized()

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -53,11 +53,14 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                     // Perform smoke tests on KVS and TimestampService
                     manager.getKeyValueService().getClusterAvailabilityStatus();
                     manager.getTimestampService().getFreshTimestamp();
+                    // Verify that the cleaner is initialised
+                    if (manager.getCleaner().isInitialized()) {
+                        isInitialized = true;
+                    }
                 } catch (NotInitializedException e) {
                     log.info("The KeyValueService is not initialized yet!");
                     throw e;
                 }
-                isInitialized = true;
             }
             return manager;
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -41,8 +41,6 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
         private final SerializableTransactionManager manager;
         private final AsyncInitializer prerequisite;
 
-        private volatile boolean isInitialized = false;
-
         public InitializeCheckingWrapper(SerializableTransactionManager manager,
                 AsyncInitializer prerequisite) {
             this.manager = manager;
@@ -51,14 +49,10 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
 
         @Override
         public SerializableTransactionManager delegate() {
-            if (!isInitialized) {
-                // Verify that the various dependent services have been initialized
-                if (isInitialized()) {
-                    isInitialized = true;
-                } else {
-                    throw new NotInitializedException("TransactionManager");
-                }
+            if (!isInitialized()) {
+                throw new NotInitializedException("TransactionManager");
             }
+
             return manager;
         }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -50,11 +50,12 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 try {
                     // SerializableTransactionManager should throw until the underlying KVS is initialized.
                     // TODO(ssouza): replace with KVS healthcheck status when that gets implemented.
-                    // Perform smoke tests on KVS and TimestampService
                     manager.getKeyValueService().getClusterAvailabilityStatus();
-                    manager.getTimestampService().getFreshTimestamp();
-                    // Verify that the cleaner is initialised
-                    if (manager.getCleaner().isInitialized()) {
+
+                    // Verify that the various dependent services have been initialized
+                    if (manager.getTimelockService().isInitialized()
+                            && manager.getTimestampService().isInitialized()
+                            && manager.getCleaner().isInitialized()) {
                         isInitialized = true;
                     }
                 } catch (NotInitializedException e) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -48,12 +48,9 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
         public SerializableTransactionManager delegate() {
             if (!isInitialized) {
                 try {
-                    // SerializableTransactionManager should throw until the underlying KVS is initialized.
-                    // TODO(ssouza): replace with KVS healthcheck status when that gets implemented.
-                    manager.getKeyValueService().getClusterAvailabilityStatus();
-
                     // Verify that the various dependent services have been initialized
-                    if (manager.getTimelockService().isInitialized()
+                    if (manager.getKeyValueService().isInitialized()
+                            && manager.getTimelockService().isInitialized()
                             && manager.getTimestampService().isInitialized()
                             && manager.getCleaner().isInitialized()) {
                         isInitialized = true;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TimelockTimestampServiceAdapter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TimelockTimestampServiceAdapter.java
@@ -29,6 +29,11 @@ public class TimelockTimestampServiceAdapter implements TimestampService {
     }
 
     @Override
+    public boolean isInitialized() {
+        return timelockService.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         return timelockService.getFreshTimestamp();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TimestampDecoratingTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TimestampDecoratingTimelockService.java
@@ -39,6 +39,11 @@ public class TimestampDecoratingTimelockService implements TimelockService {
     }
 
     @Override
+    public boolean isInitialized() {
+        return delegate.isInitialized() && decoratedTimestamps.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         return decoratedTimestamps.getFreshTimestamp();
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/SimpleCleanerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/SimpleCleanerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cleaner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SimpleCleanerTest {
+    private Scrubber mockScrubber = mock(Scrubber.class);
+    private Puncher mockPuncher = mock(Puncher.class);
+
+    private SimpleCleaner simpleCleaner;
+
+    @Before
+    public void setUp() {
+        simpleCleaner = new SimpleCleaner(mockScrubber, mockPuncher, () -> 1L);
+
+        when(mockScrubber.isInitialized()).thenReturn(true);
+        when(mockPuncher.isInitialized()).thenReturn(true);
+    }
+
+    @Test
+    public void isInitializedWhenPrerequisitesAreInitialized() {
+        assertTrue(simpleCleaner.isInitialized());
+    }
+
+    @Test
+    public void isNotInitializedWhenScrubberIsNotInitialized() {
+        when(mockScrubber.isInitialized()).thenReturn(false);
+        assertFalse(simpleCleaner.isInitialized());
+    }
+
+    @Test
+    public void isInitializedWhenPuncherIsNotInitialized() {
+        when(mockPuncher.isInitialized()).thenReturn(false);
+        assertFalse(simpleCleaner.isInitialized());
+    }
+
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/SimplePuncherTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/SimplePuncherTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.cleaner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.palantir.common.time.Clock;
+
+public class SimplePuncherTest {
+    @Test
+    public void delegatesInitializationCheck() {
+        PuncherStore delegate = mock(PuncherStore.class);
+        Puncher puncher = SimplePuncher.create(delegate, mock(Clock.class), () -> 1L);
+
+        when(delegate.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(puncher.isInitialized());
+        assertTrue(puncher.isInitialized());
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -114,6 +114,10 @@ public class SerializableTransactionManagerTest {
                 false); // initializeAsync
 
         when(mockKvs.isInitialized()).thenReturn(false);
+        when(mockTimelockService.isInitialized()).thenReturn(false);
+        when(mockCleaner.isInitialized()).thenReturn(false);
+        when(mockInitializer.isInitialized()).thenReturn(false);
+
         assertTrue(theManager.isInitialized());
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.cleaner.Cleaner;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.lock.v2.TimelockService;
+
+public class SerializableTransactionManagerTest {
+
+    private KeyValueService mockKvs = mock(KeyValueService.class);
+    private TimelockService mockTimelockService = mock(TimelockService.class);
+    private Cleaner mockCleaner = mock(Cleaner.class);
+    private AsyncInitializer mockInitializer = mock(AsyncInitializer.class);
+
+    private SerializableTransactionManager manager;
+
+    @Before
+    public void setUp() {
+        manager = SerializableTransactionManager.create(
+                mockKvs,
+                mockTimelockService,
+                null, // lockService
+                null, // transactionService
+                () -> null, // constraintMode
+                null, // conflictDetectionManager
+                null, // sweepStrategyManager
+                mockCleaner,
+                mockInitializer,
+                false, // allowHiddenTableAccess
+                () -> 1L, // lockAcquireTimeoutMs
+                1, // concurrentGetRangesThreadPoolSize
+                true); // initializeAsync
+
+        when(mockKvs.isInitialized()).thenReturn(true);
+        when(mockTimelockService.isInitialized()).thenReturn(true);
+        when(mockCleaner.isInitialized()).thenReturn(true);
+        when(mockInitializer.isInitialized()).thenReturn(true);
+    }
+
+    @Test
+    public void isInitializedWhenPrerequisitesAreInitialized() {
+        assertTrue(manager.isInitialized());
+    }
+
+    @Test
+    public void isNotInitializedWhenKvsIsNotInitialized() {
+        when(mockKvs.isInitialized()).thenReturn(false);
+        assertFalse(manager.isInitialized());
+    }
+
+    @Test
+    public void isNotInitializedWhenTimelockIsNotInitialized() {
+        when(mockTimelockService.isInitialized()).thenReturn(false);
+        assertFalse(manager.isInitialized());
+    }
+
+    @Test
+    public void isNotInitializedWhenCleanerIsNotInitialized() {
+        when(mockCleaner.isInitialized()).thenReturn(false);
+        assertFalse(manager.isInitialized());
+    }
+
+    @Test
+    public void isNotInitializedWhenInitializerIsNotInitialized() {
+        when(mockInitializer.isInitialized()).thenReturn(false);
+        assertFalse(manager.isInitialized());
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -55,6 +56,11 @@ public class SnapshotTransactionManagerTest {
             false,
             () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
             4);
+
+    @Test
+    public void isAlwaysInitialized() {
+        assertTrue(snapshotTransactionManager.isInitialized());
+    }
 
     @Test
     public void closesKeyValueServiceOnClose() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TimestampDecoratingTimelockServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TimestampDecoratingTimelockServiceTest.java
@@ -16,12 +16,16 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.palantir.lock.v2.LockImmutableTimestampRequest;
@@ -34,9 +38,41 @@ public class TimestampDecoratingTimelockServiceTest {
     private final TimelockService decoratingService =
             new TimestampDecoratingTimelockService(delegate, decoratedTimestamps);
 
+    @Before
+    public void setUp() {
+        when(delegate.isInitialized()).thenReturn(true);
+        when(decoratedTimestamps.isInitialized()).thenReturn(true);
+    }
+
     @After
     public void verifyNoOtherCallsOnDelegates() {
         verifyNoMoreInteractions(delegate, decoratedTimestamps);
+    }
+
+
+    @Test
+    public void isInitializedWhenPrerequisitesAreInitialized() {
+        assertTrue(decoratingService.isInitialized());
+
+        verify(delegate).isInitialized();
+        verify(decoratedTimestamps).isInitialized();
+    }
+
+    @Test
+    public void isNotInitializedWhenScrubberIsNotInitialized() {
+        when(delegate.isInitialized()).thenReturn(false);
+        assertFalse(decoratingService.isInitialized());
+
+        verify(delegate).isInitialized();
+    }
+
+    @Test
+    public void isInitializedWhenPuncherIsNotInitialized() {
+        when(decoratedTimestamps.isInitialized()).thenReturn(false);
+        assertFalse(decoratingService.isInitialized());
+
+        verify(delegate).isInitialized();
+        verify(decoratedTimestamps).isInitialized();
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/cleaner/AsyncPuncherTest.java
@@ -16,7 +16,10 @@
 package com.palantir.atlasdb.cleaner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.After;
 import org.junit.Before;
@@ -49,6 +52,19 @@ public class AsyncPuncherTest {
     @After
     public void tearDown() {
         asyncPuncher.shutdown();
+    }
+
+    @Test
+    public void delegatesInitializationCheck() {
+        Puncher delegate = mock(Puncher.class);
+        Puncher puncher = AsyncPuncher.create(delegate, ASYNC_PUNCHER_INTERVAL);
+
+        when(delegate.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(puncher.isInitialized());
+        assertTrue(puncher.isInitialized());
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManagerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+public class ForwardingTransactionManagerTest {
+    @Test
+    public void delegatesInitializationCheck() {
+        TestTransactionManager mockTransactionMgr = mock(TestTransactionManager.class);
+        when(mockTransactionMgr.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        ForwardingTransactionManager forwardingTransactionMgr = new CachingTestTransactionManager(mockTransactionMgr);
+
+        assertFalse(forwardingTransactionMgr.isInitialized());
+        assertTrue(forwardingTransactionMgr.isInitialized());
+
+        verify(mockTransactionMgr, times(2)).isInitialized();
+    }
+
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ForwardingTransactionManagerTest.java
@@ -40,5 +40,4 @@ public class ForwardingTransactionManagerTest {
 
         verify(mockTransactionMgr, times(2)).isInitialized();
     }
-
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,14 +45,17 @@ develop
          - Change
 
     *    - |new| |improved|
-         - AtlasDB now supports asynchronous initialization, where ``TransactionManagers.create()`` creates a ``SnapshotTransactionManager`` even when initialization fails, for instance because the KVS is not up yet.
+         - AtlasDB now supports asynchronous initialization, where ``TransactionManagers.create()`` creates a ``SerializableTransactionManager`` even when initialization fails, for instance because the KVS is not up yet.
 
            To enable asynchronous initialization, a new config option ``initializeAsync`` was added to AtlasDbConfig.
-           If this option is set to true, ``TransactionManagers.create()`` first attempts to create a ``SnapshotTransactionManager`` synchronously, i.e., consistent with current behaviour.
-           If this fails, it returns a ``SnapshotTransactionManager`` for which the necessary initialization is scheduled in the background and which throws a ``NotInitializedException`` on any method call until the initialization completes - this is, until the backing store becomes available.
+           If this option is set to true, ``TransactionManagers.create()`` first attempts to create a ``SerializableTransactionManager`` synchronously, i.e., consistent with current behaviour.
+           If this fails, it returns a ``SerializableTransactionManager`` for which the necessary initialization is scheduled in the background and which throws a ``NotInitializedException`` on any method call until the initialization completes - this is, until the backing store becomes available.
+
+           While waiting for AtlasDB to be ready, clients can poll ``isInitialized()`` on the returned ``SerializableTransactionManager``.
 
            The default value for the config  is ``false`` in order to preserve previous behaviour.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2390>`__)
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/2390>`__ and
+           `Pull Request 2 <https://github.com/palantir/atlasdb/pull/2476>`__)
 
     *    - |devbreak| |improved|
          - In order to limit the access to inner methods, and to make the implementation of the above feasible, we've extracted interfaces and renamed the following classes:

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingTimelockService.java
@@ -55,6 +55,11 @@ public class LockRefreshingTimelockService implements AutoCloseable, TimelockSer
     }
 
     @Override
+    public boolean isInitialized() {
+        return delegate.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         return delegate.getFreshTimestamp();
     }

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -32,6 +32,12 @@ import com.palantir.timestamp.TimestampRange;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface TimelockService {
+    /**
+     * @return true iff the TimelockService has been fully initialized and is ready to use.
+     */
+    default boolean isInitialized() {
+        return true;
+    }
 
     @POST
     @Path("fresh-timestamp")

--- a/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -33,7 +33,11 @@ import com.palantir.timestamp.TimestampRange;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface TimelockService {
     /**
-     * @return true iff the TimelockService has been fully initialized and is ready to use.
+     * Used for TimelockServices that can be initialized asynchronously (i.e. those extending
+     * {@link com.palantir.async.initializer.AsyncInitializer}; other TimelockServices can keep the default
+     * implementation, and return true (they're trivially fully initialized).
+     *
+     * @return true iff the TimelockService has been fully initialized and is ready to use
      */
     default boolean isInitialized() {
         return true;

--- a/lock-api/src/test/java/com/palantir/lock/client/LockRefreshingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockRefreshingTimelockServiceTest.java
@@ -17,6 +17,8 @@
 package com.palantir.lock.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -55,6 +57,16 @@ public class LockRefreshingTimelockServiceTest {
     private final TimelockService timelock = new LockRefreshingTimelockService(delegate, refresher);
 
     private static final long TIMEOUT = 10_000;
+
+    @Test
+    public void delegatesInitializationCheck() {
+        when(delegate.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(timelock.isInitialized());
+        assertTrue(timelock.isInitialized());
+    }
 
 
     @Test

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
@@ -60,6 +60,11 @@ public class LegacyTimelockService implements TimelockService {
     }
 
     @Override
+    public boolean isInitialized() {
+        return timestampService.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         return timestampService.getFreshTimestamp();
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -41,6 +41,11 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
+    public boolean isInitialized() {
+        return timestampService.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         return timestampService.getFreshTimestamp();
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/DelegatingManagedTimestampService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/DelegatingManagedTimestampService.java
@@ -36,6 +36,11 @@ public class DelegatingManagedTimestampService implements ManagedTimestampServic
     }
 
     @Override
+    public boolean isInitialized() {
+        return timestampService.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         return timestampService.getFreshTimestamp();
     }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImplTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImplTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.timelock.lock.AsyncLockService;
+import com.palantir.atlasdb.timelock.paxos.ManagedTimestampService;
+
+public class AsyncTimelockServiceImplTest {
+    @Test
+    public void delegatesInitializationCheck() {
+        ManagedTimestampService mockMts = mock(ManagedTimestampService.class);
+        AsyncTimelockServiceImpl service = new AsyncTimelockServiceImpl(mock(AsyncLockService.class), mockMts);
+        when(mockMts.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(service.isInitialized());
+        assertTrue(service.isInitialized());
+    }
+}

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/DelegatingManagedTimestampServiceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/DelegatingManagedTimestampServiceTest.java
@@ -15,10 +15,13 @@
  */
 package com.palantir.atlasdb.timelock.paxos;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
@@ -34,6 +37,16 @@ public class DelegatingManagedTimestampServiceTest {
     private final ManagedTimestampService managedTimestampService = new DelegatingManagedTimestampService(
             timestampService,
             timestampManagementService);
+
+    @Test
+    public void testIsInitializedDefersToTimestampService() {
+        when(timestampService.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(managedTimestampService.isInitialized());
+        assertTrue(managedTimestampService.isInitialized());
+    }
 
     @Test
     public void testGetFreshTimestampDefersToTimestampService() {

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -26,6 +26,13 @@ import com.palantir.logsafe.Safe;
 @Path("/timestamp")
 public interface TimestampService {
     /**
+     * @return true iff the TimestampService has been fully initialized and is ready to use.
+     */
+    default boolean isInitialized() {
+        return true;
+    }
+
+    /**
      * A request to this method should return a timestamp greater than any timestamp
      * that may have been observed before the request was initiated.
      */

--- a/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
+++ b/timestamp-api/src/main/java/com/palantir/timestamp/TimestampService.java
@@ -26,7 +26,10 @@ import com.palantir.logsafe.Safe;
 @Path("/timestamp")
 public interface TimestampService {
     /**
-     * @return true iff the TimestampService has been fully initialized and is ready to use.
+     * Used for TimestampServices that can be initialized asynchronously; other TimestampServices can keep the default
+     * implementation, and return true (they're trivially fully initialized).
+     *
+     * @return true iff the TimestampService has been fully initialized and is ready to use
      */
     default boolean isInitialized() {
         return true;

--- a/timestamp-client/src/main/java/com/palantir/timestamp/RequestBatchingTimestampService.java
+++ b/timestamp-client/src/main/java/com/palantir/timestamp/RequestBatchingTimestampService.java
@@ -68,6 +68,11 @@ public class RequestBatchingTimestampService implements TimestampService {
     }
 
     @Override
+    public boolean isInitialized() {
+        return delegate.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         Long result = null;
         do {

--- a/timestamp-client/src/test/java/com/palantir/timestamp/RequestBatchingTimestampServiceTest.java
+++ b/timestamp-client/src/test/java/com/palantir/timestamp/RequestBatchingTimestampServiceTest.java
@@ -16,6 +16,10 @@
 package com.palantir.timestamp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -27,6 +31,19 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.remoting2.tracing.Tracers;
 
 public class RequestBatchingTimestampServiceTest {
+    @Test
+    public void delegatesInitializationCheck() {
+        TimestampService delegate = mock(TimestampService.class);
+        RequestBatchingTimestampService service = new RequestBatchingTimestampService(delegate);
+
+        when(delegate.isInitialized())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        assertFalse(service.isInitialized());
+        assertTrue(service.isInitialized());
+    }
+
     @Test
     public void testRateLimiting() throws Exception {
         final long minRequestMillis = 100L;

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampServiceImpl.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentTimestampServiceImpl.java
@@ -85,6 +85,11 @@ public class PersistentTimestampServiceImpl implements PersistentTimestampServic
     }
 
     @Override
+    public boolean isInitialized() {
+        return wrapper.isInitialized();
+    }
+
+    @Override
     public long getFreshTimestamp() {
         return getFreshTimestamps(1).getLowerBound();
     }


### PR DESCRIPTION
**Goals (and why)**: `SerializableTransactionManager` now has various prerequisites that can be initialised asynchronously. This PR enhances the `isInitialized()` check: `SerializableTransactionManager` is only initialised if all of its components parts have been initialised.

**Implementation Description (bullets)**:
* Add `isInitialized()` methods to the various interfaces. To avoid making breaking changes, these have `default` implementations that return `true`.
* Wire these methods through to the places where we actually do the initialisation, using delegation along the way where appropriate (this was done by not adding the default implementation until the last minute, and fixing compile errors along the way)
* Make a big AND statement in `SerializableTransactionManager`'s wrapper.

**Concerns (what feedback would you like?)**:
* Which tests would you like to see?
* There's a bit of a hack to jam in the last piece of the puzzle, as `SerializableTransactionManager` knows nothing about `TransactionManagerInitializer` - it's too high in the dependency tree. Should I just push TMI down to STM's level? Additionally, should the reference to TMI live in the class itself, even though it's only used as a prerequisite to initialisation?

**Where should we start reviewing?**: SerializableTransactionManager

**Priority (whenever / two weeks / yesterday)**: ASAP - would like to get this in the next release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2476)
<!-- Reviewable:end -->
