### PR TITLE
Expand testing of TM.create methods

### DIFF
--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ApiTestSchema.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ApiTestSchema.java
@@ -33,7 +33,7 @@ public class ApiTestSchema implements AtlasSchema {
     private static Schema generateSchema() {
         Schema schema = new Schema("ApiTest",
                 ApiTestSchema.class.getPackage().getName() + ".generated",
-                Namespace.DEFAULT_NAMESPACE,
+                Namespace.create("test"),
                 OptionalType.JAVA8);
 
         schema.addTableDefinition("SchemaApiTest", new TableDefinition() {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/GenericTestSchema.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/GenericTestSchema.java
@@ -29,7 +29,7 @@ public class GenericTestSchema implements AtlasSchema {
     private static Schema generateSchema() {
         Schema schema = new Schema("GenericTestSchema",
                 GenericTestSchema.class.getPackage().getName() + ".generated",
-                Namespace.EMPTY_NAMESPACE,
+                Namespace.create("test"),
                 OptionalType.JAVA8);
 
         // use for testing rangeScanAllowed code


### PR DESCRIPTION
All TransactionManagers.create methods should now be tested.
[no release notes]

**Goals (and why)**: Extra testing of TM.create methods after catching #2581 - see [this comment](https://github.com/palantir/atlasdb/pull/2582#pullrequestreview-72551750).

**Implementation Description (bullets)**: Tested each method, using code coverage as a guide.

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2595)
<!-- Reviewable:end -->
