### PR TITLE
Mark AutoDelegate as source-only

### DIFF
--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegate.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegate.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 public @interface AutoDelegate {
     /**
      * The type to be extended. Can be either a class or an interface.


### PR DESCRIPTION
**Goals (and why)**: Since we just require the annotation at compile-time, to generate the `AutoDelegate_` classes, make the annotation use `RetentionPolicy.SOURCE`. If we leave them at `RetentionPolicy.CLASS`, which is the default, the compiler will complain with errors of the form:
```
[00:00:47] /home/ubuntu/atlasdb-internal-testing/atlasdb-impl-shared/build/artifacts/atlasdb-impl-shared-0.63.0-3-g9aa5ae8.jar(com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.class): warning: Cannot find annotation method 'typeToExtend()' in type 'AutoDelegate': class file for com.palantir.processors.AutoDelegate not found
```

Fixes #2489.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2594)
<!-- Reviewable:end -->
