### PR TITLE
Expose kvs and ts and tls when not initialized

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -69,8 +69,23 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
         }
 
         @Override
+        public TimelockService getTimelockService() {
+            return manager.getTimelockService();
+        }
+
+        @Override
         public LockService getLockService() {
             return manager.getLockService();
+        }
+
+        @Override
+        public TimestampService getTimestampService() {
+            return manager.getTimestampService();
+        }
+
+        @Override
+        public KeyValueService getKeyValueService() {
+            return manager.getKeyValueService();
         }
 
         @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -135,6 +135,11 @@ develop
           If you used one of the deleted or deprecated constructors, use the static ``create`` method.
           (`Pull Request <https://github.com/palantir/atlasdb/pull/2549>`__)
 
+    *   - |improved|
+        - Expose the TimestampService, KeyValueService and TimeLockService before initialization when initializing asynchronously.
+          AtlasDB users might need these objects when initializing, so we need to expose them without throwing when not initialized.
+          (`Pull Request <https://github.com/palantir/atlasdb/pull/2564>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======


### PR DESCRIPTION
**Goals (and why)**: Other products might need them for their initialization steps, so we shouldn't throw when accessing them.

**Implementation Description (bullets)**: -

**Concerns (what feedback would you like?)**: -

**Where should we start reviewing?**: -

**Priority (whenever / two weeks / yesterday)**: -

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2564)
<!-- Reviewable:end -->
