### PR TITLE
instrument the transaction service

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -335,7 +335,8 @@ public abstract class TransactionManagers {
                 registrar(),
                 config.initializeAsync());
 
-        TransactionService transactionService = TransactionServices.createTransactionService(kvs);
+        TransactionService transactionService = AtlasDbMetrics.instrument(TransactionService.class,
+                TransactionServices.createTransactionService(kvs));
         ConflictDetectionManager conflictManager = ConflictDetectionManagers.create(kvs);
         SweepStrategyManager sweepStrategyManager = SweepStrategyManagers.createDefault(kvs);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1817,6 +1817,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private Map<Long, Long> loadCommitTimestamps(Set<Long> startTimestamps) {
+        // distinguish between a single timestamp and a batch, for more granular metrics
         if (startTimestamps.size() == 1) {
             long singleTs = startTimestamps.iterator().next();
             Long commitTsOrNull = defaultTransactionService.get(singleTs);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1803,7 +1803,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
         log.trace("Getting commit timestamps for {} start timestamps in response to read from table {}",
                 gets.size(), tableRef);
-        Map<Long, Long> rawResults = defaultTransactionService.get(gets);
+        Map<Long, Long> rawResults = loadCommitTimestamps(gets);
+
         for (Map.Entry<Long, Long> e : rawResults.entrySet()) {
             if (e.getValue() != null) {
                 long startTs = e.getKey();
@@ -1813,6 +1814,16 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             }
         }
         return result;
+    }
+
+    private Map<Long, Long> loadCommitTimestamps(Set<Long> startTimestamps) {
+        if (startTimestamps.size() == 1) {
+            long singleTs = startTimestamps.iterator().next();
+            Long commitTsOrNull = defaultTransactionService.get(singleTs);
+            return commitTsOrNull == null ? ImmutableMap.of() : ImmutableMap.of(singleTs, commitTsOrNull);
+        } else {
+            return defaultTransactionService.get(startTimestamps);
+        }
     }
 
     /**

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -43,6 +43,10 @@ develop
 
     *    - Type
          - Change
+         
+    *    - |improved|
+         - Metrics are now recorded for put/get operations around commit timestamps.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2561>`__)
 
     *    - |devbreak| |fixed|
          - Move @CancelableServerCall to a more fitting package that matches internal codebase.


### PR DESCRIPTION
**Goals (and why)**:
Instrument the transaction service.

There have been ongoing discussions about optimizing the transactions cache and sweeping the transactions table. It would be good to have some metrics on this class, which actually performs the reads on this table.

**Implementation Description (bullets)**:
- Instrument `TransactionService`
- Distinguish between one timestamp and a batch

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2561)
<!-- Reviewable:end -->
