### PR TITLE
Retry and better error message if config-root is not found

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
@@ -59,18 +59,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
         if (config == null) {
             try {
                 if (configFile != null) {
-                    try {
-                        config = AtlasDbConfigs.load(configFile, configRoot);
-                    } catch (Exception e) {
-                        try {
-                            config = AtlasDbConfigs.load(configFile, ALTERNATE_ATLASDB_CONFIG_OBJECT_PATH);
-                        } catch (Exception ex) {
-                            throw new RuntimeException("Failed to load the atlasdb config. "
-                                    + "One possibility is that the AtlasDB config block root in the config is not '/atlasdb' nor '/atlas'. "
-                                    + "You can specify a different config root by specifying the --config-root option.",
-                                    ex);
-                        }
-                    }
+                    config = parseAtlasDbConfig();
                 } else if (inlineConfig != null) {
                     config = AtlasDbConfigs.loadFromString(inlineConfig, "");
                 } else {
@@ -86,6 +75,22 @@ public abstract class AbstractCommand implements Callable<Integer> {
         }
 
         return config;
+    }
+
+    private AtlasDbConfig parseAtlasDbConfig() {
+        try {
+            return AtlasDbConfigs.load(configFile, configRoot);
+        } catch (Exception e) {
+            try {
+                return AtlasDbConfigs.load(configFile, ALTERNATE_ATLASDB_CONFIG_OBJECT_PATH);
+            } catch (Exception ex) {
+                throw new RuntimeException("Failed to load the atlasdb config. One possibility"
+                        + " is that the AtlasDB block root in the config is not '/atlasdb' nor '/atlas'."
+                        + " You can specify a different config root by specifying the --config-root option"
+                        + " before the command (i.e. sweep, migrate).",
+                        ex);
+            }
+        }
     }
 
     protected boolean isOffline() {

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
@@ -66,7 +66,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
                             config = AtlasDbConfigs.load(configFile, ALTERNATE_ATLASDB_CONFIG_OBJECT_PATH);
                         } catch (Exception ex) {
                             throw new RuntimeException("Failed to load the atlasdb config. "
-                                    + "One possibility is that the AtlasDB config block root in the config is not '/atlasdb' or '/atlas'. "
+                                    + "One possibility is that the AtlasDB config block root in the config is not '/atlasdb' nor '/atlas'. "
                                     + "You can specify a different config root by specifying the --config-root option.",
                                     ex);
                         }

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/AbstractCommand.java
@@ -66,7 +66,7 @@ public abstract class AbstractCommand implements Callable<Integer> {
                             config = AtlasDbConfigs.load(configFile, ALTERNATE_ATLASDB_CONFIG_OBJECT_PATH);
                         } catch (Exception ex) {
                             throw new RuntimeException("Failed to load the atlasdb config. "
-                                    + "One possibility is that the config root in the config is not '/atlasdb'. "
+                                    + "One possibility is that the AtlasDB config block root in the config is not '/atlasdb' or '/atlas'. "
                                     + "You can specify a different config root by specifying the --config-root option.",
                                     ex);
                         }


### PR DESCRIPTION
try to parse config with config-root `atlas` is parsing with `atlasdb` fails. If it still fails log a better log message.
**Priority (whenever / two weeks / yesterday)**: small, so next release.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2623)
<!-- Reviewable:end -->
