### PR TITLE
make user agent required

### DIFF
--- a/atlasdb-config/readme.md
+++ b/atlasdb-config/readme.md
@@ -16,6 +16,7 @@ Schema atlasSchema = ...
 SerializableTransactionManager tm = TransactionManagers.builder()
     .config(atlasConfig)
     .schemas(ImmutableSet.of(atlasSchema))
+    .userAgent("user agent")
     .buildSerializable();
 ```
 
@@ -48,6 +49,7 @@ public void run(AtlasDbServerConfiguration config, Environment env) throws Excep
     TransactionManager transactionManager = TransactionManagers.builder()
         .config(config.getAtlas())
         .registrar(env.jersey()::register)
+        .userAgent("user agent")
         .buildSerializable();
     ...
 ```

--- a/atlasdb-config/readme.md
+++ b/atlasdb-config/readme.md
@@ -16,7 +16,7 @@ Schema atlasSchema = ...
 SerializableTransactionManager tm = TransactionManagers.builder()
     .config(atlasConfig)
     .schemas(ImmutableSet.of(atlasSchema))
-    .userAgent("user agent")
+    .userAgent("productName (productVersion)")
     .buildSerializable();
 ```
 
@@ -49,7 +49,7 @@ public void run(AtlasDbServerConfiguration config, Environment env) throws Excep
     TransactionManager transactionManager = TransactionManagers.builder()
         .config(config.getAtlas())
         .registrar(env.jersey()::register)
-        .userAgent("user agent")
+        .userAgent("productName (productVersion)")
         .buildSerializable();
     ...
 ```

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -173,7 +173,7 @@ public abstract class TransactionManagers {
      */
     public static SerializableTransactionManager createInMemory(Set<Schema> schemas) {
         AtlasDbConfig config = ImmutableAtlasDbConfig.builder().keyValueService(new InMemoryAtlasDbConfig()).build();
-        return builder().config(config).schemas(schemas).buildSerializable();
+        return builder().config(config).schemas(schemas).userAgent(UserAgents.DEFAULT_USER_AGENT).buildSerializable();
     }
 
     // Begin deprecated creation methods

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -139,15 +139,7 @@ public abstract class TransactionManagers {
         return false;
     }
 
-    abstract Optional<Class<?>> callingClass();
-
-    abstract Optional<String> userAgent();
-
-    // directly specified -> inferred from caller -> default
-    @Value.Derived
-    String derivedUserAgent() {
-        return userAgent().orElse(callingClass().map(UserAgents::fromClass).orElse(UserAgents.DEFAULT_USER_AGENT));
-    }
+    abstract String userAgent();
 
     public static Builder builder() {
         return new Builder();
@@ -258,7 +250,7 @@ public abstract class TransactionManagers {
                 .registrar(env::register)
                 .lockServerOptions(lockServerOptions)
                 .allowHiddenTableAccess(allowHiddenTableAccess)
-                .callingClass(callingClass)
+                .userAgent(UserAgents.fromClass(callingClass))
                 .buildSerializable();
     }
 
@@ -321,7 +313,7 @@ public abstract class TransactionManagers {
                 () -> LockServiceImpl.create(lockServerOptions()),
                 atlasFactory::getTimestampService,
                 atlasFactory.getTimestampStoreInvalidator(),
-                derivedUserAgent());
+                userAgent());
 
         KvsProfilingLogger.setSlowLogThresholdMillis(config.getKvsSlowLogThresholdMillis());
         KeyValueService kvs = ProfilingKeyValueService.create(rawKvs);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -262,6 +262,7 @@ public class TransactionManagersTest {
         TransactionManagers.builder()
                 .config(realConfig)
                 .registrar(environment)
+                .userAgent("test")
                 .buildSerializable();
 
         assertEquals(expectedTimeout, LockRequest.getDefaultLockTimeout());
@@ -304,6 +305,7 @@ public class TransactionManagersTest {
         SerializableTransactionManager manager = TransactionManagers.builder()
                 .config(realConfig)
                 .registrar(environment)
+                .userAgent("test")
                 .buildSerializable();
         manager.registerClosingCallback(callback);
         manager.close();
@@ -319,6 +321,7 @@ public class TransactionManagersTest {
         TransactionManagers.builder()
                 .config(realConfig)
                 .registrar(environment)
+                .userAgent("test")
                 .buildSerializable();
         assertThat(metricsRule.metrics().getNames().stream()
                 .anyMatch(metricName -> metricName.contains(USER_AGENT_NAME)), is(false));

--- a/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
+++ b/atlasdb-console/src/main/groovy/com/palantir/atlasdb/console/module/AtlasCoreModule.groovy
@@ -217,6 +217,7 @@ class AtlasCoreModule implements AtlasConsoleModule {
         SerializableTransactionManager tm = TransactionManagers.builder()
                 .config(config)
                 .allowHiddenTableAccess(true)
+                .userAgent("atlasdb console")
                 .buildSerializable();
         TableMetadataCache cache = new TableMetadataCache(tm.getKeyValueService())
         AtlasDbService service = new AtlasDbServiceImpl(tm.getKeyValueService(), tm, cache)

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -102,6 +102,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
                 .config(config)
                 .schemas(ETE_SCHEMAS)
                 .registrar(environment.jersey()::register)
+                .userAgent("ete test")
                 .buildSerializable();
     }
 

--- a/atlasdb-service-server/src/main/java/com/palantir/atlasdb/server/AtlasDbServiceServer.java
+++ b/atlasdb-service-server/src/main/java/com/palantir/atlasdb/server/AtlasDbServiceServer.java
@@ -46,6 +46,7 @@ public class AtlasDbServiceServer extends Application<AtlasDbServiceServerConfig
         SerializableTransactionManager tm = TransactionManagers.builder()
                 .config(config.getConfig())
                 .registrar(environment.jersey()::register)
+                .userAgent("AtlasDbServiceServer")
                 .buildSerializable();
 
         TableMetadataCache cache = new TableMetadataCache(tm.getKeyValueService());

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -73,6 +73,10 @@ develop
           Previously, the table reference was omitted, such that one might receive lines of the form ``Call to KVS.getRange on table RangeRequest{reverse=false} with range 1504 took {} ms.``.
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2474>`__)
 
+    *   - |devbreak|
+        - ``TransactionManagers.builder()`` no longer has a ``callingClass(..)`` method and now requires the consumer to directly specify their user agent via the previously optional method ``userAgent(..)``. All of the ``TransactionManagers.create(..)`` methods are still deprecated.
+          (`Pull Request <https://github.com/palantir/atlasdb/pull/2542>`__)
+
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceTransactionIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceTransactionIntegrationTest.java
@@ -86,7 +86,7 @@ public class AsyncTimelockServiceTransactionIntegrationTest extends AbstractAsyn
                                 .build())
                         .build())
                 .build();
-        txnManager = TransactionManagers.builder().config(config).buildSerializable();
+        txnManager = TransactionManagers.builder().config(config).userAgent("test").buildSerializable();
         txnManager.getKeyValueService().createTable(TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
     }
 


### PR DESCRIPTION
**Goals (and why)**: Resolves #2528 

**Implementation Description (bullets)**: Require the previously optional `userAgent` method in the `TransactionManagers` builder. Remove the `callingClass` option.

**Concerns (what feedback would you like?)**: Technically this is a breaking change, but we only just introduced this API last release and I doubt anyone is using yet. And either way people really should be doing this no matter what. The old `create` methods still exist and are still deprecated.

**Where should we start reviewing?**: `TransactionManagers`

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2542)
<!-- Reviewable:end -->
