### PR TITLE
add default getRanges concurrency level

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -101,6 +101,16 @@ public interface Transaction {
             BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor);
 
     /**
+     * Same as {@link #getRanges(TableReference, Iterable, int, BiFunction)} but uses the default concurrency
+     * value specified by AtlasDbConfig#defaultGetRangesConcurrency.
+     */
+    @Idempotent
+    <T> Stream<T> getRanges(
+            final TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor);
+
+    /**
      * Returns visitibles that scan the provided ranges. This does no pre-fetching so visiting the resulting
      * visitibles will incur database reads on first access.
      */

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -124,4 +124,6 @@ public final class AtlasDbConstants {
     public static final int POSTGRES_TABLE_NAME_CHAR_LIMIT = 63;
 
     public static final String SCHEMA_V2_TABLE_NAME = "V2Table";
+
+    public static final int DEFAULT_GET_RANGES_CONCURRENCY = 8;
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -1004,6 +1004,12 @@ public class TableRenderer {
                 line("        (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, ", RowResult, "::of)));");
             } line("}");
             line();
+            line("public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,");
+            line("                               BiFunction<RangeRequest, BatchingVisitable<", RowResult, ">, T> visitableProcessor) {"); {
+                line("return t.getRanges(tableRef, ranges,");
+                line("        (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, ", RowResult, "::of)));");
+            } line("}");
+            line();
             line("public Stream<BatchingVisitable<", RowResult, ">> getRangesLazy(Iterable<RangeRequest> ranges) {"); {
                 line("Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);");
                 line("return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, ", RowResult, "::of));");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -96,6 +96,14 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public <T> Stream<T> getRanges(
+            final TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
+        return delegate().getRanges(tableRef, rangeRequests, visitableProcessor);
+    }
+
+    @Override
     public Stream<BatchingVisitable<RowResult<byte[]>>> getRangesLazy(
             final TableReference tableRef, Iterable<RangeRequest> rangeRequests) {
         return delegate().getRangesLazy(tableRef, rangeRequests);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -86,6 +86,15 @@ public class ReadTransaction extends ForwardingTransaction {
     }
 
     @Override
+    public <T> Stream<T> getRanges(
+            final TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
+        checkTableName(tableRef);
+        return delegate().getRanges(tableRef, rangeRequests, visitableProcessor);
+    }
+
+    @Override
     public Stream<BatchingVisitable<RowResult<byte[]>>> getRangesLazy(
             final TableReference tableRef, Iterable<RangeRequest> rangeRequests) {
         checkTableName(tableRef);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -669,6 +669,12 @@ public final class GenericRangeScanTestTable implements
                 (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, GenericRangeScanTestRowResult::of)));
     }
 
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   BiFunction<RangeRequest, BatchingVisitable<GenericRangeScanTestRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, GenericRangeScanTestRowResult::of)));
+    }
+
     public Stream<BatchingVisitable<GenericRangeScanTestRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
         Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
         return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, GenericRangeScanTestRowResult::of));
@@ -793,5 +799,5 @@ public final class GenericRangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "7U+eF49QEcz74N8OF2+OjQ==";
+    static String __CLASS_HASH = "6bLdl4BXUCntnhO1r687fw==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
@@ -1,15 +1,14 @@
 package com.palantir.atlasdb.table.description.generated;
 
-import java.util.List;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class GenericTestSchemaTableFactory {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -610,6 +610,12 @@ public final class RangeScanTestTable implements
                 (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, RangeScanTestRowResult::of)));
     }
 
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   BiFunction<RangeRequest, BatchingVisitable<RangeScanTestRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, RangeScanTestRowResult::of)));
+    }
+
     public Stream<BatchingVisitable<RangeScanTestRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
         Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
         return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, RangeScanTestRowResult::of));
@@ -730,5 +736,5 @@ public final class RangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ZNS2g5wflr9FgsngCdFekQ==";
+    static String __CLASS_HASH = "kVmFUBZrAev3uaZ22BYp1g==";
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -254,6 +254,15 @@ public abstract class AtlasDbConfig {
         return AtlasDbConstants.DEFAULT_LOCK_TIMEOUT_SECONDS;
     }
 
