### PR TITLE
Feature/table tasks handle thread interruption

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
@@ -103,9 +103,8 @@ public final class TableTasks {
             CopyStats stats,
             CopyTask task,
             MutableRange range) throws InterruptedException {
-        final RangeRequest request = range.getRangeRequest();
         long startTime = System.currentTimeMillis();
-        PartialCopyStats partialStats = task.call(request, range);
+        PartialCopyStats partialStats = task.call(range.getRangeRequest(), range);
         stats.rowsCopied.addAndGet(partialStats.rowsCopied);
         stats.cellsCopied.addAndGet(partialStats.cellsCopied);
         log.info("Copied {} rows, {} cells from {} to {} in {} ms.",

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
@@ -42,6 +42,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.common.annotation.Inclusive;
@@ -112,8 +113,8 @@ public final class TableTasks {
         log.info("Copied {} rows, {} cells from {} to {} in {} ms.",
                 SafeArg.of("rowsCopied", partialStats.rowsCopied),
                 SafeArg.of("cellsCopied", partialStats.cellsCopied),
-                SafeArg.of("srcTable", srcTable),
-                SafeArg.of("dstTable", dstTable),
+                LoggingArgs.tableRef("srcTable", srcTable),
+                LoggingArgs.tableRef("dstTable", dstTable),
                 SafeArg.of("timeTaken", System.currentTimeMillis() - startTime));
     }
 
@@ -244,8 +245,8 @@ public final class TableTasks {
                     SafeArg.of("rowsCompletelyInCommon", partialStats.rowsCompletelyInCommon),
                     SafeArg.of("cellsOnlyInSource", partialStats.cellsOnlyInSource),
                     SafeArg.of("cellsInCommon", partialStats.cellsInCommon),
-                    SafeArg.of("plusTable", plusTable),
-                    SafeArg.of("minusTable", minusTable),
+                    LoggingArgs.tableRef("plusTable", plusTable),
+                    LoggingArgs.tableRef("minusTable", minusTable),
                     SafeArg.of("timeTaken", System.currentTimeMillis() - startTime));
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
@@ -102,9 +102,8 @@ public final class TableTasks {
                         log.info("Thread interrupted. Cancelling copy of range {}", range);
                         break;
                     }
-                    final RangeRequest request = range.getRangeRequest();
                     try {
-                        executeTask(srcTable, dstTable, stats, task, range, request);
+                        executeTask(srcTable, dstTable, stats, task, range);
                     } catch (InterruptedException e) {
                         throw Throwables.rewrapAndThrowUncheckedException(e);
                     }
@@ -218,9 +217,8 @@ public final class TableTasks {
                         log.info("Thread interrupted. Cancelling diff of range {}", range);
                         break;
                     }
-                    final RangeRequest request = range.getRangeRequest();
                     try {
-                        executeTask(strategy, plusTable, minusTable, stats, task, range, request);
+                        executeTask(strategy, plusTable, minusTable, stats, task, range);
                     } catch (InterruptedException e) {
                         throw Throwables.rewrapAndThrowUncheckedException(e);
                     }
@@ -231,7 +229,8 @@ public final class TableTasks {
     }
 
     private static void executeTask(TableReference srcTable, TableReference dstTable, CopyStats stats,
-            CopyTask task, MutableRange range, RangeRequest request) throws InterruptedException {
+            CopyTask task, MutableRange range) throws InterruptedException {
+        final RangeRequest request = range.getRangeRequest();
         long startTime = System.currentTimeMillis();
         PartialCopyStats partialStats = task.call(request, range);
         stats.rowsCopied.addAndGet(partialStats.rowsCopied);
@@ -245,8 +244,9 @@ public final class TableTasks {
     }
 
     private static void executeTask(DiffStrategy strategy, TableReference plusTable,
-            TableReference minusTable, DiffStats stats, DiffTask task, MutableRange range,
-            RangeRequest request) throws InterruptedException {
+            TableReference minusTable, DiffStats stats, DiffTask task, MutableRange range)
+            throws InterruptedException {
+        final RangeRequest request = range.getRangeRequest();
         long startTime = System.currentTimeMillis();
         PartialDiffStats partialStats = task.call(request, range, strategy);
         stats.rowsOnlyInSource.addAndGet(partialStats.rowsOnlyInSource);
@@ -257,13 +257,13 @@ public final class TableTasks {
         stats.cellsInCommon.addAndGet(partialStats.cellsInCommon);
         if (log.isInfoEnabled()) {
             log.info("Processed diff of "
-                    + "{} rows "
-                    + "{} rows only in source "
-                    + "{} rows partially in common "
-                    + "{} rows completely in common "
-                    + "{} cells only in source "
-                    + "{} cells in common "
-                    + "between {} and {} in {} ms.",
+                            + "{} rows "
+                            + "{} rows only in source "
+                            + "{} rows partially in common "
+                            + "{} rows completely in common "
+                            + "{} cells only in source "
+                            + "{} cells in common "
+                            + "between {} and {} in {} ms.",
                     partialStats.rowsVisited,
                     partialStats.rowsOnlyInSource,
                     partialStats.rowsPartiallyInCommon,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
@@ -95,16 +95,17 @@ public final class TableTasks {
                                     final CopyStats stats,
                                     final CopyTask task) throws InterruptedException {
         InterruptibleAction action = range -> executeTask(srcTable, dstTable, stats, task, range);
+        String actionName = "copy";
         BlockingWorkerPool pool = new BlockingWorkerPool(exec, threadCount);
         for (final MutableRange range : getRanges(threadCount, batchSize)) {
             if (Thread.currentThread().isInterrupted()) {
-                log.info("Thread interrupted. Cancelling copy of range {}", range);
+                log.info("Thread interrupted. Cancelling {} of range {}", actionName, range);
                 break;
             }
             pool.submitTask(() -> {
                 do {
                     if (Thread.currentThread().isInterrupted()) {
-                        log.info("Thread interrupted. Cancelling copy of range {}", range);
+                        log.info("Thread interrupted. Cancelling {} of range {}", actionName, range);
                         break;
                     }
                     try {
@@ -211,16 +212,17 @@ public final class TableTasks {
                                      final DiffStats stats,
                                      final DiffTask task) throws InterruptedException {
         InterruptibleAction action = range -> executeTask(strategy, plusTable, minusTable, stats, task, range);
+        String actionName = "diff";
         BlockingWorkerPool pool = new BlockingWorkerPool(exec, threadCount);
         for (final MutableRange range : getRanges(threadCount, batchSize)) {
             if (Thread.currentThread().isInterrupted()) {
-                log.info("Thread interrupted. Cancelling diff of range {}", range);
+                log.info("Thread interrupted. Cancelling {} of range {}", actionName, range);
                 break;
             }
             pool.submitTask(() -> {
                 do {
                     if (Thread.currentThread().isInterrupted()) {
-                        log.info("Thread interrupted. Cancelling diff of range {}", range);
+                        log.info("Thread interrupted. Cancelling {} of range {}", actionName, range);
                         break;
                     }
                     try {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
@@ -482,9 +482,9 @@ public final class TableTasks {
     }
 
     private static class InterruptibleRangeExecutor {
-        private ExecutorService exec;
-        private int batchSize;
-        private int threadCount;
+        private final ExecutorService exec;
+        private final int batchSize;
+        private final int threadCount;
 
         InterruptibleRangeExecutor(ExecutorService exec, int batchSize, int threadCount) {
             this.exec = exec;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/table/common/TableTasks.java
@@ -92,8 +92,16 @@ public final class TableTasks {
                                     final CopyTask task) throws InterruptedException {
         BlockingWorkerPool pool = new BlockingWorkerPool(exec, threadCount);
         for (final MutableRange range : getRanges(threadCount, batchSize)) {
+            if (Thread.currentThread().isInterrupted()) {
+                log.info("Thread interrupted. Cancelling copy of range {}", range);
+                break;
+            }
             pool.submitTask(() -> {
                 do {
+                    if (Thread.currentThread().isInterrupted()) {
+                        log.info("Thread interrupted. Cancelling copy of range {}", range);
+                        break;
+                    }
                     final RangeRequest request = range.getRangeRequest();
                     try {
                         long startTime = System.currentTimeMillis();
@@ -209,8 +217,16 @@ public final class TableTasks {
                                      final DiffTask task) throws InterruptedException {
         BlockingWorkerPool pool = new BlockingWorkerPool(exec, threadCount);
         for (final MutableRange range : getRanges(threadCount, batchSize)) {
+            if (Thread.currentThread().isInterrupted()) {
+                log.info("Thread interrupted. Cancelling diff of range {}", range);
+                break;
+            }
             pool.submitTask(() -> {
                 do {
+                    if (Thread.currentThread().isInterrupted()) {
+                        log.info("Thread interrupted. Cancelling diff of range {}", range);
+                        break;
+                    }
                     final RangeRequest request = range.getRangeRequest();
                     try {
                         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
**Goals (and why)**: Fixes #2453. Add a refactor to #2454 to extract the duplicated logic.

**Implementation Description (bullets)**:
* Review #2454 
* Notice the changes are identical
* Create a lambda similar to SchemaMutationLock.action, and tease out the duplicated logic

**Concerns (what feedback would you like?)**:
* I just bunged the new executor in the same class. It's pretty specific to TableTasks, but should it live elsewhere?
* Should I now write more tests?
* Why didn't github update 2454 when I pushed to the branch???

**Where should we start reviewing?**: Go commit-by-commit.

**Priority (whenever / two weeks / yesterday)**: soon? can't remember if the fix was slated for the LTS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2499)
<!-- Reviewable:end -->
