### PR TITLE
Sweep Progress Fix

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SweepSchema.java
@@ -40,7 +40,7 @@ public enum SweepSchema implements AtlasSchema {
                 OptionalType.JAVA8);
 
         // This table tracks progress on a sweep job of a single table.
-        schema.addTableDefinition("progress", new TableDefinition() {{
+        schema.addTableDefinition("progress_2", new TableDefinition() {{
             javaTableName("SweepProgress");
             allSafeForLoggingByDefault();
             rowName();
@@ -48,17 +48,7 @@ public enum SweepSchema implements AtlasSchema {
                 rowComponent("dummy", ValueType.VAR_LONG);
             columns();
                 // The name of the table being swept.
-                column("full_table_name", "n", ValueType.STRING);
-                // The minimum swept timestamp, used to determine min
-                // timestamp for transaction table sweep
-                column("minimum_swept_timestamp", "m", ValueType.VAR_SIGNED_LONG);
-                // The row to start sweeping from if sweeping
-                // is paused and resumed.
-                column("start_row", "s", ValueType.BLOB);
-                // The number of cells deleted so far.
-                column("cells_deleted", "d", ValueType.VAR_LONG);
-                // The number of cells examined so far.
-                column("cells_examined", "e", ValueType.VAR_LONG);
+                column("sweep_progress", "s", ValueType.BLOB);
             conflictHandler(ConflictHandler.IGNORE_ALL);
             ignoreHotspottingChecks();
         }});

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
@@ -97,7 +97,7 @@ public final class SweepProgressTable implements
                                     SweepProgressTable.SweepProgressRowResult> {
     private final Transaction t;
     private final List<SweepProgressTrigger> triggers;
-    private final static String rawTableName = "progress";
+    private final static String rawTableName = "progress_2";
     private final TableReference tableRef;
     private final static ColumnSelection allColumns = getColumnSelection(SweepProgressNamedColumn.values());
 
@@ -232,264 +232,24 @@ public final class SweepProgressTable implements
     /**
      * <pre>
      * Column value description {
-     *   type: Long;
-     * }
-     * </pre>
-     */
-    public static final class CellsDeleted implements SweepProgressNamedColumnValue<Long> {
-        private final Long value;
-
-        public static CellsDeleted of(Long value) {
-            return new CellsDeleted(value);
-        }
-
-        private CellsDeleted(Long value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getColumnName() {
-            return "cells_deleted";
-        }
-
-        @Override
-        public String getShortColumnName() {
-            return "d";
-        }
-
-        @Override
-        public Long getValue() {
-            return value;
-        }
-
-        @Override
-        public byte[] persistValue() {
-            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
-            return CompressionUtils.compress(bytes, Compression.NONE);
-        }
-
-        @Override
-        public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("d");
-        }
-
-        public static final Hydrator<CellsDeleted> BYTES_HYDRATOR = new Hydrator<CellsDeleted>() {
-            @Override
-            public CellsDeleted hydrateFromBytes(byte[] bytes) {
-                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(EncodingUtils.decodeUnsignedVarLong(bytes, 0));
-            }
-        };
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
-        }
-    }
-
-    /**
-     * <pre>
-     * Column value description {
-     *   type: Long;
-     * }
-     * </pre>
-     */
-    public static final class CellsExamined implements SweepProgressNamedColumnValue<Long> {
-        private final Long value;
-
-        public static CellsExamined of(Long value) {
-            return new CellsExamined(value);
-        }
-
-        private CellsExamined(Long value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getColumnName() {
-            return "cells_examined";
-        }
-
-        @Override
-        public String getShortColumnName() {
-            return "e";
-        }
-
-        @Override
-        public Long getValue() {
-            return value;
-        }
-
-        @Override
-        public byte[] persistValue() {
-            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
-            return CompressionUtils.compress(bytes, Compression.NONE);
-        }
-
-        @Override
-        public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("e");
-        }
-
-        public static final Hydrator<CellsExamined> BYTES_HYDRATOR = new Hydrator<CellsExamined>() {
-            @Override
-            public CellsExamined hydrateFromBytes(byte[] bytes) {
-                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(EncodingUtils.decodeUnsignedVarLong(bytes, 0));
-            }
-        };
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
-        }
-    }
-
-    /**
-     * <pre>
-     * Column value description {
-     *   type: String;
-     * }
-     * </pre>
-     */
-    public static final class FullTableName implements SweepProgressNamedColumnValue<String> {
-        private final String value;
-
-        public static FullTableName of(String value) {
-            return new FullTableName(value);
-        }
-
-        private FullTableName(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getColumnName() {
-            return "full_table_name";
-        }
-
-        @Override
-        public String getShortColumnName() {
-            return "n";
-        }
-
-        @Override
-        public String getValue() {
-            return value;
-        }
-
-        @Override
-        public byte[] persistValue() {
-            byte[] bytes = PtBytes.toBytes(value);
-            return CompressionUtils.compress(bytes, Compression.NONE);
-        }
-
-        @Override
-        public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("n");
-        }
-
-        public static final Hydrator<FullTableName> BYTES_HYDRATOR = new Hydrator<FullTableName>() {
-            @Override
-            public FullTableName hydrateFromBytes(byte[] bytes) {
-                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(PtBytes.toString(bytes, 0, bytes.length-0));
-            }
-        };
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
-        }
-    }
-
-    /**
-     * <pre>
-     * Column value description {
-     *   type: Long;
-     * }
-     * </pre>
-     */
-    public static final class MinimumSweptTimestamp implements SweepProgressNamedColumnValue<Long> {
-        private final Long value;
-
-        public static MinimumSweptTimestamp of(Long value) {
-            return new MinimumSweptTimestamp(value);
-        }
-
-        private MinimumSweptTimestamp(Long value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getColumnName() {
-            return "minimum_swept_timestamp";
-        }
-
-        @Override
-        public String getShortColumnName() {
-            return "m";
-        }
-
-        @Override
-        public Long getValue() {
-            return value;
-        }
-
-        @Override
-        public byte[] persistValue() {
-            byte[] bytes = EncodingUtils.encodeSignedVarLong(value);
-            return CompressionUtils.compress(bytes, Compression.NONE);
-        }
-
-        @Override
-        public byte[] persistColumnName() {
-            return PtBytes.toCachedBytes("m");
-        }
-
-        public static final Hydrator<MinimumSweptTimestamp> BYTES_HYDRATOR = new Hydrator<MinimumSweptTimestamp>() {
-            @Override
-            public MinimumSweptTimestamp hydrateFromBytes(byte[] bytes) {
-                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
-                return of(EncodingUtils.decodeSignedVarLong(bytes, 0));
-            }
-        };
-
-        @Override
-        public String toString() {
-            return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("Value", this.value)
-                .toString();
-        }
-    }
-
-    /**
-     * <pre>
-     * Column value description {
      *   type: byte[];
      * }
      * </pre>
      */
-    public static final class StartRow implements SweepProgressNamedColumnValue<byte[]> {
+    public static final class SweepProgress implements SweepProgressNamedColumnValue<byte[]> {
         private final byte[] value;
 
-        public static StartRow of(byte[] value) {
-            return new StartRow(value);
+        public static SweepProgress of(byte[] value) {
+            return new SweepProgress(value);
         }
 
-        private StartRow(byte[] value) {
+        private SweepProgress(byte[] value) {
             this.value = value;
         }
 
         @Override
         public String getColumnName() {
-            return "start_row";
+            return "sweep_progress";
         }
 
         @Override
@@ -513,9 +273,9 @@ public final class SweepProgressTable implements
             return PtBytes.toCachedBytes("s");
         }
 
-        public static final Hydrator<StartRow> BYTES_HYDRATOR = new Hydrator<StartRow>() {
+        public static final Hydrator<SweepProgress> BYTES_HYDRATOR = new Hydrator<SweepProgress>() {
             @Override
-            public StartRow hydrateFromBytes(byte[] bytes) {
+            public SweepProgress hydrateFromBytes(byte[] bytes) {
                 bytes = CompressionUtils.decompress(bytes, Compression.NONE);
                 return of(EncodingUtils.getBytesFromOffsetToEnd(bytes, 0));
             }
@@ -567,112 +327,24 @@ public final class SweepProgressTable implements
             };
         }
 
-        public boolean hasCellsDeleted() {
-            return row.getColumns().containsKey(PtBytes.toCachedBytes("d"));
-        }
-
-        public boolean hasCellsExamined() {
-            return row.getColumns().containsKey(PtBytes.toCachedBytes("e"));
-        }
-
-        public boolean hasFullTableName() {
-            return row.getColumns().containsKey(PtBytes.toCachedBytes("n"));
-        }
-
-        public boolean hasMinimumSweptTimestamp() {
-            return row.getColumns().containsKey(PtBytes.toCachedBytes("m"));
-        }
-
-        public boolean hasStartRow() {
+        public boolean hasSweepProgress() {
             return row.getColumns().containsKey(PtBytes.toCachedBytes("s"));
         }
 
-        public Long getCellsDeleted() {
-            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("d"));
-            if (bytes == null) {
-                return null;
-            }
-            CellsDeleted value = CellsDeleted.BYTES_HYDRATOR.hydrateFromBytes(bytes);
-            return value.getValue();
-        }
-
-        public Long getCellsExamined() {
-            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("e"));
-            if (bytes == null) {
-                return null;
-            }
-            CellsExamined value = CellsExamined.BYTES_HYDRATOR.hydrateFromBytes(bytes);
-            return value.getValue();
-        }
-
-        public String getFullTableName() {
-            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("n"));
-            if (bytes == null) {
-                return null;
-            }
-            FullTableName value = FullTableName.BYTES_HYDRATOR.hydrateFromBytes(bytes);
-            return value.getValue();
-        }
-
-        public Long getMinimumSweptTimestamp() {
-            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("m"));
-            if (bytes == null) {
-                return null;
-            }
-            MinimumSweptTimestamp value = MinimumSweptTimestamp.BYTES_HYDRATOR.hydrateFromBytes(bytes);
-            return value.getValue();
-        }
-
-        public byte[] getStartRow() {
+        public byte[] getSweepProgress() {
             byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("s"));
             if (bytes == null) {
                 return null;
             }
-            StartRow value = StartRow.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            SweepProgress value = SweepProgress.BYTES_HYDRATOR.hydrateFromBytes(bytes);
             return value.getValue();
         }
 
-        public static Function<SweepProgressRowResult, Long> getCellsDeletedFun() {
-            return new Function<SweepProgressRowResult, Long>() {
-                @Override
-                public Long apply(SweepProgressRowResult rowResult) {
-                    return rowResult.getCellsDeleted();
-                }
-            };
-        }
-
-        public static Function<SweepProgressRowResult, Long> getCellsExaminedFun() {
-            return new Function<SweepProgressRowResult, Long>() {
-                @Override
-                public Long apply(SweepProgressRowResult rowResult) {
-                    return rowResult.getCellsExamined();
-                }
-            };
-        }
-
-        public static Function<SweepProgressRowResult, String> getFullTableNameFun() {
-            return new Function<SweepProgressRowResult, String>() {
-                @Override
-                public String apply(SweepProgressRowResult rowResult) {
-                    return rowResult.getFullTableName();
-                }
-            };
-        }
-
-        public static Function<SweepProgressRowResult, Long> getMinimumSweptTimestampFun() {
-            return new Function<SweepProgressRowResult, Long>() {
-                @Override
-                public Long apply(SweepProgressRowResult rowResult) {
-                    return rowResult.getMinimumSweptTimestamp();
-                }
-            };
-        }
-
-        public static Function<SweepProgressRowResult, byte[]> getStartRowFun() {
+        public static Function<SweepProgressRowResult, byte[]> getSweepProgressFun() {
             return new Function<SweepProgressRowResult, byte[]>() {
                 @Override
                 public byte[] apply(SweepProgressRowResult rowResult) {
-                    return rowResult.getStartRow();
+                    return rowResult.getSweepProgress();
                 }
             };
         }
@@ -681,41 +353,13 @@ public final class SweepProgressTable implements
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
                 .add("RowName", getRowName())
-                .add("CellsDeleted", getCellsDeleted())
-                .add("CellsExamined", getCellsExamined())
-                .add("FullTableName", getFullTableName())
-                .add("MinimumSweptTimestamp", getMinimumSweptTimestamp())
-                .add("StartRow", getStartRow())
+                .add("SweepProgress", getSweepProgress())
                 .toString();
         }
     }
 
     public enum SweepProgressNamedColumn {
-        CELLS_DELETED {
-            @Override
-            public byte[] getShortName() {
-                return PtBytes.toCachedBytes("d");
-            }
-        },
-        CELLS_EXAMINED {
-            @Override
-            public byte[] getShortName() {
-                return PtBytes.toCachedBytes("e");
-            }
-        },
-        FULL_TABLE_NAME {
-            @Override
-            public byte[] getShortName() {
-                return PtBytes.toCachedBytes("n");
-            }
-        },
-        MINIMUM_SWEPT_TIMESTAMP {
-            @Override
-            public byte[] getShortName() {
-                return PtBytes.toCachedBytes("m");
-            }
-        },
-        START_ROW {
+        SWEEP_PROGRESS {
             @Override
             public byte[] getShortName() {
                 return PtBytes.toCachedBytes("s");
@@ -744,42 +388,10 @@ public final class SweepProgressTable implements
 
     private static final Map<String, Hydrator<? extends SweepProgressNamedColumnValue<?>>> shortNameToHydrator =
             ImmutableMap.<String, Hydrator<? extends SweepProgressNamedColumnValue<?>>>builder()
-                .put("n", FullTableName.BYTES_HYDRATOR)
-                .put("m", MinimumSweptTimestamp.BYTES_HYDRATOR)
-                .put("s", StartRow.BYTES_HYDRATOR)
-                .put("d", CellsDeleted.BYTES_HYDRATOR)
-                .put("e", CellsExamined.BYTES_HYDRATOR)
+                .put("s", SweepProgress.BYTES_HYDRATOR)
                 .build();
 
-    public Map<SweepProgressRow, String> getFullTableNames(Collection<SweepProgressRow> rows) {
-        Map<Cell, SweepProgressRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
-        for (SweepProgressRow row : rows) {
-            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("n")), row);
-        }
-        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<SweepProgressRow, String> ret = Maps.newHashMapWithExpectedSize(results.size());
-        for (Entry<Cell, byte[]> e : results.entrySet()) {
-            String val = FullTableName.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
-            ret.put(cells.get(e.getKey()), val);
-        }
-        return ret;
-    }
-
-    public Map<SweepProgressRow, Long> getMinimumSweptTimestamps(Collection<SweepProgressRow> rows) {
-        Map<Cell, SweepProgressRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
-        for (SweepProgressRow row : rows) {
-            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("m")), row);
-        }
-        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<SweepProgressRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
-        for (Entry<Cell, byte[]> e : results.entrySet()) {
-            Long val = MinimumSweptTimestamp.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
-            ret.put(cells.get(e.getKey()), val);
-        }
-        return ret;
-    }
-
-    public Map<SweepProgressRow, byte[]> getStartRows(Collection<SweepProgressRow> rows) {
+    public Map<SweepProgressRow, byte[]> getSweepProgresss(Collection<SweepProgressRow> rows) {
         Map<Cell, SweepProgressRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
         for (SweepProgressRow row : rows) {
             cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("s")), row);
@@ -787,156 +399,32 @@ public final class SweepProgressTable implements
         Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
         Map<SweepProgressRow, byte[]> ret = Maps.newHashMapWithExpectedSize(results.size());
         for (Entry<Cell, byte[]> e : results.entrySet()) {
-            byte[] val = StartRow.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            byte[] val = SweepProgress.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
             ret.put(cells.get(e.getKey()), val);
         }
         return ret;
     }
 
-    public Map<SweepProgressRow, Long> getCellsDeleteds(Collection<SweepProgressRow> rows) {
-        Map<Cell, SweepProgressRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
-        for (SweepProgressRow row : rows) {
-            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("d")), row);
-        }
-        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<SweepProgressRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
-        for (Entry<Cell, byte[]> e : results.entrySet()) {
-            Long val = CellsDeleted.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
-            ret.put(cells.get(e.getKey()), val);
-        }
-        return ret;
+    public void putSweepProgress(SweepProgressRow row, byte[] value) {
+        put(ImmutableMultimap.of(row, SweepProgress.of(value)));
     }
 
-    public Map<SweepProgressRow, Long> getCellsExamineds(Collection<SweepProgressRow> rows) {
-        Map<Cell, SweepProgressRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
-        for (SweepProgressRow row : rows) {
-            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("e")), row);
-        }
-        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
-        Map<SweepProgressRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
-        for (Entry<Cell, byte[]> e : results.entrySet()) {
-            Long val = CellsExamined.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
-            ret.put(cells.get(e.getKey()), val);
-        }
-        return ret;
-    }
-
-    public void putFullTableName(SweepProgressRow row, String value) {
-        put(ImmutableMultimap.of(row, FullTableName.of(value)));
-    }
-
-    public void putFullTableName(Map<SweepProgressRow, String> map) {
-        Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepProgressRow, String> e : map.entrySet()) {
-            toPut.put(e.getKey(), FullTableName.of(e.getValue()));
-        }
-        put(Multimaps.forMap(toPut));
-    }
-
-    public void putFullTableNameUnlessExists(SweepProgressRow row, String value) {
-        putUnlessExists(ImmutableMultimap.of(row, FullTableName.of(value)));
-    }
-
-    public void putFullTableNameUnlessExists(Map<SweepProgressRow, String> map) {
-        Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepProgressRow, String> e : map.entrySet()) {
-            toPut.put(e.getKey(), FullTableName.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
-    public void putMinimumSweptTimestamp(SweepProgressRow row, Long value) {
-        put(ImmutableMultimap.of(row, MinimumSweptTimestamp.of(value)));
-    }
-
-    public void putMinimumSweptTimestamp(Map<SweepProgressRow, Long> map) {
-        Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepProgressRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), MinimumSweptTimestamp.of(e.getValue()));
-        }
-        put(Multimaps.forMap(toPut));
-    }
-
-    public void putMinimumSweptTimestampUnlessExists(SweepProgressRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, MinimumSweptTimestamp.of(value)));
-    }
-
-    public void putMinimumSweptTimestampUnlessExists(Map<SweepProgressRow, Long> map) {
-        Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepProgressRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), MinimumSweptTimestamp.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
-    public void putStartRow(SweepProgressRow row, byte[] value) {
-        put(ImmutableMultimap.of(row, StartRow.of(value)));
-    }
-
-    public void putStartRow(Map<SweepProgressRow, byte[]> map) {
+    public void putSweepProgress(Map<SweepProgressRow, byte[]> map) {
         Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
         for (Entry<SweepProgressRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), StartRow.of(e.getValue()));
+            toPut.put(e.getKey(), SweepProgress.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
     }
 
-    public void putStartRowUnlessExists(SweepProgressRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, StartRow.of(value)));
+    public void putSweepProgressUnlessExists(SweepProgressRow row, byte[] value) {
+        putUnlessExists(ImmutableMultimap.of(row, SweepProgress.of(value)));
     }
 
