### PR TITLE
Serve requests immediately if already the leader

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -43,7 +43,11 @@ develop
 
     *    - Type
          - Change
-
+         
+    *    - |improved|
+         - Timelock server will now gain leadership synchronously, if possible, the first time a new client namespace is requested. Previously, the first request would always return 503.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2503>`__)
+           
     *    - |improved|
          - ``getRange`` is now more efficient when scanning over rows with many updates in Cassandra, if just a single column is requested.
            Previously, a range request in Cassandra would always retrieve all columns and all historical versions of each column, regardless of which columns were requested.

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -44,6 +44,13 @@ public interface LeaderElectionService {
     LeadershipToken blockOnBecomingLeader() throws InterruptedException;
 
     /**
+     * Returns a leadership token iff this node is currently the leader. This method may involve network
+     * calls to ensure that the token is valid at the time of invocation, but will return immediately if
+     * this node is not the last known leader.
+     */
+    Optional<LeadershipToken> getCurrentTokenIfLeading();
+
+    /**
      * This method actually ensures that there is a quorum of supporters that this node is still leading.
      * If this node cannot get a quorum that it is still the leader then this method will return false and this node
      * may not respond to requests and must get back in line by calling {@link #blockOnBecomingLeader()}.
@@ -60,4 +67,5 @@ public interface LeaderElectionService {
      * leader or can't cheaply find one.
      */
     Optional<HostAndPort> getSuspectedLeaderInMemory();
+
 }

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -1,5 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
+apply plugin: 'org.inferred.processors'
 
 dependencies {
   compile project(":leader-election-api")
@@ -10,6 +11,8 @@ dependencies {
   compile group: "commons-io", name: "commons-io"
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
   compile group: 'com.palantir.remoting3', name: 'tracing'
+  
+  processor group: 'org.immutables', name: 'value'
 
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
     exclude group: 'org.hamcrest'

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -91,8 +91,17 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
     }
 
     private void tryToGainLeadership() {
+        Optional<LeadershipToken> currentToken = leaderElectionService.getCurrentTokenIfLeading();
+        if (currentToken.isPresent()) {
+            onGainedLeadership(currentToken.get());
+        } else {
+            tryToGainLeadershipAsync();
+        }
+    }
+
+    private void tryToGainLeadershipAsync() {
         try {
-            executor.submit(this::gainLeadership);
+            executor.submit(this::gainLeadershipBlocking);
         } catch (RejectedExecutionException e) {
             if (!isClosed) {
                 throw new IllegalStateException("failed to submit task but proxy not closed", e);
@@ -100,31 +109,11 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         }
     }
 
-    private void gainLeadership() {
+    private void gainLeadershipBlocking() {
         try {
-            LeadershipToken leadershipToken = leaderElectionService.blockOnBecomingLeader();
-            // We are now the leader, we should create a delegate so we can service calls
-            T delegate = null;
-            while (delegate == null) {
-                try {
-                    delegate = delegateSupplier.get();
-                } catch (Throwable t) {
-                    log.error("problem creating delegate", t);
-                    if (isClosed) {
-                        return;
-                    }
-                }
-            }
-
-            // Do not modify, hide, or remove this line without considering impact on correctness.
-            delegateRef.set(delegate);
-
-            if (isClosed) {
-                clearDelegate();
-            } else {
-                leadershipTokenRef.set(leadershipToken);
-                log.info("Gained leadership for {}", SafeArg.of("leadershipToken", leadershipToken));
-            }
+            LeadershipToken leadershipToken = leaderElectionService.getCurrentTokenIfLeading()
+                    .orElse(leaderElectionService.blockOnBecomingLeader());
+            onGainedLeadership(leadershipToken);
         } catch (InterruptedException e) {
             log.warn("attempt to gain leadership interrupted", e);
         } catch (Throwable e) {
@@ -132,10 +121,41 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         }
     }
 
-    private void clearDelegate() throws IOException {
+    private boolean onGainedLeadership(LeadershipToken leadershipToken)  {
+        // We are now the leader, we should create a delegate so we can service calls
+        T delegate = null;
+        while (delegate == null) {
+            try {
+                delegate = delegateSupplier.get();
+            } catch (Throwable t) {
+                log.error("problem creating delegate", t);
+                if (isClosed) {
+                    return true;
+                }
+            }
+        }
+
+        // Do not modify, hide, or remove this line without considering impact on correctness.
+        delegateRef.set(delegate);
+
+        if (isClosed) {
+            clearDelegate();
+        } else {
+            leadershipTokenRef.set(leadershipToken);
+            log.info("Gained leadership for {}", SafeArg.of("leadershipToken", leadershipToken));
+        }
+        return false;
+    }
+
+    private void clearDelegate() {
         Object delegate = delegateRef.getAndSet(null);
         if (delegate instanceof Closeable) {
-            ((Closeable) delegate).close();
+            try {
+                ((Closeable) delegate).close();
+            } catch (IOException ex) {
+                // we don't want to rethrow here; we're likely on a background thread
+                log.warn("problem closing delegate", ex);
+            }
         }
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -129,7 +129,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
             } catch (Throwable t) {
                 log.error("problem creating delegate", t);
                 if (isClosed) {
-                    return true;
+                    return;
                 }
             }
         }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -111,8 +111,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
 
     private void gainLeadershipBlocking() {
         try {
-            LeadershipToken leadershipToken = leaderElectionService.getCurrentTokenIfLeading()
-                    .orElse(leaderElectionService.blockOnBecomingLeader());
+            LeadershipToken leadershipToken = leaderElectionService.blockOnBecomingLeader();
             onGainedLeadership(leadershipToken);
         } catch (InterruptedException e) {
             log.warn("attempt to gain leadership interrupted", e);

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -120,7 +120,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         }
     }
 
-    private boolean onGainedLeadership(LeadershipToken leadershipToken)  {
+    private void onGainedLeadership(LeadershipToken leadershipToken)  {
         // We are now the leader, we should create a delegate so we can service calls
         T delegate = null;
         while (delegate == null) {
@@ -143,7 +143,6 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
             leadershipTokenRef.set(leadershipToken);
             log.info("Gained leadership for {}", SafeArg.of("leadershipToken", leadershipToken));
         }
-        return false;
     }
 
     private void clearDelegate() {

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -130,6 +130,7 @@ public class AwaitingLeadershipProxyTest {
         Callable<Void> proxy = proxyFor(() -> {
             throw new InterruptedException(TEST_MESSAGE);
         });
+        waitForLeadershipToBeGained();
 
         assertThatThrownBy(() -> proxy.call())
                 .isInstanceOf(InterruptedException.class)

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,12 +47,13 @@ public class AwaitingLeadershipProxyTest {
     private static final String TEST_MESSAGE = "test_message";
 
     private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final LeaderElectionService.LeadershipToken leadershipToken = mock(PaxosLeadershipToken.class);
     private final LeaderElectionService leaderElectionService = mock(LeaderElectionService.class);
 
     @Before
     public void before() throws InterruptedException {
-        LeaderElectionService.LeadershipToken leadershipToken = mock(PaxosLeadershipToken.class);
         when(leaderElectionService.blockOnBecomingLeader()).thenReturn(leadershipToken);
+        when(leaderElectionService.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
         when(leaderElectionService.getSuspectedLeaderInMemory()).thenReturn(Optional.empty());
         when(leaderElectionService.isStillLeading(leadershipToken)).thenReturn(
                 LeaderElectionService.StillLeadingStatus.LEADING);
@@ -66,6 +68,7 @@ public class AwaitingLeadershipProxyTest {
         LeaderElectionService mockLeader = mock(LeaderElectionService.class);
 
         when(mockLeader.getSuspectedLeaderInMemory()).thenReturn(Optional.empty());
+        when(mockLeader.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
         when(mockLeader.isStillLeading(any(LeaderElectionService.LeadershipToken.class)))
                 .thenReturn(LeaderElectionService.StillLeadingStatus.LEADING);
 
@@ -86,6 +89,7 @@ public class AwaitingLeadershipProxyTest {
         LeaderElectionService mockLeader = mock(LeaderElectionService.class);
 
         when(mockLeader.getSuspectedLeaderInMemory()).thenReturn(Optional.empty());
+        when(mockLeader.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
         when(mockLeader.isStillLeading(any(LeaderElectionService.LeadershipToken.class)))
                 .thenReturn(LeaderElectionService.StillLeadingStatus.NOT_LEADING);
 
@@ -132,6 +136,28 @@ public class AwaitingLeadershipProxyTest {
                 .hasMessage(TEST_MESSAGE);
     }
 
+    @Test
+    public void shouldGainLeadershipImmediatelyIfAlreadyLeading() throws Exception {
+        when(leaderElectionService.getCurrentTokenIfLeading()).thenReturn(Optional.of(leadershipToken));
+
+        Callable proxy = proxyFor(() -> null);
+
+        proxy.call();
+
+        verify(leaderElectionService, never()).blockOnBecomingLeader();
+    }
+
+    @Test
+    public void shouldBlockOnGainingLeadershipIfNotCurrentlyLeading() throws Exception {
+        Callable proxy = proxyFor(() -> null);
+        waitForLeadershipToBeGained();
+
+        proxy.call();
+
+        verify(leaderElectionService).getCurrentTokenIfLeading();
+        verify(leaderElectionService).blockOnBecomingLeader();
+    }
+
     private Void loseLeadershipDuringCallToProxyFor(Callable<Void> delegate) throws Throwable {
         CountDownLatch delegateCallStarted = new CountDownLatch(1);
         CountDownLatch leadershipLost = new CountDownLatch(1);
@@ -142,6 +168,8 @@ public class AwaitingLeadershipProxyTest {
 
             return delegate.call();
         });
+
+        waitForLeadershipToBeGained();
 
         Future<Void> blockingCall = executor.submit(proxy);
         delegateCallStarted.await();
@@ -171,12 +199,12 @@ public class AwaitingLeadershipProxyTest {
     }
 
     private Callable proxyFor(Callable fn) throws InterruptedException {
-        Callable proxy = AwaitingLeadershipProxy.newProxyInstance(Callable.class, () -> fn, leaderElectionService);
+        return AwaitingLeadershipProxy.newProxyInstance(Callable.class, () -> fn, leaderElectionService);
+    }
 
-        // wait for leadership to be gained
+    private void waitForLeadershipToBeGained() throws InterruptedException {
         verify(leaderElectionService, timeout(5_000)).blockOnBecomingLeader();
         Uninterruptibles.sleepUninterruptibly(100L, TimeUnit.MILLISECONDS);
-        return proxy;
     }
 
     private LeaderElectionService mockLeaderElectionServiceWithSequence(

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -227,6 +227,15 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
+    public void clientsCreatedDynamicallyOnLeaderAreFunctionalImmediately() {
+        String client = UUID.randomUUID().toString();
+
+        CLUSTER.currentLeader()
+                .timelockServiceForClient(client)
+                .getFreshTimestamp();
+    }
+
+    @Test
     public void noConflictIfLeaderAndNonLeadersSeparatelyInitializeClient() {
         String client = UUID.randomUUID().toString();
         CLUSTER.nonLeaders().forEach(server -> {


### PR DESCRIPTION
**Goals (and why)**:
Currently, we return a 503 when creating a new client, even if we are currently the leader. While this is technically ok, it's a bit odd as it will cause all nodes to return 503, even though one should be capable of servine requests.

Hopefully this also helps fix integration test flakes.

**Implementation Description (bullets)**:
- Add a method on `LeaderElectionService` to get the token immediately, if currently leading
- See if we can synchronously become the leader in `AwaitingLeadershipProxy.newProxyInstance`

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`PaxosLeaderElectionService`

**Priority (whenever / two weeks / yesterday)**:
whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2503)
<!-- Reviewable:end -->
