### PR TITLE
Add time spent argument when logging timestamp await interruption

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,6 +57,10 @@ develop
            Previously, we would log a ``SafeArg`` for these batches that had no content.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2475>`__)
 
+    *    - |improved|
+         - Added time spent before thread inturrepted into log in ``RequestBatchingTimestampService``
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2506>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/timestamp-client/src/main/java/com/palantir/timestamp/RequestBatchingTimestampService.java
+++ b/timestamp-client/src/main/java/com/palantir/timestamp/RequestBatchingTimestampService.java
@@ -86,10 +86,13 @@ public class RequestBatchingTimestampService implements TimestampService {
                 }
             }
 
+            long startTs = System.currentTimeMillis();
             try {
                 batch.awaitPopulation();
             } catch (InterruptedException e) {
-                log.warn("Interrupted waiting for timestamp batch to populate. Trying another batch.", e);
+                long timeSpent = System.currentTimeMillis() - startTs;
+                log.warn("Interrupted waiting for timestamp batch to populate after " + timeSpent + "ms."
+                        + " Trying another batch.", e);
                 throw Throwables.rewrapAndThrowUncheckedException(e);
             }
             if (!batch.isFailed()) {


### PR DESCRIPTION
**Goals (and why)**:
We have seen await interrupted, adding time spent into log can be helpful.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
This week

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2506)
<!-- Reviewable:end -->
