### PR TITLE
SafeArgs Cassandra* Classes

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraApiVersion.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraApiVersion.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.palantir.logsafe.SafeArg;
+
 public class CassandraApiVersion {
     private static final Logger LOGGER = LoggerFactory.getLogger(CassandraApiVersion.class);
 
@@ -45,9 +47,11 @@ public class CassandraApiVersion {
         boolean supportsCheckAndSet = majorVersion > 19 || (majorVersion == 19 && minorVersion >= 37);
 
         if (supportsCheckAndSet) {
-            LOGGER.info("Your cassandra api version ({}) supports check and set.", versionString);
+            LOGGER.info("Your cassandra api version ({}) supports check and set.",
+                    SafeArg.of("cassandraVersion", versionString));
         } else {
-            LOGGER.info("Your cassandra api version ({}) does not support check and set.", versionString);
+            LOGGER.info("Your cassandra api version ({}) does not support check and set.",
+                    SafeArg.of("cassandraVersion", versionString));
         }
 
         return supportsCheckAndSet;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -46,6 +46,8 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.cassandra.CassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.remoting3.config.ssl.SslSocketFactories;
 
 public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
@@ -90,10 +92,11 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
         try {
             ret.set_keyspace(config.getKeyspaceOrThrow());
             log.debug("Created new client for {}/{}{}{}",
-                    addr,
-                    config.getKeyspaceOrThrow(),
-                    config.usingSsl() ? " over SSL" : "",
-                    config.credentials().isPresent() ? " as user " + config.credentials().get().username() : "");
+                    SafeArg.of("address", addr),
+                    UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
+                    SafeArg.of("usingSsl", config.usingSsl() ? " over SSL" : ""),
+                    UnsafeArg.of("usernameConfig", config.credentials().isPresent() ?
+                            " as user " + config.credentials().get().username() : ""));
             return ret;
         } catch (Exception e) {
             ret.getOutputProtocol().getTransport().close();
@@ -109,7 +112,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
             thriftSocket.getSocket().setKeepAlive(true);
             thriftSocket.getSocket().setSoTimeout(config.socketQueryTimeoutMillis());
         } catch (SocketException e) {
-            log.error("Couldn't set socket keep alive for {}", addr);
+            log.error("Couldn't set socket keep alive for {}", SafeArg.of("address", addr));
         }
 
         if (config.usingSsl()) {
@@ -174,7 +177,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
     @Override
     public void destroyObject(PooledObject<Client> client) {
         client.getObject().getOutputProtocol().getTransport().close();
-        log.debug("Closed transport for client {}", client.getObject());
+        log.debug("Closed transport for client {}", SafeArg.of("cassandraClient", client.getObject()));
     }
 
     static class ClientCreationFailedException extends RuntimeException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -95,8 +95,8 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
                     SafeArg.of("address", addr),
                     UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
                     SafeArg.of("usingSsl", config.usingSsl() ? " over SSL" : ""),
-                    UnsafeArg.of("usernameConfig", config.credentials().isPresent() ?
-                            " as user " + config.credentials().get().username() : ""));
+                    UnsafeArg.of("usernameConfig", config.credentials().isPresent()
+                            ? " as user " + config.credentials().get().username() : ""));
             return ret;
         } catch (Exception e) {
             ret.getOutputProtocol().getTransport().close();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -413,7 +413,9 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
             log.warn("Perf / cluster stability issue. Token aware query routing has failed because there are no known "
                     + "live hosts that claim ownership of the given range. Falling back to choosing a random live node."
                     + " Current state logged at DEBUG");
-            log.debug("Current ring view is: {} and our current host blacklist is {}", tokenMap, blacklistedHosts);
+            log.debug("Current ring view is: {} and our current host blacklist is {}",
+                    SafeArg.of("tokenMap", tokenMap),
+                    SafeArg.of("blacklistedHosts", blacklistedHosts.toString()));
             return getRandomGoodHost().getHost();
         } else {
             return getRandomHostByActiveConnections(Maps.filterKeys(currentPools, liveOwnerHosts::contains));
@@ -580,7 +582,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
         Set<InetSocketAddress> triedHosts = Sets.newHashSet();
         while (true) {
             if (log.isTraceEnabled()) {
-                log.trace("Running function on host {}.", SafeArg.of("specifiedHost", specifiedHost.getHostString()));
+                log.trace("Running function on host {}.", SafeArg.of("host", specifiedHost.getHostString()));
             }
             CassandraClientPoolingContainer hostPool = currentPools.get(specifiedHost);
 
@@ -729,7 +731,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                 }
                 tokenRangesToHost.put(ImmutableSet.copyOf(client.describe_ring(config.getKeyspaceOrThrow())), host);
             } catch (Exception e) {
-                log.warn("failed to get ring info from host: {}", host, e);
+                log.warn("Failed to get ring info from host: {}", SafeArg.of("host", host), e);
             } finally {
                 if (client != null) {
                     client.getOutputProtocol().getTransport().close();
@@ -738,7 +740,8 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
 
             if (tokenRangesToHost.isEmpty()) {
                 log.warn("Failed to get ring info for entire Cassandra cluster ({});"
-                        + " ring could not be checked for consistency.", config.getKeyspaceOrThrow());
+                        + " ring could not be checked for consistency.",
+                        UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()));
                 return;
             }
 
@@ -748,7 +751,8 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
 
             RuntimeException ex = new IllegalStateException("Hosts have differing ring descriptions."
                     + " This can lead to inconsistent reads and lost data. ");
-            log.error("QA-86204 {}: The token ranges to host are:\n{}", ex.getMessage(), tokenRangesToHost, ex);
+            log.error("QA-86204 {}: The token ranges to host are:\n{}",
+                    UnsafeArg.of("exception", ex.getMessage()), SafeArg.of("tokenRangeToHost", tokenRangesToHost), ex);
 
 
             // provide some easier to grok logging for the two most common cases