+    /**
+     * The maximum number of threads to use in concurrent getRanges requests when the user
+     * does not explicitly set a value.
+     */
+    @Value.Default
+    public int defaultGetRangesConcurrency() {
+        return AtlasDbConstants.DEFAULT_GET_RANGES_CONCURRENCY;
+    }
+
     @Value.Check
     protected final void check() {
         checkLeaderAndTimelockBlocks();

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -273,6 +273,7 @@ public final class TransactionManagers {
                 allowHiddenTableAccess,
                 () -> runtimeConfigSupplier.get().transaction().getLockAcquireTimeoutMillis(),
                 config.keyValueService().concurrentGetRangesThreadPoolSize(),
+                config.defaultGetRangesConcurrency(),
                 config.initializeAsync());
 
         PersistentLockManager persistentLockManager = new PersistentLockManager(

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -96,7 +96,8 @@ public class TransactionManagerModule {
                 sweepStrategyManager,
                 cleaner,
                 config.allowAccessToHiddenTables(),
-                config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize());
+                config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
+                config.atlasDbConfig().defaultGetRangesConcurrency());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -102,7 +102,8 @@ public class TestTransactionManagerModule {
                 sweepStrategyManager,
                 cleaner,
                 config.allowAccessToHiddenTables(),
-                config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize());
+                config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
+                config.atlasDbConfig().defaultGetRangesConcurrency());
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -74,6 +74,12 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     @Deprecated
     private static final int DEFAULT_MAX_CONCURRENT_RANGES = 64;
 
+    /**
+     * @deprecated see usage below. Should be configured with the {@link InMemoryAtlasDbConfig}.
+     */
+    @Deprecated
+    private static final int DEFAULT_GET_RANGES_CONCURRENCY = 8;
+
     @Override
     public String getType() {
         return "memory";
@@ -166,7 +172,8 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
                 conflictManager,
                 sweepStrategyManager,
                 cleaner,
-                DEFAULT_MAX_CONCURRENT_RANGES);
+                DEFAULT_MAX_CONCURRENT_RANGES,
+                DEFAULT_GET_RANGES_CONCURRENCY);
         cleaner.start(ret);
         return ret;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
@@ -49,11 +49,13 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
     protected final TransactionReadSentinelBehavior readSentinelBehavior;
     protected final boolean allowHiddenTableAccess;
     final ExecutorService getRangesExecutor;
+    final int defaultGetRangesConcurrency;
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
                                       TransactionService transactionService,
                                       AtlasDbConstraintCheckingMode constraintCheckingMode,
-                                      int concurrentGetRangesThreadPoolSize) {
+                                      int concurrentGetRangesThreadPoolSize,
+                                      int defaultGetRangesConcurrency) {
         this(
                 keyValueService,
                 transactionService,
@@ -61,7 +63,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 Suppliers.ofInstance(Long.MAX_VALUE),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 false,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
@@ -69,7 +72,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                                       AtlasDbConstraintCheckingMode constraintCheckingMode,
                                       Supplier<Long> startTimestamp,
                                       TransactionReadSentinelBehavior readSentinelBehavior,
-                                      int concurrentGetRangesThreadPoolSize) {
+                                      int concurrentGetRangesThreadPoolSize,
+                                      int defaultGetRangesConcurrency) {
         this(
                 keyValueService,
                 transactionService,
@@ -77,7 +81,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 startTimestamp,
                 readSentinelBehavior,
                 false,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
@@ -86,7 +91,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                                       Supplier<Long> startTimestamp,
                                       TransactionReadSentinelBehavior readSentinelBehavior,
                                       boolean allowHiddenTableAccess,
-                                      int concurrentGetRangesThreadPoolSize) {
+                                      int concurrentGetRangesThreadPoolSize,
+                                      int defaultGetRangesConcurrency) {
         this.keyValueService = keyValueService;
         this.transactionService = transactionService;
         this.constraintCheckingMode = constraintCheckingMode;
@@ -94,6 +100,7 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
         this.readSentinelBehavior = readSentinelBehavior;
         this.allowHiddenTableAccess = allowHiddenTableAccess;
         this.getRangesExecutor = createGetRangesExecutor(concurrentGetRangesThreadPoolSize);
+        this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
     }
 
     @Override
@@ -107,7 +114,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 readSentinelBehavior,
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
         return runTaskThrowOnConflict(task, new ReadTransaction(txn, txn.sweepStrategyManager));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -114,7 +114,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    boolean allowHiddenTableAccess,
                                    TimestampCache timestampCache,
                                    long lockAcquireTimeoutMs,
-                                   ExecutorService getRangesExecutor) {
+                                   ExecutorService getRangesExecutor,
+                                   int defaultGetRangesConcurrency) {
         super(keyValueService,
               timelockService,
               transactionService,
@@ -131,7 +132,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               allowHiddenTableAccess,
               timestampCache,
               lockAcquireTimeoutMs,
-              getRangesExecutor);
+              getRangesExecutor,
+              defaultGetRangesConcurrency);
     }
 
     @Override
