### PR TITLE
Add a bunch of (Un)SafeArgs

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1654,7 +1654,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         boolean putMetadataWillNeedASchemaChange = !onlyMetadataChangesAreForNewTables;
 
         if (!tablesToActuallyCreate.isEmpty()) {
-            log.info("Grabbing schema mutation lock to create tables {}", tablesToActuallyCreate);
+            log.info("Grabbing schema mutation lock to create tables {}",
+                    UnsafeArg.of("tablesToActuallyCreate", tablesToActuallyCreate));
             schemaMutationLock.runWithLock(() -> createTablesInternal(tablesToActuallyCreate));
         }
         internalPutMetadataForTables(tablesToUpdateMetadataFor, putMetadataWillNeedASchemaChange);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -46,6 +46,7 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.collect.Maps2;
+import com.palantir.logsafe.SafeArg;
 
 public final class CassandraVerifier {
     private static final Logger log = LoggerFactory.getLogger(CassandraVerifier.class);
@@ -212,7 +213,7 @@ public final class CassandraVerifier {
                 config);
         ks.setDurable_writes(true);
         client.system_add_keyspace(ks);
-        log.info("Created keyspace: {}", config.getKeyspaceOrThrow());
+        log.info("Created keyspace: {}", SafeArg.of("keyspace", config.getKeyspaceOrThrow()));
         CassandraKeyValueServices.waitForSchemaVersions(
                 config,
                 client,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.SafeArg;
 
 public class SchemaMutationLockTables {
     public static final String LOCK_TABLE_PREFIX = "_locks";
@@ -69,7 +70,7 @@ public class SchemaMutationLockTables {
     private TableReference createLockTable(Cassandra.Client client) throws TException {
         String lockTableName = LOCK_TABLE_PREFIX + "_" + getUniqueSuffix();
         TableReference lockTable = TableReference.createWithEmptyNamespace(lockTableName);
-        log.info("Creating lock table {}", lockTable);
+        log.info("Creating lock table {}", SafeArg.of("lockTable", lockTable));
         createTableInternal(client, lockTable);
         return lockTable;
     }


### PR DESCRIPTION
**Goals (and why)**: Ensure that the changes introduced in #2390 used SafeArg/UnsafeArg appropriately.

**Implementation Description (bullets)**: Reviewed the logging changes introduced by #2390. Most of them had no args, but a few nearby log lines without (un)safe args were spotted.

**Concerns (what feedback would you like?)**: no major concerns here

**Where should we start reviewing?**: Anywhere, the changes are all basically independent.

**Priority (whenever / two weeks / yesterday)**: this week, but after the release?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2517)
<!-- Reviewable:end -->