@@ -756,15 +760,15 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                 tokenRangesToHost.asMap().entrySet().stream()
                         .filter(entry -> entry.getValue().size() == 1)
                         .forEach(entry -> log.error("Host: {} disagrees with the other nodes about the ring state.",
-                                Iterables.getFirst(entry.getValue(), null)));
+                                SafeArg.of("host", Iterables.getFirst(entry.getValue(), null))));
             }
             if (tokenRangesToHost.keySet().size() == 2) {
                 ImmutableList<Set<TokenRange>> sets = ImmutableList.copyOf(tokenRangesToHost.keySet());
                 Set<TokenRange> set1 = sets.get(0);
                 Set<TokenRange> set2 = sets.get(1);
                 log.error("Hosts are split. group1: {} group2: {}",
-                        tokenRangesToHost.get(set1),
-                        tokenRangesToHost.get(set2));
+                        SafeArg.of("hosts1", tokenRangesToHost.get(set1)),
+                        SafeArg.of("hosts2", tokenRangesToHost.get(set2)));
             }
 
             CassandraVerifier.logErrorOrThrow(ex.getMessage(), config.ignoreInconsistentRingChecks());

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -412,10 +412,11 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
         if (liveOwnerHosts.isEmpty()) {
             log.warn("Perf / cluster stability issue. Token aware query routing has failed because there are no known "
                     + "live hosts that claim ownership of the given range. Falling back to choosing a random live node."
-                    + " Current state logged at DEBUG");
-            log.debug("Current ring view is: {} and our current host blacklist is {}",
-                    SafeArg.of("tokenMap", tokenMap),
+                    + " Current host blacklist is {}."
+                    + " Current state logged at TRACE",
                     SafeArg.of("blacklistedHosts", blacklistedHosts.toString()));
+            log.trace("Current ring view is: {}.",
+                    SafeArg.of("tokenMap", tokenMap));
             return getRandomGoodHost().getHost();
         } else {
             return getRandomHostByActiveConnections(Maps.filterKeys(currentPools, liveOwnerHosts::contains));
@@ -752,7 +753,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
             RuntimeException ex = new IllegalStateException("Hosts have differing ring descriptions."
                     + " This can lead to inconsistent reads and lost data. ");
             log.error("QA-86204 {}: The token ranges to host are:\n{}",
-                    UnsafeArg.of("exception", ex.getMessage()), SafeArg.of("tokenRangeToHost", tokenRangesToHost), ex);
+                    SafeArg.of("exception", ex.getMessage()), SafeArg.of("tokenRangeToHost", tokenRangesToHost), ex);
 
 
             // provide some easier to grok logging for the two most common cases

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1655,7 +1655,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             LoggingArgs.SafeAndUnsafeTableReferences safeAndUnsafe = LoggingArgs.tableRefs(
                     tablesToActuallyCreate.keySet());
             log.info("Grabbing schema mutation lock to create tables {} and {}",
-                    safeAndUnsafe.safeTableRefs, safeAndUnsafe.unsafeTableRefs);
+                    safeAndUnsafe.safeTableRefs(), safeAndUnsafe.unsafeTableRefs());
             schemaMutationLock.runWithLock(() -> createTablesInternal(tablesToActuallyCreate));
         }
         internalPutMetadataForTables(tablesToUpdateMetadataFor, putMetadataWillNeedASchemaChange);
@@ -2372,8 +2372,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         if (tables.size() > 0) {
             dropTablesInternal(tables);
             LoggingArgs.SafeAndUnsafeTableReferences safeAndUnsafe = LoggingArgs.tableRefs(tables);
-            log.info("Dropped tables {} and {}",
-                    safeAndUnsafe.safeTableRefs, safeAndUnsafe.unsafeTableRefs);
+            log.info("Dropped tables {} and {}", safeAndUnsafe.safeTableRefs(), safeAndUnsafe.unsafeTableRefs());
         }
         schemaMutationLock.cleanLockState();
         log.info("Reset the schema mutation lock in table [{}]",

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -122,6 +122,7 @@ import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
 import com.palantir.atlasdb.keyvalue.impl.KeyValueServices;
 import com.palantir.atlasdb.keyvalue.impl.LocalRowColumnRangeIterator;
+import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.util.AnnotatedCallable;
 import com.palantir.atlasdb.util.AnnotationType;
 import com.palantir.common.annotation.Idempotent;
@@ -337,7 +338,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     if (!ColumnFamilyDefinitions.isMatchingCf(clientSideCf, clusterSideCf)) {
                         // mismatch; we have changed how we generate schema since we last persisted
                         log.warn("Upgrading table {} to new internal Cassandra schema",
-                                UnsafeArg.of("table", tableRef));
+                                LoggingArgs.tableRef(tableRef));
                         updatedCfs.add(clientSideCf);
                     }
                 } else if (!hiddenTables.isHidden(tableRef)) {
@@ -347,7 +348,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                             + " AtlasDB metadata. If you recently did a Palantir update, try waiting until"
                             + " schema upgrades are completed on all backend CLIs/services etc and restarting"
                             + " this service. If this error re-occurs on subsequent attempted startups, please"
-                            + " contact Palantir support.", UnsafeArg.of("table", tableRef.getQualifiedName()));
+                            + " contact Palantir support.", LoggingArgs.tableRef(tableRef));
                 }
             }
 
