### PR TITLE
Increase Cell Ts pairs to 1024

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -109,8 +109,7 @@ public final class AtlasDbConstants {
     public static final long DEFAULT_SWEEP_PAUSE_MILLIS = 5 * 1000;
     public static final long DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS = 30_000L;
     public static final int DEFAULT_SWEEP_DELETE_BATCH_HINT = 1_000;
-    // TODO(gsheasby): Bump up this default once getRangeOfTimestamps has been replaced.
-    public static final int DEFAULT_SWEEP_CANDIDATE_BATCH_HINT = 1;
+    public static final int DEFAULT_SWEEP_CANDIDATE_BATCH_HINT = 10_000;
     public static final int DEFAULT_SWEEP_READ_LIMIT = 1_000;
 
     public static final int DEFAULT_STREAM_IN_MEMORY_THRESHOLD = 4 * 1024 * 1024;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -109,7 +109,7 @@ public final class AtlasDbConstants {
     public static final long DEFAULT_SWEEP_PAUSE_MILLIS = 5 * 1000;
     public static final long DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS = 30_000L;
     public static final int DEFAULT_SWEEP_DELETE_BATCH_HINT = 1_000;
-    public static final int DEFAULT_SWEEP_CANDIDATE_BATCH_HINT = 10_000;
+    public static final int DEFAULT_SWEEP_CANDIDATE_BATCH_HINT = 1024;
     public static final int DEFAULT_SWEEP_READ_LIMIT = 1_000;
 
     public static final int DEFAULT_STREAM_IN_MEMORY_THRESHOLD = 4 * 1024 * 1024;


### PR DESCRIPTION
**Goals (and why)**: After the sweep rewrite we can sweep faster without causing C* OOMs.

**Implementation Description (bullets)**: bump the config value

**Concerns (what feedback would you like?)**: Should we test on internal fruity deployment before rolling out widely? can this be 100k?

**Where should we start reviewing?**: one file

**Priority (whenever / two weeks / yesterday)**: soon

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2507)
<!-- Reviewable:end -->
