### PR TITLE
Live Reloading the TimeLock Block, Part 3: Working with 0 Nodes

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -276,6 +276,7 @@ public abstract class AtlasDbConfig {
             Preconditions.checkState(!timelock().isPresent(),
                     "If the leader block is present, then the timelock block must be absent.");
         }
+        checkLeaderBlockHasAtLeastOneServerIfPresent(leader());
 
         if (timelock().isPresent()) {
             Preconditions.checkState(areTimeAndLockConfigsAbsent(),
@@ -294,6 +295,12 @@ public abstract class AtlasDbConfig {
         serverListOptional.ifPresent(
                 serverList -> Preconditions.checkState(serverList.hasAtLeastOneServer(),
                         "Server list must have at least one server."));
+    }
+
+    private static void checkLeaderBlockHasAtLeastOneServerIfPresent(Optional<LeaderConfig> leaderConfigOptional) {
+        leaderConfigOptional.ifPresent(
+                leaderConfig -> Preconditions.checkState(!leaderConfig.leaders().isEmpty(),
+                        "Leader config must have at least one server."));
     }
 
     private String checkNamespaceConfigAndGetNamespace() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -275,8 +275,9 @@ public abstract class AtlasDbConfig {
                     "If the leader block is present, then the lock and timestamp server blocks must both be absent.");
             Preconditions.checkState(!timelock().isPresent(),
                     "If the leader block is present, then the timelock block must be absent.");
+            Preconditions.checkState(!leader().get().leaders().isEmpty(),
+                    "Leader config must have at least one server.");
         }
-        checkLeaderBlockHasAtLeastOneServerIfPresent(leader());
 
         if (timelock().isPresent()) {
             Preconditions.checkState(areTimeAndLockConfigsAbsent(),
@@ -295,12 +296,6 @@ public abstract class AtlasDbConfig {
         serverListOptional.ifPresent(
                 serverList -> Preconditions.checkState(serverList.hasAtLeastOneServer(),
                         "Server list must have at least one server."));
-    }
-
-    private static void checkLeaderBlockHasAtLeastOneServerIfPresent(Optional<LeaderConfig> leaderConfigOptional) {
-        leaderConfigOptional.ifPresent(
-                leaderConfig -> Preconditions.checkState(!leaderConfig.leaders().isEmpty(),
-                        "Leader config must have at least one server."));
     }
 
     private String checkNamespaceConfigAndGetNamespace() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -286,6 +286,14 @@ public abstract class AtlasDbConfig {
     private void checkLockAndTimestampBlocks() {
         Preconditions.checkState(lock().isPresent() == timestamp().isPresent(),
                 "Lock and timestamp server blocks must either both be present or both be absent.");
+        checkServersListHasAtLeastOneServerIfPresent(lock());
+        checkServersListHasAtLeastOneServerIfPresent(timestamp());
+    }
+
+    private static void checkServersListHasAtLeastOneServerIfPresent(Optional<ServerListConfig> serverListOptional) {
+        serverListOptional.ifPresent(
+                serverList -> Preconditions.checkState(serverList.hasAtLeastOneServer(),
+                        "Server list must have at least one server."));
     }
 
     private String checkNamespaceConfigAndGetNamespace() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
@@ -48,7 +48,10 @@ public abstract class TimeLockClientConfig {
      * for connecting to TimeLock.
      */
     @Deprecated
-    public abstract ServerListConfig serversList();
+    @Value.Default
+    public ServerListConfig serversList() {
+        return ImmutableServerListConfig.builder().build();
+    }
 
     public ServerListConfig toNamespacedServerList() {
         return ServerListConfigs.namespaceUris(serversList(), getClientOrThrow());

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockRuntimeConfig.java
@@ -25,5 +25,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 @JsonDeserialize(as = ImmutableTimeLockRuntimeConfig.class)
 @Value.Immutable
 public abstract class TimeLockRuntimeConfig {
-    public abstract ServerListConfig serversList();
+    @Value.Default
+    public ServerListConfig serversList() {
+        return ImmutableServerListConfig.builder().build();
+    }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -44,12 +44,12 @@ public class AtlasDbConfigTest {
             .localServer("me")
             .addLeaders("me")
             .build();
-    private static final ServerListConfig DEFAULT_SERVER_LIST = ImmutableServerListConfig.builder()
+    private static final ServerListConfig SINGLETON_SERVER_LIST = ImmutableServerListConfig.builder()
             .addServers("server")
             .build();
     private static final TimeLockClientConfig TIMELOCK_CONFIG = ImmutableTimeLockClientConfig.builder()
             .client("client")
-            .serversList(DEFAULT_SERVER_LIST)
+            .serversList(SINGLETON_SERVER_LIST)
             .build();
     private static final Optional<SslConfiguration> SSL_CONFIG = Optional.of(mock(SslConfiguration.class));
     private static final Optional<SslConfiguration> OTHER_SSL_CONFIG = Optional.of(mock(SslConfiguration.class));
@@ -61,12 +61,12 @@ public class AtlasDbConfigTest {
     private static final TimeLockClientConfig TIMELOCK_CONFIG_WITH_OPTIONAL_EMPTY_CLIENT = ImmutableTimeLockClientConfig
             .builder()
             .client(Optional.empty())
-            .serversList(DEFAULT_SERVER_LIST)
+            .serversList(SINGLETON_SERVER_LIST)
             .build();
     private static final TimeLockClientConfig TIMELOCK_CONFIG_WITH_OTHER_CLIENT = ImmutableTimeLockClientConfig
             .builder()
             .client(OTHER_CLIENT)
-            .serversList(DEFAULT_SERVER_LIST)
+            .serversList(SINGLETON_SERVER_LIST)
             .build();
     private static final String CLIENT_NAMESPACE = "client";
 
@@ -114,8 +114,8 @@ public class AtlasDbConfigTest {
     public void remoteLockAndTimestampConfigIsValid() {
         AtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
-                .lock(DEFAULT_SERVER_LIST)
-                .timestamp(DEFAULT_SERVER_LIST)
+                .lock(SINGLETON_SERVER_LIST)
+                .timestamp(SINGLETON_SERVER_LIST)
                 .build();
         assertThat(config.getNamespaceString(), equalTo(TEST_NAMESPACE));
         assertThat(config, not(nullValue()));
@@ -126,8 +126,8 @@ public class AtlasDbConfigTest {
         ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
                 .leader(LEADER_CONFIG)
-                .lock(DEFAULT_SERVER_LIST)
-                .timestamp(DEFAULT_SERVER_LIST)
+                .lock(SINGLETON_SERVER_LIST)
+                .timestamp(SINGLETON_SERVER_LIST)
                 .build();
     }
 
@@ -137,9 +137,9 @@ public class AtlasDbConfigTest {
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
                 .timelock(ImmutableTimeLockClientConfig.builder()
                         .client("testClient")
-                        .serversList(DEFAULT_SERVER_LIST).build())
-                .lock(DEFAULT_SERVER_LIST)
-                .timestamp(DEFAULT_SERVER_LIST)
+                        .serversList(SINGLETON_SERVER_LIST).build())
+                .lock(SINGLETON_SERVER_LIST)
+                .timestamp(SINGLETON_SERVER_LIST)
                 .build();
     }
 
@@ -157,7 +157,7 @@ public class AtlasDbConfigTest {
         ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
                 .leader(LEADER_CONFIG)
-                .lock(DEFAULT_SERVER_LIST)
+                .lock(SINGLETON_SERVER_LIST)
                 .build();
     }
 
@@ -166,7 +166,7 @@ public class AtlasDbConfigTest {
         ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
                 .leader(LEADER_CONFIG)
-                .timestamp(DEFAULT_SERVER_LIST)
+                .timestamp(SINGLETON_SERVER_LIST)
                 .build();
     }
 
@@ -174,7 +174,7 @@ public class AtlasDbConfigTest {
     public void lockBlockRequiresTimestampBlock() {
         ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
-                .lock(DEFAULT_SERVER_LIST)
+                .lock(SINGLETON_SERVER_LIST)
                 .build();
     }
 
@@ -182,7 +182,7 @@ public class AtlasDbConfigTest {
     public void timestampBlockRequiresLockBlock() {
         ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
-                .timestamp(DEFAULT_SERVER_LIST)
+                .timestamp(SINGLETON_SERVER_LIST)
                 .build();
     }
 
@@ -317,8 +317,8 @@ public class AtlasDbConfigTest {
     public void addingFallbackSslAddsItToLockBlock() {
         AtlasDbConfig withoutSsl = ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
-                .lock(DEFAULT_SERVER_LIST)
-                .timestamp(DEFAULT_SERVER_LIST)
+                .lock(SINGLETON_SERVER_LIST)
+                .timestamp(SINGLETON_SERVER_LIST)
                 .build();
         AtlasDbConfig withSsl = AtlasDbConfigs.addFallbackSslConfigurationToAtlasDbConfig(withoutSsl, SSL_CONFIG);
         assertThat(withSsl.lock().get().sslConfiguration(), is(SSL_CONFIG));
@@ -339,8 +339,8 @@ public class AtlasDbConfigTest {
     public void addingFallbackSslAddsItToTimestampBlock() {
         AtlasDbConfig withoutSsl = ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
-                .lock(DEFAULT_SERVER_LIST)
-                .timestamp(DEFAULT_SERVER_LIST)
+                .lock(SINGLETON_SERVER_LIST)
+                .timestamp(SINGLETON_SERVER_LIST)
                 .build();
         AtlasDbConfig withSsl = AtlasDbConfigs.addFallbackSslConfigurationToAtlasDbConfig(withoutSsl, SSL_CONFIG);
         assertThat(withSsl.timestamp().get().sslConfiguration(), is(SSL_CONFIG));
@@ -375,7 +375,7 @@ public class AtlasDbConfigTest {
                 .keyValueService(KVS_CONFIG_WITHOUT_NAMESPACE)
                 .namespace(CLIENT_NAMESPACE)
                 .timestamp(ImmutableServerListConfig.builder().build())
-                .lock(DEFAULT_SERVER_LIST)
+                .lock(SINGLETON_SERVER_LIST)
                 .build()).isInstanceOf(IllegalStateException.class);
     }
 
@@ -384,7 +384,7 @@ public class AtlasDbConfigTest {
         assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITHOUT_NAMESPACE)
                 .namespace(CLIENT_NAMESPACE)
-                .timestamp(DEFAULT_SERVER_LIST)
+                .timestamp(SINGLETON_SERVER_LIST)
                 .lock(ImmutableServerListConfig.builder().build())
                 .build()).isInstanceOf(IllegalStateException.class);
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -68,6 +68,7 @@ public class AtlasDbConfigTest {
             .client(OTHER_CLIENT)
             .serversList(DEFAULT_SERVER_LIST)
             .build();
+    private static final String CLIENT_NAMESPACE = "client";
 
     @BeforeClass
     public static void setUp() {
@@ -366,5 +367,36 @@ public class AtlasDbConfigTest {
                 .build();
         AtlasDbConfig withSsl = AtlasDbConfigs.addFallbackSslConfigurationToAtlasDbConfig(withoutSsl, NO_SSL_CONFIG);
         assertThat(withSsl.leader().get().sslConfiguration(), is(NO_SSL_CONFIG));
+    }
+
+    @Test
+    public void cannotSpecifyZeroServersIfUsingTimestampBlock() {
+        assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
+                .keyValueService(KVS_CONFIG_WITHOUT_NAMESPACE)
+                .namespace(CLIENT_NAMESPACE)
+                .timestamp(ImmutableServerListConfig.builder().build())
+                .lock(DEFAULT_SERVER_LIST)
+                .build()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void cannotSpecifyZeroServersIfUsingLockBlock() {
+        assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
+                .keyValueService(KVS_CONFIG_WITHOUT_NAMESPACE)
+                .namespace(CLIENT_NAMESPACE)
+                .timestamp(DEFAULT_SERVER_LIST)
+                .lock(ImmutableServerListConfig.builder().build())
+                .build()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void canSpecifyZeroServersIfUsingTimelockBlock() {
+        ImmutableAtlasDbConfig.builder()
+                .keyValueService(KVS_CONFIG_WITHOUT_NAMESPACE)
+                .namespace(CLIENT_NAMESPACE)
+                .timelock(ImmutableTimeLockClientConfig.builder()
+                        .serversList(ImmutableServerListConfig.builder().build())
+                        .build())
+                .build();
     }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ServerListConfigsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ServerListConfigsTest.java
@@ -34,6 +34,8 @@ public class ServerListConfigsTest {
     private static final ImmutableServerListConfig SERVERS_LIST_3 = ImmutableServerListConfig.builder()
             .addServers("three/")
             .build();
+    private static final ImmutableServerListConfig SERVERS_LIST_EMPTY = ImmutableServerListConfig.builder()
+            .build();
 
     private static final TimeLockClientConfig INSTALL_CONFIG = ImmutableTimeLockClientConfig.builder()
             .serversList(SERVERS_LIST_1)
@@ -61,12 +63,27 @@ public class ServerListConfigsTest {
     }
 
     @Test
+    public void namespacingCanDealWithServerListConfigsWithZeroNodes() {
+        ServerListConfig namespacedServersList = ServerListConfigs.namespaceUris(SERVERS_LIST_EMPTY, CLIENT);
+        assertThat(namespacedServersList.servers()).isEmpty();
+    }
+
+    @Test
     public void prioritisesRuntimeConfigIfAvailable() {
         ServerListConfig resolvedConfig = ServerListConfigs.parseInstallAndRuntimeConfigs(
                 INSTALL_CONFIG,
                 () -> Optional.of(RUNTIME_CONFIG),
                 CLIENT);
         assertThat(resolvedConfig.servers()).containsExactlyInAnyOrder("one/client", "two/client");
+    }
+
+    @Test
+    public void prioritisesRuntimeConfigEvenIfThatHasNoClients() {
+        ServerListConfig resolvedConfig = ServerListConfigs.parseInstallAndRuntimeConfigs(
+                INSTALL_CONFIG,
+                () -> Optional.of(ImmutableTimeLockRuntimeConfig.builder().build()),
+                CLIENT);
+        assertThat(resolvedConfig.servers()).isEmpty();
     }
 
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -188,7 +188,7 @@ public class AtlasDbHttpClientsTest {
     }
 
     @Test
-    public void httpProxyCanBeCommissionedAndDecommissionedIfNodesBecomeUnavailable() {
+    public void httpProxyCanBeCommissionedAndDecommissionedIfNodeAvailabilityChanges() {
         AtomicReference<ServerListConfig> config = new AtomicReference<>(ImmutableServerListConfig.builder().build());
 
         TestResource testResource = AtlasDbHttpClients.createLiveReloadingProxyWithQuickFailoverForTesting(
@@ -197,6 +197,8 @@ public class AtlasDbHttpClientsTest {
                 proxyConfiguration -> ProxySelector.getDefault(),
                 TestResource.class,
                 UserAgents.DEFAULT_VALUE);
+
+        // At this point, there are zero nodes in the config, so we should get ServiceNotAvailable.
         assertThatThrownBy(testResource::getTestNumber).isInstanceOf(ServiceNotAvailableException.class);
 
         config.set(ImmutableServerListConfig.builder().addServers(getUriForPort(availablePort)).build());

--- a/atlasdb-config/src/test/resources/runtime-config-block-no-servers.yml
+++ b/atlasdb-config/src/test/resources/runtime-config-block-no-servers.yml
@@ -1,0 +1,6 @@
+timestampClient:
+  enableTimestampBatching: true
+
+timelockRuntime:
+  serversList:
+    servers: []

--- a/atlasdb-config/src/test/resources/runtime-config-block.yml
+++ b/atlasdb-config/src/test/resources/runtime-config-block.yml
@@ -7,3 +7,7 @@ timelockRuntime:
       - "https://foo1:12345"
       - "https://foo2:8421"
       - "https://foo3:9421"
+    sslConfiguration:
+      trustStorePath: var/security/trustStore.jks
+      keyStorePath: var/security/keyStore.jks
+      keyStorePassword: 0987654321

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/config/ServerListConfig.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/config/ServerListConfig.java
@@ -18,8 +18,6 @@ package com.palantir.atlasdb.config;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.validation.constraints.Size;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -31,11 +29,13 @@ import com.palantir.remoting.api.config.ssl.SslConfiguration;
 @JsonSerialize(as = ImmutableServerListConfig.class)
 @Value.Immutable
 public interface ServerListConfig {
-
-    @Size(min = 1)
     Set<String> servers();
 
     Optional<SslConfiguration> sslConfiguration();
 
     Optional<ProxyConfiguration> proxyConfiguration();
+
+    default boolean hasAtLeastOneServer() {
+        return servers().size() >= 1;
+    }
 }

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/AtlasDbFeignTargetFactory.java
@@ -199,7 +199,7 @@ public final class AtlasDbFeignTargetFactory {
     private static <T> T createProxyForZeroNodes(Class<T> type) {
         return Reflection.newProxy(type, (unused1, unused2, unused3) -> {
             throw new ServiceNotAvailableException("The " + type.getSimpleName() + " is currently unavailable,"
-                    + " because we don't know how to talk to it (we think there are zero nodes).");
+                    + " because configuration contains zero servers.");
         });
     }
 }


### PR DESCRIPTION
- [x] Smoketest on internal shopping product

**Goals (and why)**:
Live reload the TimeLock cluster block, see #2622 and #2621.
This part is needed because previous work assumed that we would always have knowledge of at least 1 node, which is not necessarily a valid assumption in a K8s world.

**Implementation Description (bullets)**:
- Remove the min-size restriction of 1 in `ServerListConfig`.
- Re-enforce this min-size in the remote timestamp and lock blocks. Note that the leader block uses its own set of URIs.
- Create a failing proxy if we ever reload a timelock cluster size of 0.
- Add a bunch of tests.

**Concerns (what feedback would you like?)**:
- Technically a dev break, because users of the `ServerListConfig` object may have assumed that there was at least 1 node. Deserialization of the class appears unaffected, so probably not a user break.
- Is `ServiceNotAvailableException` the right thing to throw if making a request to a proxy with no hosts? Should I be throwing `AtlasDbRemoteException`? `IllegalStateException`?!

**Where should we start reviewing?**: `AtlasDbFeignTargetFactory`. Most of the rest is tests.

**Priority (whenever / two weeks / yesterday)**: two weeks?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2647)
<!-- Reviewable:end -->
