### PR TITLE
[no release notes] [flake] Clean the metrics registry before running …

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/monitoring/TimestampTrackerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/monitoring/TimestampTrackerTest.java
@@ -25,10 +25,12 @@ import static org.mockito.Mockito.when;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.cleaner.Cleaner;
@@ -50,6 +52,11 @@ public class TimestampTrackerTest {
     private final TimelockService timelockService = mock(TimelockService.class);
     private final Cleaner cleaner = mock(Cleaner.class);
     private final Clock mockClock = mock(Clock.class);
+
+    @BeforeClass
+    public static void cleanAtlasMetricsRegistry() {
+        AtlasDbMetrics.getMetricRegistry().removeMatching(MetricFilter.ALL);
+    }
 
     @Test
     public void defaultTrackerGeneratesTimestampMetrics() {


### PR DESCRIPTION
…the test

**Goals (and why)**: Fix #2579 

**Implementation Description (bullets)**:
- Clean the registry in a @BeforeClass

**Concerns (what feedback would you like?)**:
- Could this mess with other tests?
- I did think about using some kind of dependency inversion, so that we get a mock MetricRegistry for the timestamp tracker, but it turned out to be pretty complicated, so if this solution works (and I think it handles most cases) then I'd prefer to stick with it.

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: soon - build flakes are annoying!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2584)
<!-- Reviewable:end -->
