### PR TITLE
Revert "allow Cassandra KVS task executor to grow..." 2534

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,6 +49,10 @@ develop
          - Change
 
     *    - |fixed|
+         - Reverted the Cassandra KVS executor PR (`Pull Request <https://github.com/palantir/atlasdb/pull/2534>`__) that caused a performance regression.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2637>`__)
+
+    *    - |fixed|
          - ``CassandraTimestampBackupRunner`` now logs the backup bound correctly when performing a backup as part of TimeLock migration.
            Previously, the bound logged would have been logged as ``null`` or as a relatively arbitrary byte array, depending on the content of the timestamp table when performing migration.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2585>`__)
@@ -307,6 +311,11 @@ Logs and Metrics
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2467>`__)
 
 Bug fixes
+=======
+    *   - |fixed|
+        - ``ProfilingKeyValueService`` now logs correctly when logging a message for ``getRange``, ``getRangeOfTimestamps`` and ``DeleteRange``.
+          Previously, the table reference was omitted, such that one might receive lines of the form ``Call to KVS.getRange on table RangeRequest{reverse=false} with range 1504 took {} ms.``.
+          (`Pull Request <https://github.com/palantir/atlasdb/pull/2474>`__)
 
 .. list-table::
     :widths: 5 40

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -311,11 +311,6 @@ Logs and Metrics
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2467>`__)
 
 Bug fixes
-=======
-    *   - |fixed|
-        - ``ProfilingKeyValueService`` now logs correctly when logging a message for ``getRange``, ``getRangeOfTimestamps`` and ``DeleteRange``.
-          Previously, the table reference was omitted, such that one might receive lines of the form ``Call to KVS.getRange on table RangeRequest{reverse=false} with range 1504 took {} ms.``.
-          (`Pull Request <https://github.com/palantir/atlasdb/pull/2474>`__)
 
 .. list-table::
     :widths: 5 40
@@ -323,6 +318,11 @@ Bug fixes
 
     *    - Type
          - Change
+
+    *   - |fixed|
+        - ``ProfilingKeyValueService`` now logs correctly when logging a message for ``getRange``, ``getRangeOfTimestamps`` and ``DeleteRange``.
+          Previously, the table reference was omitted, such that one might receive lines of the form ``Call to KVS.getRange on table RangeRequest{reverse=false} with range 1504 took {} ms.``.
+          (`Pull Request <https://github.com/palantir/atlasdb/pull/2474>`__)
 
     *    - |fixed|
          - When AtlasDB thinks all Cassandra nodes are non-healthy, it logs a message containing "There are no known live hosts in the connection pool ... We're choosing one at random ...".


### PR DESCRIPTION
This reverts commit 74c3dae20ef83470b6f74aa9613ebff3dda85835.

**Goals (and why)**:
Fix perf regression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2637)
<!-- Reviewable:end -->
