### PR TITLE
Live Reloading the TimeLock Block, Part 4: Documentation and Release Notes

### DIFF
--- a/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
@@ -73,6 +73,12 @@ Optional parameters:
 Runtime Configuration
 ---------------------
 
+.. warning::
+
+    Although we support starting up without knowledge of any TimeLock nodes, note that if you are using TimeLock
+    your service will fail to start if asynchronous initialization (``initializeAsync``) is set to ``false``, as
+    initializing a ``TransactionManager`` requires communication with TimeLock.
+
 We support live reloading of the ``ServerListConfiguration`` for TimeLock. This can be optionally configured in the
 ``timelockRuntime`` block under AtlasDB's runtime configuration root.
 
@@ -167,6 +173,8 @@ Install Configuration
         fetchBatchCount: 1000
         autoRefreshNodes: false
 
+      initializeAsync: true
+
       timelock: {}
 
 The example above uses the ``namespace`` parameter; the ``client`` we will use when connecting to TimeLock will be ``yourapp``.
@@ -193,6 +201,10 @@ and it will be able to route requests to TimeLock correctly.
 
 Note that even if the ``timelock`` block in the install configuration included a ``serversList`` block, it would be
 ignored, because we consider the ``serversList`` block in the runtime configuration to take precedence.
+
+It is permitted for the ``serversList`` block here to be absent as well. In this case, AtlasDB will start up with
+knowledge of zero TimeLock nodes. Attempts to initialize a ``TransactionManager`` will fail, but will continue
+asynchronously in the background. Once the ``serversList`` block has been populated, initialization can proceed.
 
 Also, note that if the ``timelock`` block was absent in the install configuration, then this block would be ignored,
 and AtlasDB would start up using embedded timestamp and lock services.

--- a/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
@@ -119,9 +119,14 @@ Timelock Configuration Examples
 
 Here is an example of an AtlasDB configuration with the ``timelock`` block.
 
-If you are using Cassandra, then automated migration will be performed when starting up your AtlasDB clients.
-If you are using another key-value-service, then you MUST ensure that you have migrated to the Timelock Server before
-adding a ``timelock`` block to the config.
+.. warning::
+
+    If you are using Cassandra, then automated migration will be performed when starting up your AtlasDB clients.
+    If you are using another key-value-service, then you MUST ensure that you have migrated to the Timelock Server before
+    adding a ``timelock`` block to the config.
+
+Install Configuration
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
@@ -144,13 +149,32 @@ adding a ``timelock`` block to the config.
         fetchBatchCount: 1000
         autoRefreshNodes: false
 
-      timelock:
-        serversList:
-          servers:
-            - palantir-1.com:8080
-            - palantir-2.com:8080
-            - palantir-3.com:8080
-          sslConfiguration:
-            trustStorePath: var/security/truststore.jks
+      timelock: {}
 
 The example above uses the ``namespace`` parameter; the ``client`` we will use when connecting to TimeLock will be ``yourapp``.
+We don't know the URLs of the TimeLock servers nor how we will talk to them, but that is okay.
+
+Runtime Configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+    timelockRuntime:
+      serversList:
+        servers:
+          - "https://foo1:12345"
+          - "https://foo2:8421"
+          - "https://foo3:9421"
+        sslConfiguration:
+          trustStorePath: var/security/trustStore.jks
+          keyStorePath: var/security/keyStore.jks
+          keyStorePassword: 0987654321
+
+AtlasDB will at runtime determine that the ``client`` to be used is ``yourapp`` and the servers are as indicated above,
+and it will be able to route requests to TimeLock correctly.
+
+Note that even if the ``timelock`` block in the install configuration included a ``serversList`` block, it would be
+ignored, because we consider the ``serversList`` block in the runtime configuration to take precedence.
+
+Also, note that if the ``timelock`` block was absent in the install configuration, then this block would be ignored,
+and AtlasDB would start up using embedded timestamp and lock services.

--- a/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
@@ -7,12 +7,14 @@ You will need to update your AtlasDB configuration in order to have said clients
 external Timelock Servers as opposed to their embedded services. This is an extension of the leader block configuration
 options discussed at :ref:`leader-config`.
 
