### PR TITLE
plumbing to make timestampcache live re-size-able

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.schema.KeyValueServiceMigrator;
 import com.palantir.atlasdb.schema.KeyValueServiceValidator;
 import com.palantir.atlasdb.services.AtlasDbServices;
@@ -154,7 +155,8 @@ public class KvsMigrationCommand implements Callable<Integer> {
 
     public AtlasDbServices connectFromServices() throws IOException {
         AtlasDbConfig fromConfig = AtlasDbConfigs.load(fromConfigFile, configRoot);
-        ServicesConfigModule scm = ServicesConfigModule.create(makeOfflineIfNecessary(fromConfig));
+        ServicesConfigModule scm = ServicesConfigModule.create(
+                makeOfflineIfNecessary(fromConfig), AtlasDbRuntimeConfig.defaultRuntimeConfig());
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }
 
@@ -162,7 +164,8 @@ public class KvsMigrationCommand implements Callable<Integer> {
         AtlasDbConfig toConfig = toConfigFile != null
                 ? AtlasDbConfigs.load(toConfigFile, configRoot)
                 : AtlasDbConfigs.loadFromString(inlineConfig, null);
-        ServicesConfigModule scm = ServicesConfigModule.create(makeOfflineIfNecessary(toConfig));
+        ServicesConfigModule scm = ServicesConfigModule.create(
+                makeOfflineIfNecessary(toConfig), AtlasDbRuntimeConfig.defaultRuntimeConfig());
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }
 

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SingleBackendCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SingleBackendCommand.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.services.AtlasDbServices;
 import com.palantir.atlasdb.services.AtlasDbServicesFactory;
 import com.palantir.atlasdb.services.DaggerAtlasDbServices;
@@ -44,12 +45,14 @@ public abstract class SingleBackendCommand extends AbstractCommand {
     }
 
     private AtlasDbServices connect() throws IOException {
-        ServicesConfigModule scm = ServicesConfigModule.create(getAtlasDbConfig());
+        ServicesConfigModule scm = ServicesConfigModule.create(
+                getAtlasDbConfig(), AtlasDbRuntimeConfig.defaultRuntimeConfig());
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }
 
     public <T extends AtlasDbServices> T connect(AtlasDbServicesFactory factory) throws IOException {
-        return factory.connect(ServicesConfigModule.create(getAtlasDbConfig()));
+        return factory.connect(ServicesConfigModule.create(
+                getAtlasDbConfig(), AtlasDbRuntimeConfig.defaultRuntimeConfig()));
     }
 
     public abstract int execute(AtlasDbServices services);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/cache/TimestampCache.java
@@ -16,12 +16,12 @@
 package com.palantir.atlasdb.cache;
 
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.palantir.atlasdb.util.AtlasDbMetrics;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -43,10 +43,10 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     private static final int GET_RANGES_QUEUE_SIZE_WARNING_THRESHOLD = 1000;
 
     public static final Logger log = LoggerFactory.getLogger(AbstractTransactionManager.class);
-    protected final TimestampCache timestampValidationReadCache;
+    final TimestampCache timestampValidationReadCache;
     private volatile boolean closed = false;
 
-    public AbstractTransactionManager(Supplier<Long> timstampCacheSize) {
+    AbstractTransactionManager(Supplier<Long> timstampCacheSize) {
         this.timestampValidationReadCache = new TimestampCache(timstampCacheSize);
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -22,12 +22,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.cache.TimestampCache;
@@ -46,8 +46,8 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     final TimestampCache timestampValidationReadCache;
     private volatile boolean closed = false;
 
-    AbstractTransactionManager(Supplier<Long> timstampCacheSize) {
-        this.timestampValidationReadCache = new TimestampCache(timstampCacheSize);
+    AbstractTransactionManager(Supplier<Long> timestampCacheSize) {
+        this.timestampValidationReadCache = new TimestampCache(timestampCacheSize);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -42,7 +41,6 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     private static final int GET_RANGES_QUEUE_SIZE_WARNING_THRESHOLD = 1000;
 
     public static final Logger log = LoggerFactory.getLogger(AbstractTransactionManager.class);
-    protected final TimestampCache timestampValidationReadCache = new TimestampCache();
     private volatile boolean closed = false;
 
     @Override
@@ -125,11 +123,6 @@ public abstract class AbstractTransactionManager implements TransactionManager {
      */
     protected void checkOpen() {
         Preconditions.checkState(!this.closed, "Operations cannot be performed on closed TransactionManager.");
-    }
-
-    @Override
-    public void clearTimestampCache() {
-        timestampValidationReadCache.clear();
     }
 
     ExecutorService createGetRangesExecutor(int numThreads) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -254,20 +254,6 @@ public abstract class AtlasDbConfig {
         return AtlasDbConstants.DEFAULT_LOCK_TIMEOUT_SECONDS;
     }
 
-
-    /**
-     * The number of timestamps to cache that we have seen in previous reads.
-     * This will use somewhere around 90MB of heap memory per million timestamps because of various overheads
-     * from Java Objects and the cache's LRU tracking.
-     *
-     * Probably the only reason to configure away from the default would be a service that can afford the heap usage,
-     * and has read patterns that deal with a very large working set of existing transactions.
-     */
-    @Value.Default
-    public long getTimestampCacheSize() {
-        return AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE;
-    }
-
     @Value.Check
     protected final void check() {
         checkLeaderAndTimelockBlocks();

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -20,6 +20,7 @@ import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.atlasdb.AtlasDbConstants;
 
 @JsonDeserialize(as = ImmutableAtlasDbRuntimeConfig.class)
 @JsonSerialize(as = ImmutableAtlasDbRuntimeConfig.class)
@@ -42,6 +43,19 @@ public abstract class AtlasDbRuntimeConfig {
     @Value.Default
     public TransactionConfig transaction() {
         return ImmutableTransactionConfig.builder().build();
+    }
+
+    /**
+     * The number of timestamps to cache that we have seen in previous reads.
+     * This will use somewhere around 90MB of heap memory per million timestamps because of various overheads
+     * from Java Objects and the cache's LRU tracking.
+     *
+     * Probably the only reason to configure away from the default would be a service that can afford the heap usage,
+     * and has read patterns that deal with a very large working set of existing transactions.
+     */
+    @Value.Default
+    public long getTimestampCacheSize() {
+        return AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE;
     }
 
     public static ImmutableAtlasDbRuntimeConfig defaultRuntimeConfig() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -370,7 +370,7 @@ public abstract class TransactionManagers {
                 config.keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.keyValueService().defaultGetRangesConcurrency(),
                 config.initializeAsync(),
-                config.getTimestampCacheSize());
+                () -> runtimeConfigSupplier.get().getTimestampCacheSize());
 
         PersistentLockManager persistentLockManager = new PersistentLockManager(
                 persistentLockService,

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
@@ -33,7 +33,7 @@ public abstract class ServicesConfig {
 
     public abstract AtlasDbConfig atlasDbConfig();
 
-    public abstract AtlasDbRuntimeConfig atlasDbRuntimeConfigConfig();
+    public abstract AtlasDbRuntimeConfig atlasDbRuntimeConfig();
 
     @Value.Derived
     public ServiceDiscoveringAtlasSupplier atlasDbSupplier() {

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
@@ -24,6 +24,7 @@ import org.immutables.value.Value;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.factory.ServiceDiscoveringAtlasSupplier;
 import com.palantir.atlasdb.table.description.Schema;
 
@@ -31,6 +32,8 @@ import com.palantir.atlasdb.table.description.Schema;
 public abstract class ServicesConfig {
 
     public abstract AtlasDbConfig atlasDbConfig();
+
+    public abstract AtlasDbRuntimeConfig atlasDbRuntimeConfigConfig();
 
     @Value.Derived
     public ServiceDiscoveringAtlasSupplier atlasDbSupplier() {

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfigModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfigModule.java
@@ -22,6 +22,7 @@ import javax.inject.Singleton;
 
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbConfigs;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 
 import dagger.Module;
 import dagger.Provides;
@@ -31,12 +32,16 @@ public class ServicesConfigModule {
 
     private final ServicesConfig config;
 
-    public static ServicesConfigModule create(File configFile, String configRoot) throws IOException {
-        return ServicesConfigModule.create(AtlasDbConfigs.load(configFile, configRoot));
+    public static ServicesConfigModule create(File configFile, String configRoot, AtlasDbRuntimeConfig runtimeConfig)
+            throws IOException {
+        return ServicesConfigModule.create(AtlasDbConfigs.load(configFile, configRoot), runtimeConfig);
     }
 
-    public static ServicesConfigModule create(AtlasDbConfig atlasDbConfig) {
-        return new ServicesConfigModule(ImmutableServicesConfig.builder().atlasDbConfig(atlasDbConfig).build());
+    public static ServicesConfigModule create(AtlasDbConfig atlasDbConfig, AtlasDbRuntimeConfig runtimeConfig) {
+        return new ServicesConfigModule(ImmutableServicesConfig.builder()
+                .atlasDbConfig(atlasDbConfig)
+                .atlasDbRuntimeConfig(runtimeConfig)
+                .build());
     }
 
     public ServicesConfigModule(ServicesConfig config) {
@@ -55,4 +60,9 @@ public class ServicesConfigModule {
         return config.atlasDbConfig();
     }
 
+    @Provides
+    @Singleton
+    public AtlasDbRuntimeConfig provideAtlasDbRuntimeConfig() {
+        return config.atlasDbRuntimeConfig();
+    }
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -100,7 +100,7 @@ public class TransactionManagerModule {
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
-                config.atlasDbConfig().getTimestampCacheSize());
+                () -> config.atlasDbRuntimeConfigConfig().getTimestampCacheSize());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -97,12 +97,12 @@ public class TransactionManagerModule {
                 conflictManager,
                 sweepStrategyManager,
                 cleaner,
+                TimestampTrackerImpl.createNoOpTracker(),
+                () -> config.atlasDbRuntimeConfig().getTimestampCacheSize(),
                 config.allowAccessToHiddenTables(),
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                TimestampTrackerImpl.createNoOpTracker(),
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
-                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
-                () -> config.atlasDbRuntimeConfig().getTimestampCacheSize());
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -100,7 +100,7 @@ public class TransactionManagerModule {
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
-                () -> config.atlasDbRuntimeConfigConfig().getTimestampCacheSize());
+                () -> config.atlasDbRuntimeConfig().getTimestampCacheSize());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -106,7 +106,7 @@ public class TestTransactionManagerModule {
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
-                () -> config.atlasDbRuntimeConfigConfig().getTimestampCacheSize());
+                () -> config.atlasDbRuntimeConfig().getTimestampCacheSize());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -103,12 +103,12 @@ public class TestTransactionManagerModule {
                 conflictManager,
                 sweepStrategyManager,
                 cleaner,
+                TimestampTrackerImpl.createNoOpTracker(),
+                () -> config.atlasDbRuntimeConfig().getTimestampCacheSize(),
                 config.allowAccessToHiddenTables(),
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                TimestampTrackerImpl.createNoOpTracker(),
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
-                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
-                () -> config.atlasDbRuntimeConfig().getTimestampCacheSize());
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -106,7 +106,7 @@ public class TestTransactionManagerModule {
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
-                config.atlasDbConfig().getTimestampCacheSize());
+                () -> config.atlasDbRuntimeConfigConfig().getTimestampCacheSize());
     }
 
 }

--- a/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/AtlasDbServicesTest.java
+++ b/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/AtlasDbServicesTest.java
@@ -23,14 +23,17 @@ import java.nio.file.Paths;
 import org.junit.Test;
 
 import com.palantir.atlasdb.config.AtlasDbConfigs;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 
 public class AtlasDbServicesTest {
 
     @Test
     public void daggerCanInstantiateAtlas() throws URISyntaxException, IOException {
         File config = new File(getResourcePath("simple_atlas_config.yml"));
+        ServicesConfigModule servicesConfigModule = ServicesConfigModule.create(AtlasDbConfigs.load(config),
+                AtlasDbRuntimeConfig.defaultRuntimeConfig());
         DaggerAtlasDbServices.builder()
-                .servicesConfigModule(ServicesConfigModule.create(AtlasDbConfigs.load(config)))
+                .servicesConfigModule(servicesConfigModule)
                 .build();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -182,7 +182,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
                 cleaner,
                 DEFAULT_MAX_CONCURRENT_RANGES,
                 DEFAULT_GET_RANGES_CONCURRENCY,
-                DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> DEFAULT_TIMESTAMP_CACHE_SIZE);
         cleaner.start(ret);
         return ret;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
@@ -42,7 +42,7 @@ public abstract class AbstractLockAwareTransactionManager
         extends AbstractTransactionManager
         implements LockAwareTransactionManager {
 
-    AbstractLockAwareTransactionManager(java.util.function.Supplier<Long> timestampCacheSize) {
+    AbstractLockAwareTransactionManager(Supplier<Long> timestampCacheSize) {
         super(timestampCacheSize);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
@@ -42,7 +42,7 @@ public abstract class AbstractLockAwareTransactionManager
         extends AbstractTransactionManager
         implements LockAwareTransactionManager {
 
-    protected AbstractLockAwareTransactionManager(java.util.function.Supplier<Long> timestampCacheSize) {
+    AbstractLockAwareTransactionManager(java.util.function.Supplier<Long> timestampCacheSize) {
         super(timestampCacheSize);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractLockAwareTransactionManager.java
@@ -41,6 +41,11 @@ import com.palantir.lock.LockRequest;
 public abstract class AbstractLockAwareTransactionManager
         extends AbstractTransactionManager
         implements LockAwareTransactionManager {
+
+    protected AbstractLockAwareTransactionManager(java.util.function.Supplier<Long> timestampCacheSize) {
+        super(timestampCacheSize);
+    }
+
     @Override
     public <T, E extends Exception> T runTaskWithLocksWithRetry(
             Iterable<HeldLocksToken> lockTokens,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
@@ -52,10 +52,11 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
     final int defaultGetRangesConcurrency;
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
-                                      TransactionService transactionService,
-                                      AtlasDbConstraintCheckingMode constraintCheckingMode,
-                                      int concurrentGetRangesThreadPoolSize,
-                                      int defaultGetRangesConcurrency) {
+            TransactionService transactionService,
+            AtlasDbConstraintCheckingMode constraintCheckingMode,
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency,
+            Supplier<Long> timestampCacheSize) {
         this(
                 keyValueService,
                 transactionService,
@@ -64,16 +65,18 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 false,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
-                                      TransactionService transactionService,
-                                      AtlasDbConstraintCheckingMode constraintCheckingMode,
-                                      Supplier<Long> startTimestamp,
-                                      TransactionReadSentinelBehavior readSentinelBehavior,
-                                      int concurrentGetRangesThreadPoolSize,
-                                      int defaultGetRangesConcurrency) {
+            TransactionService transactionService,
+            AtlasDbConstraintCheckingMode constraintCheckingMode,
+            Supplier<Long> startTimestamp,
+            TransactionReadSentinelBehavior readSentinelBehavior,
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency,
+            Supplier<Long> timestampCacheSize) {
         this(
                 keyValueService,
                 transactionService,
@@ -82,17 +85,20 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 readSentinelBehavior,
                 false,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
-                                      TransactionService transactionService,
-                                      AtlasDbConstraintCheckingMode constraintCheckingMode,
-                                      Supplier<Long> startTimestamp,
-                                      TransactionReadSentinelBehavior readSentinelBehavior,
-                                      boolean allowHiddenTableAccess,
-                                      int concurrentGetRangesThreadPoolSize,
-                                      int defaultGetRangesConcurrency) {
+            TransactionService transactionService,
+            AtlasDbConstraintCheckingMode constraintCheckingMode,
+            Supplier<Long> startTimestamp,
+            TransactionReadSentinelBehavior readSentinelBehavior,
+            boolean allowHiddenTableAccess,
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency,
+            Supplier<Long> timestampCacheSize) {
+        super(timestampCacheSize::get);
         this.keyValueService = keyValueService;
         this.transactionService = transactionService;
         this.constraintCheckingMode = constraintCheckingMode;
@@ -181,6 +187,11 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
     @Override
     public long getUnreadableTimestamp() {
         return Long.MAX_VALUE;
+    }
+
+    @Override
+    public void clearTimestampCache() {
+
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -88,7 +88,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
     // TODO(ssouza): it's hard to change the interface of STM with this.
     // We should extract interfaces and delete this hack.
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, false, null, null, 1, 1, () -> 1L);
+        this(null, null, null, null, null, null, null, null, null, () -> 1L, false, null, 1, 1);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,
@@ -117,12 +117,12 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 conflictDetectionManager,
                 sweepStrategyManager,
                 cleaner,
+                timestampTracker,
+                timestampCacheSize,
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
-                timestampTracker,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency,
-                timestampCacheSize);
+                defaultGetRangesConcurrency);
 
         return initializeAsync
                 ? new InitializeCheckingWrapper(serializableTransactionManager, initializationPrerequisite)
@@ -149,12 +149,12 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 conflictDetectionManager,
                 sweepStrategyManager,
                 cleaner,
+                TimestampTrackerImpl.createNoOpTracker(),
+                timestampCacheSize,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                TimestampTrackerImpl.createNoOpTracker(),
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency,
-                timestampCacheSize);
+                defaultGetRangesConcurrency);
     }
 
     /**
@@ -185,12 +185,13 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 conflictDetectionManager,
                 sweepStrategyManager,
                 cleaner,
+                timestampTracker,
+                timestampCacheSize,
                 allowHiddenTableAccess,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                timestampTracker,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency,
-                timestampCacheSize);
+                defaultGetRangesConcurrency
+        );
     }
 
     // Canonical constructor.
@@ -202,12 +203,12 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             ConflictDetectionManager conflictDetectionManager,
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
+            TimestampTracker timestampTracker,
+            Supplier<Long> timestampCacheSize,
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
-            TimestampTracker timestampTracker,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency,
-            Supplier<Long> timestampCacheSize) {
+            int defaultGetRangesConcurrency) {
         super(
                 keyValueService,
                 timelockService,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -84,7 +84,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
      * use the delegate instead.
      */
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, false, null, 1, 1, 1);
+        this(null, null, null, null, null, null, null, null, false, null, 1, 1, null);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,
@@ -101,7 +101,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             boolean initializeAsync,
-            long timestampCacheSize) {
+            Supplier<Long> timestampCacheSize) {
         SerializableTransactionManager serializableTransactionManager = new SerializableTransactionManager(
                 keyValueService,
                 timelockService,
@@ -133,7 +133,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Cleaner cleaner,
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
-            long timestampCacheSize) {
+            Supplier<Long> timestampCacheSize) {
         return new SerializableTransactionManager(keyValueService,
                 new LegacyTimelockService(timestampService, lockService, lockClient),
                 lockService,
@@ -166,7 +166,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             boolean allowHiddenTableAccess,
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
-            long timestampCacheSize) {
+            Supplier<Long> timestampCacheSize) {
         this(
                 keyValueService,
                 new LegacyTimelockService(timestampService, lockService, lockClient),
@@ -196,7 +196,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
-            long timestampCacheSize) {
+            Supplier<Long> timestampCacheSize) {
         super(
                 keyValueService,
                 timelockService,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -83,8 +83,10 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
      * This constructor is necessary for the InitializeCheckingWrapper. We initialize a dummy transaction manager and
      * use the delegate instead.
      */
+    // TODO(ssouza): it's hard to change the interface of STM with this.
+    // We should extract interfaces and delete this hack.
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, false, null, 1, 1, null);
+        this(null, null, null, null, null, null, null, null, false, null, 1, 1, () -> 1L);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -88,7 +88,7 @@ import com.palantir.timestamp.TimestampService;
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             Supplier<Long> timestampCacheSize) {
-        super(timestampCacheSize::get);
+        super(timestampCacheSize);
 
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -31,7 +31,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
@@ -71,7 +70,6 @@ import com.palantir.timestamp.TimestampService;
     protected final Supplier<Long> lockAcquireTimeoutMs;
     final ExecutorService getRangesExecutor;
     final int defaultGetRangesConcurrency;
-    final TimestampCache timestampValidationReadCache;
 
     final List<Runnable> closingCallbacks;
     final AtomicBoolean isClosed;
@@ -90,6 +88,8 @@ import com.palantir.timestamp.TimestampService;
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             Supplier<Long> timestampCacheSize) {
+        super(timestampCacheSize::get);
+
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.lockService = lockService;
@@ -104,7 +104,6 @@ import com.palantir.timestamp.TimestampService;
         this.isClosed = new AtomicBoolean(false);
         this.getRangesExecutor = createGetRangesExecutor(concurrentGetRangesThreadPoolSize);
         this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
-        this.timestampValidationReadCache = new TimestampCache(timestampCacheSize.get());
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -56,7 +56,7 @@ public class SerializableTransactionManagerTest {
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 true, // initializeAsync
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         when(mockKvs.isInitialized()).thenReturn(true);
         when(mockTimelockService.isInitialized()).thenReturn(true);
@@ -116,7 +116,7 @@ public class SerializableTransactionManagerTest {
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 false, // initializeAsync
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         when(mockKvs.isInitialized()).thenReturn(false);
         when(mockTimelockService.isInitialized()).thenReturn(false);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -57,7 +57,7 @@ public class SnapshotTransactionManagerTest {
             () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
             TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
             TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
-            AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+            () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
     @Test
     public void isAlwaysInitialized() {
@@ -98,7 +98,7 @@ public class SnapshotTransactionManagerTest {
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         newTransactionManager.close(); // should not throw
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/AtlasDbServicesConnector.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/AtlasDbServicesConnector.java
@@ -48,15 +48,14 @@ public class AtlasDbServicesConnector implements Closeable {
         DockerizedDatabaseUri dburi = DockerizedDatabaseUri.fromUriString(uri);
         KeyValueServiceConfig config = dburi.getKeyValueServiceInstrumentation()
                 .getKeyValueServiceConfig(dburi.getAddress());
-        ServicesConfigModule servicesConfigModule = ServicesConfigModule.create(
-                ImmutableAtlasDbConfig.builder()
-                        .keyValueService(config)
-                        .build(),
-                ImmutableAtlasDbRuntimeConfig
-                        .defaultRuntimeConfig());
+        ImmutableAtlasDbConfig atlasDbConfig = ImmutableAtlasDbConfig.builder().keyValueService(config).build();
+        ImmutableAtlasDbRuntimeConfig runtimeConfig = ImmutableAtlasDbRuntimeConfig.defaultRuntimeConfig();
+        ServicesConfigModule servicesConfigModule = ServicesConfigModule.create(atlasDbConfig, runtimeConfig);
+
         services = DaggerAtlasDbServices.builder()
                 .servicesConfigModule(servicesConfigModule)
                 .build();
+
         return services;
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/AtlasDbServicesConnector.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/AtlasDbServicesConnector.java
@@ -23,6 +23,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
+import com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig;
 import com.palantir.atlasdb.services.AtlasDbServices;
 import com.palantir.atlasdb.services.DaggerAtlasDbServices;
 import com.palantir.atlasdb.services.ServicesConfigModule;
@@ -47,12 +48,14 @@ public class AtlasDbServicesConnector implements Closeable {
         DockerizedDatabaseUri dburi = DockerizedDatabaseUri.fromUriString(uri);
         KeyValueServiceConfig config = dburi.getKeyValueServiceInstrumentation()
                 .getKeyValueServiceConfig(dburi.getAddress());
+        ServicesConfigModule servicesConfigModule = ServicesConfigModule.create(
+                ImmutableAtlasDbConfig.builder()
+                        .keyValueService(config)
+                        .build(),
+                ImmutableAtlasDbRuntimeConfig
+                        .defaultRuntimeConfig());
         services = DaggerAtlasDbServices.builder()
-                .servicesConfigModule(
-                        ServicesConfigModule.create(
-                                ImmutableAtlasDbConfig.builder()
-                                        .keyValueService(config)
-                                        .build()))
+                .servicesConfigModule(servicesConfigModule)
                 .build();
         return services;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -71,7 +71,7 @@ public final class SweepTestUtils {
                 kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         setupTables(kvs);
         return txManager;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -78,7 +78,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -87,7 +87,8 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 @SuppressWarnings({"checkstyle:all","DefaultCharset"}) // TODO(someonebored): clean this horrible test class up!
 public abstract class AbstractTransactionTest extends TransactionTestSetup {
 
-    protected final TimestampCache timestampCache = new TimestampCache();
+    protected final TimestampCache timestampCache = new TimestampCache(
+            () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     protected boolean supportsReverse() {
         return true;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -59,7 +59,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
@@ -82,7 +82,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -56,12 +56,12 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 conflictDetectionManager,
                 sweepStrategyManager,
                 NoOpCleaner.INSTANCE,
+                TimestampTrackerImpl.createNoOpTracker(),
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                TimestampTrackerImpl.createNoOpTracker(),
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
@@ -80,12 +80,12 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 ConflictDetectionManagers.createWithoutWarmingCache(keyValueService),
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
+                TimestampTrackerImpl.createNoOpTracker(),
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                TimestampTrackerImpl.createNoOpTracker(),
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -90,7 +90,7 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         // fetch an immutable timestamp once so it's cached
         when(mockTimestampService.getFreshTimestamp()).thenReturn(1L);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -77,7 +77,7 @@ public class TableTasksTest {
                 kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         txManager = transactionManager;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -117,7 +117,8 @@ import com.palantir.remoting2.tracing.Tracers;
 
 @SuppressWarnings("checkstyle:all")
 public class SnapshotTransactionTest extends AtlasDbTestCase {
-    protected final TimestampCache timestampCache = new TimestampCache();
+    protected final TimestampCache timestampCache = new TimestampCache(
+            () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     protected final ExecutorService getRangesExecutor = Executors.newFixedThreadPool(8);
     protected final int defaultGetRangesConcurrency = 2;
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -120,6 +120,17 @@ develop
           If you used one of the deleted or deprecated constructors, use the static ``create`` method.
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2549>`__)
 
+    *    - |improved| |devbreak|
+         - Size of the transaction cache is now configurable. It is not anticipated end users will need to touch this;
+           it is more likely that this will be configured via per-service overrides for the services for whom the
+           current cache size is inadequate.
+           This is a small API change for users manually constructing a TransactionManager, which now requires a
+           transaction cache size parameter. Please add it from the AtlasDbConfig, or instead of manually creating
+           a TransactionManager, utilize the helpers in TransactionManagers to have this done for you.
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/2496>`__)
+           (`Pull Request 2 <https://github.com/palantir/atlasdb/pull/2554>`__)
+
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
@@ -139,15 +150,6 @@ v0.61.1
          - Reverted the Sweep rewrite for Cassandra as it would unnecessarily load values into memory which could
            cause Cassandra to OOM if the values are large enough.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2521>`__)
-
-    *    - |improved| |devbreak|
-         - Size of the transaction cache is now configurable. It is not anticipated end users will need to touch this;
-           it is more likely that this will be configured via per-service overrides for the services for whom the
-           current cache size is inadequate.
-           This is a small API change for users manually constructing a TransactionManager, which now requires a
-           transaction cache size parameter. Please add it from the AtlasDbConfig, or instead of manually creating
-           a TransactionManager, utilize the helpers in TransactionManagers to have this done for you.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2496>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**: Make #2496 live reload cache size

**Implementation Description (bullets)**:
- Move config from atlasdbconfig to atlasdbruntimeconfig
- Move all timestamp cache impl at TM level up to Snapshot
- Propagate size supplier all the way down the cache
- TODO: poll supplier for changes and call resize when appropriate

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2554)
<!-- Reviewable:end -->