-    public void putStartRowUnlessExists(Map<SweepProgressRow, byte[]> map) {
+    public void putSweepProgressUnlessExists(Map<SweepProgressRow, byte[]> map) {
         Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
         for (Entry<SweepProgressRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), StartRow.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
-    public void putCellsDeleted(SweepProgressRow row, Long value) {
-        put(ImmutableMultimap.of(row, CellsDeleted.of(value)));
-    }
-
-    public void putCellsDeleted(Map<SweepProgressRow, Long> map) {
-        Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepProgressRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), CellsDeleted.of(e.getValue()));
-        }
-        put(Multimaps.forMap(toPut));
-    }
-
-    public void putCellsDeletedUnlessExists(SweepProgressRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, CellsDeleted.of(value)));
-    }
-
-    public void putCellsDeletedUnlessExists(Map<SweepProgressRow, Long> map) {
-        Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepProgressRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), CellsDeleted.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
-    public void putCellsExamined(SweepProgressRow row, Long value) {
-        put(ImmutableMultimap.of(row, CellsExamined.of(value)));
-    }
-
-    public void putCellsExamined(Map<SweepProgressRow, Long> map) {
-        Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepProgressRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), CellsExamined.of(e.getValue()));
-        }
-        put(Multimaps.forMap(toPut));
-    }
-
-    public void putCellsExaminedUnlessExists(SweepProgressRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, CellsExamined.of(value)));
-    }
-
-    public void putCellsExaminedUnlessExists(Map<SweepProgressRow, Long> map) {
-        Map<SweepProgressRow, SweepProgressNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepProgressRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), CellsExamined.of(e.getValue()));
+            toPut.put(e.getKey(), SweepProgress.of(e.getValue()));
         }
         putUnlessExists(Multimaps.forMap(toPut));
     }
