### PR TITLE
Nziebart/become leader immediately 2

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -521,10 +521,10 @@ public final class TransactionManagers {
         LocalPaxosServices localPaxosServices = Leaders.createAndRegisterLocalServices(env, leaderConfig, userAgent);
         LeaderElectionService leader = localPaxosServices.leaderElectionService();
         LockService localLock = ServiceCreator.createInstrumentedService(
-                AwaitingLeadershipProxy.newProxyInstance(LockService.class, lock, leader),
+                AwaitingLeadershipProxy.newProxyInstance(LockService.class, lock, leader, false),
                 LockService.class);
         TimestampService localTime = ServiceCreator.createInstrumentedService(
-                AwaitingLeadershipProxy.newProxyInstance(TimestampService.class, time, leader),
+                AwaitingLeadershipProxy.newProxyInstance(TimestampService.class, time, leader, false),
                 TimestampService.class);
         env.register(localLock);
         env.register(localTime);

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -44,6 +44,13 @@ public interface LeaderElectionService {
     LeadershipToken blockOnBecomingLeader() throws InterruptedException;
 
     /**
+     * Returns a leadership token iff this node is currently the leader. This method may involve network
+     * calls to ensure that the token is valid at the time of invocation, but will return immediately if
+     * this node is not the last known leader.
+     */
+    Optional<LeadershipToken> getCurrentTokenIfLeading();
+
+    /**
      * This method actually ensures that there is a quorum of supporters that this node is still leading.
      * If this node cannot get a quorum that it is still the leader then this method will return false and this node
      * may not respond to requests and must get back in line by calling {@link #blockOnBecomingLeader()}.
@@ -60,4 +67,5 @@ public interface LeaderElectionService {
      * leader or can't cheaply find one.
      */
     Optional<HostAndPort> getSuspectedLeaderInMemory();
+
 }

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -44,13 +44,6 @@ public interface LeaderElectionService {
     LeadershipToken blockOnBecomingLeader() throws InterruptedException;
 
     /**
-     * Returns a leadership token iff this node is currently the leader. This method may involve network
-     * calls to ensure that the token is valid at the time of invocation, but will return immediately if
-     * this node is not the last known leader.
-     */
-    Optional<LeadershipToken> getCurrentTokenIfLeading();
-
-    /**
      * This method actually ensures that there is a quorum of supporters that this node is still leading.
      * If this node cannot get a quorum that it is still the leader then this method will return false and this node
      * may not respond to requests and must get back in line by calling {@link #blockOnBecomingLeader()}.
@@ -68,4 +61,9 @@ public interface LeaderElectionService {
      */
     Optional<HostAndPort> getSuspectedLeaderInMemory();
 
+    /**
+     * Whether this node is the last known leader, according to local information. A return value of {@code true} does
+     * not necessarily mean that this node is currently the leader.
+     */
+    boolean isLastKnownLeader();
 }

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -1,6 +1,5 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
-apply plugin: 'org.inferred.processors'
 
 dependencies {
   compile project(":leader-election-api")
@@ -12,8 +11,7 @@ dependencies {
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
   compile group: 'com.palantir.remoting3', name: 'tracing'
   
-  processor group: 'org.immutables', name: 'value'
-
+  testCompile group: 'com.jayway.awaitility', name: 'awaitility'
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
     exclude group: 'org.hamcrest'
     exclude group: 'org.ow2.asm'

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   compile group: "commons-io", name: "commons-io"
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
   compile group: 'com.palantir.remoting3', name: 'tracing'
-  
+
   testCompile group: 'com.jayway.awaitility', name: 'awaitility'
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
     exclude group: 'org.hamcrest'

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -1,5 +1,6 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
+apply plugin: 'org.inferred.processors'
 
 dependencies {
   compile project(":leader-election-api")
@@ -10,6 +11,8 @@ dependencies {
   compile group: "commons-io", name: "commons-io"
   compile group: 'com.palantir.safe-logging', name: 'safe-logging'
   compile group: 'com.palantir.remoting3', name: 'tracing'
+  
+  processor group: 'org.immutables', name: 'value'
 
   testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
     exclude group: 'org.hamcrest'

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -72,12 +72,6 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                 proxy);
     }
 
-    private static <U> void tryConfirmLeadershipSynchronously(
-            AwaitingLeadershipProxy<U> proxy,
-            LeaderElectionService leaderElectionService) {
-
-    }
-
     final Supplier<T> delegateSupplier;
     final LeaderElectionService leaderElectionService;
     final ExecutorService executor;

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,12 +47,13 @@ public class AwaitingLeadershipProxyTest {
     private static final String TEST_MESSAGE = "test_message";
 
     private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final LeaderElectionService.LeadershipToken leadershipToken = mock(PaxosLeadershipToken.class);
     private final LeaderElectionService leaderElectionService = mock(LeaderElectionService.class);
 
     @Before
     public void before() throws InterruptedException {
-        LeaderElectionService.LeadershipToken leadershipToken = mock(PaxosLeadershipToken.class);
         when(leaderElectionService.blockOnBecomingLeader()).thenReturn(leadershipToken);
+        when(leaderElectionService.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
         when(leaderElectionService.getSuspectedLeaderInMemory()).thenReturn(Optional.empty());
         when(leaderElectionService.isStillLeading(leadershipToken)).thenReturn(
                 LeaderElectionService.StillLeadingStatus.LEADING);
@@ -66,6 +68,7 @@ public class AwaitingLeadershipProxyTest {
         LeaderElectionService mockLeader = mock(LeaderElectionService.class);
 
         when(mockLeader.getSuspectedLeaderInMemory()).thenReturn(Optional.empty());
+        when(mockLeader.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
         when(mockLeader.isStillLeading(any(LeaderElectionService.LeadershipToken.class)))
                 .thenReturn(LeaderElectionService.StillLeadingStatus.LEADING);
 
@@ -86,6 +89,7 @@ public class AwaitingLeadershipProxyTest {
         LeaderElectionService mockLeader = mock(LeaderElectionService.class);
 
         when(mockLeader.getSuspectedLeaderInMemory()).thenReturn(Optional.empty());
+        when(mockLeader.getCurrentTokenIfLeading()).thenReturn(Optional.empty());
         when(mockLeader.isStillLeading(any(LeaderElectionService.LeadershipToken.class)))
                 .thenReturn(LeaderElectionService.StillLeadingStatus.NOT_LEADING);
 
@@ -132,6 +136,28 @@ public class AwaitingLeadershipProxyTest {
                 .hasMessage(TEST_MESSAGE);
     }
 
+    @Test
+    public void shouldGainLeadershipImmediatelyIfAlreadyLeading() throws Exception {
+        when(leaderElectionService.getCurrentTokenIfLeading()).thenReturn(Optional.of(leadershipToken));
+
+        Callable proxy = proxyFor(() -> null);
+
+        proxy.call();
+
+        verify(leaderElectionService, never()).blockOnBecomingLeader();
+    }
+
+    @Test
+    public void shouldBlockOnGainingLeadershipIfNotCurrentlyLeading() throws Exception {
+        Callable proxy = proxyFor(() -> null);
+        waitForLeadershipToBeGained();
+
+        proxy.call();
+
+        verify(leaderElectionService).getCurrentTokenIfLeading();
+        verify(leaderElectionService).blockOnBecomingLeader();
+    }
+
     private Void loseLeadershipDuringCallToProxyFor(Callable<Void> delegate) throws Throwable {
         CountDownLatch delegateCallStarted = new CountDownLatch(1);
         CountDownLatch leadershipLost = new CountDownLatch(1);
@@ -142,6 +168,8 @@ public class AwaitingLeadershipProxyTest {
 
             return delegate.call();
         });
+
+        waitForLeadershipToBeGained();
 
         Future<Void> blockingCall = executor.submit(proxy);
         delegateCallStarted.await();
@@ -171,12 +199,12 @@ public class AwaitingLeadershipProxyTest {
     }
 
     private Callable proxyFor(Callable fn) throws InterruptedException {
-        Callable proxy = AwaitingLeadershipProxy.newProxyInstance(Callable.class, () -> fn, leaderElectionService);
+        return AwaitingLeadershipProxy.newProxyInstance(Callable.class, () -> fn, leaderElectionService);
+    }
 
-        // wait for leadership to be gained
+    private void waitForLeadershipToBeGained() throws InterruptedException {
         verify(leaderElectionService, timeout(5_000)).blockOnBecomingLeader();
         Uninterruptibles.sleepUninterruptibly(100L, TimeUnit.MILLISECONDS);
-        return proxy;
     }
 
     private LeaderElectionService mockLeaderElectionServiceWithSequence(

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -155,6 +155,7 @@ public class AwaitingLeadershipProxyTest {
         Runnable proxy = AwaitingLeadershipProxy.newProxyInstance(Runnable.class, () -> () -> { },
                 leaderElectionService, true);
 
+        // should not have synchronously confirmed leadership
         assertThatThrownBy(() -> proxy.run()).isInstanceOf(NotCurrentLeaderException.class);
 
         Awaitility.await()

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
@@ -78,7 +78,8 @@ public class PaxosLeadershipCreator {
         return AwaitingLeadershipProxy.newProxyInstance(
                 clazz,
                 delegateSupplier::get,
-                leaderElectionService);
+                leaderElectionService,
+                true);
     }
 
     private LeaderConfig getLeaderConfig() {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -227,6 +227,15 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
+    public void clientsCreatedDynamicallyOnLeaderAreFunctionalImmediately() {
+        String client = UUID.randomUUID().toString();
+
+        CLUSTER.currentLeader()
+                .timelockServiceForClient(client)
+                .getFreshTimestamp();
+    }
+
+    @Test
     public void noConflictIfLeaderAndNonLeadersSeparatelyInitializeClient() {
         String client = UUID.randomUUID().toString();
         CLUSTER.nonLeaders().forEach(server -> {


### PR DESCRIPTION
**Goals (and why)**:
Alternative fix for https://github.com/palantir/atlasdb/pull/2503

**Implementation Description (bullets)**:
- add an option to wait synchronously for leadership confirmation in `AwaitingLeadershipProxy`

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2513)
<!-- Reviewable:end -->
