### PR TITLE
Safe args Cassandra* objects

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -92,7 +92,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
         try {
             ret.set_keyspace(config.getKeyspaceOrThrow());
             log.debug("Created new client for {}/{}{}{}",
-                    SafeArg.of("address", addr),
+                    SafeArg.of("address", addr.getHostString()),
                     UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
                     SafeArg.of("usingSsl", config.usingSsl() ? " over SSL" : ""),
                     UnsafeArg.of("usernameConfig", config.credentials().isPresent()
@@ -112,7 +112,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
             thriftSocket.getSocket().setKeepAlive(true);
             thriftSocket.getSocket().setSoTimeout(config.socketQueryTimeoutMillis());
         } catch (SocketException e) {
-            log.error("Couldn't set socket keep alive for {}", SafeArg.of("address", addr));
+            log.error("Couldn't set socket keep alive for {}", SafeArg.of("address", addr.getHostString()));
         }
 
         if (config.usingSsl()) {
@@ -177,7 +177,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
     @Override
     public void destroyObject(PooledObject<Client> client) {
         client.getObject().getOutputProtocol().getTransport().close();
-        log.debug("Closed transport for client {}", SafeArg.of("cassandraClient", client.getObject()));
+        log.debug("Closed transport for client {}", SafeArg.of("cassandraClient", addr.getHostString()));
     }
 
     static class ClientCreationFailedException extends RuntimeException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -112,7 +112,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
             thriftSocket.getSocket().setKeepAlive(true);
             thriftSocket.getSocket().setSoTimeout(config.socketQueryTimeoutMillis());
         } catch (SocketException e) {
-            log.error("Couldn't set socket keep alive for {}", SafeArg.of("address", addr.getHostString()));
+            log.error("Couldn't set socket keep alive for host {}", SafeArg.of("address", addr.getHostString()));
         }
 
         if (config.usingSsl()) {
@@ -177,7 +177,9 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
     @Override
     public void destroyObject(PooledObject<Client> client) {
         client.getObject().getOutputProtocol().getTransport().close();
-        log.debug("Closed transport for client {}", SafeArg.of("cassandraClient", addr.getHostString()));
+        log.debug("Closed transport for client {} of host {}",
+                UnsafeArg.of("client", client),
+                SafeArg.of("cassandraClient", addr.getHostString()));
     }
 
     static class ClientCreationFailedException extends RuntimeException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -92,7 +92,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
         try {
             ret.set_keyspace(config.getKeyspaceOrThrow());
             log.debug("Created new client for {}/{}{}{}",
-                    SafeArg.of("address", CassandraLogHelper.hostLog(addr)),
+                    SafeArg.of("address", CassandraLogHelper.host(addr)),
                     UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
                     SafeArg.of("usingSsl", config.usingSsl() ? " over SSL" : ""),
                     UnsafeArg.of("usernameConfig", config.credentials().isPresent()
@@ -113,7 +113,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
             thriftSocket.getSocket().setSoTimeout(config.socketQueryTimeoutMillis());
         } catch (SocketException e) {
             log.error("Couldn't set socket keep alive for host {}",
-                    SafeArg.of("address", CassandraLogHelper.hostLog(addr)));
+                    SafeArg.of("address", CassandraLogHelper.host(addr)));
         }
 
         if (config.usingSsl()) {
@@ -180,7 +180,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
         client.getObject().getOutputProtocol().getTransport().close();
         log.debug("Closed transport for client {} of host {}",
                 UnsafeArg.of("client", client),
-                SafeArg.of("cassandraClient", CassandraLogHelper.hostLog(addr)));
+                SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)));
     }
 
     static class ClientCreationFailedException extends RuntimeException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -92,7 +92,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
         try {
             ret.set_keyspace(config.getKeyspaceOrThrow());
             log.debug("Created new client for {}/{}{}{}",
-                    SafeArg.of("address", addr.getHostString()),
+                    SafeArg.of("address", CassandraLogHelper.hostLog(addr)),
                     UnsafeArg.of("keyspace", config.getKeyspaceOrThrow()),
                     SafeArg.of("usingSsl", config.usingSsl() ? " over SSL" : ""),
                     UnsafeArg.of("usernameConfig", config.credentials().isPresent()
@@ -112,7 +112,8 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
             thriftSocket.getSocket().setKeepAlive(true);
             thriftSocket.getSocket().setSoTimeout(config.socketQueryTimeoutMillis());
         } catch (SocketException e) {
-            log.error("Couldn't set socket keep alive for host {}", SafeArg.of("address", addr.getHostString()));
+            log.error("Couldn't set socket keep alive for host {}",
+                    SafeArg.of("address", CassandraLogHelper.hostLog(addr)));
         }
 
         if (config.usingSsl()) {
@@ -179,7 +180,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<Client> {
         client.getObject().getOutputProtocol().getTransport().close();
         log.debug("Closed transport for client {} of host {}",
                 UnsafeArg.of("client", client),
-                SafeArg.of("cassandraClient", addr.getHostString()));
+                SafeArg.of("cassandraClient", CassandraLogHelper.hostLog(addr)));
     }
 
     static class ClientCreationFailedException extends RuntimeException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -414,7 +414,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                     + "live hosts that claim ownership of the given range. Falling back to choosing a random live node."
                     + " Current host blacklist is {}."
                     + " Current state logged at TRACE",
-                    SafeArg.of("blacklistedHosts", CassandraLogHelper.blacklistedHostsLog(blacklistedHosts)));
+                    SafeArg.of("blacklistedHosts", CassandraLogHelper.blacklistedHosts(blacklistedHosts)));
             log.trace("Current ring view is: {}.",
                     SafeArg.of("tokenMap", CassandraLogHelper.tokenMap(tokenMap)));
             return getRandomGoodHost().getHost();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -583,7 +583,8 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
         Set<InetSocketAddress> triedHosts = Sets.newHashSet();
         while (true) {
             if (log.isTraceEnabled()) {
-                log.trace("Running function on host {}.", SafeArg.of("host", CassandraLogHelper.hostLog(specifiedHost)));
+                log.trace("Running function on host {}.",
+                        SafeArg.of("host", CassandraLogHelper.hostLog(specifiedHost)));
             }
             CassandraClientPoolingContainer hostPool = currentPools.get(specifiedHost);
 
@@ -732,7 +733,9 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                 }
                 tokenRangesToHost.put(ImmutableSet.copyOf(client.describe_ring(config.getKeyspaceOrThrow())), host);
             } catch (Exception e) {
-                log.warn("Failed to get ring info from host: {}", SafeArg.of("host", CassandraLogHelper.hostLog(host)), e);
+                log.warn("Failed to get ring info from host: {}",
+                        SafeArg.of("host", CassandraLogHelper.hostLog(host)),
+                        e);
             } finally {
                 if (client != null) {
                     client.getOutputProtocol().getTransport().close();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -621,7 +621,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                     }
                 } else if (isFastFailoverException(e)) {
                     log.info("Retrying with fast failover a query intended for host {}.",
-                            SafeArg.of("hostName", CassandraLogHelper.hostLog(hostPool.getHost()));
+                            SafeArg.of("hostName", CassandraLogHelper.hostLog(hostPool.getHost())));
                     shouldRetryOnDifferentHost = true;
                 }
             }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -126,9 +126,10 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
             return fn.apply(resource);
         } catch (Exception e) {
             if (isInvalidClientConnection(e)) {
-                log.warn("Not reusing resource {} due to {}",
-                        SafeArg.of("clientPool", resource),
-                        UnsafeArg.of("exception", e.toString()), e);
+                log.warn("Not reusing resource {} due to {} of host {}",
+                        UnsafeArg.of("resource", resource),
+                        UnsafeArg.of("exception", e.toString()),
+                        SafeArg.of("host", host.getHostString()), e);
                 shouldReuse = false;
             }
             if (e instanceof TTransportException
@@ -140,8 +141,10 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         } finally {
             if (resource != null) {
                 if (shouldReuse) {
-                    log.debug("Returning {} to pool", SafeArg.of("pool", resource));
-                    eagerlyCleanupReadBuffersFromIdleConnection(resource);
+                    log.debug("Returning {} to pool of host {}",
+                            UnsafeArg.of("resource", resource),
+                            SafeArg.of("host", host.getHostString()));
+                    eagerlyCleanupReadBuffersFromIdleConnection(resource, host);
                     clientPool.returnObject(resource);
                 } else {
                     invalidateQuietly(resource);
@@ -150,7 +153,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         }
     }
 
-    private static void eagerlyCleanupReadBuffersFromIdleConnection(Client idleClient) {
+    private static void eagerlyCleanupReadBuffersFromIdleConnection(Client idleClient, InetSocketAddress host) {
         // eagerly cleanup idle-connection read buffer to keep a smaller memory footprint
         try {
             TTransport transport = idleClient.getInputProtocol().getTransport();
@@ -160,8 +163,10 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 TMemoryInputTransport memoryInputTransport = (TMemoryInputTransport) readBuffer.get(transport);
                 byte[] underlyingBuffer = memoryInputTransport.getBuffer();
                 if (underlyingBuffer != null) {
-                    log.debug("During {} check-in, cleaned up a read buffer of {} bytes",
-                            SafeArg.of("pool", idleClient), SafeArg.of("bufferLength", underlyingBuffer.length));
+                    log.debug("During {} check-in, cleaned up a read buffer of {} bytes of host {}",
+                            UnsafeArg.of("pool", idleClient),
+                            SafeArg.of("bufferLength", underlyingBuffer.length),
+                            SafeArg.of("host", host.getHostString()));
                     memoryInputTransport.clear();
                 }
             }
@@ -178,7 +183,9 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
 
     private void invalidateQuietly(Client resource) {
         try {
-            log.debug("Discarding: {}", SafeArg.of("pool", resource));
+            log.debug("Discarding {} of host {}",
+                    UnsafeArg.of("pool", resource),
+                    SafeArg.of("host", host.getHostString()));
             clientPool.invalidateObject(resource);
         } catch (Exception e) {
             // Ignore

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -102,7 +102,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
             return runWithGoodResource(fn);
         } catch (Throwable t) {
             log.warn("Error occurred talking to host '{}': {}",
-                    SafeArg.of("host", host.getHostString()), UnsafeArg.of("exception", t.toString()));
+                    SafeArg.of("host", CassandraLogHelper.hostLog(host)), UnsafeArg.of("exception", t.toString()));
             throw t;
         } finally {
             openRequests.getAndDecrement();
@@ -129,7 +129,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 log.warn("Not reusing resource {} due to {} of host {}",
                         UnsafeArg.of("resource", resource),
                         UnsafeArg.of("exception", e.toString()),
-                        SafeArg.of("host", host.getHostString()), e);
+                        SafeArg.of("host", CassandraLogHelper.hostLog(host)), e);
                 shouldReuse = false;
             }
             if (e instanceof TTransportException
@@ -143,7 +143,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 if (shouldReuse) {
                     log.debug("Returning {} to pool of host {}",
                             UnsafeArg.of("resource", resource),
-                            SafeArg.of("host", host.getHostString()));
+                            SafeArg.of("host", CassandraLogHelper.hostLog(host)));
                     eagerlyCleanupReadBuffersFromIdleConnection(resource, host);
                     clientPool.returnObject(resource);
                 } else {
@@ -166,7 +166,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                     log.debug("During {} check-in, cleaned up a read buffer of {} bytes of host {}",
                             UnsafeArg.of("pool", idleClient),
                             SafeArg.of("bufferLength", underlyingBuffer.length),
-                            SafeArg.of("host", host.getHostString()));
+                            SafeArg.of("host", CassandraLogHelper.hostLog(host)));
                     memoryInputTransport.clear();
                 }
             }
@@ -185,7 +185,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         try {
             log.debug("Discarding {} of host {}",
                     UnsafeArg.of("pool", resource),
-                    SafeArg.of("host", host.getHostString()));
+                    SafeArg.of("host", CassandraLogHelper.hostLog(host)));
             clientPool.invalidateObject(resource);
         } catch (Exception e) {
             // Ignore
@@ -260,7 +260,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         poolConfig.setNumTestsPerEvictionRun(-(int) (1.0 / config.proportionConnectionsToCheckPerEvictionRun()));
         poolConfig.setTestWhileIdle(true);
 
-        poolConfig.setJmxNamePrefix(host.getHostString());
+        poolConfig.setJmxNamePrefix(CassandraLogHelper.hostLog(host));
         GenericObjectPool<Client> pool = new GenericObjectPool<>(cassandraClientFactory, poolConfig);
         registerMetrics(pool, poolNumber);
         return pool;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -102,7 +102,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
             return runWithGoodResource(fn);
         } catch (Throwable t) {
             log.warn("Error occurred talking to host '{}': {}",
-                    SafeArg.of("host", CassandraLogHelper.hostLog(host)), UnsafeArg.of("exception", t.toString()));
+                    SafeArg.of("host", CassandraLogHelper.host(host)), UnsafeArg.of("exception", t.toString()));
             throw t;
         } finally {
             openRequests.getAndDecrement();
@@ -129,7 +129,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 log.warn("Not reusing resource {} due to {} of host {}",
                         UnsafeArg.of("resource", resource),
                         UnsafeArg.of("exception", e.toString()),
-                        SafeArg.of("host", CassandraLogHelper.hostLog(host)), e);
+                        SafeArg.of("host", CassandraLogHelper.host(host)), e);
                 shouldReuse = false;
             }
             if (e instanceof TTransportException
@@ -143,7 +143,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 if (shouldReuse) {
                     log.debug("Returning {} to pool of host {}",
                             UnsafeArg.of("resource", resource),
-                            SafeArg.of("host", CassandraLogHelper.hostLog(host)));
+                            SafeArg.of("host", CassandraLogHelper.host(host)));
                     eagerlyCleanupReadBuffersFromIdleConnection(resource, host);
                     clientPool.returnObject(resource);
                 } else {
@@ -166,7 +166,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                     log.debug("During {} check-in, cleaned up a read buffer of {} bytes of host {}",
                             UnsafeArg.of("pool", idleClient),
                             SafeArg.of("bufferLength", underlyingBuffer.length),
-                            SafeArg.of("host", CassandraLogHelper.hostLog(host)));
+                            SafeArg.of("host", CassandraLogHelper.host(host)));
                     memoryInputTransport.clear();
                 }
             }