@@ -482,7 +483,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             if (rowCount > fetchBatchCount) {
                 log.warn("Rebatched in getRows a call to {} that attempted to multiget {} rows; "
                         + "this may indicate overly-large batching on a higher level.\n{}",
-                        UnsafeArg.of("table", tableRef.getQualifiedName()),
+                        LoggingArgs.tableRef(tableRef),
                         SafeArg.of("rowCount", rowCount),
                         SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
             }
@@ -538,7 +539,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     @Override
     public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         if (timestampByCell.isEmpty()) {
-            log.info("Attempted get on '{}' table with empty cells", UnsafeArg.of("tableRef", tableRef));
+            log.info("Attempted get on '{}' table with empty cells", LoggingArgs.tableRef(tableRef));
             return ImmutableMap.of();
         }
 
@@ -576,7 +577,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         if (log.isTraceEnabled()) {
             log.trace("Loading {} cells from {} {}starting at timestamp {}, partitioned across {} nodes.",
                     SafeArg.of("cells", cells.size()),
-                    UnsafeArg.of("table", tableRef),
+                    LoggingArgs.tableRef(tableRef),
                     SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
                     SafeArg.of("startTs", startTs),
                     SafeArg.of("totalPartitions", totalPartitions));
@@ -587,7 +588,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             if (log.isTraceEnabled()) {
                 log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
                         SafeArg.of("cells", hostsAndCells.values().size()),
-                        UnsafeArg.of("table", tableRef),
+                        LoggingArgs.tableRef(tableRef),
                         SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
                         SafeArg.of("startTs", startTs),
                         SafeArg.of("ipPort", hostAndCells.getKey()));
@@ -627,7 +628,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to "
                                 + "multiget {} rows; this may indicate overly-large batching on a higher level.\n{}",
                         SafeArg.of("host", host),
-                        UnsafeArg.of("table", tableRef),
+                        LoggingArgs.tableRef(tableRef),
                         SafeArg.of("rows", columnCells.size()),
                         SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
             }
@@ -648,7 +649,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                 if (log.isTraceEnabled()) {
                                     log.trace("Requesting {} cells from {} {}starting at timestamp {} on {}",
                                             SafeArg.of("cells", partition.size()),
-                                            UnsafeArg.of("table", tableRef),
+                                            LoggingArgs.tableRef(tableRef),
                                             SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
                                             SafeArg.of("startTs", startTs),
                                             SafeArg.of("host", host));
@@ -1581,7 +1582,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         client.system_drop_column_family(internalTableName(table));
                         putMetadataWithoutChangingSettings(table, PtBytes.EMPTY_BYTE_ARRAY);
                     } else {
-                        log.warn("Ignored call to drop a table ({}) that did not exist.", UnsafeArg.of("table", table));
+                        log.warn("Ignored call to drop a table ({}) that did not exist.",
+                                LoggingArgs.tableRef(table));
                     }
                 }
                 CassandraKeyValueServices.waitForSchemaVersions(
@@ -1650,7 +1652,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         boolean putMetadataWillNeedASchemaChange = !onlyMetadataChangesAreForNewTables;
 
         if (!tablesToActuallyCreate.isEmpty()) {
-            log.info("Grabbing schema mutation lock to create tables {}", tablesToActuallyCreate);
+            log.info("Grabbing schema mutation lock to create tables {}",
+                    LoggingArgs.tablesRef(tablesToActuallyCreate.keySet()));
             schemaMutationLock.runWithLock(() -> createTablesInternal(tablesToActuallyCreate));
         }
         internalPutMetadataForTables(tablesToUpdateMetadataFor, putMetadataWillNeedASchemaChange);
@@ -1677,14 +1680,14 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     if (Arrays.equals(
                             existingTableMetadata.get(Iterables.getOnlyElement(matchingTables)), newMetadata)) {
                         log.debug("Case-insensitive matched table already existed with same metadata,"
-                                + " skipping update to {}", UnsafeArg.of("table", tableReference));
+                                + " skipping update to {}", LoggingArgs.tableRef(tableReference));
                     } else { // existing table has different metadata, so we should perform an update
                         tableMetadataUpdates.put(tableReference, newMetadata);
                     }
                 }
             } else {
                 log.debug("Table already existed with same metadata, skipping update to {}",
-                        UnsafeArg.of("table", tableReference));
+                        LoggingArgs.tableRef(tableReference));
             }
         }
 
@@ -1710,7 +1713,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     filteredTables.put(table, metadata);
                 } else {
                     log.debug("Filtering out existing table ({}) that already existed (case insensitive).",
-                            UnsafeArg.of("table", table));
+                            LoggingArgs.tableRef(table));
                 }
             }
         } catch (Exception e) {
@@ -1786,11 +1789,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 .findFirst();
 
         if (!match.isPresent()) {
-            log.debug("Couldn't find table metadata for {}", UnsafeArg.of("table", tableRef));
+            log.debug("Couldn't find table metadata for {}", LoggingArgs.tableRef(tableRef));
             return AtlasDbConstants.EMPTY_TABLE_METADATA;
         } else {
-            log.debug("Found table metadata for {} at matching name {}", UnsafeArg.of("table", tableRef),
-                    UnsafeArg.of("matchingTable", match.get().getKey()));
+            log.debug("Found table metadata for {} at matching name {}", LoggingArgs.tableRef(tableRef),
+                    LoggingArgs.tableRef("matchingTable", match.get().getKey()));
             return match.get().getValue();
         }
     }
@@ -2005,7 +2008,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             } catch (TException e) {
                 log.info("Tried to make a deleteRange({}, RangeRequest.all())"
                                 + " into a more garbage-cleanup friendly truncate(), but this failed.",
-                        UnsafeArg.of("table", tableRef), e);
+                        LoggingArgs.tableRef(tableRef), e);
 
                 super.deleteRange(tableRef, range);
             }
