### PR TITLE
Fix/timestamp tracker metrics 0.61.x

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/KeyValueServiceConfig.java
@@ -35,4 +35,11 @@ public interface KeyValueServiceConfig {
      */
     int concurrentGetRangesThreadPoolSize();
 
+    /**
+     * The maximum number of threads from the pool of {@link #concurrentGetRangesThreadPoolSize()} to use
+     * for a single getRanges request when the user does not explicitly provide a value.
+     */
+    default int defaultGetRangesConcurrency() {
+        return Math.min(8, concurrentGetRangesThreadPoolSize() / 2);
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.base.BatchingVisitable;
@@ -98,6 +99,16 @@ public interface Transaction {
             final TableReference tableRef,
             Iterable<RangeRequest> rangeRequests,
             int concurrencyLevel,
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor);
+
+    /**
+     * Same as {@link #getRanges(TableReference, Iterable, int, BiFunction)} but uses the default concurrency
+     * value specified by {@link KeyValueServiceConfig#defaultGetRangesConcurrency()}.
+     */
+    @Idempotent
+    <T> Stream<T> getRanges(
+            final TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
             BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor);
 
     /**

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 schemas = [
     'com.palantir.atlasdb.schema.SweepSchema',
+    'com.palantir.atlasdb.table.description.ApiTestSchema',
     'com.palantir.atlasdb.table.description.GenericTestSchema'
 ]
 

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
@@ -653,6 +653,12 @@ public final class HashComponentsTestTable implements
                 (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, HashComponentsTestRowResult::of)));
     }
 
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   BiFunction<RangeRequest, BatchingVisitable<HashComponentsTestRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, HashComponentsTestRowResult::of)));
+    }
+
     public Stream<BatchingVisitable<HashComponentsTestRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
         Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
         return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, HashComponentsTestRowResult::of));
@@ -773,5 +779,5 @@ public final class HashComponentsTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "BLuA/sgNj9y8Q8N7EQdI2Q==";
+    static String __CLASS_HASH = "GxiBTkTnwx/AHV8vgSeVvw==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
@@ -749,6 +749,12 @@ public final class SchemaApiTestTable implements
                 (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, SchemaApiTestRowResult::of)));
     }
 
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   BiFunction<RangeRequest, BatchingVisitable<SchemaApiTestRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, SchemaApiTestRowResult::of)));
+    }
+
     public Stream<BatchingVisitable<SchemaApiTestRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
         Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
         return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, SchemaApiTestRowResult::of));
@@ -869,5 +875,5 @@ public final class SchemaApiTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "naMZHA9IbuXS7r60a/1+gQ==";
+    static String __CLASS_HASH = "r1lpoi0kpKMwjzfzxCBPow==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -116,6 +116,8 @@ public final class AtlasDbConstants {
 
     public static final int DEFAULT_STREAM_IN_MEMORY_THRESHOLD = 4 * 1024 * 1024;
 
+    public static final long DEFAULT_TIMESTAMP_CACHE_SIZE = 1_000_000;
+
     public static final int MAX_TABLE_PREFIX_LENGTH = 7;
     public static final int MAX_OVERFLOW_TABLE_PREFIX_LENGTH = 6;
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -1004,6 +1004,12 @@ public class TableRenderer {
                 line("        (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, ", RowResult, "::of)));");
             } line("}");
             line();
+            line("public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,");
+            line("                               BiFunction<RangeRequest, BatchingVisitable<", RowResult, ">, T> visitableProcessor) {"); {
+                line("return t.getRanges(tableRef, ranges,");
+                line("        (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, ", RowResult, "::of)));");
+            } line("}");
+            line();
             line("public Stream<BatchingVisitable<", RowResult, ">> getRangesLazy(Iterable<RangeRequest> ranges) {"); {
                 line("Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);");
                 line("return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, ", RowResult, "::of));");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -42,7 +42,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     private static final int GET_RANGES_QUEUE_SIZE_WARNING_THRESHOLD = 1000;
 
     public static final Logger log = LoggerFactory.getLogger(AbstractTransactionManager.class);
-    protected final TimestampCache timestampValidationReadCache = TimestampCache.create();
+    protected final TimestampCache timestampValidationReadCache = new TimestampCache();
     private volatile boolean closed = false;
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -96,6 +96,14 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public <T> Stream<T> getRanges(
+            final TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
+        return delegate().getRanges(tableRef, rangeRequests, visitableProcessor);
+    }
+
+    @Override
     public Stream<BatchingVisitable<RowResult<byte[]>>> getRangesLazy(
             final TableReference tableRef, Iterable<RangeRequest> rangeRequests) {
         return delegate().getRangesLazy(tableRef, rangeRequests);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -86,6 +86,15 @@ public class ReadTransaction extends ForwardingTransaction {
     }
 
     @Override
+    public <T> Stream<T> getRanges(
+            final TableReference tableRef,
+            Iterable<RangeRequest> rangeRequests,
+            BiFunction<RangeRequest, BatchingVisitable<RowResult<byte[]>>, T> visitableProcessor) {
+        checkTableName(tableRef);
+        return delegate().getRanges(tableRef, rangeRequests, visitableProcessor);
+    }
+
+    @Override
     public Stream<BatchingVisitable<RowResult<byte[]>>> getRangesLazy(
             final TableReference tableRef, Iterable<RangeRequest> rangeRequests) {
         checkTableName(tableRef);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/cache/TimestampCacheTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/cache/TimestampCacheTest.java
@@ -30,6 +30,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.cache.Cache;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.atlasdb.util.MetricsRule;
 
@@ -41,7 +42,7 @@ public class TimestampCacheTest {
 
     @Test
     public void cacheExposesMetrics() throws Exception {
-        Cache<Long, Long> cache = TimestampCache.createDefaultCache();
+        Cache<Long, Long> cache = TimestampCache.createCache(AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         AtlasDbMetrics.registerCache(cache, TEST_CACHE_NAME);
 
         TimestampCache timestampCache = new TimestampCache(cache);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -669,6 +669,12 @@ public final class GenericRangeScanTestTable implements
                 (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, GenericRangeScanTestRowResult::of)));
     }
 
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   BiFunction<RangeRequest, BatchingVisitable<GenericRangeScanTestRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, GenericRangeScanTestRowResult::of)));
+    }
+
     public Stream<BatchingVisitable<GenericRangeScanTestRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
         Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
         return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, GenericRangeScanTestRowResult::of));
@@ -793,5 +799,5 @@ public final class GenericRangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "7U+eF49QEcz74N8OF2+OjQ==";
+    static String __CLASS_HASH = "6bLdl4BXUCntnhO1r687fw==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
@@ -1,15 +1,14 @@
 package com.palantir.atlasdb.table.description.generated;
 
-import java.util.List;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class GenericTestSchemaTableFactory {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -610,6 +610,12 @@ public final class RangeScanTestTable implements
                 (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, RangeScanTestRowResult::of)));
     }
 
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   BiFunction<RangeRequest, BatchingVisitable<RangeScanTestRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, RangeScanTestRowResult::of)));
+    }
+
     public Stream<BatchingVisitable<RangeScanTestRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
         Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
         return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, RangeScanTestRowResult::of));
@@ -730,5 +736,5 @@ public final class RangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ZNS2g5wflr9FgsngCdFekQ==";
+    static String __CLASS_HASH = "kVmFUBZrAev3uaZ22BYp1g==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricsManagerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricsManagerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.ListIterator;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+
+public class MetricsManagerTest {
+    private static final Class<List> LIST_CLASS = List.class;
+    private static final Class<ListIterator> LIST_ITERATOR_CLASS = ListIterator.class;
+
+    private static final String ERROR_PREFIX = "error";
+    private static final String OUT_OF_BOUNDS = "outofbounds";
+    private static final String ERROR_OUT_OF_BOUNDS = ERROR_PREFIX + "." + OUT_OF_BOUNDS;
+    private static final String OOM = "oom";
+    private static final String ERROR_OOM = ERROR_PREFIX + "." + OOM;
+    private static final String RUNTIME = "runtime";
+    private static final String METER_NAME = "meterName";
+
+    private static final Gauge GAUGE = () -> 1L;
+
+    private final MetricRegistry registry = new MetricRegistry();
+    private final MetricsManager metricsManager = new MetricsManager(registry);
+
+    @Test
+    public void registersMetricsByName() {
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OOM, GAUGE);
+
+        assertThat(registry.getNames()).containsExactly(MetricRegistry.name(LIST_CLASS, ERROR_OOM));
+    }
+
+    @Test
+    public void registersMetricsByPrefixAndName() {
+        metricsManager.registerMetric(LIST_CLASS, ERROR_PREFIX, OUT_OF_BOUNDS, GAUGE);
+
+        assertThat(registry.getNames()).containsExactly(MetricRegistry.name(LIST_CLASS, ERROR_OUT_OF_BOUNDS));
+    }
+
+    @Test
+    public void registersMeters() {
+        metricsManager.registerMeter(LIST_CLASS, RUNTIME, METER_NAME);
+
+        assertThat(registry.getMeters().keySet()).containsExactly(
+                MetricRegistry.name(LIST_CLASS, RUNTIME, METER_NAME));
+    }
+
+    @Test
+    public void registersSameMetricNameAcrossClasses() {
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OUT_OF_BOUNDS, GAUGE);
+        metricsManager.registerMetric(LIST_ITERATOR_CLASS, ERROR_OUT_OF_BOUNDS, GAUGE);
+
+        assertThat(registry.getNames()).containsExactly(
+                MetricRegistry.name(LIST_CLASS, ERROR_OUT_OF_BOUNDS),
+                MetricRegistry.name(LIST_ITERATOR_CLASS, ERROR_OUT_OF_BOUNDS));
+    }
+
+    @Test
+    public void deregistersAllMetrics() {
+        metricsManager.registerMetric(LIST_CLASS, RUNTIME, GAUGE);
+        metricsManager.deregisterMetrics();
+
+        assertThat(registry.getNames()).isEmpty();
+    }
+
+    @Test
+    public void deregistersMetricsWithSpecificPrefix() {
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OUT_OF_BOUNDS, GAUGE);
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OOM, GAUGE);
+        metricsManager.registerMetric(LIST_CLASS, RUNTIME, GAUGE);
+
+        metricsManager.deregisterMetricsWithPrefix(LIST_CLASS, ERROR_PREFIX);
+
+        assertThat(registry.getNames()).containsExactly(MetricRegistry.name(LIST_CLASS, RUNTIME));
+    }
+
+    @Test
+    public void deregistersAllMetricsForClassIfDeregisteringWithEmptyPrefix() {
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OUT_OF_BOUNDS, GAUGE);
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OOM, GAUGE);
+        metricsManager.registerMetric(LIST_CLASS, RUNTIME, GAUGE);
+
+        metricsManager.deregisterMetricsWithPrefix(LIST_CLASS, "");
+        assertThat(registry.getNames()).isEmpty();
+    }
+
+    @Test
+    public void doesNotDeregisterMetricsThatAreRegisteredExternally() {
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OUT_OF_BOUNDS, GAUGE);
+        registry.register(MetricRegistry.name(LIST_CLASS, ERROR_OOM), GAUGE);
+
+        metricsManager.deregisterMetrics();
+        assertThat(registry.getNames()).containsExactly(MetricRegistry.name(LIST_CLASS, ERROR_OOM));
+    }
+
+    @Test
+    public void doesNotDeregisterMetricsThatWereRegisteredExternallyIfDeregisteringWithPrefix() {
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OUT_OF_BOUNDS, GAUGE);
+        registry.register(MetricRegistry.name(LIST_CLASS, ERROR_OOM), GAUGE);
+
+        metricsManager.deregisterMetricsWithPrefix(LIST_CLASS, ERROR_PREFIX);
+        assertThat(registry.getNames()).containsExactly(MetricRegistry.name(LIST_CLASS, ERROR_OOM));
+    }
+
+    @Test
+    public void doesNotDeregisterMetricsFromOtherClassesEvenIfStringPrefixesMatch() {
+        metricsManager.registerMetric(LIST_CLASS, ERROR_OUT_OF_BOUNDS, GAUGE); // java.util.List.error.outofbounds
+        metricsManager.registerMetric(LIST_ITERATOR_CLASS, ERROR_OOM, GAUGE); // java.util.ListIterator.error.oom
+
+        metricsManager.deregisterMetricsWithPrefix(LIST_CLASS, "");
+
+        assertThat(registry.getNames()).containsExactly(MetricRegistry.name(LIST_ITERATOR_CLASS, ERROR_OOM));
+    }
+
+    @After
+    public void tearDown() {
+        registry.removeMatching(MetricFilter.ALL);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -254,6 +254,20 @@ public abstract class AtlasDbConfig {
         return AtlasDbConstants.DEFAULT_LOCK_TIMEOUT_SECONDS;
     }
 
+
+    /**
+     * The number of timestamps to cache that we have seen in previous reads.
+     * This will use somewhere around 90MB of heap memory per million timestamps because of various overheads
+     * from Java Objects and the cache's LRU tracking.
+     *
+     * Probably the only reason to configure away from the default would be a service that can afford the heap usage,
+     * and has read patterns that deal with a very large working set of existing transactions.
+     */
+    @Value.Default
+    public long getTimestampCacheSize() {
+        return AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE;
+    }
+
     @Value.Check
     protected final void check() {
         checkLeaderAndTimelockBlocks();

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -282,7 +282,8 @@ public final class TransactionManagers {
                 () -> runtimeConfigSupplier.get().transaction().getLockAcquireTimeoutMillis(),
                 config.keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.keyValueService().defaultGetRangesConcurrency(),
-                config.initializeAsync());
+                config.initializeAsync(),
+                config.getTimestampCacheSize());
 
         PersistentLockManager persistentLockManager = new PersistentLockManager(
                 persistentLockService,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -281,6 +281,7 @@ public final class TransactionManagers {
                 allowHiddenTableAccess,
                 () -> runtimeConfigSupplier.get().transaction().getLockAcquireTimeoutMillis(),
                 config.keyValueService().concurrentGetRangesThreadPoolSize(),
+                config.keyValueService().defaultGetRangesConcurrency(),
                 config.initializeAsync());
 
         PersistentLockManager persistentLockManager = new PersistentLockManager(

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -97,7 +97,8 @@ public class TransactionManagerModule {
                 cleaner,
                 config.allowAccessToHiddenTables(),
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
-                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
+                config.atlasDbConfig().getTimestampCacheSize());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -96,7 +96,8 @@ public class TransactionManagerModule {
                 sweepStrategyManager,
                 cleaner,
                 config.allowAccessToHiddenTables(),
-                config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize());
+                config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -20,6 +20,7 @@ import javax.inject.Singleton;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
@@ -96,6 +97,7 @@ public class TransactionManagerModule {
                 sweepStrategyManager,
                 cleaner,
                 config.allowAccessToHiddenTables(),
+                () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
                 config.atlasDbConfig().getTimestampCacheSize());

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -98,6 +99,7 @@ public class TransactionManagerModule {
                 cleaner,
                 config.allowAccessToHiddenTables(),
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+                TimestampTrackerImpl.createNoOpTracker(),
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
                 config.atlasDbConfig().getTimestampCacheSize());

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -20,6 +20,7 @@ import javax.inject.Singleton;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
@@ -102,6 +103,7 @@ public class TestTransactionManagerModule {
                 sweepStrategyManager,
                 cleaner,
                 config.allowAccessToHiddenTables(),
+                () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
                 config.atlasDbConfig().getTimestampCacheSize());

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -102,7 +102,8 @@ public class TestTransactionManagerModule {
                 sweepStrategyManager,
                 cleaner,
                 config.allowAccessToHiddenTables(),
-                config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize());
+                config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.cleaner.Follower;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
 import com.palantir.atlasdb.services.ServicesConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
@@ -104,6 +105,7 @@ public class TestTransactionManagerModule {
                 cleaner,
                 config.allowAccessToHiddenTables(),
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+                TimestampTrackerImpl.createNoOpTracker(),
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
                 config.atlasDbConfig().getTimestampCacheSize());

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -103,7 +103,8 @@ public class TestTransactionManagerModule {
                 cleaner,
                 config.allowAccessToHiddenTables(),
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
-                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
+                config.atlasDbConfig().getTimestampCacheSize());
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -74,6 +74,12 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     @Deprecated
     private static final int DEFAULT_MAX_CONCURRENT_RANGES = 64;
 
+    /**
+     * @deprecated see usage below. Should be configured with the {@link InMemoryAtlasDbConfig}.
+     */
+    @Deprecated
+    private static final int DEFAULT_GET_RANGES_CONCURRENCY = 8;
+
     @Override
     public String getType() {
         return "memory";
@@ -166,7 +172,8 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
                 conflictManager,
                 sweepStrategyManager,
                 cleaner,
-                DEFAULT_MAX_CONCURRENT_RANGES);
+                DEFAULT_MAX_CONCURRENT_RANGES,
+                DEFAULT_GET_RANGES_CONCURRENCY);
         cleaner.start(ret);
         return ret;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -26,6 +26,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
@@ -67,6 +68,13 @@ import com.palantir.timestamp.TimestampService;
 @AutoService(AtlasDbFactory.class)
 public class InMemoryAtlasDbFactory implements AtlasDbFactory {
     private static final Logger log = LoggerFactory.getLogger(InMemoryAtlasDbFactory.class);
+
+    /**
+     * @deprecated see usage below. Should be configured with the {@link InMemoryAtlasDbConfig}.
+     * To be removed whenever someone removes the deprecated constructors that don't know about atlas configs...
+     */
+    @Deprecated
+    private static final long DEFAULT_TIMESTAMP_CACHE_SIZE = AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE;
 
     /**
      * @deprecated see usage below. Should be configured with the {@link InMemoryAtlasDbConfig}.
@@ -173,7 +181,8 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
                 sweepStrategyManager,
                 cleaner,
                 DEFAULT_MAX_CONCURRENT_RANGES,
-                DEFAULT_GET_RANGES_CONCURRENCY);
+                DEFAULT_GET_RANGES_CONCURRENCY,
+                DEFAULT_TIMESTAMP_CACHE_SIZE);
         cleaner.start(ret);
         return ret;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -170,7 +170,7 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
                 client,
                 ImmutableList.of(follower),
                 transactionService).buildCleaner();
-        SerializableTransactionManager ret = new SerializableTransactionManager(
+        SerializableTransactionManager ret = SerializableTransactionManager.createForTest(
                 keyValueService,
                 ts,
                 client,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/monitoring/TimestampTracker.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/monitoring/TimestampTracker.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.monitoring;
+
+public interface TimestampTracker extends AutoCloseable {
+    void close();
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/monitoring/TimestampTrackerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/monitoring/TimestampTrackerImpl.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.monitoring;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.CachedGauge;
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Gauge;
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.cleaner.Cleaner;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.processors.AutoDelegate;
+
+@AutoDelegate(typeToExtend = TimestampTracker.class)
+public class TimestampTrackerImpl implements TimestampTracker {
+    private class InitializingWrapper extends AsyncInitializer implements AutoDelegate_TimestampTracker {
+        @Override
+        public TimestampTracker delegate() {
+            checkInitialized();
+            return TimestampTrackerImpl.this;
+        }
+
+        @Override
+        protected void tryInitialize() {
+            TimestampTrackerImpl.this.tryInitialize();
+        }
+
+        @Override
+        protected String getInitializingClassName() {
+            return "TimestampTracker";
+        }
+
+        @Override
+        protected void cleanUpOnInitFailure() {
+            TimestampTrackerImpl.this.cleanUpOnInitFailure();
+        }
+
+        @Override
+        public void close() {
+            cancelInitialization(TimestampTrackerImpl.this::close);
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(TimestampTracker.class);
+
+    // We cache underlying calls, in case a hyper-aggressive metrics client repeatedly queries the values.
+    @VisibleForTesting
+    static final Duration CACHE_INTERVAL = Duration.ofSeconds(10L);
+
+    private final MetricsManager metricsManager = new MetricsManager();
+    private final InitializingWrapper wrapper = new InitializingWrapper();
+    private final Clock clock;
+    private final TimelockService timelockService;
+    private final Cleaner cleaner;
+
+    public static TimestampTracker createNoOpTracker() {
+        return new TimestampTrackerImpl(Clock.defaultClock(), null, null);
+    }
+
+    public static TimestampTracker createWithDefaultTrackers(TimelockService timeLockService, Cleaner cleaner,
+            boolean initializeAsync) {
+        TimestampTrackerImpl timestampTracker = new TimestampTrackerImpl(
+                Clock.defaultClock(), timeLockService, cleaner);
+        timestampTracker.wrapper.initialize(initializeAsync);
+        return timestampTracker.wrapper.isInitialized() ? timestampTracker : timestampTracker.wrapper;
+    }
+
+    @VisibleForTesting
+    TimestampTrackerImpl(Clock clock, TimelockService timelockService, Cleaner cleaner) {
+        this.clock = clock;
+        this.timelockService = timelockService;
+        this.cleaner = cleaner;
+    }
+
+    @VisibleForTesting
+    void registerTimestampForTracking(String shortName, Supplier<Long> supplier) {
+        metricsManager.registerMetric(
+                TimestampTracker.class,
+                shortName,
+                createCachingTimestampGauge(shortName, supplier));
+    }
+
+    private void tryInitialize() {
+        registerTimestampForTracking("timestamp.fresh", timelockService::getFreshTimestamp);
+        registerTimestampForTracking("timestamp.immutable", timelockService::getImmutableTimestamp);
+        registerTimestampForTracking("timestamp.unreadable", cleaner::getUnreadableTimestamp);
+    }
+
+    private void cleanUpOnInitFailure() {
+        metricsManager.deregisterMetricsWithPrefix(TimestampTracker.class, "");
+    }
+
+    private Gauge<Long> createCachingTimestampGauge(String shortName, Supplier<Long> supplier) {
+        return new CachedGauge<Long>(clock, CACHE_INTERVAL.getSeconds(), TimeUnit.SECONDS) {
+            AtomicLong upperBound = new AtomicLong(Long.MIN_VALUE);
+
+            @Override
+            protected Long loadValue() {
+                try {
+                    // Note that this gauge is only an approximation, because some timestamps can go backwards.
+                    return upperBound.accumulateAndGet(supplier.get(), Math::max);
+                } catch (Exception e) {
+                    long timestampToReturn = upperBound.get();
+                    log.info("An exception occurred when trying to update the {} timestamp for tracking purposes."
+                                    + " Returning the last known value of {}.",
+                            SafeArg.of("timestampName", shortName),
+                            SafeArg.of("timestamp", timestampToReturn),
+                            e);
+                    return timestampToReturn;
+                }
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+        // It is usually assumed that AtlasDB clients only have one TransactionManager open at a time,
+        // so deregistering everything starting with TimestampTracker is probably safe.
+        metricsManager.deregisterMetricsWithPrefix(TimestampTracker.class, "");
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadOnlyTransactionManager.java
@@ -49,11 +49,13 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
     protected final TransactionReadSentinelBehavior readSentinelBehavior;
     protected final boolean allowHiddenTableAccess;
     final ExecutorService getRangesExecutor;
+    final int defaultGetRangesConcurrency;
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
                                       TransactionService transactionService,
                                       AtlasDbConstraintCheckingMode constraintCheckingMode,
-                                      int concurrentGetRangesThreadPoolSize) {
+                                      int concurrentGetRangesThreadPoolSize,
+                                      int defaultGetRangesConcurrency) {
         this(
                 keyValueService,
                 transactionService,
@@ -61,7 +63,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 Suppliers.ofInstance(Long.MAX_VALUE),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 false,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
@@ -69,7 +72,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                                       AtlasDbConstraintCheckingMode constraintCheckingMode,
                                       Supplier<Long> startTimestamp,
                                       TransactionReadSentinelBehavior readSentinelBehavior,
-                                      int concurrentGetRangesThreadPoolSize) {
+                                      int concurrentGetRangesThreadPoolSize,
+                                      int defaultGetRangesConcurrency) {
         this(
                 keyValueService,
                 transactionService,
@@ -77,7 +81,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 startTimestamp,
                 readSentinelBehavior,
                 false,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public ReadOnlyTransactionManager(KeyValueService keyValueService,
@@ -86,7 +91,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                                       Supplier<Long> startTimestamp,
                                       TransactionReadSentinelBehavior readSentinelBehavior,
                                       boolean allowHiddenTableAccess,
-                                      int concurrentGetRangesThreadPoolSize) {
+                                      int concurrentGetRangesThreadPoolSize,
+                                      int defaultGetRangesConcurrency) {
         this.keyValueService = keyValueService;
         this.transactionService = transactionService;
         this.constraintCheckingMode = constraintCheckingMode;
@@ -94,6 +100,7 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
         this.readSentinelBehavior = readSentinelBehavior;
         this.allowHiddenTableAccess = allowHiddenTableAccess;
         this.getRangesExecutor = createGetRangesExecutor(concurrentGetRangesThreadPoolSize);
+        this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
     }
 
     @Override
@@ -107,7 +114,8 @@ public class ReadOnlyTransactionManager extends AbstractTransactionManager imple
                 readSentinelBehavior,
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
         return runTaskThrowOnConflict(task, new ReadTransaction(txn, txn.sweepStrategyManager));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -114,7 +114,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    boolean allowHiddenTableAccess,
                                    TimestampCache timestampCache,
                                    long lockAcquireTimeoutMs,
-                                   ExecutorService getRangesExecutor) {
+                                   ExecutorService getRangesExecutor,
+                                   int defaultGetRangesConcurrency) {
         super(keyValueService,
               timelockService,
               transactionService,
@@ -131,7 +132,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               allowHiddenTableAccess,
               timestampCache,
               lockAcquireTimeoutMs,
-              getRangesExecutor);
+              getRangesExecutor,
+              defaultGetRangesConcurrency);
     }
 
     @Override
@@ -722,7 +724,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs,
-                getRangesExecutor) {
+                getRangesExecutor,
+                defaultGetRangesConcurrency) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -85,7 +85,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
      * use the delegate instead.
      */
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, null, 1, 1);
+        this(null, null, null, null, null, null, null, null, null, 1, 1, 1);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,
@@ -101,7 +101,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
-            boolean initializeAsync) {
+            boolean initializeAsync,
+            long timestampCacheSize) {
         SerializableTransactionManager serializableTransactionManager = new SerializableTransactionManager(
                 keyValueService,
                 timelockService,
@@ -114,7 +115,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
 
         return initializeAsync ? new InitializeCheckingWrapper(serializableTransactionManager, initializer)
                 : serializableTransactionManager;
@@ -130,7 +132,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         this(keyValueService,
                 timestampService,
                 lockClient,
@@ -142,7 +145,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 false,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -156,7 +160,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         this(
                 keyValueService,
                 new LegacyTimelockService(timestampService, lockService, lockClient),
@@ -168,7 +173,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -181,7 +187,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         this(
                 keyValueService,
                 timelockService,
@@ -194,7 +201,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -208,7 +216,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         super(
                 keyValueService,
                 timelockService,
@@ -221,7 +230,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                timestampCacheSize);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -22,6 +22,8 @@ import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.monitoring.TimestampTracker;
+import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -85,7 +87,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
      * use the delegate instead.
      */
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, false, null, 1, 1, 1);
+        this(null, null, null, null, null, null, null, null, false, null, null, 1, 1, 1L);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,
@@ -103,6 +105,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             int defaultGetRangesConcurrency,
             boolean initializeAsync,
             long timestampCacheSize) {
+        TimestampTracker timestampTracker = TimestampTrackerImpl.createWithDefaultTrackers(
+                timelockService, cleaner, initializeAsync);
         SerializableTransactionManager serializableTransactionManager = new SerializableTransactionManager(
                 keyValueService,
                 timelockService,
@@ -114,6 +118,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
+                timestampTracker,
                 concurrentGetRangesThreadPoolSize,
                 defaultGetRangesConcurrency,
                 timestampCacheSize);
@@ -144,6 +149,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+                TimestampTrackerImpl.createNoOpTracker(),
                 concurrentGetRangesThreadPoolSize,
                 defaultGetRangesConcurrency,
                 timestampCacheSize);
@@ -164,6 +170,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
+            TimestampTracker timestampTracker,
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             long timestampCacheSize) {
@@ -178,6 +185,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+                timestampTracker,
                 concurrentGetRangesThreadPoolSize,
                 defaultGetRangesConcurrency,
                 timestampCacheSize);
@@ -194,6 +202,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
+            TimestampTracker timestampTracker,
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             long timestampCacheSize) {
@@ -208,6 +217,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
+                timestampTracker,
                 concurrentGetRangesThreadPoolSize,
                 defaultGetRangesConcurrency,
                 timestampCacheSize);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -85,7 +85,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
      * use the delegate instead.
      */
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, null, 1);
+        this(null, null, null, null, null, null, null, null, null, 1, 1);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,
@@ -100,6 +100,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency,
             boolean initializeAsync) {
         SerializableTransactionManager serializableTransactionManager = new SerializableTransactionManager(
                 keyValueService,
@@ -112,7 +113,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
 
         return initializeAsync ? new InitializeCheckingWrapper(serializableTransactionManager, initializer)
                 : serializableTransactionManager;
@@ -127,7 +129,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             ConflictDetectionManager conflictDetectionManager,
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         this(keyValueService,
                 timestampService,
                 lockClient,
@@ -138,7 +141,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 sweepStrategyManager,
                 cleaner,
                 false,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -151,7 +155,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         this(
                 keyValueService,
                 new LegacyTimelockService(timestampService, lockService, lockClient),
@@ -162,7 +167,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 sweepStrategyManager,
                 cleaner,
                 allowHiddenTableAccess,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -174,7 +180,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             SweepStrategyManager sweepStrategyManager,
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         this(
                 keyValueService,
                 timelockService,
@@ -186,7 +193,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     public SerializableTransactionManager(KeyValueService keyValueService,
@@ -199,7 +207,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         super(
                 keyValueService,
                 timelockService,
@@ -211,7 +220,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 cleaner,
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
-                concurrentGetRangesThreadPoolSize);
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency);
     }
 
     @Override
@@ -236,7 +246,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs.get(),
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -36,7 +36,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                                TransactionReadSentinelBehavior readSentinelBehavior,
                                boolean allowHiddenTableAccess,
                                TimestampCache timestampCache,
-                               ExecutorService getRangesExecutor) {
+                               ExecutorService getRangesExecutor,
+                               int defaultGetRangesConcurrency) {
         super(keyValueService,
               transactionService,
               null,
@@ -47,7 +48,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
               timestampCache,
               // never actually used, since timelockService is null
               AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-              getRangesExecutor);
+              getRangesExecutor,
+              defaultGetRangesConcurrency);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -86,7 +86,8 @@ import com.palantir.timestamp.TimestampService;
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            long timestampCacheSize) {
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.lockService = lockService;
@@ -101,6 +102,7 @@ import com.palantir.timestamp.TimestampService;
         this.isClosed = new AtomicBoolean(false);
         this.getRangesExecutor = createGetRangesExecutor(concurrentGetRangesThreadPoolSize);
         this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
+        timestampValidationReadCache.resize(timestampCacheSize);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -69,6 +69,7 @@ import com.palantir.timestamp.TimestampService;
     final boolean allowHiddenTableAccess;
     protected final Supplier<Long> lockAcquireTimeoutMs;
     final ExecutorService getRangesExecutor;
+    final int defaultGetRangesConcurrency;
 
     final List<Runnable> closingCallbacks;
     final AtomicBoolean isClosed;
@@ -84,7 +85,8 @@ import com.palantir.timestamp.TimestampService;
             Cleaner cleaner,
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
-            int concurrentGetRangesThreadPoolSize) {
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency) {
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.lockService = lockService;
@@ -98,6 +100,7 @@ import com.palantir.timestamp.TimestampService;
         this.closingCallbacks = new CopyOnWriteArrayList<>();
         this.isClosed = new AtomicBoolean(false);
         this.getRangesExecutor = createGetRangesExecutor(concurrentGetRangesThreadPoolSize);
+        this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
     }
 
     @Override
@@ -184,7 +187,8 @@ import com.palantir.timestamp.TimestampService;
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs.get(),
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
     }
 
     @Override
@@ -208,7 +212,8 @@ import com.palantir.timestamp.TimestampService;
                 allowHiddenTableAccess,
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs.get(),
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
         return runTaskThrowOnConflict(task, new ReadTransaction(transaction, sweepStrategyManager));
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/monitoring/TimestampTrackerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/monitoring/TimestampTrackerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.cleaner.Cleaner;
+import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.lock.v2.TimelockService;
+
+public class TimestampTrackerTest {
+    private static final long ONE = 1L;
+    private static final long TEN = 10L;
+    private static final long FORTY_TWO = 42L;
+
+    private static final String IMMUTABLE_TIMESTAMP_NAME = "timestamp.immutable";
+    private static final String FRESH_TIMESTAMP_NAME = "timestamp.fresh";
+    private static final String UNREADABLE_TIMESTAMP_NAME = "timestamp.unreadable";
+    private static final String FAKE_METRIC = "metric.fake";
+
+    private static final long CACHE_INTERVAL_NANOS = TimestampTrackerImpl.CACHE_INTERVAL.toNanos();
+
+    private final TimelockService timelockService = mock(TimelockService.class);
+    private final Cleaner cleaner = mock(Cleaner.class);
+    private final Clock mockClock = mock(Clock.class);
+
+    @Test
+    public void defaultTrackerGeneratesTimestampMetrics() {
+        try (TimestampTrackerImpl ignored = createDefaultTracker()) {
+            assertThat(AtlasDbMetrics.getMetricRegistry().getNames())
+                    .containsExactlyInAnyOrder(buildFullyQualifiedMetricName(IMMUTABLE_TIMESTAMP_NAME),
+                            buildFullyQualifiedMetricName(FRESH_TIMESTAMP_NAME),
+                            buildFullyQualifiedMetricName(UNREADABLE_TIMESTAMP_NAME));
+        }
+    }
+
+    @Test
+    public void immutableTimestampTrackerDelegatesToTimeLock() {
+        try (TimestampTrackerImpl ignored = createDefaultTracker()) {
+            when(timelockService.getImmutableTimestamp()).thenReturn(ONE);
+
+            assertThat(getGauge(IMMUTABLE_TIMESTAMP_NAME).getValue()).isEqualTo(ONE);
+
+            verify(timelockService).getImmutableTimestamp();
+            verifyNoMoreInteractions(timelockService, cleaner);
+        }
+    }
+
+    @Test
+    public void freshTimestampTrackerDelegatesToTimeLock() {
+        try (TimestampTrackerImpl ignored = createDefaultTracker()) {
+            when(timelockService.getFreshTimestamp()).thenReturn(TEN);
+
+            assertThat(getGauge(FRESH_TIMESTAMP_NAME).getValue()).isEqualTo(TEN);
+
+            verify(timelockService).getFreshTimestamp();
+            verifyNoMoreInteractions(timelockService, cleaner);
+        }
+    }
+
+    @Test
+    public void unreadableTimestampTrackerDelegatesToCleaner() {
+        try (TimestampTrackerImpl ignored = createDefaultTracker()) {
+            when(cleaner.getUnreadableTimestamp()).thenReturn(FORTY_TWO);
+
+            assertThat(getGauge(UNREADABLE_TIMESTAMP_NAME).getValue()).isEqualTo(FORTY_TWO);
+
+            verify(cleaner).getUnreadableTimestamp();
+            verifyNoMoreInteractions(timelockService, cleaner);
+        }
+    }
+
+    @Test
+    public void metricsAreDeregisteredUponClose() {
+        try (TimestampTrackerImpl tracker = createTrackerWithClock(Clock.defaultClock())) {
+            tracker.registerTimestampForTracking(FAKE_METRIC, () -> 1L);
+            assertThat(AtlasDbMetrics.getMetricRegistry().getNames())
+                    .contains(buildFullyQualifiedMetricName(FAKE_METRIC));
+        }
+
+        assertThat(AtlasDbMetrics.getMetricRegistry().getNames())
+                .doesNotContain(buildFullyQualifiedMetricName(FAKE_METRIC));
+    }
+
+    @Test
+    public void canCloseMultipleTimes() {
+        TimestampTrackerImpl tracker = createTrackerWithClock(Clock.defaultClock());
+        tracker.registerTimestampForTracking(FAKE_METRIC, () -> 1L);
+
+        tracker.close();
+        tracker.close();
+        assertThat(AtlasDbMetrics.getMetricRegistry().getNames())
+                .doesNotContain(buildFullyQualifiedMetricName(FAKE_METRIC));
+    }
+
+    @Test
+    public void doesNotCallSupplierOnRequestsWithinRetriggerInterval() {
+        try (TimestampTrackerImpl tracker = createTrackerWithClock(mockClock)) {
+            when(mockClock.getTick()).thenReturn(0L, 1L, 2L);
+            AtomicLong timestampValue = new AtomicLong(0L);
+            tracker.registerTimestampForTracking(FAKE_METRIC, timestampValue::incrementAndGet);
+
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(1L);
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(1L);
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    public void callsSupplierAgainAfterTimeElapses() {
+        try (TimestampTrackerImpl tracker = createTrackerWithClock(mockClock)) {
+            when(mockClock.getTick()).thenReturn(0L, CACHE_INTERVAL_NANOS - 1, CACHE_INTERVAL_NANOS + 1);
+            AtomicLong timestampValue = new AtomicLong(0L);
+            tracker.registerTimestampForTracking(FAKE_METRIC, timestampValue::incrementAndGet);
+
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(1L);
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(1L);
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(2L);
+        }
+    }
+
+    @Test
+    public void doesNotCallSupplierUnlessGaugeIsQueried() {
+        try (TimestampTrackerImpl tracker = createTrackerWithClock(mockClock)) {
+            when(mockClock.getTick()).thenReturn(0L, CACHE_INTERVAL_NANOS * 50000);
+            AtomicLong timestampValue = new AtomicLong(0L);
+            tracker.registerTimestampForTracking(FAKE_METRIC, timestampValue::incrementAndGet);
+
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(1L);
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(2L);
+        }
+    }
+
+    @Test
+    public void timestampTrackersDoNotThrowEvenIfUnderlyingSupplierThrows() {
+        try (TimestampTrackerImpl tracker = createTrackerWithClock(mockClock)) {
+            when(mockClock.getTick()).thenReturn(0L, CACHE_INTERVAL_NANOS);
+            tracker.registerTimestampForTracking(FAKE_METRIC, () -> {
+                throw new IllegalArgumentException("illegal argument");
+            });
+
+            getGauge(FAKE_METRIC).getValue();
+        }
+    }
+
+    @Test
+    public void timestampTrackersReturnTheLastKnownValueIfUnderlyingSupplierThrows() {
+        try (TimestampTrackerImpl tracker = createTrackerWithClock(mockClock)) {
+            when(mockClock.getTick()).thenReturn(0L, CACHE_INTERVAL_NANOS + 1);
+            tracker.registerTimestampForTracking(FAKE_METRIC, new Supplier<Long>() {
+                private boolean allowRequest = true;
+                @Override
+                public Long get() {
+                    Preconditions.checkArgument(allowRequest, "not allowed");
+                    allowRequest = false;
+                    return FORTY_TWO;
+                }
+            });
+
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(FORTY_TWO);
+            assertThat(getGauge(FAKE_METRIC).getValue()).isEqualTo(FORTY_TWO);
+        }
+    }
+
+    private TimestampTrackerImpl createTrackerWithClock(Clock clock) {
+        return new TimestampTrackerImpl(clock, timelockService, cleaner);
+    }
+
+    private TimestampTrackerImpl createDefaultTracker() {
+        return (TimestampTrackerImpl) TimestampTrackerImpl.createWithDefaultTrackers(timelockService, cleaner, false);
+    }
+
+    private static String buildFullyQualifiedMetricName(String shortName) {
+        return MetricRegistry.name(TimestampTracker.class, shortName);
+    }
+
+    @SuppressWarnings("unchecked") // We know the gauges we are registering produce Longs
+    private static Gauge<Long> getGauge(String shortName) {
+        return (Gauge<Long>) AtlasDbMetrics.getMetricRegistry()
+                .getGauges()
+                .get(buildFullyQualifiedMetricName(shortName));
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.lock.v2.TimelockService;
@@ -51,10 +52,11 @@ public class SerializableTransactionManagerTest {
                 mockCleaner,
                 mockInitializer,
                 false, // allowHiddenTableAccess
-                () -> 1L, // lockAcquireTimeoutMs
+                () -> 1L, // lockAcquireTimeout
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
-                true); // initializeAsync
+                true, // initializeAsync
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         when(mockKvs.isInitialized()).thenReturn(true);
         when(mockTimelockService.isInitialized()).thenReturn(true);
@@ -113,7 +115,8 @@ public class SerializableTransactionManagerTest {
                 () -> 1L, // lockAcquireTimeoutMs
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
-                false); // initializeAsync
+                false, // initializeAsync
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         when(mockKvs.isInitialized()).thenReturn(false);
         when(mockTimelockService.isInitialized()).thenReturn(false);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -52,7 +52,8 @@ public class SerializableTransactionManagerTest {
                 mockInitializer,
                 false, // allowHiddenTableAccess
                 () -> 1L, // lockAcquireTimeoutMs
-                1, // concurrentGetRangesThreadPoolSize
+                TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
+                TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 true); // initializeAsync
 
         when(mockKvs.isInitialized()).thenReturn(true);
@@ -110,7 +111,8 @@ public class SerializableTransactionManagerTest {
                 mockInitializer,
                 false, // allowHiddenTableAccess
                 () -> 1L, // lockAcquireTimeoutMs
-                1, // concurrentGetRangesThreadPoolSize
+                TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
+                TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 false); // initializeAsync
 
         when(mockKvs.isInitialized()).thenReturn(false);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -55,7 +55,8 @@ public class SnapshotTransactionManagerTest {
             cleaner,
             false,
             () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-            4);
+            TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
+            TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY);
 
     @Test
     public void isAlwaysInitialized() {
@@ -94,7 +95,8 @@ public class SnapshotTransactionManagerTest {
                 cleaner,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                4);
+                TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
+                TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY);
         newTransactionManager.close(); // should not throw
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -56,7 +56,8 @@ public class SnapshotTransactionManagerTest {
             false,
             () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
             TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
-            TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY);
+            TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
+            AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
     @Test
     public void isAlwaysInitialized() {
@@ -96,7 +97,8 @@ public class SnapshotTransactionManagerTest {
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
-                TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY);
+                TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         newTransactionManager.close(); // should not throw
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -32,6 +32,7 @@ import org.mockito.InOrder;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
 import com.palantir.lock.CloseableLockService;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
@@ -55,6 +56,7 @@ public class SnapshotTransactionManagerTest {
             cleaner,
             false,
             () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+            TimestampTrackerImpl.createNoOpTracker(),
             TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
             TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
             AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
@@ -96,6 +98,7 @@ public class SnapshotTransactionManagerTest {
                 cleaner,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+                TimestampTrackerImpl.createNoOpTracker(),
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionTestConstants.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionTestConstants.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+public final class TransactionTestConstants {
+    private TransactionTestConstants() {}
+
+    public static final int GET_RANGES_THREAD_POOL_SIZE = 16;
+    public static final int DEFAULT_GET_RANGES_CONCURRENCY = 4;
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.sweep;
 import com.google.common.base.Supplier;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.Duration;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -69,7 +70,8 @@ public final class SweepTestUtils {
         LockAwareTransactionManager txManager = new SerializableTransactionManager(
                 kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         setupTables(kvs);
         return txManager;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.table.description.Schemas;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
+import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -65,8 +66,10 @@ public final class SweepTestUtils {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING;
         ConflictDetectionManager cdm = ConflictDetectionManagers.createWithoutWarmingCache(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        LockAwareTransactionManager txManager = new SerializableTransactionManager(kvs, tsService, lockClient,
-                lockService, txService, constraints, cdm, ssm, cleaner, false, 16);
+        LockAwareTransactionManager txManager = new SerializableTransactionManager(
+                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false,
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
         setupTables(kvs);
         return txManager;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -67,8 +67,8 @@ public final class SweepTestUtils {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING;
         ConflictDetectionManager cdm = ConflictDetectionManagers.createWithoutWarmingCache(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        LockAwareTransactionManager txManager = new SerializableTransactionManager(
-                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false,
+        LockAwareTransactionManager txManager = SerializableTransactionManager.createForTest(
+                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -77,7 +77,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
 
     @Override
     protected TransactionManager getManager() {
-        return new SerializableTransactionManager(
+        return SerializableTransactionManager.createForTest(
                 keyValueService,
                 timestampService,
                 lockClient,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -76,7 +76,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 conflictDetectionManager,
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
-                AbstractTransactionTest.GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     @Override
@@ -103,7 +104,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 true,
                 timestampCache,
                 AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
-                AbstractTransactionTest.GET_RANGES_EXECUTOR) {
+                AbstractTransactionTest.GET_RANGES_EXECUTOR,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -87,7 +87,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 @SuppressWarnings({"checkstyle:all","DefaultCharset"}) // TODO(someonebored): clean this horrible test class up!
 public abstract class AbstractTransactionTest extends TransactionTestSetup {
 
-    protected final TimestampCache timestampCache = TimestampCache.create();
+    protected final TimestampCache timestampCache = new TimestampCache();
     protected boolean supportsReverse() {
         return true;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -92,8 +92,13 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         return true;
     }
 
-    protected static final int GET_RANGES_CONCURRENCY = 16;
-    protected static final ExecutorService GET_RANGES_EXECUTOR = Executors.newFixedThreadPool(GET_RANGES_CONCURRENCY);
+    // Duplicates of TransactionTestConstants since this is currently (incorrectly) in main
+    // rather than test. Can use the former once we resolve the dependency issues.
+    public static final int GET_RANGES_THREAD_POOL_SIZE = 16;
+    public static final int DEFAULT_GET_RANGES_CONCURRENCY = 4;
+
+    protected static final ExecutorService GET_RANGES_EXECUTOR =
+            Executors.newFixedThreadPool(GET_RANGES_THREAD_POOL_SIZE);
 
     protected Transaction startTransaction() {
         return new SnapshotTransaction(
@@ -110,7 +115,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
-                GET_RANGES_EXECUTOR);
+                GET_RANGES_EXECUTOR,
+                DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -24,6 +24,7 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AssertLockedKeyValueService;
+import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -57,6 +58,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 NoOpCleaner.INSTANCE,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+                TimestampTrackerImpl.createNoOpTracker(),
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
@@ -80,6 +82,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 NoOpCleaner.INSTANCE,
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+                TimestampTrackerImpl.createNoOpTracker(),
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -31,50 +31,55 @@ import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
+import com.palantir.lock.impl.LegacyTimelockService;
 import com.palantir.timestamp.TimestampService;
 
 public class TestTransactionManagerImpl extends SerializableTransactionManager implements TestTransactionManager {
 
     private final Map<TableReference, ConflictHandler> conflictHandlerOverrides = new HashMap<>();
 
+    @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
     public TestTransactionManagerImpl(KeyValueService keyValueService,
-                                      TimestampService timestampService,
-                                      LockClient lockClient,
-                                      LockService lockService,
-                                      TransactionService transactionService,
-                                      ConflictDetectionManager conflictDetectionManager,
-                                      SweepStrategyManager sweepStrategyManager) {
+            TimestampService timestampService,
+            LockClient lockClient,
+            LockService lockService,
+            TransactionService transactionService,
+            ConflictDetectionManager conflictDetectionManager,
+            SweepStrategyManager sweepStrategyManager) {
         super(
                 createAssertKeyValue(keyValueService, lockService),
-                timestampService,
-                lockClient,
+                new LegacyTimelockService(timestampService, lockService, lockClient),
                 lockService,
                 transactionService,
                 Suppliers.ofInstance(AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS),
                 conflictDetectionManager,
                 sweepStrategyManager,
                 NoOpCleaner.INSTANCE,
+                false,
+                () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
+    @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
     public TestTransactionManagerImpl(KeyValueService keyValueService,
-                                      TimestampService timestampService,
-                                      LockClient lockClient,
-                                      LockService lockService,
-                                      TransactionService transactionService,
-                                      AtlasDbConstraintCheckingMode constraintCheckingMode) {
+            TimestampService timestampService,
+            LockClient lockClient,
+            LockService lockService,
+            TransactionService transactionService,
+            AtlasDbConstraintCheckingMode constraintCheckingMode) {
         super(
                 createAssertKeyValue(keyValueService, lockService),
-                timestampService,
-                lockClient,
+                new LegacyTimelockService(timestampService, lockService, lockClient),
                 lockService,
                 transactionService,
                 Suppliers.ofInstance(constraintCheckingMode),
                 ConflictDetectionManagers.createWithoutWarmingCache(keyValueService),
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
+                false,
+                () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.base.Suppliers;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -54,7 +55,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepStrategyManager,
                 NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     public TestTransactionManagerImpl(KeyValueService keyValueService,
@@ -74,7 +76,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -36,8 +36,6 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
 
     private final Map<TableReference, ConflictHandler> conflictHandlerOverrides = new HashMap<>();
 
-    private static final int GET_RANGES_CONCURRENCY = 16;
-
     public TestTransactionManagerImpl(KeyValueService keyValueService,
                                       TimestampService timestampService,
                                       LockClient lockClient,
@@ -55,7 +53,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 conflictDetectionManager,
                 sweepStrategyManager,
                 NoOpCleaner.INSTANCE,
-                GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     public TestTransactionManagerImpl(KeyValueService keyValueService,
@@ -74,7 +73,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 ConflictDetectionManagers.createWithoutWarmingCache(keyValueService),
                 SweepStrategyManagers.createDefault(keyValueService),
                 NoOpCleaner.INSTANCE,
-                GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
     }
 
     @Override
@@ -107,7 +107,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 constraintModeSupplier.get(),
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampValidationReadCache,
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -84,7 +84,7 @@ public class TransactionManagerTest extends TransactionTestSetup {
     public void shouldNotMakeRemoteCallsInAReadonlyTransactionIfNoWorkIsDone() {
         TimestampService mockTimestampService = mock(TimestampService.class);
         LockService mockLockService = mock(LockService.class);
-        TransactionManager txnManagerWithMocks = new SerializableTransactionManager(getKeyValueService(),
+        TransactionManager txnManagerWithMocks = SerializableTransactionManager.createForTest(getKeyValueService(),
                 mockTimestampService, LockClient.of("foo"), mockLockService, transactionService,
                 () -> AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS,
                 conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
@@ -88,7 +89,8 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 () -> AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS,
                 conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
 
         // fetch an immutable timestamp once so it's cached
         when(mockTimestampService.getFreshTimestamp()).thenReturn(1L);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -86,7 +86,9 @@ public class TransactionManagerTest extends TransactionTestSetup {
         TransactionManager txnManagerWithMocks = new SerializableTransactionManager(getKeyValueService(),
                 mockTimestampService, LockClient.of("foo"), mockLockService, transactionService,
                 () -> AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS,
-                conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE, 16);
+                conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE,
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
 
         // fetch an immutable timestamp once so it's cached
         when(mockTimestampService.getFreshTimestamp()).thenReturn(1L);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -42,6 +42,7 @@ import com.palantir.atlasdb.table.common.TableTasks;
 import com.palantir.atlasdb.table.common.TableTasks.DiffStats;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
+import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -73,7 +74,9 @@ public class TableTasksTest {
         SweepStrategyManager ssm = SweepStrategyManagers.createDefault(kvs);
         Cleaner cleaner = new NoOpCleaner();
         SerializableTransactionManager transactionManager = new SerializableTransactionManager(
-                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false, 4);
+                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false,
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
         txManager = transactionManager;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -76,7 +76,8 @@ public class TableTasksTest {
         SerializableTransactionManager transactionManager = new SerializableTransactionManager(
                 kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
         txManager = transactionManager;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -73,8 +73,8 @@ public class TableTasksTest {
         ConflictDetectionManager cdm = ConflictDetectionManagers.createWithoutWarmingCache(kvs);
         SweepStrategyManager ssm = SweepStrategyManagers.createDefault(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        SerializableTransactionManager transactionManager = new SerializableTransactionManager(
-                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner, false,
+        SerializableTransactionManager transactionManager = SerializableTransactionManager.createForTest(
+                kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -1470,6 +1470,12 @@ public final class DataTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index1IdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<Index1IdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index1IdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<Index1IdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, Index1IdxRowResult::of));
@@ -2138,6 +2144,12 @@ public final class DataTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index2IdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<Index2IdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index2IdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<Index2IdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, Index2IdxRowResult::of));
@@ -2781,6 +2793,12 @@ public final class DataTable implements
                                        int concurrencyLevel,
                                        BiFunction<RangeRequest, BatchingVisitable<Index3IdxRowResult>, T> visitableProcessor) {
             return t.getRanges(tableRef, ranges, concurrencyLevel,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index3IdxRowResult::of)));
+        }
+
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<Index3IdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index3IdxRowResult::of)));
         }
 
@@ -3452,6 +3470,12 @@ public final class DataTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index4IdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<Index4IdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, Index4IdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<Index4IdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, Index4IdxRowResult::of));
@@ -3578,5 +3602,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "FULetAunPYSDC0iaixnqxQ==";
+    static String __CLASS_HASH = "AZloIvQuqPMNdSVikR5Giw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -1543,22 +1543,22 @@ public final class TwoColumnsTable implements
         /**
          * <pre>
          * FooToIdIdxRow {
-         *   {@literal Long firstComponentHash};
+         *   {@literal Long hashOfRowComponents};
          *   {@literal Long foo};
          * }
          * </pre>
          */
         public static final class FooToIdIdxRow implements Persistable, Comparable<FooToIdIdxRow> {
-            private final long firstComponentHash;
+            private final long hashOfRowComponents;
             private final long foo;
 
             public static FooToIdIdxRow of(long foo) {
-                long firstComponentHash = Hashing.murmur3_128().hashBytes(ValueType.FIXED_LONG.convertFromJava(foo)).asLong();
-                return new FooToIdIdxRow(firstComponentHash, foo);
+                long hashOfRowComponents = computeHashFirstComponents(foo);
+                return new FooToIdIdxRow(hashOfRowComponents, foo);
             }
 
-            private FooToIdIdxRow(long firstComponentHash, long foo) {
-                this.firstComponentHash = firstComponentHash;
+            private FooToIdIdxRow(long hashOfRowComponents, long foo) {
+                this.hashOfRowComponents = hashOfRowComponents;
                 this.foo = foo;
             }
 
@@ -1586,27 +1586,32 @@ public final class TwoColumnsTable implements
 
             @Override
             public byte[] persistToBytes() {
-                byte[] firstComponentHashBytes = PtBytes.toBytes(Long.MIN_VALUE ^ firstComponentHash);
+                byte[] hashOfRowComponentsBytes = PtBytes.toBytes(Long.MIN_VALUE ^ hashOfRowComponents);
                 byte[] fooBytes = PtBytes.toBytes(Long.MIN_VALUE ^ foo);
-                return EncodingUtils.add(firstComponentHashBytes, fooBytes);
+                return EncodingUtils.add(hashOfRowComponentsBytes, fooBytes);
             }
 
             public static final Hydrator<FooToIdIdxRow> BYTES_HYDRATOR = new Hydrator<FooToIdIdxRow>() {
                 @Override
                 public FooToIdIdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long firstComponentHash = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                    Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     __index += 8;
                     Long foo = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     __index += 8;
-                    return new FooToIdIdxRow(firstComponentHash, foo);
+                    return new FooToIdIdxRow(hashOfRowComponents, foo);
                 }
             };
+
+            public static long computeHashFirstComponents(long foo) {
+                byte[] fooBytes = PtBytes.toBytes(Long.MIN_VALUE ^ foo);
+                return Hashing.murmur3_128().hashBytes(EncodingUtils.add(fooBytes)).asLong();
+            }
 
             @Override
             public String toString() {
                 return MoreObjects.toStringHelper(getClass().getSimpleName())
-                    .add("firstComponentHash", firstComponentHash)
+                    .add("hashOfRowComponents", hashOfRowComponents)
                     .add("foo", foo)
                     .toString();
             }
@@ -1623,19 +1628,19 @@ public final class TwoColumnsTable implements
                     return false;
                 }
                 FooToIdIdxRow other = (FooToIdIdxRow) obj;
-                return Objects.equal(firstComponentHash, other.firstComponentHash) && Objects.equal(foo, other.foo);
+                return Objects.equal(hashOfRowComponents, other.hashOfRowComponents) && Objects.equal(foo, other.foo);
             }
 
             @SuppressWarnings("ArrayHashCode")
             @Override
             public int hashCode() {
-                return Arrays.deepHashCode(new Object[]{ firstComponentHash, foo });
+                return Arrays.deepHashCode(new Object[]{ hashOfRowComponents, foo });
             }
 
             @Override
             public int compareTo(FooToIdIdxRow o) {
                 return ComparisonChain.start()
-                    .compare(this.firstComponentHash, o.firstComponentHash)
+                    .compare(this.hashOfRowComponents, o.hashOfRowComponents)
                     .compare(this.foo, o.foo)
                     .result();
             }
@@ -2221,5 +2226,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JGRQX5KSxWmtSHt8Ei+KMQ==";
+    static String __CLASS_HASH = "wP29qfigRwiVB/u5Iav3sQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -118,7 +118,8 @@ import com.palantir.remoting2.tracing.Tracers;
 @SuppressWarnings("checkstyle:all")
 public class SnapshotTransactionTest extends AtlasDbTestCase {
     protected final TimestampCache timestampCache = TimestampCache.create();
-    protected final ExecutorService getRangesExecutor = Executors.newFixedThreadPool(4);
+    protected final ExecutorService getRangesExecutor = Executors.newFixedThreadPool(8);
+    protected final int defaultGetRangesConcurrency = 2;
 
     private class UnstableKeyValueService extends ForwardingKeyValueService {
         private final KeyValueService delegate;
@@ -282,7 +283,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
             fail();
@@ -338,7 +340,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
-                getRangesExecutor);
+                getRangesExecutor,
+                defaultGetRangesConcurrency);
         snapshot.put(TABLE, ImmutableMap.of(cell, PtBytes.EMPTY_BYTE_ARRAY));
         snapshot.commit();
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -117,7 +117,7 @@ import com.palantir.remoting2.tracing.Tracers;
 
 @SuppressWarnings("checkstyle:all")
 public class SnapshotTransactionTest extends AtlasDbTestCase {
-    protected final TimestampCache timestampCache = TimestampCache.create();
+    protected final TimestampCache timestampCache = new TimestampCache();
     protected final ExecutorService getRangesExecutor = Executors.newFixedThreadPool(8);
     protected final int defaultGetRangesConcurrency = 2;
 

--- a/docs/source/configuration/key_value_service_configs/index.rst
+++ b/docs/source/configuration/key_value_service_configs/index.rst
@@ -14,3 +14,24 @@ The configurations for supported key value services can be found below.
    postgres_key_value_service_config
    oracle_key_value_service_config
 
+.. global-config-params:
+
+Global Parameters
+=================
+
+.. list-table::
+    :widths: 10 40 5
+    :header-rows: 1
+
+    *    - Property
+         - Description
+         - Default
+
+    *    - concurrentGetRangesThreadPoolSize
+         - The size of the thread pool used for running concurrent range requests.
+         - KVS-specific
+
+    *    - defaultGetRangesConcurrency
+         - The maximum number of threads from the pool specified by ``concurrentGetRangesThreadPoolSize`` to use
+           for a single ``getRanges`` request when the user does not explicitly provide a value.
+         - 8

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,12 +56,6 @@ develop
            It also now returns information about how much data was swept.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2409>`__)
 
-    *   - |improved|
-        - Exposes another version of ``getRanges`` that uses a configurable concurrency level when not explicitly
-          provided a value. This defaults to 8 and can be configured with the ``KeyValueServiceConfig#defaultGetRangesConcurrency`` parameter.
-          Check the full configuration docs `here <https://palantir.github.io/atlasdb/html/configuration/key_value_service_configs/index.html>`__.
-          (`Pull Request <https://github.com/palantir/atlasdb/pull/2484>`__)
-
     *    - |fixed|
          - Sweep candidate batches are now logged correctly.
            Previously, we would log a ``SafeArg`` for these batches that had no content.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,12 @@ develop
            It also now returns information about how much data was swept.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2409>`__)
 
+    *   - |improved|
+        - Exposes another version of ``getRanges`` that uses a configurable concurrency level when not explicitly
+          provided a value. This defaults to 8 and can be configured with the ``KeyValueServiceConfig#defaultGetRangesConcurrency`` parameter.
+          Check the full configuration docs `here <https://palantir.github.io/atlasdb/html/configuration/key_value_service_configs/index.html>`__.
+          (`Pull Request <https://github.com/palantir/atlasdb/pull/2484>`__)
+
     *    - |fixed|
          - Sweep candidate batches are now logged correctly.
            Previously, we would log a ``SafeArg`` for these batches that had no content.

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -1849,6 +1849,12 @@ public final class UserProfileTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CookiesIdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<CookiesIdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CookiesIdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<CookiesIdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, CookiesIdxRowResult::of));
@@ -2526,6 +2532,12 @@ public final class UserProfileTable implements
                                        int concurrencyLevel,
                                        BiFunction<RangeRequest, BatchingVisitable<CreatedIdxRowResult>, T> visitableProcessor) {
             return t.getRanges(tableRef, ranges, concurrencyLevel,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CreatedIdxRowResult::of)));
+        }
+
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<CreatedIdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CreatedIdxRowResult::of)));
         }
 
@@ -3209,6 +3221,12 @@ public final class UserProfileTable implements
                     (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of)));
         }
 
+        public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                       BiFunction<RangeRequest, BatchingVisitable<UserBirthdaysIdxRowResult>, T> visitableProcessor) {
+            return t.getRanges(tableRef, ranges,
+                    (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of)));
+        }
+
         public Stream<BatchingVisitable<UserBirthdaysIdxRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
             Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
             return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, UserBirthdaysIdxRowResult::of));
@@ -3335,5 +3353,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XZOm4bE0zgUGoCBxygi4sQ==";
+    static String __CLASS_HASH = "3fqOZ+qIJ6uwBrHQDwnW6Q==";
 }


### PR DESCRIPTION
**Goals (and why)**: Cherry-pick timestamp tracker metrics.

**Implementation Description (bullets)**:
Picked up the following commits
1. getRange default param
2. STM refactors
3. Timestamp tracker metrics
1 & 2 were required to avoid conflicts and get clean cherry-picks.

Mostly clean except the last one. 

**Concerns (what feedback would you like?)**: N/A. Will handle release-notes in a separate PR.

**Where should we start reviewing?**: anywhere.

**Priority (whenever / two weeks / yesterday)**: today/early tomorrow.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2568)
<!-- Reviewable:end -->
