### PR TITLE
Fix tests that fail after regenerating schemas

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -1240,8 +1241,9 @@ public final class SweepPriorityTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "gUKvXfI0gPVeg5jGILInrg==";
+    static String __CLASS_HASH = "0/YxsjZHklo6DNpEROBJag==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepProgressTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -1240,8 +1241,9 @@ public final class SweepProgressTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "g2hIFMWJqz1aBbgwYc6j4A==";
+    static String __CLASS_HASH = "rdpVgkOt4kzP5JwH0T+1KA==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ApiTestSchema.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ApiTestSchema.java
@@ -34,7 +34,7 @@ public class ApiTestSchema implements AtlasSchema {
     private static Schema generateSchema() {
         Schema schema = new Schema("ApiTest",
                 ApiTestSchema.class.getPackage().getName() + ".generated",
-                Namespace.create("test"),
+                Namespace.create("default"),
                 OptionalType.JAVA8);
 
         schema.addTableDefinition("SchemaApiTest", new TableDefinition() {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ApiTestSchema.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ApiTestSchema.java
@@ -34,7 +34,7 @@ public class ApiTestSchema implements AtlasSchema {
     private static Schema generateSchema() {
         Schema schema = new Schema("ApiTest",
                 ApiTestSchema.class.getPackage().getName() + ".generated",
-                Namespace.create("default"),
+                Namespace.DEFAULT_NAMESPACE,
                 OptionalType.JAVA8);
 
         schema.addTableDefinition("SchemaApiTest", new TableDefinition() {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -796,8 +797,9 @@ public final class GenericRangeScanTestTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "6bLdl4BXUCntnhO1r687fw==";
+    static String __CLASS_HASH = "S49NvKcB1MEC2LvdAnQEdw==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericTestSchemaTableFactory.java
@@ -12,7 +12,7 @@ import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class GenericTestSchemaTableFactory {
-    private static final Namespace defaultNamespace = Namespace.EMPTY_NAMESPACE;
+    private static final Namespace defaultNamespace = Namespace.create("test", Namespace.UNCHECKED_NAME);
 
     private final List<Function<? super Transaction, SharedTriggers>> sharedTriggers;
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -733,8 +734,9 @@ public final class RangeScanTestTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "kVmFUBZrAev3uaZ22BYp1g==";
+    static String __CLASS_HASH = "dv0yt8ncZc+tkbAwWGXfDA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -684,8 +685,9 @@ public final class CheckAndSetTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "h/HVXKlpZkP4yJK4D8RwEA==";
+    static String __CLASS_HASH = "41OfghqF/21hRLujZXqUcQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -3599,8 +3600,9 @@ public final class DataTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "AZloIvQuqPMNdSVikR5Giw==";
+    static String __CLASS_HASH = "ShIqXVgEIVVQr/BcTtWnvA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -2223,8 +2224,9 @@ public final class TwoColumnsTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "wP29qfigRwiVB/u5Iav3sQ==";
+    static String __CLASS_HASH = "mISpua2RtrhYSzXBQfqcZQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -684,8 +685,9 @@ public final class KeyValueTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "DNtXMcJseN1IXp+lBbJMNw==";
+    static String __CLASS_HASH = "FywAYzLeV7fRBQjGFBX/nQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -743,8 +744,9 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XCOREv2E+WkJrORRzAuQ2Q==";
+    static String __CLASS_HASH = "93ooXo9GB8XvKrs3nUXIxQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -743,8 +744,9 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UqZuV6+wSHAeAyC6SaZgxA==";
+    static String __CLASS_HASH = "YJegzgATA9HaVGttkcbJ6A==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -708,8 +709,9 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "az7LPfbueatwCl631Hwngg==";
+    static String __CLASS_HASH = "AgHr/jG0A8uFXTCjSLt/tg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -696,8 +697,9 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "hd6nGG4sbUdh+e7SXpKxtg==";
+    static String __CLASS_HASH = "KPPAgMABU1yC0t+0X6Y7lQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -743,8 +744,9 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "uYF33MTfZj1ax2tZjsU1sQ==";
+    static String __CLASS_HASH = "VCPeU/e8KVrn5kUjr5w53g==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -743,8 +744,9 @@ public final class StreamTestStreamIdxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "aoT4LBo9ZRVdOwMFpXoknA==";
+    static String __CLASS_HASH = "sp1q42ZHvZEGZKmjbkx6gA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -708,8 +709,9 @@ public final class StreamTestStreamMetadataTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Cfea6/4iOIVRUDwxgalrhQ==";
+    static String __CLASS_HASH = "qzQiB9PN2ekCvdz/rk6TJw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -696,8 +697,9 @@ public final class StreamTestStreamValueTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "gAOWPVuqI4dH7uXMbIPAyQ==";
+    static String __CLASS_HASH = "4EcUhq32x2OWNRVUm1kHbw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -743,8 +744,9 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "FR/nYktAUB807xIzz1cC/Q==";
+    static String __CLASS_HASH = "9FqzcWU31bRlEGdqwSnvcw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -757,8 +758,9 @@ public final class StreamTestWithHashStreamIdxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "mHTyb6swG41IjFXUCfD/qQ==";
+    static String __CLASS_HASH = "Wfa8ovjvRMXcN8uAnLPUiQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -722,8 +723,9 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "dKu8ah8b0CeaheJZb6bgdg==";
+    static String __CLASS_HASH = "LiCJlE6VY+dYyN9CtFhlpA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -710,8 +711,9 @@ public final class StreamTestWithHashStreamValueTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ob5ahzk5qpKE0Ot/EJM7Pw==";
+    static String __CLASS_HASH = "ul4VXZdFu5UaZ3VKj5Bxng==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -743,8 +744,9 @@ public final class TestHashComponentsStreamHashAidxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "fSNqWPNyRdQ3Y6hC4L2uig==";
+    static String __CLASS_HASH = "347bSgavSxAXs97Ls4JKdQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -757,8 +758,9 @@ public final class TestHashComponentsStreamIdxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ZD89FVlOOCQH+8OXDaVWXw==";
+    static String __CLASS_HASH = "QLpZWBW1Z82u4/HCUU4YSw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -722,8 +723,9 @@ public final class TestHashComponentsStreamMetadataTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "DuL2a5B8YmGHzs9oDp7q/w==";
+    static String __CLASS_HASH = "e3os93HFIDmZAQMysgTE1A==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -711,8 +712,9 @@ public final class TestHashComponentsStreamValueTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1h8uGitJmzr9XVFk+6LDkw==";
+    static String __CLASS_HASH = "8TUz4dfbkXAMknGEt+6peQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -743,8 +744,9 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Yfhs803eH4skZC4typZzUg==";
+    static String __CLASS_HASH = "/UBEutcJ6Vz08djUnCJAIg==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -743,8 +744,9 @@ public final class UserPhotosStreamIdxTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "cRfNWltUJdrIE2WYQp2oIQ==";
+    static String __CLASS_HASH = "GsgciB8SYL+DqcYPTdb7jA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -708,8 +709,9 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "pdX/Zh13u2W1C5jkP04eIA==";
+    static String __CLASS_HASH = "EMCfzhKIQnpK0mA5QIViaQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -696,8 +697,9 @@ public final class UserPhotosStreamValueTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "syJ6MxMtIYfYjTU0q2Yk7g==";
+    static String __CLASS_HASH = "yUsG+A2rF92y3Gc+S8EuIQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -138,38 +139,38 @@ public final class UserProfileTable implements
     /**
      * <pre>
      * UserProfileRow {
-     *   {@literal java.util.UUID id};
+     *   {@literal UUID id};
      * }
      * </pre>
      */
     public static final class UserProfileRow implements Persistable, Comparable<UserProfileRow> {
-        private final java.util.UUID id;
+        private final UUID id;
 
-        public static UserProfileRow of(java.util.UUID id) {
+        public static UserProfileRow of(UUID id) {
             return new UserProfileRow(id);
         }
 
-        private UserProfileRow(java.util.UUID id) {
+        private UserProfileRow(UUID id) {
             this.id = id;
         }
 
-        public java.util.UUID getId() {
+        public UUID getId() {
             return id;
         }
 
-        public static Function<UserProfileRow, java.util.UUID> getIdFun() {
-            return new Function<UserProfileRow, java.util.UUID>() {
+        public static Function<UserProfileRow, UUID> getIdFun() {
+            return new Function<UserProfileRow, UUID>() {
                 @Override
-                public java.util.UUID apply(UserProfileRow row) {
+                public UUID apply(UserProfileRow row) {
                     return row.id;
                 }
             };
         }
 
-        public static Function<java.util.UUID, UserProfileRow> fromIdFun() {
-            return new Function<java.util.UUID, UserProfileRow>() {
+        public static Function<UUID, UserProfileRow> fromIdFun() {
+            return new Function<UUID, UserProfileRow>() {
                 @Override
-                public UserProfileRow apply(java.util.UUID row) {
+                public UserProfileRow apply(UUID row) {
                     return UserProfileRow.of(row);
                 }
             };
@@ -185,7 +186,7 @@ public final class UserProfileTable implements
             @Override
             public UserProfileRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                java.util.UUID id = EncodingUtils.decodeUUID(__input, __index);
+                UUID id = EncodingUtils.decodeUUID(__input, __index);
                 __index += 16;
                 return new UserProfileRow(id);
             }
@@ -845,7 +846,7 @@ public final class UserProfileTable implements
                     UserProfileRow row = e.getKey();
                     CookiesIdxTable table = CookiesIdxTable.of(this);
                     Iterable<String> cookieIterable = com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
-                    java.util.UUID id = row.getId();
+                    UUID id = row.getId();
                     for (String cookie : cookieIterable) {
                         CookiesIdxTable.CookiesIdxRow indexRow = CookiesIdxTable.CookiesIdxRow.of(cookie);
                         CookiesIdxTable.CookiesIdxColumn indexCol = CookiesIdxTable.CookiesIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
@@ -861,7 +862,7 @@ public final class UserProfileTable implements
                     UserProfileRow row = e.getKey();
                     CreatedIdxTable table = CreatedIdxTable.of(this);
                     long time = col.getValue().getTimeCreated();
-                    java.util.UUID id = row.getId();
+                    UUID id = row.getId();
                     CreatedIdxTable.CreatedIdxRow indexRow = CreatedIdxTable.CreatedIdxRow.of(time);
                     CreatedIdxTable.CreatedIdxColumn indexCol = CreatedIdxTable.CreatedIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
                     CreatedIdxTable.CreatedIdxColumnValue indexColVal = CreatedIdxTable.CreatedIdxColumnValue.of(indexCol, 0L);
@@ -875,7 +876,7 @@ public final class UserProfileTable implements
                     UserProfileRow row = e.getKey();
                     UserBirthdaysIdxTable table = UserBirthdaysIdxTable.of(this);
                     long birthday = col.getValue().getBirthEpochDay();
-                    java.util.UUID id = row.getId();
+                    UUID id = row.getId();
                     UserBirthdaysIdxTable.UserBirthdaysIdxRow indexRow = UserBirthdaysIdxTable.UserBirthdaysIdxRow.of(birthday);
                     UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol = UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
                     UserBirthdaysIdxTable.UserBirthdaysIdxColumnValue indexColVal = UserBirthdaysIdxTable.UserBirthdaysIdxColumnValue.of(indexCol, 0L);
@@ -921,7 +922,7 @@ public final class UserProfileTable implements
             Metadata col = (Metadata) shortNameToHydrator.get("m").hydrateFromBytes(result.getValue());
             UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getRowName());
             long birthday = col.getValue().getBirthEpochDay();
-            java.util.UUID id = row.getId();
+            UUID id = row.getId();
             UserBirthdaysIdxTable.UserBirthdaysIdxRow indexRow = UserBirthdaysIdxTable.UserBirthdaysIdxRow.of(birthday);
             UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol = UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
             indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
@@ -947,7 +948,7 @@ public final class UserProfileTable implements
             Create col = (Create) shortNameToHydrator.get("c").hydrateFromBytes(result.getValue());
             UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getRowName());
             long time = col.getValue().getTimeCreated();
-            java.util.UUID id = row.getId();
+            UUID id = row.getId();
             CreatedIdxTable.CreatedIdxRow indexRow = CreatedIdxTable.CreatedIdxRow.of(time);
             CreatedIdxTable.CreatedIdxColumn indexCol = CreatedIdxTable.CreatedIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
             indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
@@ -973,7 +974,7 @@ public final class UserProfileTable implements
             Json col = (Json) shortNameToHydrator.get("j").hydrateFromBytes(result.getValue());
             UserProfileRow row = UserProfileRow.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getRowName());
             Iterable<String> cookieIterable = com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
-            java.util.UUID id = row.getId();
+            UUID id = row.getId();
             for (String cookie : cookieIterable) {
                 CookiesIdxTable.CookiesIdxRow indexRow = CookiesIdxTable.CookiesIdxRow.of(cookie);
                 CookiesIdxTable.CookiesIdxColumn indexCol = CookiesIdxTable.CookiesIdxColumn.of(row.persistToBytes(), col.persistColumnName(), id);
@@ -1136,7 +1137,7 @@ public final class UserProfileTable implements
                 Json col = (Json) e.getValue();{
                     UserProfileRow row = e.getKey();
                     Iterable<String> cookieIterable = com.palantir.example.profile.schema.ProfileSchema.getCookies(col.getValue());
-                    java.util.UUID id = row.getId();
+                    UUID id = row.getId();
                     for (String cookie : cookieIterable) {
                         CookiesIdxTable.CookiesIdxRow indexRow = CookiesIdxTable.CookiesIdxRow.of(cookie);
                         CookiesIdxTable.CookiesIdxColumn indexCol = CookiesIdxTable.CookiesIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
@@ -1155,7 +1156,7 @@ public final class UserProfileTable implements
                 Create col = (Create) e.getValue();{
                     UserProfileRow row = e.getKey();
                     long time = col.getValue().getTimeCreated();
-                    java.util.UUID id = row.getId();
+                    UUID id = row.getId();
                     CreatedIdxTable.CreatedIdxRow indexRow = CreatedIdxTable.CreatedIdxRow.of(time);
                     CreatedIdxTable.CreatedIdxColumn indexCol = CreatedIdxTable.CreatedIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
                     indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
@@ -1172,7 +1173,7 @@ public final class UserProfileTable implements
                 Metadata col = (Metadata) e.getValue();{
                     UserProfileRow row = e.getKey();
                     long birthday = col.getValue().getBirthEpochDay();
-                    java.util.UUID id = row.getId();
+                    UUID id = row.getId();
                     UserBirthdaysIdxTable.UserBirthdaysIdxRow indexRow = UserBirthdaysIdxTable.UserBirthdaysIdxRow.of(birthday);
                     UserBirthdaysIdxTable.UserBirthdaysIdxColumn indexCol = UserBirthdaysIdxTable.UserBirthdaysIdxColumn.of(row.persistToBytes(), e.getValue().persistColumnName(), id);
                     indexCells.add(Cell.create(indexRow.persistToBytes(), indexCol.persistToBytes()));
@@ -1353,20 +1354,20 @@ public final class UserProfileTable implements
          * CookiesIdxColumn {
          *   {@literal byte[] rowName};
          *   {@literal byte[] columnName};
-         *   {@literal java.util.UUID id};
+         *   {@literal UUID id};
          * }
          * </pre>
          */
         public static final class CookiesIdxColumn implements Persistable, Comparable<CookiesIdxColumn> {
             private final byte[] rowName;
             private final byte[] columnName;
-            private final java.util.UUID id;
+            private final UUID id;
 
-            public static CookiesIdxColumn of(byte[] rowName, byte[] columnName, java.util.UUID id) {
+            public static CookiesIdxColumn of(byte[] rowName, byte[] columnName, UUID id) {
                 return new CookiesIdxColumn(rowName, columnName, id);
             }
 
-            private CookiesIdxColumn(byte[] rowName, byte[] columnName, java.util.UUID id) {
+            private CookiesIdxColumn(byte[] rowName, byte[] columnName, UUID id) {
                 this.rowName = rowName;
                 this.columnName = columnName;
                 this.id = id;
@@ -1380,7 +1381,7 @@ public final class UserProfileTable implements
                 return columnName;
             }
 
-            public java.util.UUID getId() {
+            public UUID getId() {
                 return id;
             }
 
@@ -1402,10 +1403,10 @@ public final class UserProfileTable implements
                 };
             }
 
-            public static Function<CookiesIdxColumn, java.util.UUID> getIdFun() {
-                return new Function<CookiesIdxColumn, java.util.UUID>() {
+            public static Function<CookiesIdxColumn, UUID> getIdFun() {
+                return new Function<CookiesIdxColumn, UUID>() {
                     @Override
-                    public java.util.UUID apply(CookiesIdxColumn row) {
+                    public UUID apply(CookiesIdxColumn row) {
                         return row.id;
                     }
                 };
@@ -1427,7 +1428,7 @@ public final class UserProfileTable implements
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
-                    java.util.UUID id = EncodingUtils.decodeUUID(__input, __index);
+                    UUID id = EncodingUtils.decodeUUID(__input, __index);
                     __index += 16;
                     return new CookiesIdxColumn(rowName, columnName, id);
                 }
@@ -1504,7 +1505,7 @@ public final class UserProfileTable implements
          * Column name description {
          *   {@literal byte[] rowName};
          *   {@literal byte[] columnName};
-         *   {@literal java.util.UUID id};
+         *   {@literal UUID id};
          * }
          * Column value description {
          *   type: Long;
@@ -2039,20 +2040,20 @@ public final class UserProfileTable implements
          * CreatedIdxColumn {
          *   {@literal byte[] rowName};
          *   {@literal byte[] columnName};
-         *   {@literal java.util.UUID id};
+         *   {@literal UUID id};
          * }
          * </pre>
          */
         public static final class CreatedIdxColumn implements Persistable, Comparable<CreatedIdxColumn> {
             private final byte[] rowName;
             private final byte[] columnName;
-            private final java.util.UUID id;
+            private final UUID id;
 
-            public static CreatedIdxColumn of(byte[] rowName, byte[] columnName, java.util.UUID id) {
+            public static CreatedIdxColumn of(byte[] rowName, byte[] columnName, UUID id) {
                 return new CreatedIdxColumn(rowName, columnName, id);
             }
 
-            private CreatedIdxColumn(byte[] rowName, byte[] columnName, java.util.UUID id) {
+            private CreatedIdxColumn(byte[] rowName, byte[] columnName, UUID id) {
                 this.rowName = rowName;
                 this.columnName = columnName;
                 this.id = id;
@@ -2066,7 +2067,7 @@ public final class UserProfileTable implements
                 return columnName;
             }
 
-            public java.util.UUID getId() {
+            public UUID getId() {
                 return id;
             }
 
@@ -2088,10 +2089,10 @@ public final class UserProfileTable implements
                 };
             }
 
-            public static Function<CreatedIdxColumn, java.util.UUID> getIdFun() {
-                return new Function<CreatedIdxColumn, java.util.UUID>() {
+            public static Function<CreatedIdxColumn, UUID> getIdFun() {
+                return new Function<CreatedIdxColumn, UUID>() {
                     @Override
-                    public java.util.UUID apply(CreatedIdxColumn row) {
+                    public UUID apply(CreatedIdxColumn row) {
                         return row.id;
                     }
                 };
@@ -2113,7 +2114,7 @@ public final class UserProfileTable implements
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
-                    java.util.UUID id = EncodingUtils.decodeUUID(__input, __index);
+                    UUID id = EncodingUtils.decodeUUID(__input, __index);
                     __index += 16;
                     return new CreatedIdxColumn(rowName, columnName, id);
                 }
@@ -2190,7 +2191,7 @@ public final class UserProfileTable implements
          * Column name description {
          *   {@literal byte[] rowName};
          *   {@literal byte[] columnName};
-         *   {@literal java.util.UUID id};
+         *   {@literal UUID id};
          * }
          * Column value description {
          *   type: Long;
@@ -2725,20 +2726,20 @@ public final class UserProfileTable implements
          * UserBirthdaysIdxColumn {
          *   {@literal byte[] rowName};
          *   {@literal byte[] columnName};
-         *   {@literal java.util.UUID id};
+         *   {@literal UUID id};
          * }
          * </pre>
          */
         public static final class UserBirthdaysIdxColumn implements Persistable, Comparable<UserBirthdaysIdxColumn> {
             private final byte[] rowName;
             private final byte[] columnName;
-            private final java.util.UUID id;
+            private final UUID id;
 
-            public static UserBirthdaysIdxColumn of(byte[] rowName, byte[] columnName, java.util.UUID id) {
+            public static UserBirthdaysIdxColumn of(byte[] rowName, byte[] columnName, UUID id) {
                 return new UserBirthdaysIdxColumn(rowName, columnName, id);
             }
 
-            private UserBirthdaysIdxColumn(byte[] rowName, byte[] columnName, java.util.UUID id) {
+            private UserBirthdaysIdxColumn(byte[] rowName, byte[] columnName, UUID id) {
                 this.rowName = rowName;
                 this.columnName = columnName;
                 this.id = id;
@@ -2752,7 +2753,7 @@ public final class UserProfileTable implements
                 return columnName;
             }
 
-            public java.util.UUID getId() {
+            public UUID getId() {
                 return id;
             }
 
@@ -2774,10 +2775,10 @@ public final class UserProfileTable implements
                 };
             }
 
-            public static Function<UserBirthdaysIdxColumn, java.util.UUID> getIdFun() {
-                return new Function<UserBirthdaysIdxColumn, java.util.UUID>() {
+            public static Function<UserBirthdaysIdxColumn, UUID> getIdFun() {
+                return new Function<UserBirthdaysIdxColumn, UUID>() {
                     @Override
-                    public java.util.UUID apply(UserBirthdaysIdxColumn row) {
+                    public UUID apply(UserBirthdaysIdxColumn row) {
                         return row.id;
                     }
                 };
@@ -2799,7 +2800,7 @@ public final class UserProfileTable implements
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
-                    java.util.UUID id = EncodingUtils.decodeUUID(__input, __index);
+                    UUID id = EncodingUtils.decodeUUID(__input, __index);
                     __index += 16;
                     return new UserBirthdaysIdxColumn(rowName, columnName, id);
                 }
@@ -2876,7 +2877,7 @@ public final class UserProfileTable implements
          * Column name description {
          *   {@literal byte[] rowName};
          *   {@literal byte[] columnName};
-         *   {@literal java.util.UUID id};
+         *   {@literal UUID id};
          * }
          * Column value description {
          *   type: Long;
@@ -3350,8 +3351,9 @@ public final class UserProfileTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "3fqOZ+qIJ6uwBrHQDwnW6Q==";
+    static String __CLASS_HASH = "i4ubDZ10Q8TP6mjH1iLMJw==";
 }


### PR DESCRIPTION
If you take the current develop, run `./gradlew generateSchemas` and run tests, then SchemaApiTestImpl will fail.

I changed ApiTestSchema to use the namespace "default" instead of "test" and re-generated the schemas.

We really need to generate schemas automatically on every build and stop checking them in to prevent this from happening.

This is blocking my other PR: https://github.com/palantir/atlasdb/pull/2599

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2601)
<!-- Reviewable:end -->