@@ -722,7 +724,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs,
-                getRangesExecutor) {
+                getRangesExecutor,
+                defaultGetRangesConcurrency) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -76,7 +76,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
      * use the delegate instead.
      */
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, null, 1);
+        this(null, null, null, null, null, null, null, null, null, 1, 1);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,
@@ -90,6 +90,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency,
             boolean initializeAsync) {
         SerializableTransactionManager serializableTransactionManager = new SerializableTransactionManager(
                 keyValueService,
@@ -102,7 +103,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
 
         return initializeAsync ? new InitializeCheckingWrapper(serializableTransactionManager)
                 : serializableTransactionManager;
@@ -117,7 +119,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             ConflictDetectionManager conflictDetectionManager,
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         this(keyValueService,
                 timestampService,
                 lockClient,
@@ -128,7 +131,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 sweepStrategyManager,
                 cleaner,
                 false,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -141,7 +145,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         this(
                 keyValueService,
                 new LegacyTimelockService(timestampService, lockService, lockClient),
@@ -152,7 +157,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 sweepStrategyManager,
                 cleaner,
                 allowHiddenTableAccess,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -164,7 +170,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         this(
                 keyValueService,
                 timelockService,
@@ -176,7 +183,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -189,7 +197,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         super(
                 keyValueService,
                 timelockService,
@@ -201,7 +210,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     @Override
@@ -226,7 +236,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs.get(),
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -36,7 +36,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                                TransactionReadSentinelBehavior readSentinelBehavior,
                                boolean allowHiddenTableAccess,
                                TimestampCache timestampCache,
-                               ExecutorService getRangesExecutor) {
+                               ExecutorService getRangesExecutor,
+                               int defaultGetRangesConcurrency) {
         super(keyValueService,
               transactionService,
               null,
@@ -47,7 +48,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
               timestampCache,
               // never actually used, since timelockService is null
               AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-              getRangesExecutor);
+              getRangesExecutor,
+              defaultGetRangesConcurrency);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -69,6 +69,7 @@ import com.palantir.timestamp.TimestampService;
     final boolean allowHiddenTableAccess;
     protected final Supplier<Long> lockAcquireTimeoutMs;
     final ExecutorService getRangesExecutor;
+    final int defaultGetRangesConcurrency;
 
     final List<Runnable> closingCallbacks;
     final AtomicBoolean isClosed;
@@ -84,7 +85,8 @@ import com.palantir.timestamp.TimestampService;
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.lockService = lockService;
@@ -98,6 +100,7 @@ import com.palantir.timestamp.TimestampService;
         this.closingCallbacks = new CopyOnWriteArrayList<>();
         this.isClosed = new AtomicBoolean(false);
         this.getRangesExecutor = createGetRangesExecutor(concurrentGetRangesThreadPoolSize);
+        this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
     }
 
     @Override
@@ -184,7 +187,8 @@ import com.palantir.timestamp.TimestampService;
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs.get(),
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
     }
 
     @Override
@@ -208,7 +212,8 @@ import com.palantir.timestamp.TimestampService;
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs.get(),
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
         return runTaskThrowOnConflict(task, new ReadTransaction(transaction, sweepStrategyManager));
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -54,7 +54,8 @@ public class SnapshotTransactionManagerTest {
             cleaner,
             false,
             () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-            4);
+            8,
+            2);
 
     @Test
     public void closesKeyValueServiceOnClose() {
@@ -88,7 +89,8 @@ public class SnapshotTransactionManagerTest {
                 cleaner,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                4);
+                8,
+                2);
         newTransactionManager.close(); // should not throw
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -66,7 +66,7 @@ public final class SweepTestUtils {
         ConflictDetectionManager cdm = ConflictDetectionManagers.createWithoutWarmingCache(kvs);
         Cleaner cleaner = new NoOpCleaner();
         LockAwareTransactionManager txManager = new SerializableTransactionManager(kvs, tsService, lockClient,
-                lockService, txService, constraints, cdm, ssm, cleaner, false, 16);
+                lockService, txService, constraints, cdm, ssm, cleaner, false, 16, 4);
         setupTables(kvs);
         return txManager;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -76,7 +76,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 conflictDetectionManager,
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
-                AbstractTransactionTest.GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     @Override
@@ -103,7 +104,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 true,
                 timestampCache,
                 AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                AbstractTransactionTest.GET_RANGES_EXECUTOR) {
+                AbstractTransactionTest.GET_RANGES_EXECUTOR,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -92,8 +92,10 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         return true;
     }
 
-    protected static final int GET_RANGES_CONCURRENCY = 16;
-    protected static final ExecutorService GET_RANGES_EXECUTOR = Executors.newFixedThreadPool(GET_RANGES_CONCURRENCY);
+    protected static final int GET_RANGES_THREAD_POOL_SIZE = 16;
+    protected static final ExecutorService GET_RANGES_EXECUTOR =
+            Executors.newFixedThreadPool(GET_RANGES_THREAD_POOL_SIZE);
+    protected static final int DEFAULT_GET_RANGES_CONCURRENCY = 4;
 
     protected Transaction startTransaction() {
         return new SnapshotTransaction(
@@ -110,7 +112,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
-                GET_RANGES_EXECUTOR);
+                GET_RANGES_EXECUTOR,
+                DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -36,7 +36,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
 
     private final Map<TableReference, ConflictHandler> conflictHandlerOverrides = new HashMap<>();
 
-    private static final int GET_RANGES_CONCURRENCY = 16;
+    private static final int GET_RANGES_THREAD_POOL_SIZE = 16;
+    private static final int DEFAULT_GET_RANGES_CONCURRENCY = 4;
 
     public TestTransactionManagerImpl(KeyValueService keyValueService,
                                       TimestampService timestampService,
@@ -55,7 +56,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 conflictDetectionManager,
                 sweepStrategyManager,
                 NoOpCleaner.INSTANCE,
-                GET_RANGES_CONCURRENCY);
+                GET_RANGES_THREAD_POOL_SIZE,
+                DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     public TestTransactionManagerImpl(KeyValueService keyValueService,
@@ -74,7 +76,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 ConflictDetectionManagers.createWithoutWarmingCache(keyValueService),
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
-                GET_RANGES_CONCURRENCY);
+                GET_RANGES_THREAD_POOL_SIZE,
+                DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     @Override
@@ -107,7 +110,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 constraintModeSupplier.get(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampValidationReadCache,
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -86,7 +86,7 @@ public class TransactionManagerTest extends TransactionTestSetup {
         TransactionManager txnManagerWithMocks = new SerializableTransactionManager(getKeyValueService(),
                 mockTimestampService, LockClient.of("foo"), mockLockService, transactionService,
                 () -> AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS,
-                conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE, 16);
+                conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE, 16, 4);
 
         // fetch an immutable timestamp once so it's cached
         when(mockTimestampService.getFreshTimestamp()).thenReturn(1L);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -73,7 +73,7 @@ public class TableTasksTest {
         SweepStrategyManager ssm = SweepStrategyManagers.createDefault(kvs);
         Cleaner cleaner = new NoOpCleaner();
         SerializableTransactionManager transactionManager = new SerializableTransactionManager(
-                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false, 4);
+                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false, 8, 2);
         txManager = transactionManager;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -1470,6 +1470,12 @@ public final class DataTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index1IdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<Index1IdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index1IdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<Index1IdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, Index1IdxRowResult::of));
@@ -2138,6 +2144,12 @@ public final class DataTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index2IdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<Index2IdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index2IdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<Index2IdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, Index2IdxRowResult::of));
@@ -2781,6 +2793,12 @@ public final class DataTable implements
                                        int concurrencyLevel,
                                        BiFunction<RangeRequest, BatchingVisitable<Index3IdxRowResult>, T> visitableProcessor) {
             return t.getRanges(tableRef, ranges, concurrencyLevel,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index3IdxRowResult::of)));