@@ -2189,7 +2192,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     + " If you actually want to clear deleted data immediately"
                     + " from Cassandra, lower your gc_grace_seconds setting and"
                     + " run `nodetool compact {} {}`.", UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
-                    UnsafeArg.of("table", internalTableName(tableRef)));
+                    LoggingArgs.tableRef(tableRef));
             return;
         }
         long timeoutInSeconds = config.jmx().get().compactionTimeoutSeconds();
@@ -2199,12 +2202,12 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             compactionManager.get().performTombstoneCompaction(timeoutInSeconds, keyspace, tableRef);
         } catch (TimeoutException e) {
             log.error("Compaction for {}.{} could not finish in {} seconds.", UnsafeArg.of("keyspace", keyspace),
-                    UnsafeArg.of("table", tableRef), SafeArg.of("timeout", timeoutInSeconds), e);
+                    LoggingArgs.tableRef(tableRef), SafeArg.of("timeout", timeoutInSeconds), e);
             log.error("Compaction status: {}",
                     UnsafeArg.of("compactionStatus", compactionManager.get().getCompactionStatus()));
         } catch (InterruptedException e) {
             log.error("Compaction for {}.{} was interrupted.", UnsafeArg.of("keyspace", keyspace),
-                    UnsafeArg.of("table", tableRef));
+                    LoggingArgs.tableRef(tableRef));
         } finally {
             alterGcAndTombstone(
                     keyspace,
@@ -2319,10 +2322,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                 tableRef.getQualifiedName());
                         log.trace("gc_grace_seconds is set to {} for {}.{}",
                                 SafeArg.of("gcGraceSeconds", gcGraceSeconds), UnsafeArg.of("keyspace", keyspace),
-                                UnsafeArg.of("table", tableRef));
+                                LoggingArgs.tableRef(tableRef));
                         log.trace("tombstone_threshold_ratio is set to {} for {}.{}",
                                 SafeArg.of("tombstoneThresholdRatio", tombstoneThresholdRatio),
-                                UnsafeArg.of("keyspace", keyspace), UnsafeArg.of("table", tableRef));
+                                UnsafeArg.of("keyspace", keyspace), LoggingArgs.tableRef(tableRef));
                     }
                 }
                 return null;
@@ -2332,7 +2335,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     SafeArg.of("gcGraceSeconds", gcGraceSeconds),
                     SafeArg.of("tombstoneThresholdRatio", tombstoneThresholdRatio),
                     UnsafeArg.of("keyspace", keyspace),
-                    UnsafeArg.of("table", tableRef),
+                    LoggingArgs.tableRef(tableRef),
                     e);
         }
     }
@@ -2366,11 +2369,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         tables.remove(tableToKeep.get());
         if (tables.size() > 0) {
             dropTablesInternal(tables);
-            log.info("Dropped tables [{}]", UnsafeArg.of("table names", tables));
+            log.info("Dropped tables [{}]", LoggingArgs.tablesRef(tables));
         }
         schemaMutationLock.cleanLockState();
         log.info("Reset the schema mutation lock in table [{}]",
-                UnsafeArg.of("table name", tableToKeep.get().toString()));
+                LoggingArgs.tableRef(tableToKeep.get()));
     }
 
     private <V> Map<InetSocketAddress, Map<Cell, V>> partitionMapByHost(Iterable<Map.Entry<Cell, V>> cells) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -131,11 +131,9 @@ import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.exception.PalantirRuntimeException;
-import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.processors.AutoDelegate;
-import com.palantir.util.Pair;
 import com.palantir.util.paging.AbstractPagingIterable;
 import com.palantir.util.paging.SimpleTokenBackedResultsPage;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
@@ -1654,10 +1652,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         boolean putMetadataWillNeedASchemaChange = !onlyMetadataChangesAreForNewTables;
 
         if (!tablesToActuallyCreate.isEmpty()) {
-            Pair<Arg<List<TableReference>>, Arg<List<TableReference>>> safeAndUnsafeTables = LoggingArgs.tablesRef(
+            LoggingArgs.SafeAndUnsafeTableReferences safeAndUnsafe = LoggingArgs.tableRefs(
                     tablesToActuallyCreate.keySet());
             log.info("Grabbing schema mutation lock to create tables {} and {}",
-                    safeAndUnsafeTables.lhSide, safeAndUnsafeTables.rhSide);
+                    safeAndUnsafe.safeTableRefs, safeAndUnsafe.unsafeTableRefs);
             schemaMutationLock.runWithLock(() -> createTablesInternal(tablesToActuallyCreate));
         }
         internalPutMetadataForTables(tablesToUpdateMetadataFor, putMetadataWillNeedASchemaChange);
@@ -2373,9 +2371,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         tables.remove(tableToKeep.get());
         if (tables.size() > 0) {
             dropTablesInternal(tables);
-            Pair<Arg<List<TableReference>>, Arg<List<TableReference>>> safeAndUnsafeTables =
-                    LoggingArgs.tablesRef(tables);
-            log.info("Dropped tables {} and {}", safeAndUnsafeTables.lhSide, safeAndUnsafeTables.rhSide);
+            LoggingArgs.SafeAndUnsafeTableReferences safeAndUnsafe = LoggingArgs.tableRefs(tables);
+            log.info("Dropped tables {} and {}",
+                    safeAndUnsafe.safeTableRefs, safeAndUnsafe.unsafeTableRefs);
         }
         schemaMutationLock.cleanLockState();
         log.info("Reset the schema mutation lock in table [{}]",

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -36,6 +36,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.base.Throwables;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.util.Pair;
 
 public class CassandraTimestampBackupRunner {
@@ -88,7 +89,7 @@ public class CassandraTimestampBackupRunner {
                             CassandraTimestampUtils.BACKUP_COLUMN_NAME,
                             Pair.create(currentBackupBound, backupValue));
             executeAndVerifyCas(client, casMap);
-            log.info("[BACKUP] Backed up the value {}", currentBackupBound);
+            log.info("[BACKUP] Backed up the value {}", SafeArg.of("currentBackupBound", currentBackupBound));
             return PtBytes.toLong(backupValue);
         });
     }
