### PR TITLE
Async executor for Shrinking oracle tables after sweep.

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -37,6 +37,7 @@ import com.palantir.db.oracle.JdbcHandler;
 public abstract class OracleDdlConfig extends DdlConfig {
     public static final String TYPE = "oracle";
 
+
     public abstract JdbcHandler jdbcHandler();
 
     @Value.Default
@@ -60,8 +61,8 @@ public abstract class OracleDdlConfig extends DdlConfig {
     }
 
     @Value.Default
-    public boolean enableShrinkOnOracleStandardEdition() {
-        return true;
+    public OracleStandardEditionShrinkConfiguration shrinkConfig() {
+        return ImmutableOracleStandardEditionShrinkConfiguration.builder().build();
     }
 
     @Value.Default

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleStandardEditionShrinkConfiguration.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleStandardEditionShrinkConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public class OracleStandardEditionShrinkConfiguration {
+    @Value.Default
+    public boolean enableShrinkOnOracleStandardEdition() {
+        return false;
+    }
+
+    @Value.Default
+    public long shrinkPauseSeconds() {
+        return 10;
+    }
+
+    @Value.Default
+    public long shrinkPauseOnFailureSeconds() {
+        // ShrinkExecutor will sleep for 30 minutes if a Shrink fails.
+        return 30 * 60;
+    }
+
+    @Value.Default
+    public int shrinkConnectionTimeoutMillis() {
+        // This is set to 10 minutes as we saw socket timeouts with 5 minutes.
+        return 10 * 60 * 1000;
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +49,8 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
@@ -67,6 +70,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Atomics;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
@@ -103,6 +107,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.util.DbKvsPartitioners;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
 import com.palantir.atlasdb.keyvalue.impl.LocalRowColumnRangeIterator;
+import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.common.annotation.Output;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.ClosableIterators;
@@ -193,14 +198,32 @@ public final class DbKvs extends AbstractKeyValueService {
         OverflowValueLoader overflowValueLoader = new OracleOverflowValueLoader(oracleDdlConfig, tableNameGetter);
         DbKvsGetRange getRange = new OracleGetRange(
                 connections, overflowValueLoader, tableNameGetter, valueStyleCache, oracleDdlConfig);
+        OracleShrinkExecutor oracleShrinkExecutor = createOracleShrinkExecutor(
+                connections, tableNameGetter, oracleDdlConfig);
         return new DbKvs(
                 executor,
                 oracleDdlConfig,
-                new OracleDbTableFactory(oracleDdlConfig, tableNameGetter, prefixedTableNames, valueStyleCache),
+                new OracleDbTableFactory(
+                        oracleDdlConfig, tableNameGetter, prefixedTableNames, valueStyleCache, oracleShrinkExecutor),
                 connections,
                 new ImmediateSingleBatchTaskRunner(),
                 overflowValueLoader,
                 getRange);
+    }
+
+    private static OracleShrinkExecutor createOracleShrinkExecutor(
+            SqlConnectionSupplier connections,
+            OracleTableNameGetter tableNameGetter,
+            OracleDdlConfig oracleDdlConfig) {
+        InstrumentedExecutorService oracleShrinkExecutorService = new InstrumentedExecutorService(
+                    Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+                            .setNameFormat("oracle-shrink-%d")
+                            .setDaemon(true)
+                            .build()),
+                    AtlasDbMetrics.getMetricRegistry(),
+                    MetricRegistry.name(OracleShrinkExecutor.class, "executor"));
+        return new OracleShrinkExecutor(connections, oracleShrinkExecutorService, tableNameGetter,
+                oracleDdlConfig.shrinkConfig());
     }
 
     private DbKvs(ExecutorService executor,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleDbTableFactory.java
@@ -32,15 +32,18 @@ public class OracleDbTableFactory implements DbTableFactory {
     private final OracleTableNameGetter oracleTableNameGetter;
     private final OraclePrefixedTableNames oraclePrefixedTableNames;
     private final TableValueStyleCache valueStyleCache;
+    private final OracleShrinkExecutor oracleShrinkExecutor;
 
     public OracleDbTableFactory(OracleDdlConfig config,
-                                OracleTableNameGetter oracleTableNameGetter,
-                                OraclePrefixedTableNames oraclePrefixedTableNames,
-                                TableValueStyleCache valueStyleCache) {
+            OracleTableNameGetter oracleTableNameGetter,
+            OraclePrefixedTableNames oraclePrefixedTableNames,
+            TableValueStyleCache valueStyleCache,
+            OracleShrinkExecutor oracleShrinkExecutor) {
         this.config = config;
         this.oracleTableNameGetter = oracleTableNameGetter;
         this.oraclePrefixedTableNames = oraclePrefixedTableNames;
         this.valueStyleCache = valueStyleCache;
+        this.oracleShrinkExecutor = oracleShrinkExecutor;
     }
 
     @Override
@@ -50,7 +53,8 @@ public class OracleDbTableFactory implements DbTableFactory {
 
     @Override
     public DbDdlTable createDdl(TableReference tableRef, ConnectionSupplier conns) {
-        return OracleDdlTable.create(tableRef, conns, config, oracleTableNameGetter, valueStyleCache);
+        return OracleDdlTable.create(tableRef, conns, config, oracleTableNameGetter, valueStyleCache,
+                oracleShrinkExecutor);
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/OracleShrinkExecutor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Palantir Technologies
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl;
+
+import java.sql.SQLException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleStandardEditionShrinkConfiguration;
+import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
+import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
+import com.palantir.exception.PalantirSqlException;
+import com.palantir.nexus.db.sql.SqlConnection;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class OracleShrinkExecutor {
+    private static final Logger log = LoggerFactory.getLogger(OracleShrinkExecutor.class);
+
+    private final SqlConnectionSupplier connectionPool;
+    private final ExecutorService executorService;
+    private final OracleTableNameGetter oracleTableNameGetter;
+    private final OracleStandardEditionShrinkConfiguration shrinkConfig;
+
+    public OracleShrinkExecutor(
+            SqlConnectionSupplier connectionPool,
+            ExecutorService executorService,
+            OracleTableNameGetter oracleTableNameGetter,
+            OracleStandardEditionShrinkConfiguration shrinkConfig) {
+        this.connectionPool = connectionPool;
+        this.executorService = executorService;
+        this.oracleTableNameGetter = oracleTableNameGetter;
+        this.shrinkConfig = shrinkConfig;
+    }
+
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+    public void shrinkAsync(TableReference tableRef) {
+        executorService.submit(() -> shrinkCompactFollowedByShrink(tableRef));
+    }
+
+    private boolean shrinkCompactFollowedByShrink(TableReference tableRef) {
+        try {
+            TimeUnit.SECONDS.sleep(shrinkConfig.shrinkPauseSeconds());
+        } catch (InterruptedException e) {
+            log.warn("Skipping Shrink for table: {} because the thread was interrupted.", tableRef);
+            return false;
+        }
+
+        Stopwatch timer = Stopwatch.createStarted();
+        ConnectionSupplier conns = new ConnectionSupplier(connectionPool);
+        try {
+            runShrinkCommandAndLogTime(tableRef, conns, " SHRINK SPACE COMPACT");
+            runShrinkCommandAndLogTime(tableRef, conns, " SHRINK SPACE");
+
+            return true;
+        } catch (PalantirSqlException e) {
+            log.error("Tried to clean up {} bloat after a sweep operation via Oracle Shrink, but failed."
+                    + " If you are running against Enterprise Edition, you can set enableOracleEnterpriseFeatures"
+                    + " to true in the configuration to start running Oracle EE move online operations."
+                    + " Otherwise, good practice would be to do occasional offline manual maintenance of rebuilding"
+                    + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
+                    + " like more information.", tableRef, e);
+            Uninterruptibles.sleepUninterruptibly(shrinkConfig.shrinkPauseOnFailureSeconds(), TimeUnit.SECONDS);
+            return false;
+        } catch (TableMappingNotFoundException e) {
+            throw new RuntimeException(e);
+        } finally {
+            //closing so that other operations cannot grab the increased timeout connection.
+            conns.close();
+            log.info("Call to KVS.compactInternally on table {} took {} ms.",
+                    tableRef, timer.elapsed(TimeUnit.MILLISECONDS));
+        }
+    }
+
+    private void runShrinkCommandAndLogTime(TableReference tableRef, ConnectionSupplier conns, String command)
+            throws TableMappingNotFoundException {
+        Stopwatch timer = Stopwatch.createStarted();
+        getConnectionWithIncreasedTimeout(conns).executeUnregisteredQuery(
+                "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef) + command);
+        log.info("Call to{} on table {} took {} ms.", command, tableRef,
+                timer.elapsed(TimeUnit.MILLISECONDS));
+    }
+
+    private SqlConnection getConnectionWithIncreasedTimeout(ConnectionSupplier conns) {
+        SqlConnection sqlConnection = conns.get();
+        try {
+            int originalNetworkTimeout = sqlConnection.getUnderlyingConnection().getNetworkTimeout();
+            int newNetworkTimeout = shrinkConfig.shrinkConnectionTimeoutMillis();
+            sqlConnection.getUnderlyingConnection().setNetworkTimeout(Executors.newSingleThreadExecutor(),
+                    newNetworkTimeout);
+            log.info("Increased sql socket read timeout from {} to {}", originalNetworkTimeout, newNetworkTimeout);
+            return sqlConnection;
+        } catch (SQLException e) {
+            log.warn("Failed to increase socket read timeout for the connection. Encountered an exception:", e);
+            return sqlConnection;
+        }
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -15,14 +15,10 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
-import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Stopwatch;
-import com.google.common.base.Throwables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -31,6 +27,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.OracleErrorConstants;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbDdlTable;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.OracleShrinkExecutor;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyle;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyleCache;
@@ -49,18 +46,21 @@ public final class OracleDdlTable implements DbDdlTable {
     private final TableReference tableRef;
     private final OracleTableNameGetter oracleTableNameGetter;
     private final TableValueStyleCache valueStyleCache;
+    private OracleShrinkExecutor oracleShrinkExecutor;
 
     private OracleDdlTable(
             OracleDdlConfig config,
             ConnectionSupplier conns,
             TableReference tableRef,
             OracleTableNameGetter oracleTableNameGetter,
-            TableValueStyleCache valueStyleCache) {
+            TableValueStyleCache valueStyleCache,
+            OracleShrinkExecutor oracleShrinkExecutor) {
         this.config = config;
         this.conns = conns;
         this.tableRef = tableRef;
         this.oracleTableNameGetter = oracleTableNameGetter;
         this.valueStyleCache = valueStyleCache;
+        this.oracleShrinkExecutor = oracleShrinkExecutor;
     }
 
     public static OracleDdlTable create(
@@ -68,8 +68,10 @@ public final class OracleDdlTable implements DbDdlTable {
             ConnectionSupplier conns,
             OracleDdlConfig config,
             OracleTableNameGetter oracleTableNameGetter,
-            TableValueStyleCache valueStyleCache) {
-        return new OracleDdlTable(config, conns, tableRef, oracleTableNameGetter, valueStyleCache);
+            TableValueStyleCache valueStyleCache,
+            OracleShrinkExecutor oracleShrinkExecutor) {
+        return new OracleDdlTable(
+                config, conns, tableRef, oracleTableNameGetter, valueStyleCache, oracleShrinkExecutor);
     }
 
     @Override
@@ -242,55 +244,25 @@ public final class OracleDdlTable implements DbDdlTable {
 
     @Override
     public void compactInternally() {
-        final String compactionFailureTemplate = "Tried to clean up {} bloat after a sweep operation,"
-                + " but underlying Oracle database or configuration does not support this {} feature online. "
-                + " Since this can't be automated in your configuration,"
-                + " good practice would be do to occasional offline manual maintenance of rebuilding"
-                + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
-                + " like more information. Underlying error was: {}";
-
         if (config.enableOracleEnterpriseFeatures()) {
             try {
                 conns.get().executeUnregisteredQuery(
                         "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
                                 + " MOVE ONLINE");
             } catch (PalantirSqlException e) {
-                log.error(compactionFailureTemplate,
-                        tableRef,
-                        "(Enterprise Edition that requires this user to be able to perform DDL operations)",
-                        e.getMessage());
-            } catch (TableMappingNotFoundException e) {
-                throw Throwables.propagate(e);
-            }
-        } else if (config.enableShrinkOnOracleStandardEdition()) {
-            Stopwatch timer = Stopwatch.createStarted();
-            try {
-                Stopwatch shrinkAndCompactTimer = Stopwatch.createStarted();
-                conns.get().executeUnregisteredQuery(
-                        "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
-                                + " SHRINK SPACE COMPACT");
-                log.info("Call to SHRINK SPACE COMPACT on table {} took {} ms.",
-                        tableRef, shrinkAndCompactTimer.elapsed(TimeUnit.MILLISECONDS));
-
-                Stopwatch shrinkTimer = Stopwatch.createStarted();
-                conns.get().executeUnregisteredQuery(
-                        "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
-                                + " SHRINK SPACE");
-                log.info("Call to SHRINK SPACE on table {} took {} ms."
-                                + " This implies that locks on the entire table were held for this period.",
-                        tableRef, shrinkTimer.elapsed(TimeUnit.MILLISECONDS));
-            } catch (PalantirSqlException e) {
-                log.error(compactionFailureTemplate,
-                        tableRef,
-                        "(If you are running against Enterprise Edition,"
-                                + " you can set enableOracleEnterpriseFeatures to true in the configuration.)",
-                        e.getMessage());
+                log.error("Tried to clean up {} bloat after a sweep operation,"
+                        + " but underlying Oracle database or configuration does not support this"
+                        + " (Enterprise Edition that requires this user to be able to perform DDL operations)"
+                        + " feature online. Since this can't be automated in your configuration,"
+                        + " good practice would be do to occasional offline manual maintenance of rebuilding"
+                        + " IOT tables to compensate for bloat. You can contact Palantir Support if you'd"
+                        + " like more information. Underlying error was: {}",
+                        tableRef.toString(), e.getMessage());
             } catch (TableMappingNotFoundException e) {
                 throw new RuntimeException(e);
-            } finally {
-                log.info("Call to KVS.compactInternally on table {} took {} ms.",
-                        tableRef, timer.elapsed(TimeUnit.MILLISECONDS));
             }
+        } else if (config.shrinkConfig().enableShrinkOnOracleStandardEdition()) {
+            oracleShrinkExecutor.shrinkAsync(tableRef);
         }
     }
 }


### PR DESCRIPTION
Backport of #2526 to the LTS branch.

Add a config for increasing the shrinkConnectionTimeout (you can get the same connection from the pool and thus multiplying by 5 is not ideal)

Close the connection supplier so that the increased timeout connection is not reused for other operations

Revamp shrink executor

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2620)
<!-- Reviewable:end -->
