### PR TITLE
Use getBytes instead of getBlob [no release notes]

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/UpdateExecutor.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/UpdateExecutor.java
@@ -89,7 +89,7 @@ public class UpdateExecutor {
                 cell.getColumnName(),
                 ts)) {
             List<byte[]> actualValues = Lists.newArrayList();
-            results.forEach(row -> actualValues.add(row.getBlob(DbKvs.VAL)));
+            results.forEach(row -> actualValues.add(row.getBytes(DbKvs.VAL)));
             return actualValues;
         }
     }


### PR DESCRIPTION
**Goals (and why)**: fix internal oracle tests, which break when someone uses getBlob


**Priority (whenever / two weeks / yesterday)**: now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2645)
<!-- Reviewable:end -->
