### PR TITLE
Clarify logging on allSafeForLogging

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
@@ -84,6 +84,7 @@ public class TableDefinition extends AbstractDefinition {
      * default. Individual row components or named columns may still be marked as unsafe by explicitly creating them
      * as unsafe (by constructing them with UNSAFE values of LogSafety).
      * Note that specifying this by itself does NOT make the table name safe for logging.
+     * Note that this logging DOES NOT mark the values of either the rows or the columns as safe for logging.
      */
     public void namedComponentsSafeByDefault() {
         Preconditions.checkState(state == State.NONE, "Specifying components are safe by default should be done outside"
@@ -97,6 +98,8 @@ public class TableDefinition extends AbstractDefinition {
      *
      * If you wish to have a table with an unsafe name but safe components, please use namedComponentsSafeByDefault()
      * instead.
+     *
+     * Note that this logging DOES NOT mark the values of either the rows or the columns as safe for logging.
      */
     public void allSafeForLoggingByDefault() {
         tableNameLogSafety(LogSafety.SAFE);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
@@ -83,8 +83,10 @@ public class TableDefinition extends AbstractDefinition {
      * If specified, this indicates that the names of all row components and named columns should be marked as safe by
      * default. Individual row components or named columns may still be marked as unsafe by explicitly creating them
      * as unsafe (by constructing them with UNSAFE values of LogSafety).
-     * Note that specifying this by itself does NOT make the table name safe for logging.
-     * Note that this logging DOES NOT mark the values of either the rows or the columns as safe for logging.
+     *
+     * Note that specifying this by itself DOES NOT make the table name safe for logging.
+     *
+     * Note that this DOES NOT make the values of either the rows or the columns safe for logging.
      */
     public void namedComponentsSafeByDefault() {
         Preconditions.checkState(state == State.NONE, "Specifying components are safe by default should be done outside"
@@ -99,7 +101,7 @@ public class TableDefinition extends AbstractDefinition {
      * If you wish to have a table with an unsafe name but safe components, please use namedComponentsSafeByDefault()
      * instead.
      *
-     * Note that this logging DOES NOT mark the values of either the rows or the columns as safe for logging.
+     * Note that this DOES NOT make the values of either the rows or the columns safe for logging.
      */
     public void allSafeForLoggingByDefault() {
         tableNameLogSafety(LogSafety.SAFE);


### PR DESCRIPTION
**Goals (and why)**: Clarify the logging of the `allSafeForLoggingByDefault` to explicitly say that that metadata doesn't make the **values** of either the rows or the columns safe for logging. We currently don't support that behavior.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2593)
<!-- Reviewable:end -->