+TimeLock client configuration spans both ``install`` and ``runtime`` configuration.
+
+Install-Time Configuration
+--------------------------
+
 Instead of configuring a ``leader`` block, or both a ``timestamp`` and ``lock`` block, one must instead specify a
 single ``timelock`` block if your product uses the Timelock Server. The ``leader`` block and the ``timestamp``/``lock``
 blocks must be absent from the config if you are using the Timelock Server.
-
-Timelock
---------
 
 .. danger::
 
@@ -38,12 +40,13 @@ Required parameters:
            Note that client names must be non-empty and consist of only alphanumeric characters, dashes and
            underscores (succinctly, ``[a-zA-Z0-9_-]+``) and for backwards compatibility cannot be the reserved word ``leader``.
 
-    *    - serversList::servers
-         - A list of all hosts. The hosts must be specified as addresses, i.e. ``https://host:port``.
-           At least one server must be specified. AtlasDB assumes that the Timelock Servers being pointed at
-           are part of the same Timelock cluster.
-
 Optional parameters:
+
+.. note::
+
+    Specifying the ``serversList`` (a ``ServerListConfig``) in the install configuration has been deprecated, but is
+    maintained for backward compatibility. Please switch to declaring the ``ServerListConfig`` in the runtime
+    configuration as soon as possible.
 
 .. list-table::
     :widths: 5 40
@@ -52,10 +55,62 @@ Optional parameters:
     *    - Property
          - Description
 
+    *    - serversList::servers
+         - A list of all hosts. The hosts must be specified as addresses, i.e. ``https://host:port``.
+           AtlasDB assumes that the Timelock Servers being pointed at are part of the same Timelock cluster.
+           If this is not provided, it defaults to the empty list.
+
     *    - serversList::sslConfiguration
          - The SSL configuration of the service. This should follow the
-           `palantir/http-remoting <https://github.com/palantir/http-remoting/blob/develop/ssl-config/src/main/java/com/palantir/remoting2/config/ssl/SslConfiguration.java>`__
+           `palantir/http-remoting-api <https://github.com/palantir/http-remoting-api/blob/1.4.0/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java>`__
            library. This should also be in alignment with the protocol used when configuring the servers.
+
+    *    - serversList::proxyConfiguration
+         - The proxy configuration of the service. This should follow the
+           `palantir/http-remoting-api <https://github.com/palantir/http-remoting-api/blob/1.4.0/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java>`__
+           library.
+
+Runtime Configuration
+---------------------
+
+We support live reloading of the ``ServerListConfiguration`` for TimeLock. This can be optionally configured in the
+``timelockRuntime`` block under AtlasDB's runtime configuration root.
+
+Note that if this block is present, then the ``ServerListConfiguration`` in the install configuration will be ignored.
+
+Also, although we support live-reloading of the server configuration, AtlasDB needs to know at install time that it
+should talk to TimeLock - thus, the install configuration must contain a ``timelock`` block (even if said block is
+possibly empty).
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Property
+         - Description
+
+    *    - serversList::servers
+         - A list of all hosts. The hosts must be specified as addresses, i.e. ``https://host:port``.
+           AtlasDB assumes that the Timelock Servers being pointed at are part of the same Timelock cluster.
+           If this is not provided, it defaults to the empty list.
+
+    *    - serversList::sslConfiguration
+         - The SSL configuration of the service. This should follow the
+           `palantir/http-remoting-api <https://github.com/palantir/http-remoting-api/blob/1.4.0/ssl-config/src/main/java/com/palantir/remoting/api/config/ssl/SslConfiguration.java>`__
+           library. This should also be in alignment with the protocol used when configuring the servers.
+
+    *    - serversList::proxyConfiguration
+         - The proxy configuration of the service. This should follow the
+           `palantir/http-remoting-api <https://github.com/palantir/http-remoting-api/blob/1.4.0/service-config/src/main/java/com/palantir/remoting/api/config/service/ProxyConfiguration.java>`__
+           library.
+
+
+.. _semantics-for-live-reloading:
+
+Semantics for Live Reloading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO jkong
 
 .. _timelock-config-examples:
 

--- a/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
+++ b/docs/source/configuration/external_timelock_service_configs/timelock_client_config.rst
@@ -48,6 +48,10 @@ Optional parameters:
     maintained for backward compatibility. Please switch to declaring the ``ServerListConfig`` in the runtime
     configuration as soon as possible.
 
