### PR TITLE
allow changing timestamp cache size

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -114,6 +114,8 @@ public final class AtlasDbConstants {
 
     public static final int DEFAULT_STREAM_IN_MEMORY_THRESHOLD = 4 * 1024 * 1024;
 
+    public static final long DEFAULT_TIMESTAMP_CACHE_SIZE = 1_000_000;
+
     public static final int MAX_TABLE_PREFIX_LENGTH = 7;
     public static final int MAX_OVERFLOW_TABLE_PREFIX_LENGTH = 6;
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
@@ -31,7 +31,7 @@ import com.palantir.atlasdb.util.AtlasDbMetrics;
  */
 public class TimestampCache {
 
-    private Cache<Long, Long> startToCommitTimestampCache;
+    private volatile Cache<Long, Long> startToCommitTimestampCache;
 
     public TimestampCache() {
         startToCommitTimestampCache = createCache(AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
@@ -15,12 +15,15 @@
  */
 package com.palantir.atlasdb.cache;
 
+import java.util.concurrent.ConcurrentMap;
+
 import javax.annotation.Nullable;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 
 /**
@@ -28,13 +31,18 @@ import com.palantir.atlasdb.util.AtlasDbMetrics;
  */
 public class TimestampCache {
 
-    private final Cache<Long, Long> startToCommitTimestampCache;
+    private Cache<Long, Long> startToCommitTimestampCache;
 
-    public static TimestampCache create() {
-        TimestampCache timestampCache = new TimestampCache(createDefaultCache());
-        AtlasDbMetrics.registerCache(timestampCache.startToCommitTimestampCache,
+    public TimestampCache() {
+        startToCommitTimestampCache = createCache(AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+        AtlasDbMetrics.registerCache(startToCommitTimestampCache,
                 MetricRegistry.name(TimestampCache.class, "startToCommitTimestamp"));
-        return timestampCache;
+    }
+
+    public void resize(long newSize) {
+        ConcurrentMap<Long, Long> existing = startToCommitTimestampCache.asMap();
+        startToCommitTimestampCache = createCache(newSize);
+        startToCommitTimestampCache.putAll(existing);
     }
 
     @VisibleForTesting
@@ -43,9 +51,9 @@ public class TimestampCache {
     }
 
     @VisibleForTesting
-    static Cache<Long, Long> createDefaultCache() {
+    static Cache<Long, Long> createCache(long size) {
         return CacheBuilder.newBuilder()
-                .maximumSize(1_000_000) // up to ~72MB with java Long object bloat
+                .maximumSize(size)
                 .recordStats()
                 .build();
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -42,7 +42,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     private static final int GET_RANGES_QUEUE_SIZE_WARNING_THRESHOLD = 1000;
 
     public static final Logger log = LoggerFactory.getLogger(AbstractTransactionManager.class);
-    protected final TimestampCache timestampValidationReadCache = TimestampCache.create();
+    protected final TimestampCache timestampValidationReadCache = new TimestampCache();
     private volatile boolean closed = false;
 
     @Override

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/cache/TimestampCacheTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/cache/TimestampCacheTest.java
@@ -30,6 +30,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.cache.Cache;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsRule;
 
@@ -41,7 +42,7 @@ public class TimestampCacheTest {
 
     @Test
     public void cacheExposesMetrics() throws Exception {
-        Cache<Long, Long> cache = TimestampCache.createDefaultCache();
+        Cache<Long, Long> cache = TimestampCache.createCache(AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         AtlasDbMetrics.registerCache(cache, TEST_CACHE_NAME);
 
         TimestampCache timestampCache = new TimestampCache(cache);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -254,6 +254,20 @@ public abstract class AtlasDbConfig {
         return AtlasDbConstants.DEFAULT_LOCK_TIMEOUT_SECONDS;
     }
 
+
+    /**
+     * The number of timestamps to cache that we have seen in previous reads.
+     * This will use somewhere around 90MB of heap memory per million timestamps because of various overheads
+     * from Java Objects and the cache's LRU tracking.
+     *
+     * Probably the only reason to configure away from the default would be a service that can afford the heap usage,
+     * and has read patterns that deal with a very large working set of existing transactions.
+     */
+    @Value.Default
+    public long getTimestampCacheSize() {
+        return AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE;
+    }
+
     @Value.Check
     protected final void check() {
         checkLeaderAndTimelockBlocks();

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -374,7 +374,8 @@ public abstract class TransactionManagers {
                 () -> runtimeConfigSupplier.get().transaction().getLockAcquireTimeoutMillis(),
                 config.keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.keyValueService().defaultGetRangesConcurrency(),
-                config.initializeAsync());
+                config.initializeAsync(),
+                config.getTimestampCacheSize());
 
         PersistentLockManager persistentLockManager = new PersistentLockManager(
                 persistentLockService,

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -97,7 +97,8 @@ public class TransactionManagerModule {
                 cleaner,
                 config.allowAccessToHiddenTables(),
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
-                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
+                config.atlasDbConfig().getTimestampCacheSize());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -103,7 +103,8 @@ public class TestTransactionManagerModule {
                 cleaner,
                 config.allowAccessToHiddenTables(),
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
-                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
+                config.atlasDbConfig().getTimestampCacheSize());
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -26,6 +26,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
@@ -67,6 +68,13 @@ import com.palantir.timestamp.TimestampService;
 @AutoService(AtlasDbFactory.class)
 public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     private static final Logger log = LoggerFactory.getLogger(InMemoryAtlasDbFactory.class);
+
+    /**
+     * @deprecated see usage below. Should be configured with the {@link InMemoryAtlasDbConfig}.
+     * To be removed whenever someone removes the deprecated constructors that don't know about atlas configs...
+     */
+    @Deprecated
+    private static final long DEFAULT_TIMESTAMP_CACHE_SIZE = AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE;
 
     /**
      * @deprecated see usage below. Should be configured with the {@link InMemoryAtlasDbConfig}.
@@ -173,7 +181,8 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
                 sweepStrategyManager,
                 cleaner,
                 DEFAULT_MAX_CONCURRENT_RANGES,
-                DEFAULT_GET_RANGES_CONCURRENCY);
+                DEFAULT_GET_RANGES_CONCURRENCY,
+                DEFAULT_TIMESTAMP_CACHE_SIZE);
         cleaner.start(ret);
         return ret;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -85,7 +85,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
      * use the delegate instead.
      */
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, null, 1, 1);
+        this(null, null, null, null, null, null, null, null, null, 1, 1, 1);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,
@@ -101,7 +101,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
-            boolean initializeAsync) {
+            boolean initializeAsync,
+            long timestampCacheSize) {
         SerializableTransactionManager serializableTransactionManager = new SerializableTransactionManager(
                 keyValueService,
                 timelockService,
@@ -114,7 +115,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
 
         return initializeAsync ? new InitializeCheckingWrapper(serializableTransactionManager, initializer)
                 : serializableTransactionManager;
@@ -130,7 +132,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         this(keyValueService,
                 timestampService,
                 lockClient,
@@ -142,7 +145,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 false,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -156,7 +160,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         this(
                 keyValueService,
                 new LegacyTimelockService(timestampService, lockService, lockClient),
@@ -168,7 +173,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -181,7 +187,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         this(
                 keyValueService,
                 timelockService,
@@ -194,7 +201,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -208,7 +216,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         super(
                 keyValueService,
                 timelockService,
@@ -221,7 +230,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -86,7 +86,8 @@ import com.palantir.timestamp.TimestampService;
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.lockService = lockService;
@@ -101,6 +102,7 @@ import com.palantir.timestamp.TimestampService;
         this.isClosed = new AtomicBoolean(false);
         this.getRangesExecutor = createGetRangesExecutor(concurrentGetRangesThreadPoolSize);
         this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
+        timestampValidationReadCache.resize(timestampCacheSize);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.lock.v2.TimelockService;
@@ -51,10 +52,11 @@ public class SerializableTransactionManagerTest {
                 mockCleaner,
                 mockInitializer,
                 false, // allowHiddenTableAccess
-                () -> 1L, // lockAcquireTimeoutMs
+                () -> 1L, // lockAcquireTimeout
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
-                true); // initializeAsync
+                true, // initializeAsync
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         when(mockKvs.isInitialized()).thenReturn(true);
         when(mockTimelockService.isInitialized()).thenReturn(true);
@@ -113,7 +115,8 @@ public class SerializableTransactionManagerTest {
                 () -> 1L, // lockAcquireTimeoutMs
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
-                false); // initializeAsync
+                false, // initializeAsync
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         when(mockKvs.isInitialized()).thenReturn(false);
         when(mockTimelockService.isInitialized()).thenReturn(false);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -56,7 +56,8 @@ public class SnapshotTransactionManagerTest {
             false,
             () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
             TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
-            TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY);
+            TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
+            AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
     @Test
     public void isAlwaysInitialized() {
@@ -96,7 +97,8 @@ public class SnapshotTransactionManagerTest {
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
-                TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY);
+                TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         newTransactionManager.close(); // should not throw
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.sweep;
 import com.google.common.base.Supplier;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -69,7 +70,8 @@ public final class SweepTestUtils {
         LockAwareTransactionManager txManager = new SerializableTransactionManager(
                 kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         setupTables(kvs);
         return txManager;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -77,7 +77,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -87,7 +87,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 @SuppressWarnings({"checkstyle:all","DefaultCharset"}) // TODO(someonebored): clean this horrible test class up!
 public abstract class AbstractTransactionTest extends TransactionTestSetup {
 
-    protected final TimestampCache timestampCache = TimestampCache.create();
+    protected final TimestampCache timestampCache = new TimestampCache();
     protected boolean supportsReverse() {
         return true;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.base.Suppliers;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -54,7 +55,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepStrategyManager,
                 NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     public TestTransactionManagerImpl(KeyValueService keyValueService,
@@ -74,7 +76,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
@@ -88,7 +89,8 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 () -> AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS,
                 conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         // fetch an immutable timestamp once so it's cached
         when(mockTimestampService.getFreshTimestamp()).thenReturn(1L);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -76,7 +76,8 @@ public class TableTasksTest {
         SerializableTransactionManager transactionManager = new SerializableTransactionManager(
                 kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         txManager = transactionManager;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -117,7 +117,7 @@ import com.palantir.remoting2.tracing.Tracers;
 
 @SuppressWarnings("checkstyle:all")
 public class SnapshotTransactionTest extends AtlasDbTestCase {
-    protected final TimestampCache timestampCache = TimestampCache.create();
+    protected final TimestampCache timestampCache = new TimestampCache();
     protected final ExecutorService getRangesExecutor = Executors.newFixedThreadPool(8);
     protected final int defaultGetRangesConcurrency = 2;
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -109,6 +109,11 @@ v0.61.0
            Previously, we would log a ``SafeArg`` for these batches that had no content.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2475>`__)
 
+    *    - |improved|
+         - Size of the transaction cache is now configurable. It is not anticipated end users will need to touch this;
+           it is more likely that this will be configured via per-service overrides for the services for whom the
+           current cache size is inadequate.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2496>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -74,6 +74,15 @@ develop
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2474>`__)
 
 
+    *    - |improved| |devbreak|
+         - Size of the transaction cache is now configurable. It is not anticipated end users will need to touch this;
+           it is more likely that this will be configured via per-service overrides for the services for whom the
+           current cache size is inadequate.
+           This is a small API change for users manually constructing a TransactionManager, which now requires a
+           transaction cache size parameter. Please add it from the AtlasDbConfig, or instead of manually creating
+           a TransactionManager, utilize the helpers in TransactionManagers to have this done for you.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2496>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -109,11 +118,6 @@ v0.61.0
            Previously, we would log a ``SafeArg`` for these batches that had no content.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2475>`__)
 
-    *    - |improved|
-         - Size of the transaction cache is now configurable. It is not anticipated end users will need to touch this;
-           it is more likely that this will be configured via per-service overrides for the services for whom the
-           current cache size is inadequate.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2496>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
also a little bit of drive-by cleanup to some still-not-great test classes

**Goals (and why)**:
There is an internal service whose basic premise is to catalogue small pieces of metadata, and build up large views of this data from these many individual smaller pieces/transactions.

As such, this service ends up commonly reading a plethora of historical commit timestamps across all points in time, and has a large active working set of read-in historical transactions.

Because the working set trends to higher than the current 1M timestamp cache size, I'm told by @tpetracca that this service has poor timestamp cache hit rate which in turn increases query latency from roundtrips on cache miss.

This is an easy stop-gap measure; the harder long term real fix is to implement transaction table sweeping, which I am currently looking into the requirements for, and have already found at least one issue with that needs to be fixed internally before I can start adding things to atlas. (notably, there is an internal product that has its own stack of nested KVSs and is accidentally bypassing sweep knowing about some of its tables)

**Priority (whenever / two weeks / yesterday)**:
whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2496)
<!-- Reviewable:end -->
