### PR TITLE
The cause of an ExecutionException is more interesting.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -490,7 +489,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             }
             return ImmutableMap.copyOf(result);
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -562,7 +561,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             }
             return builder.build();
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -779,7 +778,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             }
             return ret;
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -817,7 +816,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         }
                     });
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -958,7 +957,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         try {
             putInternal(tableRef, KeyValueServices.toConstantTimestampValues(values.entrySet(), timestamp));
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -978,7 +977,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         try {
             putInternal(tableRef, values.entries());
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -1246,7 +1245,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 throw new PalantirRuntimeException("Truncating tables requires all Cassandra nodes"
                         + " to be up and available.");
             } catch (TException e) {
-                throw Throwables.throwUncheckedException(e);
+                throw Throwables.unwrapAndThrowUncheckedException(e);
             }
         }
     }
@@ -1377,7 +1376,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         } catch (UnavailableException e) {
             throw new PalantirRuntimeException("Deleting requires all Cassandra nodes to be up and available.");
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -1720,7 +1719,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 }
             }
         } catch (Exception e) {
-            Throwables.throwUncheckedException(e);
+            Throwables.unwrapAndThrowUncheckedException(e);
         }
 
         return filteredTables;
@@ -1741,7 +1740,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 } catch (TException thriftException) {
                     if (thriftException.getMessage() != null
                             && !thriftException.getMessage().contains("already existing table")) {
-                        Throwables.throwUncheckedException(thriftException);
+                        Throwables.unwrapAndThrowUncheckedException(thriftException);
                     }
                 }
             }
@@ -1983,7 +1982,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 return null;
             });
         } catch (Exception e) {
-            Throwables.throwUncheckedException(e);
+            Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -2047,7 +2046,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             final Value value = Value.create(PtBytes.EMPTY_BYTE_ARRAY, Value.INVALID_VALUE_TIMESTAMP);
             putInternal(tableRef, Iterables.transform(cells, cell -> Maps.immutableEntry(cell, value)));
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -2104,7 +2103,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 return null;
             });
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -2137,8 +2136,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 }
                 return null;
             });
-        } catch (TException e) {
-            throw Throwables.throwUncheckedException(e);
+        } catch (CheckAndSetException e) {
+            throw e;
+        } catch (Exception e) {
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         }
     }
 
@@ -2422,7 +2423,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 //Callable<Void> returns null, so can't use immutable list
                 return Collections.singletonList(tasks.get(0).call());
             } catch (Exception e) {
-                throw Throwables.throwUncheckedException(e);
+                throw Throwables.unwrapAndThrowUncheckedException(e);
             }
         }
 
@@ -2436,10 +2437,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 results.add(future.get());
             }
             return results;
-        } catch (ExecutionException e) {
-            throw Throwables.throwUncheckedException(e.getCause());
         } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
+            throw Throwables.unwrapAndThrowUncheckedException(e);
         } finally {
             for (Future<V> future : futures) {
                 future.cancel(true);
@@ -2448,10 +2447,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private static class TableCellAndValue {
-        public static final Function<TableCellAndValue, byte[]> EXTRACT_ROW_NAME_FUNCTION =
+        private static final Function<TableCellAndValue, byte[]> EXTRACT_ROW_NAME_FUNCTION =
                 input -> input.cell.getRowName();
 
-        public static final Function<TableCellAndValue, Long> SIZING_FUNCTION =
+        private static final Function<TableCellAndValue, Long> SIZING_FUNCTION =
                 input -> input.value.length + Cells.getApproxSizeOfCell(input.cell);
 
         private final TableReference tableRef;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -2435,6 +2436,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 results.add(future.get());
             }
             return results;
+        } catch (ExecutionException e) {
+            throw Throwables.throwUncheckedException(e.getCause());
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         } finally {

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -19,6 +19,7 @@ import java.io.InterruptedIOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -82,6 +83,13 @@ public final class Throwables {
      * If Throwable is a RuntimeException or Error, rethrow it. If not, throw a
      * new PalantirRuntimeException(ex)
      */
+    public static RuntimeException unwrapAndThrowUncheckedException(Throwable ex) {
+        if (isInstance(ex, ExecutionException.class) || isInstance(ex, InvocationTargetException.class)) {
+            throwUncheckedException(ex.getCause());
+        }
+        throw throwUncheckedException(ex);
+    }
+
     public static RuntimeException throwUncheckedException(Throwable ex) {
         throwIfInstance(ex, RuntimeException.class);
         throwIfInstance(ex, Error.class);
@@ -142,10 +150,14 @@ public final class Throwables {
      */
     @SuppressWarnings("unchecked")
     public static <K extends Throwable> void throwIfInstance(Throwable t, Class<K> clazz) throws K {
-        if ((t != null) && clazz.isAssignableFrom(t.getClass())) {
+        if (isInstance(t, clazz)) {
             K kt = (K) t;
             throw kt;
         }
+    }
+
+    private static <K extends Throwable> boolean isInstance(Throwable t, Class<K> clazz) {
+        return (t != null) && clazz.isAssignableFrom(t.getClass());
     }
 
     /**


### PR DESCRIPTION
**Goals (and why)**: Have consistency in exceptions even if its thrown from the executor.
If C* is down:
1. getRow does a C* call and throws CassandraCientCreationException
but
2. getRows does a C* call and throws `PalantirRuntimeException(ExecutionException(CassandraCientCreationException)))` where `Ex(c)` implies that `c` is the cause of exception `Ex`.

This would be a small step for #2550 Step1.

**Implementation Description (bullets)**: Extract the exception from the `ExecutionException`. We dont have the complete stacktraces after this, should we port over the stacktrace from the executionException?

**Concerns (what feedback would you like?)**: Is this an API break?

**Where should we start reviewing?**: one file.

**Priority (whenever / two weeks / yesterday)**: this week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2551)
<!-- Reviewable:end -->