### PR TITLE
Release notes 64

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,7 +41,23 @@ Changelog
 develop
 =======
 
-.. replace this with the release date
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    -
+         -
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
+v0.64.0
+=======
+
+1 November 2017
 
 .. list-table::
     :widths: 5 40
@@ -57,27 +73,30 @@ develop
 
     *    - |improved|
          - The executor used by the Cassandra KVS is now allowed to grow larger so that we can better delegate blocking to the underlying Cassandra client pools.
-           Please note that for Cassandra users this may result in increased Atlas thread counts when receiving spikes in requests. The underlying throtting is the same, however, so Cassandra load shouldn't be impacted.
+           Please note that for Cassandra users this may result in increased Atlas thread counts when receiving spikes in requests.
+           The underlying throttling is the same, however, so Cassandra load shouldn't be impacted.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2534>`__)
 
     *    - |improved| |metrics|
-         - ``BackgroupSweeperImpl`` now records additional metrics on how each run of sweep went.  Metrics report the number of occurences of each outcome in the 1 minute prior to the metrics being gathered, we may change this duration in the future.
+         - ``BackgroupSweeperImpl`` now records additional metrics on how each run of sweep went.
+           Metrics report the number of occurrences of each outcome in the 1 minute prior to the metrics being gathered, we may change this duration in the future.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2531>`__)
 
-    *   - |fixed| |logs|
-        - Log host names in Cassandra* classes.
-          (`Pull Request <https://github.com/palantir/atlasdb/pull/2592>`__)
+    *    - |improved| |logs|
+         - Log host names in Cassandra* classes.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2592>`__)
 
-    *   - |fixed|
-        - The executors used when async initializing objects are never shutdown anymore.
-          You should be affected by this bug only if you had `AtlasDbConfig.initializeAsync = true`. If so, we recommend upgrading to a version of AtlasDB with this fix.
-          (`Pull Request <https://github.com/palantir/atlasdb/pull/2547>`__)
+    *    - |fixed|
+         - The executors used when async initializing objects are never shutdown anymore.
+           You should be affected by this bug only if you had ``AtlasDbConfig.initializeAsync = true``.
+           Previously, we would shut down the executors after a successful initialization, which could lead to a race condition with the submission of a ``cancelInitialization`` task.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2547>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
-======
-0.63.0
-======
+=======
+v0.63.0
+=======
 
 27 October 2017
 
@@ -99,9 +118,9 @@ develop
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
-======
-0.62.1
-======
+=======
+v0.62.1
+=======
 
 27 October 2017
 
@@ -118,9 +137,9 @@ develop
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
-======
-0.62.0
-======
+=======
+v0.62.0
+=======
 
 26 October 2017
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -78,7 +78,7 @@ v0.64.0
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2534>`__)
 
     *    - |improved| |metrics|
-         - ``BackgroupSweeperImpl`` now records additional metrics on how each run of sweep went.
+         - ``BackgroundSweeperImpl`` now records additional metrics on how each run of sweep went.
            Metrics report the number of occurrences of each outcome in the 1 minute prior to the metrics being gathered.
            We may change this duration in the future.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2531>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -79,7 +79,8 @@ v0.64.0
 
     *    - |improved| |metrics|
          - ``BackgroupSweeperImpl`` now records additional metrics on how each run of sweep went.
-           Metrics report the number of occurrences of each outcome in the 1 minute prior to the metrics being gathered, we may change this duration in the future.
+           Metrics report the number of occurrences of each outcome in the 1 minute prior to the metrics being gathered.
+           We may change this duration in the future.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2531>`__)
 
     *    - |improved| |logs|


### PR DESCRIPTION
**Goals (and why)**:
- Cleanup the release notes for 0.64.0
- Drive-by fix of a bug where release note links were broken, because it seems Sphinx does not like bookmarks that begin with numbers.

**Implementation Description (bullets)**:
- Cleanup the release notes
- Add `v` to the last few version headings.

**Concerns (what feedback would you like?)**: nothing in particular

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: this week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2602)
<!-- Reviewable:end -->