+    Also, note that we internally select ``serverList`` blocks as a whole, prioritising the block in the runtime
+    configuration if it exists. In other words, if you want to specify a dynamic list of TimeLock nodes but a static
+    security configuration, the static security configuration **must** be placed in the runtime configuration block.
+
 .. list-table::
     :widths: 5 40
     :header-rows: 1
@@ -76,8 +80,9 @@ Runtime Configuration
 .. warning::
 
     Although we support starting up without knowledge of any TimeLock nodes, note that if you are using TimeLock
-    your service will fail to start if asynchronous initialization (``initializeAsync``) is set to ``false``, as
-    initializing a ``TransactionManager`` requires communication with TimeLock.
+    your service will fail to start if there are no TimeLock nodes and asynchronous initialization
+    (``initializeAsync``) is set to ``false``, as initializing a ``TransactionManager`` requires communication with
+    TimeLock.
 
 We support live reloading of the ``ServerListConfiguration`` for TimeLock. This can be optionally configured in the
 ``timelockRuntime`` block under AtlasDB's runtime configuration root.
@@ -86,7 +91,8 @@ Note that if this block is present, then the ``ServerListConfiguration`` in the 
 
 Also, although we support live-reloading of the server configuration, AtlasDB needs to know at install time that it
 should talk to TimeLock - thus, the install configuration must contain a ``timelock`` block (even if said block is
-possibly empty).
+possibly empty). Specifying an empty block in the configuration is done in the same way as specifying an empty block in
+YAML i.e. ``{}``.
 
 .. list-table::
     :widths: 5 40

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,26 +53,26 @@ develop
            This is required for internal work on running services in Kubernetes.
            We still require that clients are configured to use TimeLock (as opposed to a leader, remote timestamp/lock or embedded service) at install time.
            Note that this change does not affect TimeLock Server, which still requires knowledge of the entire cluster as well.
-           Please consult TODO for more detail regarding the config changes needed.
-           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/XXXX>`__ and
-            `Pull Request 2 <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+           Please consult the :ref:`documentation <timelock-client-configuration>` for more detail regarding the config changes needed.
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/2621>`__ and
+            `Pull Request 2 <https://github.com/palantir/atlasdb/pull/2622>`__)
 
     *    - |deprecated|
          - The ``servers`` block within an AtlasDB ``timelock`` block is now deprecated.
            Please use the live-reloadable ``servers`` block within the ``timelockRuntime`` block of the runtime configuration instead.
