### PR TITLE
Refactor/specific table sweeper

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -175,7 +175,7 @@ public class SpecificTableSweeper {
         sweepPerfLogger.logSweepResults(performanceResults);
     }
 
-    private void logSweepError(TableReference tableRef, byte[] startRow, SweepBatchConfig config, RuntimeException e) {
+    private void logSweepError(TableReference tableRef, byte[] startRow, SweepBatchConfig config, RuntimeException exception) {
         log.info("Failed to sweep table {}"
                         + " at row {}"
                         + " with candidate batch size {},"
@@ -186,7 +186,7 @@ public class SpecificTableSweeper {
                 SafeArg.of("candidateBatchSize", config.candidateBatchSize()),
                 SafeArg.of("deleteBatchSize", config.deleteBatchSize()),
                 SafeArg.of("maxCellTsPairsToExamine", config.maxCellTsPairsToExamine()),
-                e);
+                exception);
     }
 
     private void saveSweepResults(TableToSweep tableToSweep, SweepResults currentIteration) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -175,7 +175,8 @@ public class SpecificTableSweeper {
         sweepPerfLogger.logSweepResults(performanceResults);
     }
 
-    private void logSweepError(TableReference tableRef, byte[] startRow, SweepBatchConfig config, RuntimeException exception) {
+    private void logSweepError(TableReference tableRef, byte[] startRow, SweepBatchConfig config,
+            RuntimeException exception) {
         log.info("Failed to sweep table {}"
                         + " at row {}"
                         + " with candidate batch size {},"

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -263,13 +263,13 @@ public class SpecificTableSweeper {
         }
     }
 
-    private void saveFinalSweepResults(TableToSweep tableToSweep, SweepResults sweepResults) {
+    private void saveFinalSweepResults(TableToSweep tableToSweep, SweepResults finalSweepResults) {
         txManager.runTaskWithRetry((TxTask) tx -> {
             ImmutableUpdateSweepPriority.Builder update = ImmutableUpdateSweepPriority.builder()
-                    .newStaleValuesDeleted(sweepResults.getStaleValuesDeleted())
-                    .newCellTsPairsExamined(sweepResults.getCellTsPairsExamined())
+                    .newStaleValuesDeleted(finalSweepResults.getStaleValuesDeleted())
+                    .newCellTsPairsExamined(finalSweepResults.getCellTsPairsExamined())
                     .newLastSweepTimeMillis(wallClock.getTimeMillis())
-                    .newMinimumSweptTimestamp(sweepResults.getSweptTimestamp());
+                    .newMinimumSweptTimestamp(finalSweepResults.getSweptTimestamp());
             if (!tableToSweep.hasPreviousProgress()) {
                 // This is the first (and only) set of results being written for this table.
                 update.newWriteCount(0L);
@@ -278,6 +278,10 @@ public class SpecificTableSweeper {
             return null;
         });
 
+        reportSweepMetrics(finalSweepResults);
+    }
+
+    private void reportSweepMetrics(SweepResults sweepResults) {
         sweepMetrics.examinedCells(sweepResults.getCellTsPairsExamined());
         sweepMetrics.deletedCells(sweepResults.getStaleValuesDeleted());
     }


### PR DESCRIPTION
**Goals (and why)**: Some basic refactoring of `SpecificTableSweeper`, hopefully improves readability of code.  Next step is to change where we record sweep metrics and this refactor will make this trivial and easy to see the diff.

**Implementation Description (bullets)**: pulled out some methods and renamed some bits.

**Concerns (what feedback would you like?)**: have I introduced a bug?

**Where should we start reviewing?**: `SpecificTableSweeper`

**Priority (whenever / two weeks / yesterday)**: would be nice to get this and follow up PR into a release next week.

No release notes as this is just a refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2533)
<!-- Reviewable:end -->