@@ -115,7 +116,7 @@ public class CassandraTimestampBackupRunner {
                     CassandraTimestampUtils.BACKUP_COLUMN_NAME,
                     Pair.create(currentBackupBound, PtBytes.EMPTY_BYTE_ARRAY));
             executeAndVerifyCas(client, casMap);
-            log.info("[RESTORE] Restored the value {}", currentBackupBound);
+            log.info("[RESTORE] Restored the value {}", SafeArg.of("currentBackupBound", currentBackupBound));
             return null;
         });
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -45,6 +45,7 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.processors.AutoDelegate;
 import com.palantir.timestamp.AutoDelegate_TimestampBoundStore;
 import com.palantir.timestamp.DebugLogger;
@@ -195,8 +196,14 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                     ConsistencyLevel.SERIAL,
                     ConsistencyLevel.EACH_QUORUM);
         } catch (Exception e) {
-            log.error("[CAS] Error trying to set from {} to {}", oldVal, newVal, e);
-            DebugLogger.logger.error("[CAS] Error trying to set from {} to {}", oldVal, newVal, e);
+            log.error("[CAS] Error trying to set from {} to {}",
+                    SafeArg.of("oldValue", oldVal),
+                    SafeArg.of("newValue", newVal),
+                    e);
+            DebugLogger.logger.error("[CAS] Error trying to set from {} to {}",
+                    SafeArg.of("oldValue", oldVal),
+                    SafeArg.of("newValue", newVal),
+                    e);
             throw Throwables.throwUncheckedException(e);
         }
         if (!result.isSuccess()) {
@@ -212,9 +219,20 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                             newVal,
                             currentLimit,
                             getCurrentTimestampValues(result)));