-           (`Pull Request 2 <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+           (`Pull Request 2 <https://github.com/palantir/atlasdb/pull/2622>`__)
 
     *    - |improved|
          - AtlasDB clients using TimeLock can now start up with knowledge of zero TimeLock nodes.
            Requests to TimeLock will throw ``ServiceUnavailableException`` until the config is live reloaded with one or more nodes.
            If live reloading causes the number of nodes to fall to zero, we also fail gracefully; ``ServiceUnavailableException`` will be thrown until the config is live reloaded with one or more nodes.
            Note that this does not affect remote timestamp, lock or leader configurations; those still require at least one server.
-           (`Pull Request 3 <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+           (`Pull Request 3 <https://github.com/palantir/atlasdb/pull/2647>`__)
 
     *    - |improved| |devbreak|
          - ``ServerListConfig`` can now be created with zero servers, as part of work supporting Atlas clients starting up without knowing TimeLock nodes.
            This is strictly more permissive, but may affect developers that use ``ServerListConfig`` directly, especially if it is being serialized.
-           (`Pull Request 3 <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+           (`Pull Request 3 <https://github.com/palantir/atlasdb/pull/2647>`__)
 
     *    - |fixed| |metrics|
          - ``MetricsManager`` now logs failures to register metrics at ``WARN`` instead of ``ERROR``, as failure to do so is not necessarily a systemic failure.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,32 @@ develop
     *    - Type
          - Change
 
+    *    - |new|
+         - AtlasDB clients are now able to live reload TimeLock URLs.
+           This is required for internal work on running products in Kubernetes.
+           We still require that clients are configured to use TimeLock (as opposed to a leader, remote timestamp/lock or embedded service) at install time.
+           Note that this change does not affect TimeLock Server, which currently requires knowledge of the entire cluster as well.
+           Please consult TODO for more detail regarding the config changes needed.
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/XXXX>`__ and
+            `Pull Request 2 <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+
+    *    - |deprecated|
+         - The ``servers`` block within an AtlasDB ``timelock`` block is now deprecated.
+           Please use the live-reloadable ``servers`` block within the ``timelockRuntime`` block of the runtime configuration instead.
+           (`Pull Request 2 <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+
+    *    - |improved|
+         - AtlasDB clients using TimeLock can now start up with knowledge of zero TimeLock nodes.
+           Requests to TimeLock will throw ``ServiceUnavailableException`` until the config is live reloaded with one or more nodes.
+           If live reloading causes the number of nodes to fall to zero, we also fail gracefully; ``ServiceUnavailableException`` will be thrown until the config is live reloaded with one or more nodes.
+           Note that this does not affect remote timestamp, lock or leader configurations; those still require at least one server.
+           (`Pull Request 3 <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+
+    *    - |improved| |devbreak|
+         - ``ServerListConfig`` can now be created with zero servers, as part of work supporting Atlas clients starting up without knowing TimeLock nodes.
+           This is strictly more permissive, but may affect developers that use ``ServerListConfig`` directly, especially if it is being serialized.
+           (`Pull Request 3 <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+
     *    - |fixed| |metrics|
          - ``MetricsManager`` now logs failures to register metrics at ``WARN`` instead of ``ERROR``, as failure to do so is not necessarily a systemic failure.
            Also, we now log the name of the metric as a Safe argument (previously it was logged as Unsafe).

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,7 +55,7 @@ develop
            Note that this change does not affect TimeLock Server, which still requires knowledge of the entire cluster as well.
            Please consult the :ref:`documentation <timelock-client-configuration>` for more detail regarding the config changes needed.
            (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/2621>`__ and
-            `Pull Request 2 <https://github.com/palantir/atlasdb/pull/2622>`__)
+           `Pull Request 2 <https://github.com/palantir/atlasdb/pull/2622>`__)
 
     *    - |deprecated|
          - The ``servers`` block within an AtlasDB ``timelock`` block is now deprecated.
@@ -67,6 +67,7 @@ develop
            Requests to TimeLock will throw ``ServiceUnavailableException`` until the config is live reloaded with one or more nodes.
            If live reloading causes the number of nodes to fall to zero, we also fail gracefully; ``ServiceUnavailableException`` will be thrown until the config is live reloaded with one or more nodes.
            Note that this does not affect remote timestamp, lock or leader configurations; those still require at least one server.
+           Also, note that if one is using TimeLock without async initialization, then one still needs to provide information about the TimeLock cluster on startup.
            (`Pull Request 3 <https://github.com/palantir/atlasdb/pull/2647>`__)
 
     *    - |improved| |devbreak|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,9 +50,9 @@ develop
 
     *    - |new|
          - AtlasDB clients are now able to live reload TimeLock URLs.
-           This is required for internal work on running products in Kubernetes.
+           This is required for internal work on running services in Kubernetes.
            We still require that clients are configured to use TimeLock (as opposed to a leader, remote timestamp/lock or embedded service) at install time.
-           Note that this change does not affect TimeLock Server, which currently requires knowledge of the entire cluster as well.
+           Note that this change does not affect TimeLock Server, which still requires knowledge of the entire cluster as well.
            Please consult TODO for more detail regarding the config changes needed.
            (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/XXXX>`__ and
             `Pull Request 2 <https://github.com/palantir/atlasdb/pull/XXXX>`__)


### PR DESCRIPTION
**Goals (and why)**:
Live reload the timelock block - see #2621, #2622 and #2647
This is the last in the series for now. There _is_ a Part 5 I might want to do (ETE testing) but that's not as high on internal priority list at this time.

**Implementation Description (bullets)**:
- Document how the live reloadable config works
- Document some of the pitfalls involved, and semantics for some edge cases.

**Concerns (what feedback would you like?)**:
- Do the docs make sense?
- The release notes are quite long, mainly because this change does affect quite a bunch of things.

**Where should we start reviewing?**: `timelock_client_config.rst`

**Priority (whenever / two weeks / yesterday)**: this week?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2648)
<!-- Reviewable:end -->