@@ -964,52 +452,12 @@ public final class SweepProgressTable implements
         put(toPut);
     }
 
-    public void deleteFullTableName(SweepProgressRow row) {
-        deleteFullTableName(ImmutableSet.of(row));
+    public void deleteSweepProgress(SweepProgressRow row) {
+        deleteSweepProgress(ImmutableSet.of(row));
     }
 
-    public void deleteFullTableName(Iterable<SweepProgressRow> rows) {
-        byte[] col = PtBytes.toCachedBytes("n");
-        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
-        t.delete(tableRef, cells);
-    }
-
-    public void deleteMinimumSweptTimestamp(SweepProgressRow row) {
-        deleteMinimumSweptTimestamp(ImmutableSet.of(row));
-    }
-
-    public void deleteMinimumSweptTimestamp(Iterable<SweepProgressRow> rows) {
-        byte[] col = PtBytes.toCachedBytes("m");
-        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
-        t.delete(tableRef, cells);
-    }
-
-    public void deleteStartRow(SweepProgressRow row) {
-        deleteStartRow(ImmutableSet.of(row));
-    }
-
-    public void deleteStartRow(Iterable<SweepProgressRow> rows) {
+    public void deleteSweepProgress(Iterable<SweepProgressRow> rows) {
         byte[] col = PtBytes.toCachedBytes("s");
-        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
-        t.delete(tableRef, cells);
-    }
-
-    public void deleteCellsDeleted(SweepProgressRow row) {
-        deleteCellsDeleted(ImmutableSet.of(row));
-    }
-
-    public void deleteCellsDeleted(Iterable<SweepProgressRow> rows) {
-        byte[] col = PtBytes.toCachedBytes("d");
-        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
-        t.delete(tableRef, cells);
-    }
-
-    public void deleteCellsExamined(SweepProgressRow row) {
-        deleteCellsExamined(ImmutableSet.of(row));
-    }
-
-    public void deleteCellsExamined(Iterable<SweepProgressRow> rows) {
-        byte[] col = PtBytes.toCachedBytes("e");
         Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
         t.delete(tableRef, cells);
     }
@@ -1022,11 +470,7 @@ public final class SweepProgressTable implements
     @Override
     public void delete(Iterable<SweepProgressRow> rows) {
         List<byte[]> rowBytes = Persistables.persistAll(rows);
-        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size() * 5);
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("d")));
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("e")));
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("n")));
-        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("m")));
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
         cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("s")));
         t.delete(tableRef, cells);
     }