-            log.error(msg, oldVal, newVal, currentLimit, getCurrentTimestampValues(result), err);
-            DebugLogger.logger.error(msg, oldVal, newVal, currentLimit, getCurrentTimestampValues(result), err);
-            DebugLogger.logger.error("Thread dump: {}", ThreadDumps.programmaticThreadDump());
+            log.error(msg,
+                    SafeArg.of("oldValue", oldVal),
+                    SafeArg.of("newValue", newVal),
+                    SafeArg.of("inMemoryLimit", currentLimit),
+                    SafeArg.of("dbLimit", getCurrentTimestampValues(result)),
+                    err);
+            DebugLogger.logger.error(msg,
+                    SafeArg.of("oldValue", oldVal),
+                    SafeArg.of("newValue", newVal),
+                    SafeArg.of("inMemoryLimit", currentLimit),
+                    SafeArg.of("dbLimit", getCurrentTimestampValues(result)),
+                    err);
+            DebugLogger.logger.error("Thread dump: {}",
+                    SafeArg.of("threadDump", ThreadDumps.programmaticThreadDump()));
             throw err;
         } else {
             DebugLogger.logger.debug("[CAS] Setting cached limit to {}.", newVal);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
@@ -217,7 +217,7 @@ final class SchemaMutationLock {
                     if (stopwatch.elapsed(TimeUnit.MILLISECONDS) > mutationTimeoutMillis) {
                         TimeoutException schemaLockTimeoutError = generateSchemaLockTimeoutException(stopwatch);
                         log.error("Timed out after waiting for {} milliseconds for the schema mutation lock",
-                                stopwatch.elapsed(TimeUnit.MILLISECONDS));
+                                SafeArg.of("wait duration", stopwatch.elapsed(TimeUnit.MILLISECONDS)));
                         throw Throwables.rewrapAndThrowUncheckedException(schemaLockTimeoutError);
                     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
@@ -48,6 +48,7 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
+import com.palantir.logsafe.SafeArg;
 
 final class SchemaMutationLock {
     public static final long GLOBAL_DDL_LOCK_CLEARED_ID = Long.MAX_VALUE;
@@ -215,7 +216,8 @@ final class SchemaMutationLock {
                     // lock holder taking unreasonable amount of time, signal something's wrong
                     if (stopwatch.elapsed(TimeUnit.MILLISECONDS) > mutationTimeoutMillis) {
                         TimeoutException schemaLockTimeoutError = generateSchemaLockTimeoutException(stopwatch);
-                        log.error("Schema lock timeout", schemaLockTimeoutError);
+                        log.error("Timed out after waiting for {} milliseconds for the schema mutation lock",
+                                stopwatch.elapsed(TimeUnit.MILLISECONDS));
                         throw Throwables.rewrapAndThrowUncheckedException(schemaLockTimeoutError);
                     }
 
@@ -227,7 +229,8 @@ final class SchemaMutationLock {
                 }
 
                 // we won the lock!
-                log.info("Successfully acquired schema mutation lock with id [{}]", perOperationNodeId);
+                log.info("Successfully acquired schema mutation lock with id [{}]",
+                        SafeArg.of("lockId", perOperationNodeId));
                 return null;
             });
         } catch (InterruptedException e) {
@@ -328,7 +331,8 @@ final class SchemaMutationLock {
                 List<Column> ourExpectedLock = ImmutableList.of(existingColumn);
                 CASResult casResult = writeDdlLockWithCas(client, ourExpectedLock, clearedLock);
                 if (casResult.isSuccess()) {
-                    log.info("Successfully released schema mutation lock with id [{}]", existingLockId);
+                    log.info("Successfully released schema mutation lock with id [{}]",
+                            SafeArg.of("lockId", existingLockId));
                 }
                 return casResult.isSuccess();
             });
@@ -347,7 +351,7 @@ final class SchemaMutationLock {
                     () -> client.get(getGlobalDdlLockRowName(), columnPath, ConsistencyLevel.LOCAL_QUORUM));
             existingColumn = result.getColumn();
         } catch (NotFoundException e) {
-            log.debug("No existing schema lock found in table [{}]", lockTableRef);
+            log.debug("No existing schema lock found in table [{}]", SafeArg.of("tableName", lockTableRef));
         }
         return Optional.ofNullable(existingColumn);
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.SafeArg;
 
 public class SchemaMutationLockTables {
     public static final String LOCK_TABLE_PREFIX = "_locks";
@@ -69,7 +70,7 @@ public class SchemaMutationLockTables {
     private TableReference createLockTable(Cassandra.Client client) throws TException {
         String lockTableName = LOCK_TABLE_PREFIX + "_" + getUniqueSuffix();
         TableReference lockTable = TableReference.createWithEmptyNamespace(lockTableName);
-        log.info("Creating lock table {}", lockTable);
+        log.info("Creating lock table {}", SafeArg.of("schemaMutationTableName", lockTable));
         createTableInternal(client, lockTable);
         return lockTable;
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.immutables.value.Value;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
@@ -41,16 +43,10 @@ import com.palantir.logsafe.UnsafeArg;
  * Always returns unsafe, until hydrated.
  */
 public final class LoggingArgs {
-    public static class SafeAndUnsafeTableReferences {
-        public final SafeArg<List<TableReference>> safeTableRefs;
-        public final UnsafeArg<List<TableReference>> unsafeTableRefs;
-
-        private SafeAndUnsafeTableReferences(
-                SafeArg<List<TableReference>> safeTableRefs,
-                UnsafeArg<List<TableReference>> unsafeTableRefs) {
-            this.safeTableRefs = safeTableRefs;
-            this.unsafeTableRefs = unsafeTableRefs;
-        }
+    @Value.Immutable
+    public interface SafeAndUnsafeTableReferences {
+        SafeArg<List<TableReference>> safeTableRefs();
+        UnsafeArg<List<TableReference>> unsafeTableRefs();
     }
 
     private static volatile KeyValueServiceLogArbitrator logArbitrator = KeyValueServiceLogArbitrator.ALL_UNSAFE;
@@ -80,8 +76,10 @@ public final class LoggingArgs {
             }
         }
 
-        return new SafeAndUnsafeTableReferences(SafeArg.of("tableRefs", safeTableRefs),
-                UnsafeArg.of("tableRefs", unsafeTableRefs));
+        return ImmutableSafeAndUnsafeTableReferences.builder()
+                .safeTableRefs(SafeArg.of("tableRefs", safeTableRefs))
+                .unsafeTableRefs(UnsafeArg.of("tableRefs", unsafeTableRefs))
+                .build();
     }
 
     /**

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -16,8 +16,11 @@
 
 package com.palantir.atlasdb.logging;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
@@ -51,6 +54,12 @@ public final class LoggingArgs {
     @VisibleForTesting
     static synchronized void setLogArbitrator(KeyValueServiceLogArbitrator arbitrator) {
         logArbitrator = arbitrator;
+    }
+
+    public static List<Arg<TableReference>> tablesRef(Collection<TableReference> tableReferences) {
+        return tableReferences.stream()
+                .map(LoggingArgs::tableRef)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -34,7 +34,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
-import com.palantir.util.Pair;
 
 /**
  * Includes utilities for generating logging args that may be safe or unsafe, depending on table metadata.
@@ -42,6 +41,18 @@ import com.palantir.util.Pair;
  * Always returns unsafe, until hydrated.
  */
 public final class LoggingArgs {
+    public static class SafeAndUnsafeTableReferences {
+        public final SafeArg<List<TableReference>> safeTableRefs;
+        public final UnsafeArg<List<TableReference>> unsafeTableRefs;
+
+        private SafeAndUnsafeTableReferences(
+                SafeArg<List<TableReference>> safeTableRefs,
+                UnsafeArg<List<TableReference>> unsafeTableRefs) {
+            this.safeTableRefs = safeTableRefs;
+            this.unsafeTableRefs = unsafeTableRefs;
+        }
+    }
+
     private static volatile KeyValueServiceLogArbitrator logArbitrator = KeyValueServiceLogArbitrator.ALL_UNSAFE;
 
     private LoggingArgs() {
@@ -57,13 +68,7 @@ public final class LoggingArgs {
         logArbitrator = arbitrator;
     }
 
-    /**
-     * Partition the given {@code tableReferences} in a pair of safe and unsafe tables for logging.
-     * The first element of the pair are the safe to log tables, while the second element of the pair are the unsafe.
-     */
-    public static Pair<Arg<List<TableReference>>, Arg<List<TableReference>>> tablesRef(
-            Collection<TableReference> tableReferences) {
-
+    public static SafeAndUnsafeTableReferences tableRefs(Collection<TableReference> tableReferences) {
         List<TableReference> safeTableRefs = new ArrayList<>();
         List<TableReference> unsafeTableRefs = new ArrayList<>();
 
@@ -75,7 +80,8 @@ public final class LoggingArgs {
             }
         }
 
-        return new Pair<>(SafeArg.of("tableRefs", safeTableRefs), UnsafeArg.of("tableRefs", unsafeTableRefs));
+        return new SafeAndUnsafeTableReferences(SafeArg.of("tableRefs", safeTableRefs),
+                UnsafeArg.of("tableRefs", unsafeTableRefs));
     }
 
     /**

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -132,6 +132,7 @@ public class LoggingArgsTest {
     }
 
     @Test
+    @SuppressWarnings("CheckReturnValue") // We test that returnedArgs will contain both a safe and unsafe references.
     public void canReturnListOfSafeTableReferences() {
         LoggingArgs.SafeAndUnsafeTableReferences returnedArgs =
                 LoggingArgs.tableRefs(LIST_OF_SAFE_AND_UNSAFE_TABLE_REFERENCES);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -37,7 +37,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
-import com.palantir.util.Pair;
 
 public class LoggingArgsTest {
     private static final String ARG_NAME = "argName";
@@ -134,14 +133,11 @@ public class LoggingArgsTest {
 
     @Test
     public void canReturnListOfSafeTableReferences() {
-        Pair<Arg<List<TableReference>>, Arg<List<TableReference>>> returnedArgs =
-                LoggingArgs.tablesRef(LIST_OF_SAFE_AND_UNSAFE_TABLE_REFERENCES);
+        LoggingArgs.SafeAndUnsafeTableReferences returnedArgs =
+                LoggingArgs.tableRefs(LIST_OF_SAFE_AND_UNSAFE_TABLE_REFERENCES);
 
-        assertThat(returnedArgs.lhSide).isInstanceOf(SafeArg.class);
-        assertThat(returnedArgs.lhSide.getValue().contains(SAFE_TABLE_REFERENCE));
-
-        assertThat(returnedArgs.rhSide).isInstanceOf(UnsafeArg.class);
-        assertThat(returnedArgs.rhSide.getValue().contains(UNSAFE_TABLE_REFERENCE));
+        assertThat(returnedArgs.safeTableRefs.getValue().contains(SAFE_TABLE_REFERENCE));
+        assertThat(returnedArgs.unsafeTableRefs.getValue().contains(UNSAFE_TABLE_REFERENCE));
     }
 
     @Test

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -136,8 +136,8 @@ public class LoggingArgsTest {
         LoggingArgs.SafeAndUnsafeTableReferences returnedArgs =
                 LoggingArgs.tableRefs(LIST_OF_SAFE_AND_UNSAFE_TABLE_REFERENCES);
 
-        assertThat(returnedArgs.safeTableRefs.getValue().contains(SAFE_TABLE_REFERENCE));
-        assertThat(returnedArgs.unsafeTableRefs.getValue().contains(UNSAFE_TABLE_REFERENCE));
+        assertThat(returnedArgs.safeTableRefs().getValue().contains(SAFE_TABLE_REFERENCE));
+        assertThat(returnedArgs.unsafeTableRefs().getValue().contains(UNSAFE_TABLE_REFERENCE));
     }
 
     @Test

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -20,12 +20,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.Comparator;
+import java.util.List;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -39,6 +43,10 @@ public class LoggingArgsTest {
     private static final String ARG_NAME = "argName";
     private static final TableReference SAFE_TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("foo.safe");
     private static final TableReference UNSAFE_TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("foo.bar");
+    private static final List<TableReference> LIST_OF_TABLE_SAFE_AND_UNSAFE_REFERENCES = Lists.newArrayList(
+            SAFE_TABLE_REFERENCE,
+            UNSAFE_TABLE_REFERENCE
+    );
 
     private static final String SAFE_ROW_NAME = "saferow";
     private static final String UNSAFE_ROW_NAME = "row";
@@ -122,6 +130,14 @@ public class LoggingArgsTest {
     public void canReturnBothSafeAndUnsafeTableReferences() {
         assertThat(LoggingArgs.tableRef(ARG_NAME, SAFE_TABLE_REFERENCE)).isInstanceOf(SafeArg.class);
         assertThat(LoggingArgs.tableRef(ARG_NAME, UNSAFE_TABLE_REFERENCE)).isInstanceOf(UnsafeArg.class);
+    }
+
+    @Test
+    public void canReturnListOfSafeTableReferences() {
+        List<Arg<TableReference>> returnedArgs = LoggingArgs.tablesRef(LIST_OF_TABLE_SAFE_AND_UNSAFE_REFERENCES);
+        returnedArgs.sort(Comparator.comparing(arg -> arg.getValue().getTablename()));
+        assertThat(returnedArgs.get(0)).isInstanceOf(UnsafeArg.class);
+        assertThat(returnedArgs.get(1)).isInstanceOf(SafeArg.class);
     }
 
     @Test

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
-import java.util.Comparator;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -38,12 +37,13 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
+import com.palantir.util.Pair;
 
 public class LoggingArgsTest {
     private static final String ARG_NAME = "argName";
     private static final TableReference SAFE_TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("foo.safe");
     private static final TableReference UNSAFE_TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("foo.bar");
-    private static final List<TableReference> LIST_OF_TABLE_SAFE_AND_UNSAFE_REFERENCES = Lists.newArrayList(
+    private static final List<TableReference> LIST_OF_SAFE_AND_UNSAFE_TABLE_REFERENCES = Lists.newArrayList(
             SAFE_TABLE_REFERENCE,
             UNSAFE_TABLE_REFERENCE
     );
@@ -134,10 +134,14 @@ public class LoggingArgsTest {
 
     @Test
     public void canReturnListOfSafeTableReferences() {
-        List<Arg<TableReference>> returnedArgs = LoggingArgs.tablesRef(LIST_OF_TABLE_SAFE_AND_UNSAFE_REFERENCES);
-        returnedArgs.sort(Comparator.comparing(arg -> arg.getValue().getTablename()));
-        assertThat(returnedArgs.get(0)).isInstanceOf(UnsafeArg.class);
-        assertThat(returnedArgs.get(1)).isInstanceOf(SafeArg.class);
+        Pair<Arg<List<TableReference>>, Arg<List<TableReference>>> returnedArgs =
+                LoggingArgs.tablesRef(LIST_OF_SAFE_AND_UNSAFE_TABLE_REFERENCES);
+
+        assertThat(returnedArgs.lhSide).isInstanceOf(SafeArg.class);
+        assertThat(returnedArgs.lhSide.getValue().contains(SAFE_TABLE_REFERENCE));
+
+        assertThat(returnedArgs.rhSide).isInstanceOf(UnsafeArg.class);
+        assertThat(returnedArgs.rhSide.getValue().contains(UNSAFE_TABLE_REFERENCE));
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -110,7 +110,6 @@ v0.61.1
          - Reverted the Sweep rewrite for Cassandra as it would unnecessarily load values into memory which could
            cause Cassandra to OOM if the values are large enough.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2521>`__)
->>>>>>> e3a8cffbadae0500cdcd83fe9c2b237732edba4b
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -74,7 +74,7 @@ develop
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2474>`__)
 
     *   - |improved|
-        - Safe and Unsafe args were used for Cassandra* classes.
+        - Specified which logs from Cassandra* classes were Safe or Unsafe for collection, improving the data that we can collect for debugging purposes.
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2537>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -73,6 +73,9 @@ develop
           Previously, the table reference was omitted, such that one might receive lines of the form ``Call to KVS.getRange on table RangeRequest{reverse=false} with range 1504 took {} ms.``.
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2474>`__)
 
+    *   - |improved|
+        - Safe and Unsafe args were used for Cassandra* classes.
+          (`Pull Request <https://github.com/palantir/atlasdb/pull/2537>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -15,21 +15,15 @@
  */
 package com.palantir.atlasdb.timelock;
 
-import java.util.List;
 import java.util.function.Consumer;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.google.common.collect.Lists;
 import com.palantir.atlasdb.timelock.config.CombinedTimeLockServerConfiguration;
 import com.palantir.atlasdb.timelock.config.TimeLockConfigMigrator;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 import com.palantir.atlasdb.timelock.logging.NonBlockingFileAppenderFactory;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.remoting3.servers.jersey.HttpRemotingJerseyFeature;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.MetricRegistries;
@@ -57,19 +51,13 @@ public class TimeLockServerLauncher extends Application<TimeLockServerConfigurat
     public void run(TimeLockServerConfiguration configuration, Environment environment) {
         environment.getObjectMapper().registerModule(new Jdk8Module());
         environment.jersey().register(HttpRemotingJerseyFeature.INSTANCE);
-        List<SafeArg> safeArgs = Lists.newArrayList(
-                SafeArg.of("table1", ":D"),
-                SafeArg.of("table2", ":D"),
-                SafeArg.of("table3", ":D"));
-        Logger logger = LoggerFactory.getLogger("TimeLocksServerLauncher");
-        logger.info("test safe args: {}", safeArgs);
 
         CombinedTimeLockServerConfiguration combined = TimeLockConfigMigrator.convert(configuration, environment);
         Consumer<Object> registrar = component -> environment.jersey().register(component);
         TimeLockAgent agent = new TimeLockAgent(
                 combined.install(),
                 combined::runtime, // this won't actually live reload
-                combined.deprecated(),gd
+                combined.deprecated(),
                 registrar);
         agent.createAndRegisterResources();
     }

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -15,15 +15,21 @@
  */
 package com.palantir.atlasdb.timelock;
 
+import java.util.List;
 import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.Lists;
 import com.palantir.atlasdb.timelock.config.CombinedTimeLockServerConfiguration;
 import com.palantir.atlasdb.timelock.config.TimeLockConfigMigrator;
 import com.palantir.atlasdb.timelock.config.TimeLockServerConfiguration;
 import com.palantir.atlasdb.timelock.logging.NonBlockingFileAppenderFactory;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.remoting3.servers.jersey.HttpRemotingJerseyFeature;
 import com.palantir.timelock.paxos.TimeLockAgent;
 import com.palantir.tritium.metrics.MetricRegistries;
@@ -51,13 +57,19 @@ public class TimeLockServerLauncher extends Application<TimeLockServerConfigurat
     public void run(TimeLockServerConfiguration configuration, Environment environment) {
         environment.getObjectMapper().registerModule(new Jdk8Module());
         environment.jersey().register(HttpRemotingJerseyFeature.INSTANCE);
+        List<SafeArg> safeArgs = Lists.newArrayList(
+                SafeArg.of("table1", ":D"),
+                SafeArg.of("table2", ":D"),
+                SafeArg.of("table3", ":D"));
+        Logger logger = LoggerFactory.getLogger("TimeLocksServerLauncher");
+        logger.info("test safe args: {}", safeArgs);
 
         CombinedTimeLockServerConfiguration combined = TimeLockConfigMigrator.convert(configuration, environment);
         Consumer<Object> registrar = component -> environment.jersey().register(component);
         TimeLockAgent agent = new TimeLockAgent(
                 combined.install(),
                 combined::runtime, // this won't actually live reload
-                combined.deprecated(),
+                combined.deprecated(),gd
                 registrar);
         agent.createAndRegisterResources();
     }


### PR DESCRIPTION
**Goals (and why)**: Mark C* safe arguments.

**Implementation Description (bullets)**: Read all `log.` logs, mark parameters as unsafe or safe.

**Concerns (what feedback would you like?)**:
- Did I forget any logs?
- Did I mark unsafe parameters as safe?
- Did I forget to add a `toString()` on a Java object?

**Where should we start reviewing?**: LoggingArgs, as one method was added there.

**Priority (whenever / two weeks / yesterday)**: Soonish, as it's very annoying for anyone to not be able to read a safe parameter when you need it the most.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2537)
<!-- Reviewable:end -->
