### PR TITLE
Metrics for tx conflicts

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,6 +45,10 @@ develop
          - Change
 
     *    - |improved|
+         - We now report metrics for Transaction conflicts.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2540>`__)
+
+    *    - |improved|
          - ``getRange`` is now more efficient when scanning over rows with many updates in Cassandra, if just a single column is requested.
            Previously, a range request in Cassandra would always retrieve all columns and all historical versions of each column, regardless of which columns were requested.
            Now, we only request the latest version of the specific column requested, if only one column is requested. Requesting multiple columns still results in the previous behavior, however this will also be optimized in a future release.


### PR DESCRIPTION
**Goals (and why)**: Metrics for visualizing the number of tx conflicts serializable/snapshot txns are encountering. This will help us point out long running transactions.

Want to add tables and the txType as tags, once the functionality is available.

**Implementation Description (bullets)**: standard metrics

**Concerns (what feedback would you like?)**:
1. Should we have more microlevel metrics, a txConflict can happen in 5 ways, do we want to capture the condition under which it occurred?

**Where should we start reviewing?**: two files.

**Priority (whenever / two weeks / yesterday)**: one week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2540)
<!-- Reviewable:end -->
