### PR TITLE
TimeLock + Async Initialization, Part 1

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -71,6 +71,7 @@ public abstract class AsyncInitializer {
                     SafeArg.of("className", getInitializingClassName()),
                     SafeArg.of("numberOfAttempts", numberOfInitializationAttempts),
                     SafeArg.of("initializationDuration", System.currentTimeMillis() - initializationStartTime));
+            singleThreadedExecutor.shutdown();
         } catch (Throwable throwable) {
             log.info("Failed to initialize {} on the attempt {}",
                     SafeArg.of("className", getInitializingClassName()),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
@@ -370,7 +371,8 @@ public abstract class TransactionManagers {
                 conflictManager,
                 sweepStrategyManager,
                 cleaner,
-                initializer::isInitialized,
+                () -> initializer.isInitialized()
+                        && lockAndTimestampServices.migrator().map(AsyncInitializer::isInitialized).orElse(true),
                 allowHiddenTableAccess(),
                 () -> runtimeConfigSupplier.get().transaction().getLockAcquireTimeoutMillis(),
                 config.keyValueService().concurrentGetRangesThreadPoolSize(),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
@@ -20,12 +20,11 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.config.TimeLockClientConfig;
 import com.palantir.atlasdb.factory.ServiceCreator;
-import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 
-public class TimeLockMigrator extends AsyncInitializer {
+public final class TimeLockMigrator extends AsyncInitializer {
     private final TimestampStoreInvalidator source;
     private final TimestampManagementService destination;
     private final boolean initializeAsync;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
@@ -24,7 +24,8 @@ import com.palantir.common.annotation.Idempotent;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 
-public final class TimeLockMigrator extends AsyncInitializer {
+@SuppressWarnings("FinalClass")
+public class TimeLockMigrator extends AsyncInitializer {
     private final TimestampStoreInvalidator source;
     private final TimestampManagementService destination;
     private final boolean initializeAsync;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
@@ -96,7 +96,7 @@ public class TimeLockMigrator extends AsyncInitializer {
 
     @Override
     protected String getInitializingClassName() {
-        return TransactionManagers.class.getName();
+        return TimeLockMigrator.class.getSimpleName();
     }
 }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
@@ -15,38 +15,54 @@
  */
 package com.palantir.atlasdb.factory.startup;
 
+import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.config.TimeLockClientConfig;
 import com.palantir.atlasdb.factory.ServiceCreator;
+import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 
-public class TimeLockMigrator {
+public class TimeLockMigrator extends AsyncInitializer {
     private final TimestampStoreInvalidator source;
     private final TimestampManagementService destination;
+    private final boolean initializeAsync;
 
-    public TimeLockMigrator(TimestampStoreInvalidator source, TimestampManagementService destination) {
+    private TimeLockMigrator(
+            TimestampStoreInvalidator source,
+            TimestampManagementService destination,
+            boolean initializeAsync) {
         this.source = source;
         this.destination = destination;
+        this.initializeAsync = initializeAsync;
     }
 
     public static TimeLockMigrator create(
             TimeLockClientConfig config,
             TimestampStoreInvalidator invalidator,
             String userAgent) {
+        return create(config, invalidator, userAgent, AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+    }
+
+    public static TimeLockMigrator create(
+            TimeLockClientConfig config,
+            TimestampStoreInvalidator invalidator,
+            String userAgent,
+            boolean initializeAsync) {
         TimestampManagementService remoteTimestampManagementService =
                 createRemoteManagementService(config, userAgent);
-        return new TimeLockMigrator(invalidator, remoteTimestampManagementService);
+        return new TimeLockMigrator(invalidator, remoteTimestampManagementService, initializeAsync);
     }
 
     /**
      * Migration works as follows:
      * 1. Ping the destination Timelock Server. If this fails, throw.
      * 2. Backup and invalidate the Timestamp Bound, returning TS.
-     *    At this point, the database should contain an invalidated timestamp bound, plus a backup bound of TS.
+     * At this point, the database should contain an invalidated timestamp bound, plus a backup bound of TS.
      * 3. Fast-forward the destination to TS.
-     *
+     * <p>
      * The purpose of step 1 is largely to handle cases where users accidentally mis-configure their AtlasDB clients to
      * attempt to talk to Timelock; we want to ensure there's a legitimate Timelock Server present before doing the
      * invalidation. In the event of a failure between steps 2 and 3, rerunning this method is safe, because
@@ -56,13 +72,7 @@ public class TimeLockMigrator {
     @Idempotent
     @SuppressWarnings("CheckReturnValue") // errorprone doesn't pick up "when=NEVER"
     public void migrate() {
-        try {
-            destination.ping();
-        } catch (Exception e) {
-            throw new IllegalStateException("Could not contact the Timelock Server.", e);
-        }
-        long currentTimestamp = source.backupAndInvalidate();
-        destination.fastForwardTimestamp(currentTimestamp);
+        initialize(initializeAsync);
     }
 
     private static TimestampManagementService createRemoteManagementService(
@@ -72,4 +82,21 @@ public class TimeLockMigrator {
         return new ServiceCreator<>(TimestampManagementService.class, userAgent)
                 .apply(serverListConfig);
     }
+
+    @Override
+    protected synchronized void tryInitialize() {
+        try {
+            destination.ping();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not contact the Timelock Server.", e);
+        }
+        long currentTimestamp = source.backupAndInvalidate();
+        destination.fastForwardTimestamp(currentTimestamp);
+    }
+
+    @Override
+    protected String getInitializingClassName() {
+        return TransactionManagers.class.getName();
+    }
 }
+

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/startup/TimeLockMigrator.java
@@ -70,7 +70,6 @@ public class TimeLockMigrator extends AsyncInitializer {
      * is unreadable.
      */
     @Idempotent
-    @SuppressWarnings("CheckReturnValue") // errorprone doesn't pick up "when=NEVER"
     public void migrate() {
         initialize(initializeAsync);
     }
@@ -84,6 +83,7 @@ public class TimeLockMigrator extends AsyncInitializer {
     }
 
     @Override
+    @SuppressWarnings({"CheckReturnValue", "ResultOfMethodCallIgnored"}) // errorprone doesn't pick up "when=NEVER"
     protected synchronized void tryInitialize() {
         try {
             destination.ping();

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -230,11 +230,11 @@ public class TransactionManagersTest {
         setUpForRemoteServices();
         setupLeaderBlockInConfig();
 
-        TransactionManagers.LockAndTimestampServices lockAndTimestampServices = getLockAndTimestampServices();
+        TransactionManagers.LockAndTimestampServices lockAndTimestamp = getLockAndTimestampServices();
         availableServer.verify(getRequestedFor(urlMatching(LEADER_UUID_PATH)));
 
-        lockAndTimestampServices.timelock().getFreshTimestamp();
-        lockAndTimestampServices.lock().currentTimeMillis();
+        lockAndTimestamp.timelock().getFreshTimestamp();
+        lockAndTimestamp.lock().currentTimeMillis();
 
         availableServer.verify(postRequestedFor(urlMatching(TIMESTAMP_PATH))
                 .withHeader(USER_AGENT_HEADER, WireMock.equalTo(USER_AGENT)));
@@ -247,11 +247,11 @@ public class TransactionManagersTest {
         setUpForLocalServices();
         setupLeaderBlockInConfig();
 
-        TransactionManagers.LockAndTimestampServices lockAndTimestampServices = getLockAndTimestampServices();
+        TransactionManagers.LockAndTimestampServices lockAndTimestamp = getLockAndTimestampServices();
         availableServer.verify(getRequestedFor(urlMatching(LEADER_UUID_PATH)));
 
-        lockAndTimestampServices.timelock().getFreshTimestamp();
-        lockAndTimestampServices.lock().currentTimeMillis();
+        lockAndTimestamp.timelock().getFreshTimestamp();
+        lockAndTimestamp.lock().currentTimeMillis();
 
         availableServer.verify(0, postRequestedFor(urlMatching(TIMESTAMP_PATH))
                 .withHeader(USER_AGENT_HEADER, WireMock.equalTo(USER_AGENT)));
@@ -393,9 +393,9 @@ public class TransactionManagersTest {
         assertThat(metricsRule.metrics().timer(timestampMetric).getCount(), is(equalTo(0L)));
         assertThat(metricsRule.metrics().timer(lockMetric).getCount(), is(equalTo(0L)));
 
-        TransactionManagers.LockAndTimestampServices lockAndTimestampServices = getLockAndTimestampServices();
-        lockAndTimestampServices.timelock().getFreshTimestamp();
-        lockAndTimestampServices.timelock().currentTimeMillis();
+        TransactionManagers.LockAndTimestampServices lockAndTimestamp = getLockAndTimestampServices();
+        lockAndTimestamp.timelock().getFreshTimestamp();
+        lockAndTimestamp.timelock().currentTimeMillis();
 
         assertThat(metricsRule.metrics().timer(timestampMetric).getCount(), is(equalTo(1L)));
         assertThat(metricsRule.metrics().timer(lockMetric).getCount(), is(equalTo(1L)));
@@ -453,7 +453,7 @@ public class TransactionManagersTest {
     }
 
     private void verifyUserAgentOnTimestampAndLockRequests(String timestampPath, String lockPath) {
-        TransactionManagers.LockAndTimestampServices lockAndTimestampServices =
+        TransactionManagers.LockAndTimestampServices lockAndTimestamp =
                 TransactionManagers.createLockAndTimestampServices(
                         config,
                         () -> ImmutableTimestampClientConfig.of(false),
@@ -462,8 +462,8 @@ public class TransactionManagersTest {
                         InMemoryTimestampService::new,
                         invalidator,
                         USER_AGENT);
-        lockAndTimestampServices.timelock().getFreshTimestamp();
-        lockAndTimestampServices.timelock().currentTimeMillis();
+        lockAndTimestamp.timelock().getFreshTimestamp();
+        lockAndTimestamp.timelock().currentTimeMillis();
 
         availableServer.verify(postRequestedFor(urlMatching(timestampPath))
                 .withHeader(USER_AGENT_HEADER, WireMock.equalTo(USER_AGENT)));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.transaction.impl;
 import java.util.Optional;
 
 import com.google.common.base.Supplier;
-import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -39,12 +38,12 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
 
     public static class InitializeCheckingWrapper extends AutoDelegate_SerializableTransactionManager {
         private final SerializableTransactionManager manager;
-        private final AsyncInitializer prerequisite;
+        private final Supplier<Boolean> initializationPrerequisite;
 
         public InitializeCheckingWrapper(SerializableTransactionManager manager,
-                AsyncInitializer prerequisite) {
+                Supplier<Boolean> initializationPrerequisite) {
             this.manager = manager;
-            this.prerequisite = prerequisite;
+            this.initializationPrerequisite = initializationPrerequisite;
         }
 
         @Override
@@ -66,7 +65,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                     && manager.getTimelockService().isInitialized()
                     && manager.getTimestampService().isInitialized()
                     && manager.getCleaner().isInitialized()
-                    && prerequisite.isInitialized();
+                    && initializationPrerequisite.get();
         }
 
         @Override
@@ -96,7 +95,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             ConflictDetectionManager conflictDetectionManager,
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
-            AsyncInitializer initializer,
+            Supplier<Boolean> initializationPrerequisite,
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
@@ -114,7 +113,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 lockAcquireTimeoutMs,
                 concurrentGetRangesThreadPoolSize);
 
-        return initializeAsync ? new InitializeCheckingWrapper(serializableTransactionManager, initializer)
+        return initializeAsync
+                ? new InitializeCheckingWrapper(serializableTransactionManager, initializationPrerequisite)
                 : serializableTransactionManager;
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -49,7 +49,7 @@ public class SerializableTransactionManagerTest {
                 null, // conflictDetectionManager
                 null, // sweepStrategyManager
                 mockCleaner,
-                mockInitializer,
+                mockInitializer::isInitialized,
                 false, // allowHiddenTableAccess
                 () -> 1L, // lockAcquireTimeoutMs
                 1, // concurrentGetRangesThreadPoolSize
@@ -107,7 +107,7 @@ public class SerializableTransactionManagerTest {
                 null, // conflictDetectionManager
                 null, // sweepStrategyManager
                 mockCleaner,
-                mockInitializer,
+                mockInitializer::isInitialized,
                 false, // allowHiddenTableAccess
                 () -> 1L, // lockAcquireTimeoutMs
                 1, // concurrentGetRangesThreadPoolSize

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -85,6 +85,16 @@ v0.61.0
            Previously, we would log a ``SafeArg`` for these batches that had no content.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2475>`__)
 
+    *    - |fixed|
+         - Async Initialization now works with TimeLock and Cassandra KVS.
+           Previously, we would attempt to immediately migrate the timestamp bound from Cassandra to TimeLock on startup, which would fail if neither of them was available.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
+
+    *    - |fixed|
+         - ``AsyncInitializer`` now shuts down its executor after initialization has completed.
+           Previously, the executor service wasn't shut down, which could lead to the initializer thread hanging around unnecessarily.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -59,7 +59,7 @@ develop
     *    - |fixed|
          - Async Initialization now works with TimeLock Server.
            Previously, for Cassandra we would attempt to immediately migrate the timestamp bound from Cassandra to TimeLock on startup, which would fail if either of them was unavailable.
-           For DBKVS or other key-value services, we would attempt to ping TimeLock on startup, which would fail if TimeLock was available (though the KVS could be unavailable).
+           For DBKVS or other key-value services, we would attempt to ping TimeLock on startup, which would fail if TimeLock was unavailable (though the KVS need not be available).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2518>`__)
 
     *    - |fixed|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -67,6 +67,7 @@ develop
            Previously, the executor service wasn't shut down, which could lead to the initializer thread hanging around unnecessarily.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2518>`__)
 
+    *    - |fixed|
          - TimeLock Server's ``ClockSkewMonitor`` now attempts to contact all other nodes in the TimeLock cluster, even in the presence of remoting exceptions or clock skews.
            Previously, we would stop querying nodes once we encountered a remoting exception or detected clock skew.
            Also, the log line ``ClockSkewMonitor threw an exception`` which was previously logged every second when a TimeLock node was down or otherwise uncontactable is now restricted to once every 10 minutes.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,18 @@ develop
            The existing ``create`` methods are deprecated and will be removed by November 15th, 2017.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2459>`__)
 
+    *    - |fixed|
+         - Async Initialization now works with TimeLock Server.
+           Previously, for Cassandra we would attempt to immediately migrate the timestamp bound from Cassandra to TimeLock on startup, which would fail if either of them was unavailable.
+           For DBKVS or other key-value services, we would attempt to ping TimeLock on startup, which would fail if TimeLock was available (though the KVS could be unavailable).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2518>`__)
+
+    *    - |fixed|
+         - ``AsyncInitializer`` now shuts down its executor after initialization has completed.
+           Previously, the executor service wasn't shut down, which could lead to the initializer thread hanging around unnecessarily.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2518>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -84,16 +96,6 @@ v0.61.0
          - Sweep candidate batches are now logged correctly.
            Previously, we would log a ``SafeArg`` for these batches that had no content.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2475>`__)
-
-    *    - |fixed|
-         - Async Initialization now works with TimeLock and Cassandra KVS.
-           Previously, we would attempt to immediately migrate the timestamp bound from Cassandra to TimeLock on startup, which would fail if either of them was unavailable.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
-
-    *    - |fixed|
-         - ``AsyncInitializer`` now shuts down its executor after initialization has completed.
-           Previously, the executor service wasn't shut down, which could lead to the initializer thread hanging around unnecessarily.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -87,7 +87,7 @@ v0.61.0
 
     *    - |fixed|
          - Async Initialization now works with TimeLock and Cassandra KVS.
-           Previously, we would attempt to immediately migrate the timestamp bound from Cassandra to TimeLock on startup, which would fail if neither of them was available.
+           Previously, we would attempt to immediately migrate the timestamp bound from Cassandra to TimeLock on startup, which would fail if either of them was unavailable.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
 
     *    - |fixed|


### PR DESCRIPTION
**Goals (and why)**:
- Previously, for Cassandra we would attempt to immediately migrate the timestamp bound from Cassandra to TimeLock on startup, which would fail if either of them was unavailable. For DBKVS or other key-value services, we would attempt to ping TimeLock on startup, which would fail if TimeLock was available (though the KVS could be unavailable).
- Fix #2500
- Drive by fix of a thread leak in the async initializer (it doesn't shut down the executor service after successfully initializing the client)

**Implementation Description (bullets)**:
- Make TimeLockMigrator an AsyncInitializer
- Change SerializableTransactionManager to take a Supplier<Boolean> instead of an AsyncInitializer for its TransactionManagersInitializer check
- Require both TLM and TMI to be happy before that prerequisite passes.

**Concerns (what feedback would you like?)**:
- Is the TransactionManagers part too hacky?
- Are there any pitfalls I've missed out on?

**Where should we start reviewing?**: TimeLockMigrator

**Priority (whenever / two weeks / yesterday)**: next week, this would probably block GA of Async Initialization

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2520)
<!-- Reviewable:end -->
