### PR TITLE
Fix the External Build

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -25,11 +25,14 @@ dependencies {
 
 task longTest(type: Test) {
     include '**/CassandraKeyValueServiceTransactionIntegrationTest.class'
-    include '**/CassandraKeyValueServiceSweeperIntegrationTest.class'
+}
+
+task memorySensitiveTest(type: Test) {
+    include '**/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.class'
 }
 
 test {
     dependsOn longTest
     exclude '**/CassandraKeyValueServiceTransactionIntegrationTest.class'
-    exclude '**/CassandraKeyValueServiceSweeperIntegrationTest.class'
+    exclude '**/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.class'
 }

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -65,16 +65,21 @@ fi
 
 ETE_EXCLUDES=('-x :atlasdb-ete-tests:longTest')
 
-# Timelock and Startup ordering require Docker 1.12; currently unavailable on external Circle. Might not be needed if
-# we move to CircleCI 2.0.
 if [[ $INTERNAL_BUILD != true ]]; then
+    # Timelock and Startup ordering require Docker 1.12; currently unavailable on external Circle. Might not be needed
+    # if we move to CircleCI 2.0.
     ETE_EXCLUDES+=('-x :atlasdb-ete-tests:timeLockTest')
     ETE_EXCLUDES+=('-x :atlasdb-ete-tests:startupIndependenceTest')
+
+    # Sweep tests include a test that we do not OOM when writing a lot of data.
+    # Running this test is not feasible on external Circle owing to small size of the containers, but it gives good
+    # signal so it's worth keeping it around on internal runs.
+    ETE_EXCLUDES+=('-x :atlasdb-cassandra-integration-tests:memorySensitiveTest')
 fi
 
 case $CIRCLE_NODE_INDEX in
     0) ./gradlew $BASE_GRADLE_ARGS check $CONTAINER_0_EXCLUDE_ARGS ;;
-    1) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_1[@]} -x :atlasdb-cassandra-integration-tests:longTest ;;
+    1) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_1[@]} ${ETE_EXCLUDES[@]} -x :atlasdb-cassandra-integration-tests:longTest ;;
     2) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_2[@]} ${ETE_EXCLUDES[@]} -x :atlasdb-ete-tests:startupIndependenceTest;;
     3) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_3[@]} ;;
     4) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_4[@]} ;;


### PR DESCRIPTION
**Goals (and why)**: Fix External Circle builds. These were actually deterministically failing but I don't think we realised that!

First failing build: https://circleci.com/gh/palantir/atlasdb/12329#tests/containers/1
Proof this works: https://circleci.com/gh/palantir/atlasdb/12428

This actually goes back to just after the sweep PR, because there was a test added that wrote (I think) 200 megs of data in one row - 100 versions x 2MB per version and then checked that we could sweep it without OOMing. This is well and fine, but C* on external Circle runs with 160M (and we can't increase this by much because the whole container can't go above 4G and we already run an atlas ete server and other things in Docker). Thus, when writing the lot-of-data we want to be able to query without OOMing, we actually OOM (an artificially wimpy) C*.

**Implementation Description (bullets)**:
- Ignore the Sweep integration tests when running on external Circle. Continue to run them on internal Circle.
- Drive-by fix of include/excludes that became irrelevant because the test names changed.

**Concerns (what feedback would you like?)**:
- Did I set up the gradle things correctly?
- I thought about toning down the test itself to avoid snowflakiness of this, but decided against it because it gives useful signal when run on internal Circle.
- Is there a more elegant fix?

**Where should we start reviewing?**: wherever

**Priority (whenever / two weeks / yesterday)**: Yesterday. Blocks Bintray publishing. 🔥

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2633)
<!-- Reviewable:end -->