+        }
+
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<Index3IdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index3IdxRowResult::of)));
         }
 
@@ -3452,6 +3470,12 @@ public final class DataTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index4IdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<Index4IdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index4IdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<Index4IdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, Index4IdxRowResult::of));
@@ -3578,5 +3602,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "FULetAunPYSDC0iaixnqxQ==";
+    static String __CLASS_HASH = "AZloIvQuqPMNdSVikR5Giw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -1543,22 +1543,22 @@ public final class TwoColumnsTable implements
         /**
          * <pre>
          * FooToIdIdxRow {
-         *   {@literal Long firstComponentHash};
+         *   {@literal Long hashOfRowComponents};
          *   {@literal Long foo};
          * }
          * </pre>
          */
         public static final class FooToIdIdxRow implements Persistable, Comparable<FooToIdIdxRow> {
-            private final long firstComponentHash;
+            private final long hashOfRowComponents;
             private final long foo;
 
             public static FooToIdIdxRow of(long foo) {
-                long firstComponentHash = Hashing.murmur3_128().hashBytes(ValueType.FIXED_LONG.convertFromJava(foo)).asLong();
-                return new FooToIdIdxRow(firstComponentHash, foo);
+                long hashOfRowComponents = computeHashFirstComponents(foo);
+                return new FooToIdIdxRow(hashOfRowComponents, foo);
             }
 
-            private FooToIdIdxRow(long firstComponentHash, long foo) {
-                this.firstComponentHash = firstComponentHash;
+            private FooToIdIdxRow(long hashOfRowComponents, long foo) {
+                this.hashOfRowComponents = hashOfRowComponents;
                 this.foo = foo;
             }
 
@@ -1586,27 +1586,32 @@ public final class TwoColumnsTable implements
 
             @Override
             public byte[] persistToBytes() {
-                byte[] firstComponentHashBytes = PtBytes.toBytes(Long.MIN_VALUE ^ firstComponentHash);
+                byte[] hashOfRowComponentsBytes = PtBytes.toBytes(Long.MIN_VALUE ^ hashOfRowComponents);
                 byte[] fooBytes = PtBytes.toBytes(Long.MIN_VALUE ^ foo);
-                return EncodingUtils.add(firstComponentHashBytes, fooBytes);
+                return EncodingUtils.add(hashOfRowComponentsBytes, fooBytes);
             }
 
             public static final Hydrator<FooToIdIdxRow> BYTES_HYDRATOR = new Hydrator<FooToIdIdxRow>() {
                 @Override
                 public FooToIdIdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long firstComponentHash = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                    Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     __index += 8;
                     Long foo = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     __index += 8;
-                    return new FooToIdIdxRow(firstComponentHash, foo);
+                    return new FooToIdIdxRow(hashOfRowComponents, foo);
                 }
             };
+
+            public static long computeHashFirstComponents(long foo) {
+                byte[] fooBytes = PtBytes.toBytes(Long.MIN_VALUE ^ foo);
+                return Hashing.murmur3_128().hashBytes(EncodingUtils.add(fooBytes)).asLong();
+            }
 
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("firstComponentHash", firstComponentHash)
+                    .add("hashOfRowComponents", hashOfRowComponents)
                     .add("foo", foo)
                     .toString();
             }