@@ -185,7 +185,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         try {
             log.debug("Discarding {} of host {}",
                     UnsafeArg.of("pool", resource),
-                    SafeArg.of("host", CassandraLogHelper.hostLog(host)));
+                    SafeArg.of("host", CassandraLogHelper.host(host)));
             clientPool.invalidateObject(resource);
         } catch (Exception e) {
             // Ignore
@@ -260,7 +260,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         poolConfig.setNumTestsPerEvictionRun(-(int) (1.0 / config.proportionConnectionsToCheckPerEvictionRun()));
         poolConfig.setTestWhileIdle(true);
 
-        poolConfig.setJmxNamePrefix(CassandraLogHelper.hostLog(host));
+        poolConfig.setJmxNamePrefix(CassandraLogHelper.host(host));
         GenericObjectPool<Client> pool = new GenericObjectPool<>(cassandraClientFactory, poolConfig);
         registerMetrics(pool, poolNumber);
         return pool;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -102,7 +102,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
             return runWithGoodResource(fn);
         } catch (Throwable t) {
             log.warn("Error occurred talking to host '{}': {}",
-                    SafeArg.of("host", host), UnsafeArg.of("exception", t.toString()));
+                    SafeArg.of("host", host.getHostString()), UnsafeArg.of("exception", t.toString()));
             throw t;
         } finally {
             openRequests.getAndDecrement();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -615,7 +615,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             if (columnCells.size() > fetchBatchCount) {
                 log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to "
                                 + "multiget {} rows; this may indicate overly-large batching on a higher level.\n{}",
-                        SafeArg.of("host", CassandraLogHelper.hostLog(host)),
+                        SafeArg.of("host", CassandraLogHelper.host(host)),
                         LoggingArgs.tableRef(tableRef),
                         SafeArg.of("rows", columnCells.size()),
                         SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
@@ -640,7 +640,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                             LoggingArgs.tableRef(tableRef),
                                             SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
                                             SafeArg.of("startTs", startTs),
-                                            SafeArg.of("host", CassandraLogHelper.hostLog(host)));
+                                            SafeArg.of("host", CassandraLogHelper.host(host)));
                                 }
 
                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results =

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -615,7 +615,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             if (columnCells.size() > fetchBatchCount) {
                 log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to "
                                 + "multiget {} rows; this may indicate overly-large batching on a higher level.\n{}",
-                        SafeArg.of("host", host),
+                        SafeArg.of("host", host.getHostString()),
                         LoggingArgs.tableRef(tableRef),
                         SafeArg.of("rows", columnCells.size()),
                         SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
@@ -640,7 +640,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                             LoggingArgs.tableRef(tableRef),
                                             SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
                                             SafeArg.of("startTs", startTs),
-                                            SafeArg.of("host", host));
+                                            SafeArg.of("host", host.getHostString()));
                                 }
 
                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results =

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -615,7 +615,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             if (columnCells.size() > fetchBatchCount) {
                 log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to "
                                 + "multiget {} rows; this may indicate overly-large batching on a higher level.\n{}",
-                        SafeArg.of("host", host.getHostString()),
+                        SafeArg.of("host", CassandraLogHelper.hostLog(host)),
                         LoggingArgs.tableRef(tableRef),
                         SafeArg.of("rows", columnCells.size()),
                         SafeArg.of("stacktrace", CassandraKeyValueServices.getFilteredStackTrace("com.palantir")));
