### PR TITLE
Fix/oracle shrink timeouts

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -37,6 +37,7 @@ import com.palantir.db.oracle.JdbcHandler;
 public abstract class OracleDdlConfig extends DdlConfig {
     public static final String TYPE = "oracle";
 
+
     public abstract JdbcHandler jdbcHandler();
 
     @Value.Default
@@ -62,6 +63,16 @@ public abstract class OracleDdlConfig extends DdlConfig {
     @Value.Default
     public boolean enableShrinkOnOracleStandardEdition() {
         return false;
+    }
+
+    @Value.Default
+    public long shrinkPauseSeconds() {
+        return 10;
+    }
+
+    @Value.Default
+    public long shrinkPauseOnFailureSeconds() {
+        return 60 * 30;
     }
 
     @Value.Default

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -60,7 +60,7 @@ public abstract class OracleDdlConfig extends DdlConfig {
         return false;
     }
 
-    //Create a ShrinkConfig class
+    //TODO(hsaraogi): Create a ShrinkConfig class
     @Value.Default
     public boolean enableShrinkOnOracleStandardEdition() {
         return false;
@@ -78,6 +78,7 @@ public abstract class OracleDdlConfig extends DdlConfig {
 
     @Value.Default
     public int shrinkConnectionTimeoutMillis() {
+        // This is set to 10 minutes as we saw socket timeouts with 5 minutes.
         return 60 * 10 * 1000;
     }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -108,10 +108,6 @@ public abstract class OracleDdlConfig extends DdlConfig {
                 overflowTablePrefix().length() <= AtlasDbConstants.MAX_OVERFLOW_TABLE_PREFIX_LENGTH,
                 "Oracle 'overflowTablePrefix' cannot be more than %s characters long.",
                 AtlasDbConstants.MAX_OVERFLOW_TABLE_PREFIX_LENGTH);
-        Preconditions.checkState(
-                overflowTablePrefix().length() <= AtlasDbConstants.MAX_OVERFLOW_TABLE_PREFIX_LENGTH,
-                "Oracle 'overflowTablePrefix' cannot be more than %s characters long.",
-                AtlasDbConstants.MAX_OVERFLOW_TABLE_PREFIX_LENGTH);
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -60,7 +60,7 @@ public abstract class OracleDdlConfig extends DdlConfig {
         return false;
     }
 
-    //TODO(hsaraogi): Create a ShrinkConfig class
+    // TODO(hsaraogi): Create a ShrinkConfig class
     @Value.Default
     public boolean enableShrinkOnOracleStandardEdition() {
         return false;

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -60,26 +60,9 @@ public abstract class OracleDdlConfig extends DdlConfig {
         return false;
     }
 
-    // TODO(hsaraogi): Create a ShrinkConfig class
     @Value.Default
-    public boolean enableShrinkOnOracleStandardEdition() {
-        return false;
-    }
-
-    @Value.Default
-    public long shrinkPauseSeconds() {
-        return 10;
-    }
-
-    @Value.Default
-    public long shrinkPauseOnFailureSeconds() {
-        return 60 * 30;
-    }
-
-    @Value.Default
-    public int shrinkConnectionTimeoutMillis() {
-        // This is set to 10 minutes as we saw socket timeouts with 5 minutes.
-        return 60 * 10 * 1000;
+    public OracleStandardEditionShrinkConfiguration shrinkConfig() {
+        return ImmutableOracleStandardEditionShrinkConfiguration.builder().build();
     }
 
     @Value.Default
@@ -121,6 +104,10 @@ public abstract class OracleDdlConfig extends DdlConfig {
         Preconditions.checkState(
                 overflowTablePrefix().endsWith("_"),
                 "Oracle 'overflowTablePrefix' must end with an underscore.");
+        Preconditions.checkState(
+                overflowTablePrefix().length() <= AtlasDbConstants.MAX_OVERFLOW_TABLE_PREFIX_LENGTH,
+                "Oracle 'overflowTablePrefix' cannot be more than %s characters long.",
+                AtlasDbConstants.MAX_OVERFLOW_TABLE_PREFIX_LENGTH);
         Preconditions.checkState(
                 overflowTablePrefix().length() <= AtlasDbConstants.MAX_OVERFLOW_TABLE_PREFIX_LENGTH,
                 "Oracle 'overflowTablePrefix' cannot be more than %s characters long.",

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -60,6 +60,7 @@ public abstract class OracleDdlConfig extends DdlConfig {
         return false;
     }
 
+    //Create a ShrinkConfig class
     @Value.Default
     public boolean enableShrinkOnOracleStandardEdition() {
         return false;
@@ -73,6 +74,11 @@ public abstract class OracleDdlConfig extends DdlConfig {
     @Value.Default
     public long shrinkPauseOnFailureSeconds() {
         return 60 * 30;
+    }
+
+    @Value.Default
+    public int shrinkConnectionTimeoutMillis() {
+        return 60 * 10 * 1000;
     }
 
     @Value.Default

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleStandardEditionShrinkConfiguration.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleStandardEditionShrinkConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public class OracleStandardEditionShrinkConfiguration {
+    @Value.Default
+    public boolean enableShrinkOnOracleStandardEdition() {
+        return false;
+    }
+
+    @Value.Default
+    public long shrinkPauseSeconds() {
+        return 10;
+    }
+
+    @Value.Default
+    public long shrinkPauseOnFailureSeconds() {
+        // ShrinkExecutor will sleep for 30 minutes if a Shrink fails.
+        return 30 * 60;
+    }
+
+    @Value.Default
+    public int shrinkConnectionTimeoutMillis() {
+        // This is set to 10 minutes as we saw socket timeouts with 5 minutes.
+        return 10 * 60 * 1000;
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -236,7 +236,8 @@ public final class DbKvs extends AbstractKeyValueService {
                             .build()),
                     AtlasDbMetrics.getMetricRegistry(),
                     MetricRegistry.name(OracleShrinkExecutor.class, "executor"));
-        return new OracleShrinkExecutor(connections, oracleShrinkExecutorService, tableNameGetter, oracleDdlConfig.shrinkConfig());
+        return new OracleShrinkExecutor(connections, oracleShrinkExecutorService, tableNameGetter,
+                oracleDdlConfig.shrinkConfig());
     }
 
     private DbKvs(ExecutorService executor,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -236,7 +236,7 @@ public final class DbKvs extends AbstractKeyValueService {
                             .build()),
                     AtlasDbMetrics.getMetricRegistry(),
                     MetricRegistry.name(OracleShrinkExecutor.class, "executor"));
-        return new OracleShrinkExecutor(connections, oracleShrinkExecutorService, tableNameGetter, oracleDdlConfig);
+        return new OracleShrinkExecutor(connections, oracleShrinkExecutorService, tableNameGetter, oracleDdlConfig.shrinkConfig());
     }
 
     private DbKvs(ExecutorService executor,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
@@ -32,7 +32,7 @@ public class OracleDbTableFactory implements DbTableFactory {
     private final OracleTableNameGetter oracleTableNameGetter;
     private final OraclePrefixedTableNames oraclePrefixedTableNames;
     private final TableValueStyleCache valueStyleCache;
-    private OracleShrinkExecutor oracleShrinkExecutor;
+    private final OracleShrinkExecutor oracleShrinkExecutor;
 
     public OracleDbTableFactory(OracleDdlConfig config,
             OracleTableNameGetter oracleTableNameGetter,
@@ -53,7 +53,8 @@ public class OracleDbTableFactory implements DbTableFactory {
 
     @Override
     public DbDdlTable createDdl(TableReference tableRef, ConnectionSupplier conns) {
-        return OracleDdlTable.create(tableRef, conns, config, oracleTableNameGetter, valueStyleCache, oracleShrinkExecutor);
+        return OracleDdlTable.create(tableRef, conns, config, oracleTableNameGetter, valueStyleCache,
+                oracleShrinkExecutor);
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
@@ -32,15 +32,18 @@ public class OracleDbTableFactory implements DbTableFactory {
     private final OracleTableNameGetter oracleTableNameGetter;
     private final OraclePrefixedTableNames oraclePrefixedTableNames;
     private final TableValueStyleCache valueStyleCache;
+    private OracleShrinkExecutor oracleShrinkExecutor;
 
     public OracleDbTableFactory(OracleDdlConfig config,
-                                OracleTableNameGetter oracleTableNameGetter,
-                                OraclePrefixedTableNames oraclePrefixedTableNames,
-                                TableValueStyleCache valueStyleCache) {
+            OracleTableNameGetter oracleTableNameGetter,
+            OraclePrefixedTableNames oraclePrefixedTableNames,
+            TableValueStyleCache valueStyleCache,
+            OracleShrinkExecutor oracleShrinkExecutor) {
         this.config = config;
         this.oracleTableNameGetter = oracleTableNameGetter;
         this.oraclePrefixedTableNames = oraclePrefixedTableNames;
         this.valueStyleCache = valueStyleCache;
+        this.oracleShrinkExecutor = oracleShrinkExecutor;
     }
 
     @Override
@@ -50,7 +53,7 @@ public class OracleDbTableFactory implements DbTableFactory {
 
     @Override
     public DbDdlTable createDdl(TableReference tableRef, ConnectionSupplier conns) {
-        return OracleDdlTable.create(tableRef, conns, config, oracleTableNameGetter, valueStyleCache);
+        return OracleDdlTable.create(tableRef, conns, config, oracleTableNameGetter, valueStyleCache, oracleShrinkExecutor);
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
@@ -89,7 +89,8 @@ public class OracleShrinkExecutor {
         }
 
         Stopwatch timer = Stopwatch.createStarted();
-        try (ConnectionSupplier conns = new ConnectionSupplier(connectionPool)) {
+        ConnectionSupplier conns = new ConnectionSupplier(connectionPool);
+        try {
             Stopwatch shrinkAndCompactTimer = Stopwatch.createStarted();
             getConnectionWithIncreasedTimeout(conns).executeUnregisteredQuery(
                     "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
@@ -118,6 +119,7 @@ public class OracleShrinkExecutor {
         } catch (TableMappingNotFoundException e) {
             throw new RuntimeException(e);
         } finally {
+            conns.close();
             log.info("Call to KVS.compactInternally on table {} took {} ms.",
                     tableRef, timer.elapsed(TimeUnit.MILLISECONDS));
         }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import java.sql.SQLException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Stopwatch;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
+import com.palantir.atlasdb.logging.LoggingArgs;
+import com.palantir.exception.PalantirSqlException;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.nexus.db.sql.SqlConnection;
+
+public class OracleShrinkExecutor {
+    private static final Logger log = LoggerFactory.getLogger(OracleShrinkExecutor.class);
+
+    private final SqlConnectionSupplier connectionPool;
+    private final ExecutorService executorService;
+    private final OracleTableNameGetter oracleTableNameGetter;
+    private OracleDdlConfig oracleDdlConfig;
+
+    private static Future<Boolean> previousShrinkFuture;
+
+    public OracleShrinkExecutor(
+            SqlConnectionSupplier connectionPool,
+            ExecutorService executorService,
+            OracleTableNameGetter oracleTableNameGetter,
+            OracleDdlConfig oracleDdlConfig) {
+        this.connectionPool = connectionPool;
+        this.executorService = executorService;
+        this.oracleTableNameGetter = oracleTableNameGetter;
+        this.oracleDdlConfig = oracleDdlConfig;
+    }
+
+    public void shrinkAsync(TableReference tableRef) {
+        final long secondsToWaitBeforeShrink = getSecondsToWaitBeforeShrink();
+        previousShrinkFuture = executorService.submit(
+                () -> shrinkCompactFollowedByShrink(tableRef, secondsToWaitBeforeShrink));
+
+    }
+
+    private long getSecondsToWaitBeforeShrink() {
+        long secondsToWaitBeforeShrink = oracleDdlConfig.shrinkPauseSeconds();
+        if (previousShrinkFuture != null) {
+            try {
+                if (!previousShrinkFuture.get()) {
+                    secondsToWaitBeforeShrink =
+                            secondsToWaitBeforeShrink + oracleDdlConfig.shrinkPauseOnFailureSeconds();
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                secondsToWaitBeforeShrink = secondsToWaitBeforeShrink + oracleDdlConfig.shrinkPauseOnFailureSeconds();
+            }
+        }
+        return secondsToWaitBeforeShrink;
+    }
+
+    private boolean shrinkCompactFollowedByShrink(TableReference tableRef, long secondsToWaitBeforeShrink) {
+
+        try {
+            TimeUnit.SECONDS.sleep(secondsToWaitBeforeShrink);
+        } catch (InterruptedException e) {
+            log.warn("Skipping Shrink for table: {}", LoggingArgs.tableRef("tableToShrink", tableRef));
+            return false;
+        }
+
+        Stopwatch timer = Stopwatch.createStarted();
+        try (ConnectionSupplier conns = new ConnectionSupplier(connectionPool)) {
+            Stopwatch shrinkAndCompactTimer = Stopwatch.createStarted();
+            getConnectionWithIncreasedTimeout(conns).executeUnregisteredQuery(
+                    "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
+                            + " SHRINK SPACE COMPACT");
+            log.info("Call to SHRINK SPACE COMPACT on table {} took {} ms.",
+                    tableRef, shrinkAndCompactTimer.elapsed(TimeUnit.MILLISECONDS));
+
+            Stopwatch shrinkTimer = Stopwatch.createStarted();
+            getConnectionWithIncreasedTimeout(conns).executeUnregisteredQuery(
+                    "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
+                            + " SHRINK SPACE");
+            log.info("Call to SHRINK SPACE on table {} took {} ms."
+                            + " This implies that locks on the entire table were held for this period.",
+                    tableRef, shrinkTimer.elapsed(TimeUnit.MILLISECONDS));
+            return true;
+        } catch (PalantirSqlException e) {
+            log.error("Tried to clean up {} bloat after a sweep operation via Oracle Shrink, but failed."
+                    + " If you are running against Enterprise Edition, you can set enableOracleEnterpriseFeatures"
+                    + " to true in the configuration to start running Oracle EE move online operations."
+                    + " Otherwise, good practice would be to do occasional offline manual maintenance of rebuilding"
+                    + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
+                    + " like more information. Underlying error was: {}",
+                    LoggingArgs.tableRef("tableToShrink", tableRef),
+                    e.getMessage());
+            return false;
+        } catch (TableMappingNotFoundException e) {
+            throw new RuntimeException(e);
+        } finally {
+            log.info("Call to KVS.compactInternally on table {} took {} ms.",
+                    tableRef, timer.elapsed(TimeUnit.MILLISECONDS));
+        }
+    }
+
+    private SqlConnection getConnectionWithIncreasedTimeout(ConnectionSupplier conns) {
+        SqlConnection sqlConnection = conns.get();
+        try {
+            int originalNetworkTimeout = sqlConnection.getUnderlyingConnection().getNetworkTimeout();
+            int newNetworkTimeout = originalNetworkTimeout * 5;
+            sqlConnection.getUnderlyingConnection().setNetworkTimeout(Executors.newSingleThreadExecutor(),
+                    newNetworkTimeout);
+            log.info("Increased sql socket read timeout from {} to {}",
+                    SafeArg.of("originalNetworkTimeout", originalNetworkTimeout),
+                    SafeArg.of("newNetworkTimeout", newNetworkTimeout));
+            return sqlConnection;
+        } catch (SQLException e) {
+            log.warn("Failed to increase socket read timeout for the connection. Encountered an exception:", e);
+            return sqlConnection;
+        }
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
@@ -64,7 +64,8 @@ public class OracleShrinkExecutor {
         try {
             TimeUnit.SECONDS.sleep(shrinkConfig.shrinkPauseSeconds());
         } catch (InterruptedException e) {
-            log.warn("Skipping Shrink for table: {} because the thread was interrupted.", LoggingArgs.tableRef("tableToShrink", tableRef));
+            log.warn("Skipping Shrink for table: {} because the thread was interrupted.",
+                    LoggingArgs.tableRef("tableToShrink", tableRef));
             return false;
         }
 

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
@@ -127,7 +127,7 @@ public class OracleShrinkExecutor {
         SqlConnection sqlConnection = conns.get();
         try {
             int originalNetworkTimeout = sqlConnection.getUnderlyingConnection().getNetworkTimeout();
-            int newNetworkTimeout = originalNetworkTimeout * 5;
+            int newNetworkTimeout = oracleDdlConfig.shrinkConnectionTimeoutMillis();
             sqlConnection.getUnderlyingConnection().setNetworkTimeout(Executors.newSingleThreadExecutor(),
                     newNetworkTimeout);
             log.info("Increased sql socket read timeout from {} to {}",

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -32,8 +32,10 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyle;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyleCache;
 import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
+import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.exception.PalantirSqlException;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
 import com.palantir.util.VersionStrings;
 
@@ -70,8 +72,8 @@ public final class OracleDdlTable implements DbDdlTable {
             OracleTableNameGetter oracleTableNameGetter,
             TableValueStyleCache valueStyleCache,
             OracleShrinkExecutor oracleShrinkExecutor) {
-        return new OracleDdlTable(config, conns, tableRef, oracleTableNameGetter, valueStyleCache,
-                oracleShrinkExecutor);
+        return new OracleDdlTable(
+                config, conns, tableRef, oracleTableNameGetter, valueStyleCache, oracleShrinkExecutor);
     }
 
     @Override
@@ -256,11 +258,13 @@ public final class OracleDdlTable implements DbDdlTable {
                         + " feature online. Since this can't be automated in your configuration,"
                         + " good practice would be do to occasional offline manual maintenance of rebuilding"
                         + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
-                        + " like more information. Underlying error was: {}", tableRef, e.getMessage());
+                        + " like more information. Underlying error was: {}",
+                        LoggingArgs.tableRef(tableRef),
+                        UnsafeArg.of("exception message", e.getMessage()));
             } catch (TableMappingNotFoundException e) {
                 throw new RuntimeException(e);
             }
-        } else if (config.enableShrinkOnOracleStandardEdition()) {
+        } else if (config.shrinkConfig().enableShrinkOnOracleStandardEdition()) {
             oracleShrinkExecutor.shrinkAsync(tableRef);
         }
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Throwables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -71,7 +70,8 @@ public final class OracleDdlTable implements DbDdlTable {
             OracleTableNameGetter oracleTableNameGetter,
             TableValueStyleCache valueStyleCache,
             OracleShrinkExecutor oracleShrinkExecutor) {
-        return new OracleDdlTable(config, conns, tableRef, oracleTableNameGetter, valueStyleCache, oracleShrinkExecutor);
+        return new OracleDdlTable(config, conns, tableRef, oracleTableNameGetter, valueStyleCache,
+                oracleShrinkExecutor);
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -15,13 +15,11 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
-import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -30,6 +28,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.OracleErrorConstants;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbDdlTable;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OracleShrinkExecutor;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyle;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyleCache;
@@ -48,18 +47,21 @@ public final class OracleDdlTable implements DbDdlTable {
     private final TableReference tableRef;
     private final OracleTableNameGetter oracleTableNameGetter;
     private final TableValueStyleCache valueStyleCache;
+    private OracleShrinkExecutor oracleShrinkExecutor;
 
     private OracleDdlTable(
             OracleDdlConfig config,
             ConnectionSupplier conns,
             TableReference tableRef,
             OracleTableNameGetter oracleTableNameGetter,
-            TableValueStyleCache valueStyleCache) {
+            TableValueStyleCache valueStyleCache,
+            OracleShrinkExecutor oracleShrinkExecutor) {
         this.config = config;
         this.conns = conns;
         this.tableRef = tableRef;
         this.oracleTableNameGetter = oracleTableNameGetter;
         this.valueStyleCache = valueStyleCache;
+        this.oracleShrinkExecutor = oracleShrinkExecutor;
     }
 
     public static OracleDdlTable create(
@@ -67,8 +69,9 @@ public final class OracleDdlTable implements DbDdlTable {
             ConnectionSupplier conns,
             OracleDdlConfig config,
             OracleTableNameGetter oracleTableNameGetter,
-            TableValueStyleCache valueStyleCache) {
-        return new OracleDdlTable(config, conns, tableRef, oracleTableNameGetter, valueStyleCache);
+            TableValueStyleCache valueStyleCache,
+            OracleShrinkExecutor oracleShrinkExecutor) {
+        return new OracleDdlTable(config, conns, tableRef, oracleTableNameGetter, valueStyleCache, oracleShrinkExecutor);
     }
 
     @Override
@@ -241,55 +244,24 @@ public final class OracleDdlTable implements DbDdlTable {
 
     @Override
     public void compactInternally() {
-        final String compactionFailureTemplate = "Tried to clean up {} bloat after a sweep operation,"
-                + " but underlying Oracle database or configuration does not support this {} feature online. "
-                + " Since this can't be automated in your configuration,"
-                + " good practice would be do to occasional offline manual maintenance of rebuilding"
-                + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
-                + " like more information. Underlying error was: {}";
-
         if (config.enableOracleEnterpriseFeatures()) {
             try {
                 conns.get().executeUnregisteredQuery(
                         "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
                                 + " MOVE ONLINE");
             } catch (PalantirSqlException e) {
-                log.error(compactionFailureTemplate,
-                        tableRef,
-                        "(Enterprise Edition that requires this user to be able to perform DDL operations)",
-                        e.getMessage());
+                log.error("Tried to clean up {} bloat after a sweep operation,"
+                        + " but underlying Oracle database or configuration does not support this"
+                        + " (Enterprise Edition that requires this user to be able to perform DDL operations)"
+                        + " feature online. Since this can't be automated in your configuration,"
+                        + " good practice would be do to occasional offline manual maintenance of rebuilding"
+                        + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
+                        + " like more information. Underlying error was: {}", tableRef, e.getMessage());
             } catch (TableMappingNotFoundException e) {
                 throw new RuntimeException(e);
             }
         } else if (config.enableShrinkOnOracleStandardEdition()) {
-            Stopwatch timer = Stopwatch.createStarted();
-            try {
-                Stopwatch shrinkAndCompactTimer = Stopwatch.createStarted();
-                conns.get().executeUnregisteredQuery(
-                        "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
-                                + " SHRINK SPACE COMPACT");
-                log.info("Call to SHRINK SPACE COMPACT on table {} took {} ms.",
-                        tableRef, shrinkAndCompactTimer.elapsed(TimeUnit.MILLISECONDS));
-
-                Stopwatch shrinkTimer = Stopwatch.createStarted();
-                conns.get().executeUnregisteredQuery(
-                        "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
-                                + " SHRINK SPACE");
-                log.info("Call to SHRINK SPACE on table {} took {} ms."
-                                + " This implies that locks on the entire table were held for this period.",
-                        tableRef, shrinkTimer.elapsed(TimeUnit.MILLISECONDS));
-            } catch (PalantirSqlException e) {
-                log.error(compactionFailureTemplate,
-                        tableRef,
-                        "(If you are running against Enterprise Edition,"
-                                + " you can set enableOracleEnterpriseFeatures to true in the configuration.)",
-                        e.getMessage());
-            } catch (TableMappingNotFoundException e) {
-                throw new RuntimeException(e);
-            } finally {
-                log.info("Call to KVS.compactInternally on table {} took {} ms.",
-                        tableRef, timer.elapsed(TimeUnit.MILLISECONDS));
-            }
+            oracleShrinkExecutor.shrinkAsync(tableRef);
         }
     }
 }


### PR DESCRIPTION
**Goals (and why)**: More context in internal ticket PDS-56588. Fixes #2461.

**Implementation Description (bullets)**: Have a single threaded async executor for running shrinks. Increase the connection timeouts for shrink(to 10 minutes, which is configurable) and sleep for 20 minutes(configurable) if the previous shrink timed out.

**Concerns (what feedback would you like?)**: Does this sound reasonable, we can sleep for longer if the SHRINK can take more time to run.

**Where should we start reviewing?**: OracleDdlTable

**Priority (whenever / two weeks / yesterday)**: want a review soon and will merge to develop only after testing on an internal stack.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2526)
<!-- Reviewable:end -->
