### PR TITLE
Fix/circle build by excluding the test

### DIFF
--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -49,6 +49,7 @@ task longTest(type: Test) {
 task timeLockTest(type: Test) {
     dependsOn prepareForEteTests, ':timelock-server-distribution:dockerTag'
     include '**/*TimeLock*.class'
+    include '**/PostgresDbPersistenceTimelockTestSuite.class'
 }
 
 task startupIndependenceTest(type: Test) {
@@ -60,6 +61,7 @@ test {
     dependsOn longTest, prepareForEteTests, timeLockTest, startupIndependenceTest
     exclude '**/MultiCassandraTestSuite.class'
     exclude '**/*TimeLock*.class'
+    exclude '**/PostgresDbPersistenceTimelockTestSuite.class'
     exclude '**/*EteTest.class'
 }
 

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -49,7 +49,6 @@ task longTest(type: Test) {
 task timeLockTest(type: Test) {
     dependsOn prepareForEteTests, ':timelock-server-distribution:dockerTag'
     include '**/*TimeLock*.class'
-    include '**/PostgresDbPersistenceTimelockTestSuite.class'
 }
 
 task startupIndependenceTest(type: Test) {
@@ -61,7 +60,6 @@ test {
     dependsOn longTest, prepareForEteTests, timeLockTest, startupIndependenceTest
     exclude '**/MultiCassandraTestSuite.class'
     exclude '**/*TimeLock*.class'
-    exclude '**/PostgresDbPersistenceTimelockTestSuite.class'
     exclude '**/*EteTest.class'
 }
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/PostgresDbPersistenceTimeLockTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/PostgresDbPersistenceTimeLockTestSuite.java
@@ -29,12 +29,12 @@ import com.google.common.collect.ImmutableList;
         TodoEteTest.class,
         CommandLineEteTest.class
         })
-public class PostgresDbPersistenceTimelockTestSuite extends EteSetup {
+public class PostgresDbPersistenceTimeLockTestSuite extends EteSetup {
     private static final List<String> CLIENTS = ImmutableList.of("ete1");
 
     @ClassRule
     public static final RuleChain COMPOSITION_SETUP = EteSetup.setupComposition(
-            PostgresDbPersistenceTimelockTestSuite.class,
+            PostgresDbPersistenceTimeLockTestSuite.class,
             "docker-compose.timelock.database.bound.postgres.yml",
             CLIENTS);
 }


### PR DESCRIPTION
**Goals (and why)**: Fix external circleCI failures for the PostgresDbPersistenceTimeLockTestSuite.

**Implementation Description (bullets)**: Rename class :P
1. The timelock image cant build on external circle because it uses HEALTHCHECK which is supported starting docker version 1.12.0, but CircleCI 1.0 does not support versions past 1.10.0. See 
https://github.com/docker/hub-feedback/issues/749 and https://discuss.circleci.com/t/support-docker-versions-newer-than-v1-9-1/7789.
2. We exclude these tests in external circle by excluding the timelock test gradle task.
3. The task includes all the `**/*TimeLock*.class` test classes. The regex is case sensitive and hence we were hitting this issue.

**Concerns (what feedback would you like?)**: NA

**Where should we start reviewing?**: one file

**Priority (whenever / two weeks / yesterday)**: asap

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2490)
<!-- Reviewable:end -->