@@ -1243,5 +687,5 @@ public final class SweepProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "g2hIFMWJqz1aBbgwYc6j4A==";
+    static String __CLASS_HASH = "777bj0FAeQ6/IVuCQHfJ8g==";
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -191,7 +191,8 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
                 new TransactionTask<Optional<TableToSweep>, RuntimeException>() {
                     @Override
                     public Optional<TableToSweep> execute(Transaction tx) {
-                        Optional<SweepProgress> progress = specificTableSweeper.getSweepProgressStore().loadProgress();
+                        Optional<SweepProgress> progress = specificTableSweeper.getSweepProgressStore()
+                                .loadProgress(tx);
                         if (progress.isPresent()) {
                             return Optional.of(new TableToSweep(progress.get().tableRef(), progress));
                         } else {
@@ -215,7 +216,8 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
     boolean checkAndRepairTableDrop() {
         try {
             Set<TableReference> tables = specificTableSweeper.getKvs().getAllTableNames();
-            Optional<SweepProgress> progress = specificTableSweeper.getSweepProgressStore().loadProgress();
+            Optional<SweepProgress> progress = specificTableSweeper.getTxManager().runTaskReadOnly(
+                    specificTableSweeper.getSweepProgressStore()::loadProgress);
             if (!progress.isPresent() || tables.contains(progress.get().tableRef())) {
                 return false;
             } else {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -191,8 +191,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
                 new TransactionTask<Optional<TableToSweep>, RuntimeException>() {
                     @Override
                     public Optional<TableToSweep> execute(Transaction tx) {
-                        Optional<SweepProgress> progress = specificTableSweeper.getSweepProgressStore().loadProgress(
-                                tx);
+                        Optional<SweepProgress> progress = specificTableSweeper.getSweepProgressStore().loadProgress();
                         if (progress.isPresent()) {
                             return Optional.of(new TableToSweep(progress.get().tableRef(), progress));
                         } else {
@@ -216,8 +215,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
     boolean checkAndRepairTableDrop() {
         try {
             Set<TableReference> tables = specificTableSweeper.getKvs().getAllTableNames();
-            Optional<SweepProgress> progress = specificTableSweeper.getTxManager().runTaskReadOnly(
-                    specificTableSweeper.getSweepProgressStore()::loadProgress);
+            Optional<SweepProgress> progress = specificTableSweeper.getSweepProgressStore().loadProgress();
             if (!progress.isPresent() || tables.contains(progress.get().tableRef())) {
                 return false;
             } else {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -235,9 +235,10 @@ public class SpecificTableSweeper {
                     .cellTsPairsExamined(results.getCellTsPairsExamined())
                     //noinspection OptionalGetWithoutIsPresent // covered by precondition above
                     .startRow(results.getNextStartRow().get())
+                    .startColumn(PtBytes.toBytes("unused"))
                     .minimumSweptTimestamp(results.getSweptTimestamp())
                     .build();
-            sweepProgressStore.saveProgress(tx, newProgress);
+            sweepProgressStore.saveProgress(newProgress);
             return null;
         });
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -238,7 +238,7 @@ public class SpecificTableSweeper {
                     .startColumn(PtBytes.toBytes("unused"))
                     .minimumSweptTimestamp(results.getSweptTimestamp())
                     .build();
-            sweepProgressStore.saveProgress(newProgress);
+            sweepProgressStore.saveProgress(tx, newProgress);
             return null;
         });
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgress.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgress.java
@@ -17,14 +17,20 @@ package com.palantir.atlasdb.sweep.progress;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
+@JsonSerialize(as = ImmutableSweepProgress.class)
+@JsonDeserialize(as = ImmutableSweepProgress.class)
 @Value.Immutable
 public interface SweepProgress {
 
     TableReference tableRef();
 
     byte[] startRow();
+
+    byte[] startColumn();
 
     long staleValuesDeleted();
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStore.java
@@ -15,42 +15,57 @@
  */
 package com.palantir.atlasdb.sweep.progress;
 
+import java.util.Map;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.schema.generated.SweepProgressTable;
-import com.palantir.atlasdb.schema.generated.SweepProgressTable.SweepProgressRow;
-import com.palantir.atlasdb.schema.generated.SweepProgressTable.SweepProgressRowResult;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
-import com.palantir.atlasdb.transaction.api.Transaction;
 
 public class SweepProgressStore {
+    private static final Logger log = LoggerFactory.getLogger(SweepProgressStore.class);
 
     private final KeyValueService kvs;
-    private final SweepTableFactory tableFactory;
+    private final SweepProgressTable progressTable;
+    private final TableReference tableRef;
+
+    private static final byte[] row = PtBytes.toBytes("dummy");
+    private static final byte[] column = PtBytes.toBytes("s");
+    private static final Cell CELL = Cell.create(row, column);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
 
     public SweepProgressStore(KeyValueService kvs, SweepTableFactory tableFactory) {
         this.kvs = kvs;
-        this.tableFactory = tableFactory;
+        this.progressTable = tableFactory.getSweepProgressTable(null);
+        this.tableRef = progressTable.getTableRef();
     }
 
-    public Optional<SweepProgress> loadProgress(Transaction tx)  {
-        SweepProgressTable progressTable = tableFactory.getSweepProgressTable(tx);
-        Optional<SweepProgressRowResult> result = Optional.ofNullable(
-                progressTable.getRow(SweepProgressRow.of(0)).orElse(null));
-        return result.map(SweepProgressStore::hydrateProgress);
+    public Optional<SweepProgress> loadProgress()  {
+        Map<Cell, Value> entry = kvs.get(tableRef, ImmutableMap.of(CELL, Long.MAX_VALUE));
+        return hydrateProgress(entry);
     }
 
-    public void saveProgress(Transaction tx, SweepProgress progress) {
-        SweepProgressTable progressTable = tableFactory.getSweepProgressTable(tx);
-        SweepProgressRow row = SweepProgressRow.of(0);
-        progressTable.putFullTableName(row, progress.tableRef().getQualifiedName());
-        progressTable.putStartRow(row, progress.startRow());
-        progressTable.putCellsDeleted(row, progress.staleValuesDeleted());
-        progressTable.putCellsExamined(row, progress.cellTsPairsExamined());
-        progressTable.putMinimumSweptTimestamp(row, progress.minimumSweptTimestamp());
+    public void saveProgress(SweepProgress newProgress) {
+        Optional<SweepProgress> oldProgress = loadProgress();
+        try {
+            kvs.checkAndSet(casProgressRequest(oldProgress, newProgress));
+        } catch (Exception e) {
+            log.warn("Exception trying to persist sweep progress.", e);
+        }
     }
 
     /**
@@ -61,17 +76,28 @@ public class SweepProgressStore {
         // 1) The table should be small, performance difference should be negligible.
         // 2) Truncate takes an exclusive lock in Postgres, which can interfere
         // with concurrently running backups.
-        kvs.deleteRange(tableFactory.getSweepProgressTable(null).getTableRef(), RangeRequest.all());
+        kvs.deleteRange(tableRef, RangeRequest.all());
     }
 
-    private static SweepProgress hydrateProgress(SweepProgressTable.SweepProgressRowResult rr) {
-        return ImmutableSweepProgress.builder()
-                .tableRef(TableReference.createUnsafe(rr.getFullTableName()))
-                .startRow(rr.getStartRow())
-                .cellTsPairsExamined(rr.getCellsExamined())
-                .staleValuesDeleted(rr.getCellsDeleted())
-                .minimumSweptTimestamp(rr.getMinimumSweptTimestamp())
-                .build();
+    private CheckAndSetRequest casProgressRequest(Optional<SweepProgress> oldProgress, SweepProgress newProgress)
+            throws JsonProcessingException {
+        if (!oldProgress.isPresent()) {
+            return CheckAndSetRequest.newCell(tableRef, CELL, progressToBytes(newProgress));
+        }
+        return CheckAndSetRequest.singleCell(tableRef,
+                CELL, progressToBytes(oldProgress.get()), progressToBytes(newProgress));
     }
 
+    private byte[] progressToBytes(SweepProgress value) throws JsonProcessingException {
+        return OBJECT_MAPPER.writeValueAsBytes(value);
+    }
+
+    public static Optional<SweepProgress> hydrateProgress(Map<Cell, Value> result) {
+        try {
+            return Optional.of(OBJECT_MAPPER.readValue(result.get(CELL).getContents(), ImmutableSweepProgress.class));
+        } catch (Exception e) {
+            log.info("Encountered an exception loading persisted sweep progress. Defaulting to no progress.", e);
+            return Optional.empty();
+        }
+    }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.ImmutableSweepResults;
 import com.palantir.atlasdb.sweep.priority.ImmutableUpdateSweepPriority;
 import com.palantir.atlasdb.sweep.progress.ImmutableSweepProgress;
@@ -56,6 +57,7 @@ public class BackgroundSweeperFastTest extends SweeperTestSetup {
                 .cellTsPairsExamined(11)
                 .minimumSweptTimestamp(4567L)
                 .startRow(new byte[] {1, 2, 3})
+                .startColumn(PtBytes.toBytes("unused"))
                 .build());
         setupTaskRunner(ImmutableSweepResults.builder()
                 .staleValuesDeleted(2)
@@ -87,13 +89,13 @@ public class BackgroundSweeperFastTest extends SweeperTestSetup {
                 .build());
         backgroundSweeper.runOnce();
         Mockito.verify(progressStore).saveProgress(
-                Mockito.any(),
                 Mockito.eq(ImmutableSweepProgress.builder()
                         .tableRef(TABLE_REF)
                         .staleValuesDeleted(2)
                         .cellTsPairsExamined(10)
                         .minimumSweptTimestamp(12345L)
                         .startRow(new byte[] {1, 2, 3})
+                        .startColumn(PtBytes.toBytes("unused"))
                         .build()));
     }
 
@@ -140,6 +142,7 @@ public class BackgroundSweeperFastTest extends SweeperTestSetup {
                         .cellTsPairsExamined(11)
                         .minimumSweptTimestamp(4567L)
                         .startRow(new byte[] {1, 2, 3})
+                        .startColumn(PtBytes.toBytes("unused"))
                         .build());
         setupTaskRunner(ImmutableSweepResults.builder()
                 .staleValuesDeleted(2)

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
@@ -89,6 +89,7 @@ public class BackgroundSweeperFastTest extends SweeperTestSetup {
                 .build());
         backgroundSweeper.runOnce();
         Mockito.verify(progressStore).saveProgress(
+                Mockito.any(),
                 Mockito.eq(ImmutableSweepProgress.builder()
                         .tableRef(TABLE_REF)
                         .staleValuesDeleted(2)

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
@@ -183,7 +183,7 @@ public class SweeperServiceImplTest extends SweeperTestSetup {
     }
 
     private void verifyNoSweepResultsSaved() {
-        verify(progressStore, never()).saveProgress(any(), any());
+        verify(progressStore, never()).saveProgress(any());
         verify(priorityStore, never()).update(any(), any(), any());
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperServiceImplTest.java
@@ -183,7 +183,7 @@ public class SweeperServiceImplTest extends SweeperTestSetup {
     }
 
     private void verifyNoSweepResultsSaved() {
-        verify(progressStore, never()).saveProgress(any());
+        verify(progressStore, never()).saveProgress(any(), any());
         verify(priorityStore, never()).update(any(), any(), any());
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperTestSetup.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperTestSetup.java
@@ -94,11 +94,11 @@ public class SweeperTestSetup {
     }
 
     protected void setNoProgress() {
-        Mockito.doReturn(Optional.empty()).when(progressStore).loadProgress();
+        Mockito.doReturn(Optional.empty()).when(progressStore).loadProgress(Mockito.any());
     }
 
     protected void setProgress(SweepProgress progress) {
-        Mockito.doReturn(Optional.of(progress)).when(progressStore).loadProgress();
+        Mockito.doReturn(Optional.of(progress)).when(progressStore).loadProgress(Mockito.any());
     }
 
     protected void setNextTableToSweep(TableReference tableRef) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperTestSetup.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweeperTestSetup.java
@@ -94,11 +94,11 @@ public class SweeperTestSetup {
     }
 
     protected void setNoProgress() {
-        Mockito.doReturn(Optional.empty()).when(progressStore).loadProgress(Mockito.any());
+        Mockito.doReturn(Optional.empty()).when(progressStore).loadProgress();
     }
 
     protected void setProgress(SweepProgress progress) {
-        Mockito.doReturn(Optional.of(progress)).when(progressStore).loadProgress(Mockito.any());
+        Mockito.doReturn(Optional.of(progress)).when(progressStore).loadProgress();
     }
 
     protected void setNextTableToSweep(TableReference tableRef) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/progress/SweepProgressStoreTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/progress/SweepProgressStoreTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
@@ -39,6 +40,7 @@ public class SweepProgressStoreTest {
 
     private static final SweepProgress PROGRESS = ImmutableSweepProgress.builder()
             .startRow(new byte[] {1, 2, 3})
+            .startColumn(PtBytes.toBytes("unused"))
             .minimumSweptTimestamp(12345L)
             .staleValuesDeleted(10L)
             .cellTsPairsExamined(200L)
@@ -46,6 +48,7 @@ public class SweepProgressStoreTest {
             .build();
     private static final SweepProgress OTHER_PROGRESS = ImmutableSweepProgress.builder()
             .startRow(new byte[] {4, 5, 6})
+            .startColumn(PtBytes.toBytes("unused"))
             .minimumSweptTimestamp(67890L)
             .staleValuesDeleted(11L)
             .cellTsPairsExamined(202L)
@@ -67,40 +70,27 @@ public class SweepProgressStoreTest {
 
     @Test
     public void testLoadEmpty() {
-        Assert.assertFalse(txManager.runTaskReadOnly(progressStore::loadProgress).isPresent());
+        Assert.assertFalse(progressStore.loadProgress().isPresent());
     }
 
     @Test
     public void testSaveAndLoad() {
-        txManager.runTaskWithRetry(tx -> {
-            progressStore.saveProgress(tx, PROGRESS);
-            return null;
-        });
-        Assert.assertEquals(Optional.of(PROGRESS), txManager.runTaskReadOnly(progressStore::loadProgress));
+        progressStore.saveProgress(PROGRESS);
+        Assert.assertEquals(Optional.of(PROGRESS), progressStore.loadProgress());
     }
 
     @Test
     public void testOverwrite() {
-        txManager.runTaskWithRetry(tx -> {
-            progressStore.saveProgress(tx, PROGRESS);
-            return null;
-        });
-        txManager.runTaskWithRetry(tx -> {
-            progressStore.saveProgress(tx, OTHER_PROGRESS);
-            return null;
-        });
-        Assert.assertEquals(Optional.of(OTHER_PROGRESS), txManager.runTaskReadOnly(progressStore::loadProgress));
+        progressStore.saveProgress(PROGRESS);
+        progressStore.saveProgress(OTHER_PROGRESS);
+        Assert.assertEquals(Optional.of(OTHER_PROGRESS), progressStore.loadProgress());
     }
 
     @Test
     public void testClear() {
-        txManager.runTaskWithRetry(tx -> {
-            progressStore.saveProgress(tx, PROGRESS);
-            return null;
-        });
-        Assert.assertTrue(txManager.runTaskReadOnly(progressStore::loadProgress).isPresent());
+        progressStore.saveProgress(PROGRESS);
+        Assert.assertEquals(Optional.of(PROGRESS), progressStore.loadProgress());
         progressStore.clearProgress();
-        Assert.assertFalse(txManager.runTaskReadOnly(progressStore::loadProgress).isPresent());
+        Assert.assertFalse(progressStore.loadProgress().isPresent());
     }
-
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -45,6 +45,11 @@ develop
          - Change
 
     *    - |improved|
+         - Sweep progress is now persisted as a blob. This allows us to use check and set to avoid versioning the entries in the sweep progress table.
+           No migration is necessary as the data is persisted to a new table, however sweep will start sweeping a new table since the previously persisted sweep progress will be ignored.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2555>`__)
+
+    *    - |improved|
          - ``getRange`` is now more efficient when scanning over rows with many updates in Cassandra, if just a single column is requested.
            Previously, a range request in Cassandra would always retrieve all columns and all historical versions of each column, regardless of which columns were requested.
            Now, we only request the latest version of the specific column requested, if only one column is requested. Requesting multiple columns still results in the previous behavior, however this will also be optimized in a future release.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,9 +44,10 @@ develop
     *    - Type
          - Change
 
-    *    - |improved|
-         - Sweep progress is now persisted as a blob. This allows us to use check and set to avoid versioning the entries in the sweep progress table.
-           No migration is necessary as the data is persisted to a new table, however sweep will start sweeping a new table since the previously persisted sweep progress will be ignored.
+    *    - |improved| |fixed|
+         - Sweep progress is now persisted as a blob.
+           This allows us constant time loading of the persisted SweepResult which was previously linear in the size of the table being swept.
+           No migration is necessary as the data is persisted to a new table, however sweep will ignore any previously persisted sweep progress.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2555>`__)
 
     *    - |improved|


### PR DESCRIPTION
**Goals (and why)**:
Avoid high versioning of the sweep progress table

**Implementation Description (bullets)**:
We now store the SweepProgress object as a blob, and use kvs level CAS to replace it each time we save, avoiding versioning.
Also added a currentRow component to the SweepResult, since we might want it in the future for sweep, and want to preempt serialization issues.

**Concerns (what feedback would you like?)**:
I am completely bypassing transactionality and using only kvs level operations. 
- Is this necessary/desirable? 
- Does CAS actually work the way I think it does? (my initial tests say it does)
- Is there even a point to having the table schema at this point?

**Where should we start reviewing?**:
SweepProgressStore.java

**Priority (whenever / two weeks / yesterday)**:
Today?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2555)
<!-- Reviewable:end -->