@@ -640,7 +640,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                             LoggingArgs.tableRef(tableRef),
                                             SafeArg.of("timestampClause", loadAllTs ? "for all timestamps " : ""),
                                             SafeArg.of("startTs", startTs),
-                                            SafeArg.of("host", host.getHostString()));
+                                            SafeArg.of("host", CassandraLogHelper.hostLog(host)));
                                 }
 
                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results =

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -38,7 +38,7 @@ final class CassandraLogHelper {
         return host.getHostString();
     }
 
-    static List<String> blacklistedHostsLog(Map<InetSocketAddress, Long> blacklistedHosts) {
+    static List<String> blacklistedHosts(Map<InetSocketAddress, Long> blacklistedHosts) {
         return blacklistedHosts.entrySet().stream()
                 .map(blacklistedHostToBlacklistTime -> String.format("host: %s was blacklisted at %s",
                         host(blacklistedHostToBlacklistTime.getKey()),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -34,38 +34,38 @@ final class CassandraLogHelper {
         // Utility class.
     }
 
-    static String hostLog(InetSocketAddress host) {
+    static String host(InetSocketAddress host) {
         return host.getHostString();
     }
 
     static List<String> blacklistedHostsLog(Map<InetSocketAddress, Long> blacklistedHosts) {
         return blacklistedHosts.entrySet().stream()
                 .map(blacklistedHostToBlacklistTime -> String.format("host: %s was blacklisted at %s",
-                        hostLog(blacklistedHostToBlacklistTime.getKey()),
+                        host(blacklistedHostToBlacklistTime.getKey()),
                         blacklistedHostToBlacklistTime.getValue().longValue()))
                 .collect(Collectors.toList());
     }
 
-    static Collection<String> collectionOfHostsLog(Collection<InetSocketAddress> hosts) {
-        return hosts.stream().map(CassandraLogHelper::hostLog).collect(Collectors.toSet());
+    static Collection<String> collectionOfHosts(Collection<InetSocketAddress> hosts) {
+        return hosts.stream().map(CassandraLogHelper::host).collect(Collectors.toSet());
     }
 
-    static List<String> tokenRangesToHostLog(Multimap<Set<TokenRange>, InetSocketAddress> tokenRangesToHost) {
+    static List<String> tokenRangesToHost(Multimap<Set<TokenRange>, InetSocketAddress> tokenRangesToHost) {
         return tokenRangesToHost.entries().stream()
                 .map(entry -> String.format("host %s has range %s",
                         entry.getKey().toString(),
-                        hostLog(entry.getValue())))
+                        host(entry.getValue())))
                 .collect(Collectors.toList());
     }
 
-    static List<String> getTokenMapLog(
+    static List<String> tokenMap(
             RangeMap<CassandraClientPoolImpl.LightweightOppToken, List<InetSocketAddress>> tokenMap) {
 
         return tokenMap.asMapOfRanges().entrySet().stream()
                 .map(rangeListToHostEntry -> String.format("range from %s to %s is on host %s",
                         getLowerEndpoint(rangeListToHostEntry.getKey()),
                         getUpperEndpoint(rangeListToHostEntry.getKey()),
-                        CassandraLogHelper.collectionOfHostsLog(rangeListToHostEntry.getValue())))
+                        CassandraLogHelper.collectionOfHosts(rangeListToHostEntry.getValue())))
                 .collect(Collectors.toList());
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -30,6 +30,10 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 
 final class CassandraLogHelper {
+    private CassandraLogHelper() {
+        // Utility class.
+    }
+
     static String hostLog(InetSocketAddress host) {
         return host.getHostString();
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -30,23 +30,27 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 
 final class CassandraLogHelper {
+    static String hostLog(InetSocketAddress host) {
+        return host.getHostString();
+    }
+
     static List<String> blacklistedHostsLog(Map<InetSocketAddress, Long> blacklistedHosts) {
         return blacklistedHosts.entrySet().stream()
                 .map(blacklistedHostToBlacklistTime -> String.format("host: %s was blacklisted at %s",
-                        blacklistedHostToBlacklistTime.getKey().getHostString(),
+                        hostLog(blacklistedHostToBlacklistTime.getKey()),
                         blacklistedHostToBlacklistTime.getValue().longValue()))
                 .collect(Collectors.toList());
     }
 
     static Collection<String> collectionOfHostsLog(Collection<InetSocketAddress> hosts) {
-        return hosts.stream().map(InetSocketAddress::getHostString).collect(Collectors.toSet());
+        return hosts.stream().map(CassandraLogHelper::hostLog).collect(Collectors.toSet());
     }
 
     static List<String> tokenRangesToHostLog(Multimap<Set<TokenRange>, InetSocketAddress> tokenRangesToHost) {
         return tokenRangesToHost.entries().stream()
                 .map(entry -> String.format("host %s has range %s",
                         entry.getKey().toString(),
-                        entry.getValue().getHostString()))
+                        hostLog(entry.getValue())))
                 .collect(Collectors.toList());
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.thrift.TokenRange;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+
+final class CassandraLogHelper {
+    static List<String> blacklistedHostsLog(Map<InetSocketAddress, Long> blacklistedHosts) {
+        return blacklistedHosts.entrySet().stream()
+                .map(blacklistedHostToBlacklistTime -> String.format("host: %s was blacklisted at %s",
+                        blacklistedHostToBlacklistTime.getKey().getHostString(),
+                        blacklistedHostToBlacklistTime.getValue().longValue()))
+                .collect(Collectors.toList());
+    }
+
+    static Collection<String> collectionOfHostsLog(Collection<InetSocketAddress> hosts) {
+        return hosts.stream().map(InetSocketAddress::getHostString).collect(Collectors.toSet());
+    }
+
+    static List<String> tokenRangesToHostLog(Multimap<Set<TokenRange>, InetSocketAddress> tokenRangesToHost) {
+        return tokenRangesToHost.entries().stream()
+                .map(entry -> String.format("host %s has range %s",
+                        entry.getKey().toString(),
+                        entry.getValue().getHostString()))
+                .collect(Collectors.toList());
+    }
+
+    static List<String> getTokenMapLog(
+            RangeMap<CassandraClientPoolImpl.LightweightOppToken, List<InetSocketAddress>> tokenMap) {
+
+        return tokenMap.asMapOfRanges().entrySet().stream()
+                .map(rangeListToHostEntry -> String.format("range from %s to %s is on host %s",
+                        getLowerEndpoint(rangeListToHostEntry.getKey()),
+                        getUpperEndpoint(rangeListToHostEntry.getKey()),
+                        CassandraLogHelper.collectionOfHostsLog(rangeListToHostEntry.getValue())))
+                .collect(Collectors.toList());
+    }
+
+    private static String getLowerEndpoint(Range<CassandraClientPoolImpl.LightweightOppToken> range) {
+        if (range.hasLowerBound()) {
+            return "(no lower bound)";
+        }
+        return range.lowerEndpoint().toString();
+    }
+
+    private static String getUpperEndpoint(Range<CassandraClientPoolImpl.LightweightOppToken> range) {
+        if (range.hasUpperBound()) {
+            return "(no upper bound)";
+        }
+        return range.upperEndpoint().toString();
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -184,7 +184,7 @@ public final class CassandraVerifier {
                         + " It returned exception \"{}\" during the attempt."
                         + " We will retry on other nodes, so this shouldn't be a problem unless all nodes failed."
                         + " See the debug-level log for the stack trace.",
-                        SafeArg.of("host", host.getHostString()),
+                        SafeArg.of("host", CassandraLogHelper.hostLog(host)),
                         UnsafeArg.of("exceptionMessage", exception.toString()));
                 log.debug("Specifically, creating the keyspace failed with the following stack trace", exception);
             }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -184,7 +184,7 @@ public final class CassandraVerifier {
                         + " It returned exception \"{}\" during the attempt."
                         + " We will retry on other nodes, so this shouldn't be a problem unless all nodes failed."
                         + " See the debug-level log for the stack trace.",
-                        SafeArg.of("host", host),
+                        SafeArg.of("host", host.getHostString()),
                         UnsafeArg.of("exceptionMessage", exception.toString()));
                 log.debug("Specifically, creating the keyspace failed with the following stack trace", exception);
             }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -184,7 +184,7 @@ public final class CassandraVerifier {
                         + " It returned exception \"{}\" during the attempt."
                         + " We will retry on other nodes, so this shouldn't be a problem unless all nodes failed."
                         + " See the debug-level log for the stack trace.",
-                        SafeArg.of("host", CassandraLogHelper.hostLog(host)),
+                        SafeArg.of("host", CassandraLogHelper.host(host)),
                         UnsafeArg.of("exceptionMessage", exception.toString()));
                 log.debug("Specifically, creating the keyspace failed with the following stack trace", exception);
             }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,6 +44,10 @@ develop
     *    - Type
          - Change
 
+    *   - |changed|
+        - Log host names in Cassandra* classes.
+          (`Pull Request <https://github.com/palantir/atlasdb/pull/2592>`__)
+
     *    - |improved|
          - ``getRange`` is now more efficient when scanning over rows with many updates in Cassandra, if just a single column is requested.
            Previously, a range request in Cassandra would always retrieve all columns and all historical versions of each column, regardless of which columns were requested.


### PR DESCRIPTION
**Goals (and why)**: Extract exactly what's relevant of all the objects logged. Since they're not marked as JSON serializable, our internal logging framework just logged them as empty strings.

**Implementation Description (bullets)**: -

**Priority (whenever / two weeks / yesterday)**: Should go into the next release.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2592)
<!-- Reviewable:end -->
