### PR TITLE
Sweep progress/async init

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -34,7 +34,7 @@ public final class AtlasDbConstants {
     public static final TableReference SCRUB_TABLE = TableReference.createWithEmptyNamespace("_scrub2");
     public static final TableReference NAMESPACE_TABLE = TableReference.createWithEmptyNamespace("_namespace");
     public static final TableReference TIMESTAMP_TABLE = TableReference.createWithEmptyNamespace("_timestamp");
-    public static final TableReference SWEEP_PROGRESS_TABLE = TableReference.createWithEmptyNamespace("_sweep_progress");
+    public static final TableReference SWEEP_PROGRESS_TABLE = TableReference.createWithEmptyNamespace("_sweep_progress2");
     public static final TableReference TIMELOCK_TIMESTAMP_TABLE = TableReference.createWithEmptyNamespace("pt_metropolis_ts");
     public static final TableReference PERSISTED_LOCKS_TABLE = TableReference.createWithEmptyNamespace(
             "_persisted_locks");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -34,6 +34,7 @@ public final class AtlasDbConstants {
     public static final TableReference SCRUB_TABLE = TableReference.createWithEmptyNamespace("_scrub2");
     public static final TableReference NAMESPACE_TABLE = TableReference.createWithEmptyNamespace("_namespace");
     public static final TableReference TIMESTAMP_TABLE = TableReference.createWithEmptyNamespace("_timestamp");
+    public static final TableReference SWEEP_PROGRESS_TABLE = TableReference.createWithEmptyNamespace("_sweep_progress");
     public static final TableReference TIMELOCK_TIMESTAMP_TABLE = TableReference.createWithEmptyNamespace("pt_metropolis_ts");
     public static final TableReference PERSISTED_LOCKS_TABLE = TableReference.createWithEmptyNamespace(
             "_persisted_locks");
@@ -79,7 +80,8 @@ public final class AtlasDbConstants {
             SCRUB_TABLE,
             NAMESPACE_TABLE,
             PARTITION_MAP_TABLE,
-            PERSISTED_LOCKS_TABLE);
+            PERSISTED_LOCKS_TABLE,
+            SWEEP_PROGRESS_TABLE);
 
     /**
      * Tables that must always be on a KVS that supports an atomic putUnlessExists operation.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SweepSchema.java
@@ -39,20 +39,6 @@ public enum SweepSchema implements AtlasSchema {
                 NAMESPACE,
                 OptionalType.JAVA8);
 
-        // This table tracks progress on a sweep job of a single table.
-        schema.addTableDefinition("progress_2", new TableDefinition() {{
-            javaTableName("SweepProgress");
-            allSafeForLoggingByDefault();
-            rowName();
-                // This table has at most one row.
-                rowComponent("dummy", ValueType.VAR_LONG);
-            columns();
-                // The name of the table being swept.
-                column("sweep_progress", "s", ValueType.BLOB);
-            conflictHandler(ConflictHandler.IGNORE_ALL);
-            ignoreHotspottingChecks();
-        }});
-
         // This table tracks stats about tables that are relevant
         // in determining when and in which order they should be swept.
         schema.addTableDefinition("priority", new TableDefinition() {{

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemasTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemasTest.java
@@ -110,7 +110,6 @@ public class SchemasTest {
     @Test
     public void testDeleteTablesForSweepSchema() {
         Set<TableReference> allTableNames = Sets.newHashSet();
-        allTableNames.add(TableReference.createFromFullyQualifiedName("sweep.progress_2"));
         allTableNames.add(TableReference.createFromFullyQualifiedName("sweep.priority"));
 
         mockery.checking(new Expectations(){{

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -446,7 +446,8 @@ public abstract class TransactionManagers {
                 sweepRunner,
                 sweepPerfLogger,
                 sweepBatchConfig,
-                sweepMetrics);
+                sweepMetrics,
+                config.initializeAsync());
 
         BackgroundSweeperImpl backgroundSweeper = BackgroundSweeperImpl.create(
                 () -> runtimeConfigSupplier.get().sweep().enabled(),
@@ -465,7 +466,8 @@ public abstract class TransactionManagers {
             SweepTaskRunner sweepRunner,
             BackgroundSweeperPerformanceLogger sweepPerfLogger,
             com.google.common.base.Supplier<SweepBatchConfig> sweepBatchConfig,
-            SweepMetrics sweepMetrics) {
+            SweepMetrics sweepMetrics,
+            boolean initializeAsync) {
         SpecificTableSweeper specificTableSweeper = SpecificTableSweeper.create(
                 transactionManager,
                 kvs,
@@ -473,7 +475,8 @@ public abstract class TransactionManagers {
                 sweepBatchConfig,
                 SweepTableFactory.of(),
                 sweepPerfLogger,
-                sweepMetrics);
+                sweepMetrics,
+                initializeAsync);
         env.accept(new SweeperServiceImpl(specificTableSweeper));
         return specificTableSweeper;
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
@@ -18,11 +18,9 @@ package com.palantir.atlasdb.factory;
 
 import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
 import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.logging.LoggingArgs;
-import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.table.description.Schemas;
 import com.palantir.atlasdb.transaction.impl.TransactionTables;
@@ -51,12 +49,7 @@ public final class TransactionManagersInitializer extends AsyncInitializer {
     public synchronized void tryInitialize() {
         TransactionTables.createTables(keyValueService);
 
-        Set<Schema> allSchemas = ImmutableSet.<Schema>builder()
-                .add(SweepSchema.INSTANCE.getLatestSchema())
-                .addAll(schemas)
-                .build();
-
-        for (Schema schema : allSchemas) {
+        for (Schema schema : schemas) {
             Schemas.createTablesAndIndexes(schema, keyValueService);
         }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -107,6 +107,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
     public void run() {
         try (SweepLocks locks = createSweepLocks()) {
             // Wait a while before starting so short lived clis don't try to sweep.
+            waitUntilSpecificTableSweeperIsInitialized();
             Thread.sleep(getBackoffTimeWhenSweepHasNotRun());
             log.info("Starting background sweeper.");
             while (true) {
@@ -115,6 +116,15 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
             }
         } catch (InterruptedException e) {
             log.warn("Shutting down background sweeper. Please restart the service to rerun background sweep.");
+        }
+    }
+
+    private void waitUntilSpecificTableSweeperIsInitialized() throws InterruptedException {
+        while (!specificTableSweeper.isInitialized()) {
+            log.info("Sweep Priority Table and Sweep Progress Table are not initialized yet. If you have enabled "
+                    + "asynchronous initialization, these tables are being initialized asynchronously. Background "
+                    + "sweeper will start once the initialization is complete.");
+            Thread.sleep(getBackoffTimeWhenSweepHasNotRun());
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStore.java
@@ -13,89 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.palantir.atlasdb.sweep.priority;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.OptionalLong;
 
-import com.google.common.collect.Collections2;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.schema.generated.SweepPriorityTable;
-import com.palantir.atlasdb.schema.generated.SweepPriorityTable.SweepPriorityRow;
-import com.palantir.atlasdb.schema.generated.SweepTableFactory;
 import com.palantir.atlasdb.transaction.api.Transaction;
-import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
-import com.palantir.atlasdb.transaction.impl.UnmodifiableTransaction;
 
-public class SweepPriorityStore {
-    private final SweepTableFactory sweepTableFactory;
+public interface SweepPriorityStore {
+    void delete(Transaction tx, Collection<TableReference> tableRefs);
+    void update(Transaction tx, TableReference tableRef, UpdateSweepPriority update);
+    List<SweepPriority> loadNewPriorities(Transaction tx);
+    List<SweepPriority> loadOldPriorities(Transaction tx, long sweepTimestamp);
 
-    public SweepPriorityStore(SweepTableFactory sweepTableFactory) {
-        this.sweepTableFactory = sweepTableFactory;
+    default boolean isInitialized() {
+        return true;
     }
-
-    public List<SweepPriority> loadOldPriorities(Transaction tx, long sweepTimestamp) {
-        return loadPriorities(new SweepPriorityTransaction(tx, sweepTimestamp));
-    }
-
-    public List<SweepPriority> loadNewPriorities(Transaction tx) {
-        return loadPriorities(tx);
-    }
-
-    public void update(Transaction tx, TableReference tableRef, UpdateSweepPriority update) {
-        SweepPriorityRow row = SweepPriorityRow.of(tableRef.getQualifiedName());
-        SweepPriorityTable table = sweepTableFactory.getSweepPriorityTable(tx);
-        update.newStaleValuesDeleted().ifPresent(n -> table.putCellsDeleted(row, n));
-        update.newCellTsPairsExamined().ifPresent(n -> table.putCellsExamined(row, n));
-        update.newLastSweepTimeMillis().ifPresent(t -> table.putLastSweepTime(row, t));
-        update.newMinimumSweptTimestamp().ifPresent(t -> table.putMinimumSweptTimestamp(row, t));
-        update.newWriteCount().ifPresent(c -> table.putWriteCount(row, c));
-    }
-
-    public void delete(Transaction tx, Collection<TableReference> tableRefs) {
-        sweepTableFactory.getSweepPriorityTable(tx).delete(
-                Collections2.transform(tableRefs, tr -> SweepPriorityRow.of(tr.getQualifiedName())));
-    }
-
-    private List<SweepPriority> loadPriorities(Transaction tx) {
-        SweepPriorityTable table = sweepTableFactory.getSweepPriorityTable(tx);
-        return table.getAllRowsUnordered().transform(SweepPriorityStore::hydrate).immutableCopy();
-    }
-
-    private static SweepPriority hydrate(SweepPriorityTable.SweepPriorityRowResult rr) {
-        return ImmutableSweepPriority.builder()
-                .tableRef(TableReference.createUnsafe(rr.getRowName().getFullTableName()))
-                .writeCount(rr.hasWriteCount() ? rr.getWriteCount() : 0L)
-                .lastSweepTimeMillis(rr.hasLastSweepTime()
-                        ? OptionalLong.of(rr.getLastSweepTime())
-                        : OptionalLong.empty())
-                .minimumSweptTimestamp(rr.hasMinimumSweptTimestamp() ? rr.getMinimumSweptTimestamp() : Long.MIN_VALUE)
-                .staleValuesDeleted(rr.hasCellsDeleted() ? rr.getCellsDeleted() : 0L)
-                .cellTsPairsExamined(rr.hasCellsExamined() ? rr.getCellsExamined() : 0L)
-                .build();
-    }
-
-    // I didn't write this ****, only moved it from another file.
-    // This has never worked as intended.
-    // We probably need to completely redesign how we store historical priorities.
-    private static class SweepPriorityTransaction extends UnmodifiableTransaction {
-        private final long sweepTimestamp;
-
-        SweepPriorityTransaction(Transaction delegate, long sweepTimestamp) {
-            super(delegate);
-            this.sweepTimestamp = sweepTimestamp;
-        }
-
-        @Override
-        public long getTimestamp() {
-            return sweepTimestamp;
-        }
-
-        @Override
-        public TransactionReadSentinelBehavior getReadSentinelBehavior() {
-            return TransactionReadSentinelBehavior.IGNORE;
-        }
-    }
-
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStoreImpl.java
@@ -55,7 +55,7 @@ public final class SweepPriorityStoreImpl implements SweepPriorityStore {
     }
 
     private final KeyValueService kvs;
-    private final  SweepTableFactory sweepTableFactory;
+    private final SweepTableFactory sweepTableFactory;
     private InitializingWrapper wrapper = new InitializingWrapper();
 
     private SweepPriorityStoreImpl(KeyValueService kvs, SweepTableFactory sweepTableFactory) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStoreImpl.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.sweep.priority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.OptionalLong;
+
+import com.google.common.collect.Collections2;
+import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.schema.SweepSchema;
+import com.palantir.atlasdb.schema.generated.SweepPriorityTable;
+import com.palantir.atlasdb.schema.generated.SweepPriorityTable.SweepPriorityRow;
+import com.palantir.atlasdb.schema.generated.SweepTableFactory;
+import com.palantir.atlasdb.table.description.Schemas;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.UnmodifiableTransaction;
+import com.palantir.processors.AutoDelegate;
+
+@AutoDelegate(typeToExtend = SweepPriorityStore.class)
+public final class SweepPriorityStoreImpl implements SweepPriorityStore {
+    private class InitializingWrapper extends AsyncInitializer implements AutoDelegate_SweepPriorityStore {
+
+        @Override
+        public SweepPriorityStoreImpl delegate() {
+            checkInitialized();
+            return SweepPriorityStoreImpl.this;
+        }
+        @Override
+        protected void tryInitialize() {
+            SweepPriorityStoreImpl.this.tryInitialize();
+        }
+
+        @Override
+        protected String getInitializingClassName() {
+            return "SweepPriorityStore";
+        }
+
+    }
+
+    private final KeyValueService kvs;
+    private final  SweepTableFactory sweepTableFactory;
+    private InitializingWrapper wrapper = new InitializingWrapper();
+
+    private SweepPriorityStoreImpl(KeyValueService kvs, SweepTableFactory sweepTableFactory) {
+        this.kvs = kvs;
+        this.sweepTableFactory = sweepTableFactory;
+    }
+
+    public static SweepPriorityStore create(KeyValueService kvs, SweepTableFactory sweepTableFactory,
+            boolean initializeAsync) {
+        SweepPriorityStoreImpl sweepPriorityStore = new SweepPriorityStoreImpl(kvs, sweepTableFactory);
+        sweepPriorityStore.wrapper.initialize(initializeAsync);
+        return sweepPriorityStore.wrapper.isInitialized() ? sweepPriorityStore : sweepPriorityStore.wrapper;
+    }
+
+    @Override
+    public List<SweepPriority> loadOldPriorities(Transaction tx, long sweepTimestamp) {
+        return loadPriorities(new SweepPriorityTransaction(tx, sweepTimestamp));
+    }
+
+    @Override
+    public List<SweepPriority> loadNewPriorities(Transaction tx) {
+        return loadPriorities(tx);
+    }
+
+    @Override
+    public void update(Transaction tx, TableReference tableRef, UpdateSweepPriority update) {
+        SweepPriorityRow row = SweepPriorityRow.of(tableRef.getQualifiedName());
+        SweepPriorityTable table = sweepTableFactory.getSweepPriorityTable(tx);
+        update.newStaleValuesDeleted().ifPresent(n -> table.putCellsDeleted(row, n));
+        update.newCellTsPairsExamined().ifPresent(n -> table.putCellsExamined(row, n));
+        update.newLastSweepTimeMillis().ifPresent(t -> table.putLastSweepTime(row, t));
+        update.newMinimumSweptTimestamp().ifPresent(t -> table.putMinimumSweptTimestamp(row, t));
+        update.newWriteCount().ifPresent(c -> table.putWriteCount(row, c));
+    }
+
+    @Override
+    public void delete(Transaction tx, Collection<TableReference> tableRefs) {
+        sweepTableFactory.getSweepPriorityTable(tx).delete(
+                Collections2.transform(tableRefs, tr -> SweepPriorityRow.of(tr.getQualifiedName())));
+    }
+
+    private void tryInitialize() {
+        Schemas.createTablesAndIndexes(SweepSchema.INSTANCE.getLatestSchema(), kvs);
+    }
+
+    private List<SweepPriority> loadPriorities(Transaction tx) {
+        SweepPriorityTable table = sweepTableFactory.getSweepPriorityTable(tx);
+        return table.getAllRowsUnordered().transform(SweepPriorityStoreImpl::hydrate).immutableCopy();
+    }
+
+    private static SweepPriority hydrate(SweepPriorityTable.SweepPriorityRowResult rr) {
+        return ImmutableSweepPriority.builder()
+                .tableRef(TableReference.createUnsafe(rr.getRowName().getFullTableName()))
+                .writeCount(rr.hasWriteCount() ? rr.getWriteCount() : 0L)
+                .lastSweepTimeMillis(rr.hasLastSweepTime()
+                        ? OptionalLong.of(rr.getLastSweepTime())
+                        : OptionalLong.empty())
+                .minimumSweptTimestamp(rr.hasMinimumSweptTimestamp() ? rr.getMinimumSweptTimestamp() : Long.MIN_VALUE)
+                .staleValuesDeleted(rr.hasCellsDeleted() ? rr.getCellsDeleted() : 0L)
+                .cellTsPairsExamined(rr.hasCellsExamined() ? rr.getCellsExamined() : 0L)
+                .build();
+    }
+
+    // I didn't write this ****, only moved it from another file.
+    // This has never worked as intended.
+    // We probably need to completely redesign how we store historical priorities.
+    private static class SweepPriorityTransaction extends UnmodifiableTransaction {
+        private final long sweepTimestamp;
+
+        SweepPriorityTransaction(Transaction delegate, long sweepTimestamp) {
+            super(delegate);
+            this.sweepTimestamp = sweepTimestamp;
+        }
+
+        @Override
+        public long getTimestamp() {
+            return sweepTimestamp;
+        }
+
+        @Override
+        public TransactionReadSentinelBehavior getReadSentinelBehavior() {
+            return TransactionReadSentinelBehavior.IGNORE;
+        }
+    }
+
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStore.java
@@ -13,98 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.palantir.atlasdb.sweep.progress;
 
-import java.util.Map;
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+public interface SweepProgressStore {
+    void clearProgress();
+    void saveProgress(SweepProgress newProgress);
+    Optional<SweepProgress> loadProgress();
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
-import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.keyvalue.api.RangeRequest;
-import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.schema.generated.SweepProgressTable;
-import com.palantir.atlasdb.schema.generated.SweepTableFactory;
-
-public class SweepProgressStore {
-    private static final Logger log = LoggerFactory.getLogger(SweepProgressStore.class);
-
-    private final KeyValueService kvs;
-    private final TableReference tableRef;
-
-    private static final byte[] BYTE_ROW = SweepProgressTable.SweepProgressRow.of(0).persistToBytes();
-    private static final byte[] BYTE_COL = SweepProgressTable.SweepProgressNamedColumn.SWEEP_PROGRESS.getShortName();
-    private static final Cell CELL = Cell.create(BYTE_ROW, BYTE_COL);
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module())
-            .registerModule(new AfterburnerModule());
-
-    public SweepProgressStore(KeyValueService kvs, SweepTableFactory tableFactory) {
-        this.kvs = kvs;
-        this.tableRef = tableFactory.getSweepProgressTable(null).getTableRef();
-    }
-
-    public Optional<SweepProgress> loadProgress()  {
-        Map<Cell, Value> entry = kvs.get(tableRef, ImmutableMap.of(CELL, Long.MAX_VALUE));
-        return hydrateProgress(entry);
-    }
-
-    public void saveProgress(SweepProgress newProgress) {
-        Optional<SweepProgress> oldProgress = loadProgress();
-        try {
-            kvs.checkAndSet(casProgressRequest(oldProgress, newProgress));
-        } catch (Exception e) {
-            log.warn("Exception trying to persist sweep progress. The intermediate progress might not have been "
-                    + "persisted. This should not cause sweep issues unless the problem persists.", e);
-        }
-    }
-
-    /**
-     * Fully remove the contents of the sweep progress table.
-     */
-    public void clearProgress() {
-        // Use deleteRange instead of truncate
-        // 1) The table should be small, performance difference should be negligible.
-        // 2) Truncate takes an exclusive lock in Postgres, which can interfere
-        // with concurrently running backups.
-        kvs.deleteRange(tableRef, RangeRequest.all());
-    }
-
-    private CheckAndSetRequest casProgressRequest(Optional<SweepProgress> oldProgress, SweepProgress newProgress)
-            throws JsonProcessingException {
-        if (!oldProgress.isPresent()) {
-            return CheckAndSetRequest.newCell(tableRef, CELL, progressToBytes(newProgress));
-        }
-        return CheckAndSetRequest.singleCell(tableRef,
-                CELL, progressToBytes(oldProgress.get()), progressToBytes(newProgress));
-    }
-
-    private byte[] progressToBytes(SweepProgress value) throws JsonProcessingException {
-        return OBJECT_MAPPER.writeValueAsBytes(value);
-    }
-
-    private static Optional<SweepProgress> hydrateProgress(Map<Cell, Value> result) {
-        if (result.isEmpty()) {
-            log.info("No persisted intermittent SweepProgress information found. "
-                    + "Sweep will choose a new table to sweep.");
-            return Optional.empty();
-        }
-        try {
-            return Optional.of(OBJECT_MAPPER.readValue(result.get(CELL).getContents(), SweepProgress.class));
-        } catch (Exception e) {
-            log.warn("Error deserializing SweepProgress object while attempting to load intermediate result. "
-                    + "Sweep will choose a new table to sweep.", e);
-            return Optional.empty();
-        }
+    default boolean isInitialized() {
+        return true;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/progress/SweepProgressStoreImpl.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.sweep.progress;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
+import com.palantir.atlasdb.table.description.ColumnValueDescription;
+import com.palantir.atlasdb.table.description.NameComponentDescription;
+import com.palantir.atlasdb.table.description.NameMetadataDescription;
+import com.palantir.atlasdb.table.description.NamedColumnDescription;
+import com.palantir.atlasdb.table.description.TableMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.processors.AutoDelegate;
+
+@AutoDelegate(typeToExtend = SweepProgressStore.class)
+public final class SweepProgressStoreImpl implements SweepProgressStore {
+    private class InitializingWrapper extends AsyncInitializer implements AutoDelegate_SweepProgressStore {
+        @Override
+        public SweepProgressStoreImpl delegate() {
+            checkInitialized();
+            return SweepProgressStoreImpl.this;
+        }
+
+        @Override
+        protected void tryInitialize() {
+            SweepProgressStoreImpl.this.tryInitialize();
+        }
+
+        @Override
+        protected String getInitializingClassName() {
+            return "SweepProgressStore";
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(SweepProgressStoreImpl.class);
+
+    private final KeyValueService kvs;
+    private final InitializingWrapper wrapper = new InitializingWrapper();
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new Jdk8Module())
+            .registerModule(new AfterburnerModule());
+
+    private static final String ROW_AND_COLUMN_NAME = "s";
+    private static final byte[] ROW_AND_COLUMN_NAME_BYTES = PtBytes.toCachedBytes(ROW_AND_COLUMN_NAME);
+    private static final Cell CELL = Cell.create(ROW_AND_COLUMN_NAME_BYTES, ROW_AND_COLUMN_NAME_BYTES);
+
+    private static final TableMetadata SWEEP_PROGRESS_METADATA = new TableMetadata(
+            NameMetadataDescription.create(ImmutableList.of(
+                    new NameComponentDescription.Builder()
+                            .componentName("dummy")
+                            .type(ValueType.STRING)
+                            .build())),
+            new ColumnMetadataDescription(ImmutableList.of(
+                    new NamedColumnDescription(
+                            ROW_AND_COLUMN_NAME,
+                            "sweep_progress",
+                            ColumnValueDescription.forType(ValueType.BLOB)))),
+            ConflictHandler.IGNORE_ALL);
+
+    private SweepProgressStoreImpl(KeyValueService kvs) {
+        this.kvs = kvs;
+    }
+
+    public static SweepProgressStore create(KeyValueService kvs, boolean initializeAsync) {
+        SweepProgressStoreImpl progressStore = new SweepProgressStoreImpl(kvs);
+        progressStore.wrapper.initialize(initializeAsync);
+        return progressStore.wrapper.isInitialized() ? progressStore : progressStore.wrapper;
+    }
+
+    @Override
+    public Optional<SweepProgress> loadProgress()  {
+        Map<Cell, Value> entry = kvs.get(AtlasDbConstants.SWEEP_PROGRESS_TABLE, ImmutableMap.of(CELL, 1L));
+        return hydrateProgress(entry);
+    }
+
+    @Override
+    public void saveProgress(SweepProgress newProgress) {
+        Optional<SweepProgress> oldProgress = loadProgress();
+        try {
+            kvs.checkAndSet(casProgressRequest(oldProgress, newProgress));
+        } catch (Exception e) {
+            log.warn("Exception trying to persist sweep progress. The intermediate progress might not have been "
+                    + "persisted. This should not cause sweep issues unless the problem persists.", e);
+        }
+    }
+
+    /**
+     * Fully remove the contents of the sweep progress table.
+     */
+    @Override
+    public void clearProgress() {
+        // Use deleteRange instead of truncate
+        // 1) The table should be small, performance difference should be negligible.
+        // 2) Truncate takes an exclusive lock in Postgres, which can interfere
+        // with concurrently running backups.
+        kvs.deleteRange(AtlasDbConstants.SWEEP_PROGRESS_TABLE, RangeRequest.all());
+    }
+
+    private CheckAndSetRequest casProgressRequest(Optional<SweepProgress> oldProgress, SweepProgress progress)
+            throws JsonProcessingException {
+        if (!oldProgress.isPresent()) {
+            return CheckAndSetRequest.newCell(AtlasDbConstants.SWEEP_PROGRESS_TABLE, CELL, progressToBytes(progress));
+        }
+        return CheckAndSetRequest.singleCell(AtlasDbConstants.SWEEP_PROGRESS_TABLE,
+                CELL, progressToBytes(oldProgress.get()), progressToBytes(progress));
+    }
+
+    private void tryInitialize() {
+        kvs.createTable(AtlasDbConstants.SWEEP_PROGRESS_TABLE, SWEEP_PROGRESS_METADATA.persistToBytes());
+    }
+
+    private byte[] progressToBytes(SweepProgress value) throws JsonProcessingException {
+        return OBJECT_MAPPER.writeValueAsBytes(value);
+    }
+
+    private static Optional<SweepProgress> hydrateProgress(Map<Cell, Value> result) {
+        if (result.isEmpty()) {
+            log.info("No persisted intermittent SweepProgress information found. "
+                    + "Sweep will choose a new table to sweep.");
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(OBJECT_MAPPER.readValue(result.get(CELL).getContents(), SweepProgress.class));
+        } catch (Exception e) {
+            log.warn("Error deserializing SweepProgress object while attempting to load intermediate result. "
+                    + "Sweep will choose a new table to sweep.", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractBackgroundSweeperIntegrationTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractBackgroundSweeperIntegrationTest.java
@@ -38,7 +38,7 @@ import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
 import com.palantir.atlasdb.sweep.priority.SweepPriority;
-import com.palantir.atlasdb.sweep.priority.SweepPriorityStore;
+import com.palantir.atlasdb.sweep.priority.SweepPriorityStoreImpl;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
@@ -90,7 +90,8 @@ public abstract class AbstractBackgroundSweeperIntegrationTest {
                 () -> sweepBatchConfig,
                 SweepTableFactory.of(),
                 new NoOpBackgroundSweeperPerformanceLogger(),
-                sweepMetrics);
+                sweepMetrics,
+                false);
 
         backgroundSweeper = BackgroundSweeperImpl.create(
                 () -> true, // sweepEnabled
@@ -119,7 +120,7 @@ public abstract class AbstractBackgroundSweeperIntegrationTest {
         verifyTableSwept(TABLE_1, 75, true);
         verifyTableSwept(TABLE_2, 58, false);
         List<SweepPriority> priorities = txManager.runTaskReadOnly(
-                tx -> new SweepPriorityStore(SweepTableFactory.of()).loadNewPriorities(tx));
+                tx -> SweepPriorityStoreImpl.create(kvs, SweepTableFactory.of(), false).loadNewPriorities(tx));
         Assert.assertTrue(priorities.stream().anyMatch(p -> p.tableRef().equals(TABLE_1)));
         Assert.assertTrue(priorities.stream().anyMatch(p -> p.tableRef().equals(TABLE_2)));
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStoreTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/priority/SweepPriorityStoreTest.java
@@ -46,7 +46,7 @@ public class SweepPriorityStoreTest {
         exec = Tracers.wrap(PTExecutors.newCachedThreadPool());
         KeyValueService kvs = new InMemoryKeyValueService(false, exec);
         txManager = SweepTestUtils.setupTxManager(kvs);
-        priorityStore = new SweepPriorityStore(SweepTableFactory.of());
+        priorityStore = SweepPriorityStoreImpl.create(kvs, SweepTableFactory.of(), false);
     }
 
     @After

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/progress/SweepProgressStoreTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/progress/SweepProgressStoreTest.java
@@ -27,7 +27,6 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
-import com.palantir.atlasdb.schema.generated.SweepTableFactory;
 import com.palantir.atlasdb.sweep.SweepTestUtils;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.common.concurrent.PTExecutors;
@@ -60,7 +59,7 @@ public class SweepProgressStoreTest {
         exec = Tracers.wrap(PTExecutors.newCachedThreadPool());
         KeyValueService kvs = new InMemoryKeyValueService(false, exec);
         txManager = SweepTestUtils.setupTxManager(kvs);
-        progressStore = new SweepProgressStore(kvs, SweepTableFactory.of());
+        progressStore = SweepProgressStoreImpl.create(kvs, false);
     }
 
     @After


### PR DESCRIPTION
**Goals (and why)**:
Fix async initialization of BackgroundSweeper and use a non-atlas table for sweep progress.

**Implementation Description (bullets)**:
Relatively straightforward.

**Concerns (what feedback would you like?)**:
Is the metadata for sweep progress correct?

**Where should we start reviewing?**:
SweepProgressStoreImpl.java

**Priority (whenever / two weeks / yesterday)**:
Asap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2598)
<!-- Reviewable:end -->
