### PR TITLE
Fix flakes: wait for lock service to respond before returning

### DIFF
--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -137,6 +137,7 @@ public class PaxosTimeLockServerIntegrationTest {
                         // Returns true only if this node is ready to serve timestamps and locks on all clients.
                         CLIENTS.forEach(client -> getTimelockService(client).getFreshTimestamp());
                         CLIENTS.forEach(client -> getTimelockService(client).currentTimeMillis());
+                        CLIENTS.forEach(client -> getLockService(client).currentTimeMillis());
                         return leader.ping();
                     } catch (Throwable t) {
                         return false;
@@ -163,8 +164,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
     @Test
     public void throwsOnSingleClientRequestingSameLockTooManyTimes() throws Exception {
-        List<LockService> lockServiceList = ImmutableList.of(
-                getLockService(CLIENT_1));
+        List<LockService> lockServiceList = ImmutableList.of(getLockService(CLIENT_1));
+
         int exceedingRequests = 10;
         int maxRequestsForOneClient = SHARED_TC_LIMIT;
 


### PR DESCRIPTION
**Goals (and why)**: Attempt to fix the most common flake. Its the test called `throwsOnSingleClientRequestingSameLockTooManyTimes` and we get method invoked on non-leader exception when we try to call lock.

**Implementation Description (bullets)**: Ensure the lock service responds too in BeforeClass.

**Concerns (what feedback would you like?)**: N/A

**Where should we start reviewing?**: one file

**Priority (whenever / two weeks / yesterday)**: soon

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2515)
<!-- Reviewable:end -->