@@ -1623,19 +1628,19 @@ public final class TwoColumnsTable implements
                     return false;
                 }
                 FooToIdIdxRow other = (FooToIdIdxRow) obj;
-                return Objects.equal(firstComponentHash, other.firstComponentHash) && Objects.equal(foo, other.foo);
+                return Objects.equal(hashOfRowComponents, other.hashOfRowComponents) && Objects.equal(foo, other.foo);
             }
 
             @SuppressWarnings("ArrayHashCode")
             @Override
             public int hashCode() {
-                return Arrays.deepHashCode(new Object[]{ firstComponentHash, foo });
+                return Arrays.deepHashCode(new Object[]{ hashOfRowComponents, foo });
             }
 
             @Override
             public int compareTo(FooToIdIdxRow o) {
                 return ComparisonChain.start()
-                    .compare(this.firstComponentHash, o.firstComponentHash)
+                    .compare(this.hashOfRowComponents, o.hashOfRowComponents)
                     .compare(this.foo, o.foo)
                     .result();
             }
@@ -2221,5 +2226,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JGRQX5KSxWmtSHt8Ei+KMQ==";
+    static String __CLASS_HASH = "wP29qfigRwiVB/u5Iav3sQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -118,7 +118,8 @@ import com.palantir.remoting2.tracing.Tracers;
 @SuppressWarnings("checkstyle:all")
 public class SnapshotTransactionTest extends AtlasDbTestCase {
     protected final TimestampCache timestampCache = TimestampCache.create();
-    protected final ExecutorService getRangesExecutor = Executors.newFixedThreadPool(4);
+    protected final ExecutorService getRangesExecutor = Executors.newFixedThreadPool(8);
+    protected final int defaultGetRangesConcurrency = 2;
 
     private class UnstableKeyValueService extends ForwardingKeyValueService {
         private final KeyValueService delegate;
@@ -282,7 +283,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
             fail();
@@ -338,7 +340,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
         snapshot.put(TABLE, ImmutableMap.of(cell, PtBytes.EMPTY_BYTE_ARRAY));
         snapshot.commit();
 

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -1849,6 +1849,12 @@ public final class UserProfileTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CookiesIdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<CookiesIdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CookiesIdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<CookiesIdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, CookiesIdxRowResult::of));
@@ -2526,6 +2532,12 @@ public final class UserProfileTable implements
                                        int concurrencyLevel,
                                        BiFunction<RangeRequest, BatchingVisitable<CreatedIdxRowResult>, T> visitableProcessor) {
             return t.getRanges(tableRef, ranges, concurrencyLevel,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CreatedIdxRowResult::of)));
+        }
+
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<CreatedIdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CreatedIdxRowResult::of)));
         }
 
@@ -3209,6 +3221,12 @@ public final class UserProfileTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<UserBirthdaysIdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<UserBirthdaysIdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of));
@@ -3335,5 +3353,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XZOm4bE0zgUGoCBxygi4sQ==";
+    static String __CLASS_HASH = "3fqOZ+qIJ6uwBrHQDwnW6Q==";
 }


### PR DESCRIPTION
Adds a configurable default concurrency level for the new getRanges implementation. Realized when I started wiring up various products that most are probably just going to hard-code or configure a single value like this so probably makes sense to just put in Atlas. I'm hoping to eventually figure out a way to add throttling to this as well, but couldn't find a clean way at the moment to do that so will follow-up with that later.

Location of the configs is admittedly a little odd -- thread pool size is in the KVS config and this new config is in Atlas config. However, former should be a function of connections which is KVS-specific so I think that makes sense. Let me know if you disagree.