### PR TITLE
Extract interface for Cassandra client

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -161,7 +161,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
     private void assertThatGcGraceSecondsIs(CassandraKeyValueService kvs, int gcGraceSeconds) throws TException {
         List<CfDef> knownCfs = kvs.getClientPool().runWithRetry(client ->
-                client.describe_keyspace("atlasdb").getCf_defs());
+                client.rawClient().describe_keyspace("atlasdb").getCf_defs());
         CfDef clusterSideCf = Iterables.getOnlyElement(knownCfs.stream()
                 .filter(cf -> cf.getName().equals(getInternalTestTableName()))
                 .collect(Collectors.toList()));
@@ -185,7 +185,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         kvs.createTable(testTable, tableMetadata);
 
         List<CfDef> knownCfs = kvs.getClientPool().runWithRetry(client ->
-                client.describe_keyspace("atlasdb").getCf_defs());
+                client.rawClient().describe_keyspace("atlasdb").getCf_defs());
         CfDef clusterSideCf = Iterables.getOnlyElement(knownCfs.stream()
                 .filter(cf -> cf.getName().equals(getInternalTestTableName()))
                 .collect(Collectors.toList()));

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTestTools.java
@@ -19,7 +19,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
@@ -106,7 +105,7 @@ public final class SchemaMutationLockTestTools {
         return CassandraKeyValueServices.encodeAsHex(str.getBytes(StandardCharsets.UTF_8));
     }
 
-    private static CqlResult runCqlQuery(String query, Cassandra.Client client, ConsistencyLevel consistency)
+    private static CqlResult runCqlQuery(String query, CassandraClient client, ConsistencyLevel consistency)
             throws TException {
         ByteBuffer queryBuffer = ByteBuffer.wrap(query.getBytes(StandardCharsets.UTF_8));
         return client.execute_cql3_query(queryBuffer, Compression.NONE, consistency);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -25,11 +25,16 @@ import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
+import org.apache.cassandra.thrift.ColumnPath;
+import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.Mutation;
+import org.apache.cassandra.thrift.NotFoundException;
+import org.apache.cassandra.thrift.SchemaDisagreementException;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.cassandra.thrift.UnavailableException;
@@ -38,7 +43,7 @@ import org.apache.cassandra.thrift.UnavailableException;
 public interface CassandraClient {
     Cassandra.Client rawClient();
 
-    Map<ByteBuffer,List<ColumnOrSuperColumn>> multiget_slice(List<ByteBuffer> keys, ColumnParent column_parent,
+    Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(List<ByteBuffer> keys, ColumnParent column_parent,
             SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
@@ -49,7 +54,15 @@ public interface CassandraClient {
     void batch_mutate(Map<ByteBuffer,Map<String,List<Mutation>>> mutation_map, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
+    public ColumnOrSuperColumn get(ByteBuffer key, ColumnPath column_path, ConsistencyLevel consistency_level)
+            throws InvalidRequestException, NotFoundException, UnavailableException, TimedOutException,
+            org.apache.thrift.TException;
+
     CASResult cas(ByteBuffer key, String column_family, List<Column> expected, List<Column> updates,
             ConsistencyLevel serial_consistency_level, ConsistencyLevel commit_consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
+
+    public CqlResult execute_cql3_query(ByteBuffer query, Compression compression, ConsistencyLevel consistency)
+            throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException,
+            org.apache.thrift.TException;
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.ColumnOrSuperColumn;
+import org.apache.cassandra.thrift.ColumnParent;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.InvalidRequestException;
+import org.apache.cassandra.thrift.KeyRange;
+import org.apache.cassandra.thrift.KeySlice;
+import org.apache.cassandra.thrift.Mutation;
+import org.apache.cassandra.thrift.SlicePredicate;
+import org.apache.cassandra.thrift.TimedOutException;
+import org.apache.cassandra.thrift.UnavailableException;
+
+@SuppressWarnings({"all"}) // thrift variable names.
+public interface CassandraClient {
+    Cassandra.Client rawClient();
+
+    Map<ByteBuffer,List<ColumnOrSuperColumn>> multiget_slice(List<ByteBuffer> keys, ColumnParent column_parent,
+            SlicePredicate predicate, ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
+
+    List<KeySlice> get_range_slices(ColumnParent column_parent, SlicePredicate predicate, KeyRange range,
+            ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
+
+    void batch_mutate(Map<ByteBuffer,Map<String,List<Mutation>>> mutation_map, ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -20,7 +20,9 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cassandra.thrift.CASResult;
 import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
 import org.apache.cassandra.thrift.ConsistencyLevel;
@@ -45,5 +47,9 @@ public interface CassandraClient {
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
     void batch_mutate(Map<ByteBuffer,Map<String,List<Mutation>>> mutation_map, ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
+
+    CASResult cas(ByteBuffer key, String column_family, List<Column> expected, List<Column> updates,
+            ConsistencyLevel serial_consistency_level, ConsistencyLevel commit_consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -25,11 +25,16 @@ import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
+import org.apache.cassandra.thrift.ColumnPath;
+import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.Mutation;
+import org.apache.cassandra.thrift.NotFoundException;
+import org.apache.cassandra.thrift.SchemaDisagreementException;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.cassandra.thrift.UnavailableException;
@@ -70,9 +75,22 @@ public class CassandraClientImpl implements CassandraClient {
     }
 
     @Override
+    public ColumnOrSuperColumn get(ByteBuffer key, ColumnPath column_path, ConsistencyLevel consistency_level)
+            throws InvalidRequestException, NotFoundException, UnavailableException, TimedOutException, TException {
+        return client.get(key, column_path, consistency_level);
+    }
+
+    @Override
     public CASResult cas(ByteBuffer key, String column_family, List<Column> expected, List<Column> updates,
             ConsistencyLevel serial_consistency_level, ConsistencyLevel commit_consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         return client.cas(key, column_family, expected, updates, serial_consistency_level, commit_consistency_level);
+    }
+
+    @Override
+    public CqlResult execute_cql3_query(ByteBuffer query, Compression compression, ConsistencyLevel consistency)
+            throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException,
+            TException {
+        return client.execute_cql3_query(query, compression, consistency);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.ColumnOrSuperColumn;
+import org.apache.cassandra.thrift.ColumnParent;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.InvalidRequestException;
+import org.apache.cassandra.thrift.KeyRange;
+import org.apache.cassandra.thrift.KeySlice;
+import org.apache.cassandra.thrift.Mutation;
+import org.apache.cassandra.thrift.SlicePredicate;
+import org.apache.cassandra.thrift.TimedOutException;
+import org.apache.cassandra.thrift.UnavailableException;
+import org.apache.thrift.TException;
+
+@SuppressWarnings({"all"}) // thrift variable names.
+public class CassandraClientImpl implements CassandraClient {
+    private Cassandra.Client client;
+
+    public CassandraClientImpl(Cassandra.Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public Cassandra.Client rawClient() {
+        return client;
+    }
+
+    @Override
+    public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(List<ByteBuffer> keys, ColumnParent column_parent,
+            SlicePredicate predicate, ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        return client.multiget_slice(keys, column_parent, predicate, consistency_level);
+    }
+
+    @Override
+    public List<KeySlice> get_range_slices(ColumnParent column_parent, SlicePredicate predicate, KeyRange range,
+            ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        return client.get_range_slices(column_parent, predicate, range, consistency_level);
+    }
+
+    @Override
+    public void batch_mutate(Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
+            ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        client.batch_mutate(mutation_map, consistency_level);
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -20,7 +20,9 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cassandra.thrift.CASResult;
 import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
 import org.apache.cassandra.thrift.ConsistencyLevel;
@@ -65,5 +67,12 @@ public class CassandraClientImpl implements CassandraClient {
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         client.batch_mutate(mutation_map, consistency_level);
+    }
+
+    @Override
+    public CASResult cas(ByteBuffer key, String column_family, List<Column> expected, List<Column> updates,
+            ConsistencyLevel serial_consistency_level, ConsistencyLevel commit_consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        return client.cas(key, column_family, expected, updates, serial_consistency_level, commit_consistency_level);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -20,8 +20,6 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 
-import org.apache.cassandra.thrift.Cassandra;
-
 import com.palantir.common.base.FunctionCheckedException;
 
 public interface CassandraClientPool {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPool.java
@@ -25,14 +25,14 @@ import org.apache.cassandra.thrift.Cassandra;
 import com.palantir.common.base.FunctionCheckedException;
 
 public interface CassandraClientPool {
-    FunctionCheckedException<Cassandra.Client, Void, Exception> getValidatePartitioner();
+    FunctionCheckedException<CassandraClient, Void, Exception> getValidatePartitioner();
     <V, K extends Exception> V runOnHost(InetSocketAddress specifiedHost,
-            FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
-    <V, K extends Exception> V run(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
+            FunctionCheckedException<CassandraClient, V, K> fn) throws K;
+    <V, K extends Exception> V run(FunctionCheckedException<CassandraClient, V, K> fn) throws K;
     <V, K extends Exception> V runWithRetryOnHost(
             InetSocketAddress specifiedHost,
-            FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
-    <V, K extends Exception> V runWithRetry(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K;
+            FunctionCheckedException<CassandraClient, V, K> fn) throws K;
+    <V, K extends Exception> V runWithRetry(FunctionCheckedException<CassandraClient, V, K> fn) throws K;
     InetSocketAddress getAddressForHost(String host) throws UnknownHostException;
     InetSocketAddress getRandomHostForKey(byte[] key);
     Map<InetSocketAddress, CassandraClientPoolingContainer> getCurrentPools();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -561,23 +561,23 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
         }
     }
 
-    private FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception> describeRing =
-            new FunctionCheckedException<Cassandra.Client, List<TokenRange>, Exception>() {
+    private FunctionCheckedException<CassandraClient, List<TokenRange>, Exception> describeRing =
+            new FunctionCheckedException<CassandraClient, List<TokenRange>, Exception>() {
                 @Override
-                public List<TokenRange> apply(Cassandra.Client client) throws Exception {
-                    return client.describe_ring(config.getKeyspaceOrThrow());
+                public List<TokenRange> apply(CassandraClient client) throws Exception {
+                    return client.rawClient().describe_ring(config.getKeyspaceOrThrow());
                 }
             };
 
     @Override
-    public <V, K extends Exception> V runWithRetry(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
+    public <V, K extends Exception> V runWithRetry(FunctionCheckedException<CassandraClient, V, K> fn) throws K {
         return runWithRetryOnHost(getRandomGoodHost().getHost(), fn);
     }
 
     @Override
     public <V, K extends Exception> V runWithRetryOnHost(
             InetSocketAddress specifiedHost,
-            FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
+            FunctionCheckedException<CassandraClient, V, K> fn) throws K {
         int numTries = 0;
         boolean shouldRetryOnDifferentHost = false;
         Set<InetSocketAddress> triedHosts = Sets.newHashSet();
@@ -630,20 +630,20 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
     }
 
     @Override
-    public <V, K extends Exception> V run(FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
+    public <V, K extends Exception> V run(FunctionCheckedException<CassandraClient, V, K> fn) throws K {
         return runOnHost(getRandomGoodHost().getHost(), fn);
     }
 
     @Override
     public <V, K extends Exception> V runOnHost(InetSocketAddress specifiedHost,
-            FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
+            FunctionCheckedException<CassandraClient, V, K> fn) throws K {
         CassandraClientPoolingContainer hostPool = currentPools.get(specifiedHost);
         return runWithPooledResourceRecordingMetrics(hostPool, fn);
     }
 
     private <V, K extends Exception> V runWithPooledResourceRecordingMetrics(
             CassandraClientPoolingContainer hostPool,
-            FunctionCheckedException<Cassandra.Client, V, K> fn) throws K {
+            FunctionCheckedException<CassandraClient, V, K> fn) throws K {
 
         recordRequestOnHost(hostPool);
         try {
@@ -823,17 +823,17 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                 || isFastFailoverException(ex.getCause()));
     }
 
-    private final FunctionCheckedException<Cassandra.Client, Void, Exception> validatePartitioner =
-            new FunctionCheckedException<Cassandra.Client, Void, Exception>() {
+    private final FunctionCheckedException<CassandraClient, Void, Exception> validatePartitioner =
+            new FunctionCheckedException<CassandraClient, Void, Exception>() {
                 @Override
-                public Void apply(Cassandra.Client client) throws Exception {
-                    CassandraVerifier.validatePartitioner(client.describe_partitioner(), config);
+                public Void apply(CassandraClient client) throws Exception {
+                    CassandraVerifier.validatePartitioner(client.rawClient().describe_partitioner(), config);
                     return null;
                 }
             };
 
     @Override
-    public FunctionCheckedException<Cassandra.Client, Void, Exception> getValidatePartitioner() {
+    public FunctionCheckedException<CassandraClient, Void, Exception> getValidatePartitioner() {
         return validatePartitioner;
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -152,7 +152,8 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         }
     }
 
-    private static void eagerlyCleanupReadBuffersFromIdleConnection(CassandraClient idleClient, InetSocketAddress host) {
+    private static void eagerlyCleanupReadBuffersFromIdleConnection(CassandraClient idleClient,
+            InetSocketAddress host) {
         // eagerly cleanup idle-connection read buffer to keep a smaller memory footprint
         try {
             TTransport transport = idleClient.rawClient().getInputProtocol().getTransport();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.thrift.protocol.TProtocolException;
@@ -46,7 +45,7 @@ import com.palantir.common.pooling.PoolingContainer;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 
-public class CassandraClientPoolingContainer implements PoolingContainer<Client> {
+public class CassandraClientPoolingContainer implements PoolingContainer<CassandraClient> {
     private static final Logger log = LoggerFactory.getLogger(CassandraClientPoolingContainer.class);
 
     private final InetSocketAddress host;
@@ -54,7 +53,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
     private final MetricsManager metricsManager = new MetricsManager();
     private final AtomicLong count = new AtomicLong();
     private final AtomicInteger openRequests = new AtomicInteger();
-    private final GenericObjectPool<Client> clientPool;
+    private final GenericObjectPool<CassandraClient> clientPool;
 
     public CassandraClientPoolingContainer(
             InetSocketAddress host,
@@ -90,7 +89,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
     }
 
     @Override
-    public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<Client, V, K> fn)
+    public <V, K extends Exception> V runWithPooledResource(FunctionCheckedException<CassandraClient, V, K> fn)
             throws K {
         final String origName = Thread.currentThread().getName();
         Thread.currentThread().setName(origName
@@ -111,16 +110,16 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
     }
 
     @Override
-    public <V> V runWithPooledResource(Function<Client, V> fn) {
+    public <V> V runWithPooledResource(Function<CassandraClient, V> fn) {
         throw new UnsupportedOperationException("you should use FunctionCheckedException<?, ?, Exception> "
                 + "to ensure the TTransportException type is propagated correctly.");
     }
 
     @SuppressWarnings("unchecked")
-    private <V, K extends Exception> V runWithGoodResource(FunctionCheckedException<Client, V, K> fn)
+    private <V, K extends Exception> V runWithGoodResource(FunctionCheckedException<CassandraClient, V, K> fn)
             throws K {
         boolean shouldReuse = true;
-        Client resource = null;
+        CassandraClient resource = null;
         try {
             resource = clientPool.borrowObject();
             return fn.apply(resource);
@@ -153,10 +152,10 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         }
     }
 
-    private static void eagerlyCleanupReadBuffersFromIdleConnection(Client idleClient, InetSocketAddress host) {
+    private static void eagerlyCleanupReadBuffersFromIdleConnection(CassandraClient idleClient, InetSocketAddress host) {
         // eagerly cleanup idle-connection read buffer to keep a smaller memory footprint
         try {
-            TTransport transport = idleClient.getInputProtocol().getTransport();
+            TTransport transport = idleClient.rawClient().getInputProtocol().getTransport();
             if (transport instanceof TFramedTransport) {
                 Field readBuffer = ((TFramedTransport) transport).getClass().getDeclaredField("readBuffer_");
                 readBuffer.setAccessible(true);
@@ -181,7 +180,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
                 || ex instanceof NoSuchElementException;
     }
 
-    private void invalidateQuietly(Client resource) {
+    private void invalidateQuietly(CassandraClient resource) {
         try {
             log.debug("Discarding {} of host {}",
                     UnsafeArg.of("pool", resource),
@@ -234,7 +233,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
      *
      * @param poolNumber number of the pool for metric registration.
      */
-    private GenericObjectPool<Client> createClientPool(int poolNumber) {
+    private GenericObjectPool<CassandraClient> createClientPool(int poolNumber) {
         CassandraClientFactory cassandraClientFactory = new CassandraClientFactory(host, config);
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
 
@@ -261,12 +260,12 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Client>
         poolConfig.setTestWhileIdle(true);
 
         poolConfig.setJmxNamePrefix(CassandraLogHelper.host(host));
-        GenericObjectPool<Client> pool = new GenericObjectPool<>(cassandraClientFactory, poolConfig);
+        GenericObjectPool<CassandraClient> pool = new GenericObjectPool<>(cassandraClientFactory, poolConfig);
         registerMetrics(pool, poolNumber);
         return pool;
     }
 
-    private void registerMetrics(GenericObjectPool<Client> pool, int poolNumber) {
+    private void registerMetrics(GenericObjectPool<CassandraClient> pool, int poolNumber) {
         registerMetric(getMetricName("meanActiveTimeMillis", poolNumber), pool::getMeanActiveTimeMillis);
         registerMetric(getMetricName("meanIdleTimeMillis", poolNumber), pool::getMeanIdleTimeMillis);
         registerMetric(getMetricName("meanBorrowWaitTimeMillis", poolNumber), pool::getMeanBorrowWaitTimeMillis);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -161,7 +161,7 @@ public final class CassandraKeyValueServices {
             clientPool.run(client -> {
                 waitForSchemaVersions(
                         config,
-                        client,
+                        client.rawClient(),
                         "(none, just an initialization check)",
                         true);
                 return null;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupRunner.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.CqlResult;
@@ -151,7 +150,7 @@ public class CassandraTimestampBackupRunner {
         return backupBoundReadable ? BoundReadability.BACKUP : BoundReadability.NEITHER;
     }
 
-    private BoundData getCurrentBoundData(Cassandra.Client client) {
+    private BoundData getCurrentBoundData(CassandraClient client) {
         checkTimestampTableExists();
 
         ByteBuffer selectQuery = CassandraTimestampUtils.constructSelectFromTimestampTableQuery();
@@ -171,14 +170,14 @@ public class CassandraTimestampBackupRunner {
                 "[BACKUP/RESTORE] Tried to get timestamp bound data when the timestamp table didn't exist!");
     }
 
-    private void executeAndVerifyCas(Cassandra.Client client, Map<String, Pair<byte[], byte[]>> casMap) {
+    private void executeAndVerifyCas(CassandraClient client, Map<String, Pair<byte[], byte[]>> casMap) {
         ByteBuffer casQueryBuffer = CassandraTimestampUtils.constructCheckAndSetMultipleQuery(casMap);
 
         CqlResult casResult = executeQueryUnchecked(client, casQueryBuffer);
         CassandraTimestampUtils.verifyCompatible(casResult, casMap);
     }
 
-    private CqlResult executeQueryUnchecked(Cassandra.Client client, ByteBuffer query) {
+    private CqlResult executeQueryUnchecked(CassandraClient client, ByteBuffer query) {
         try {
             return queryRunner().run(client,
                     AtlasDbConstants.TIMESTAMP_TABLE,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -310,7 +310,7 @@ public final class CassandraVerifier {
         sanityCheckReplicationFactor(ks, config, dcs);
     }
 
-    static void currentRfOnKeyspaceMatchesDesiredRf(Client client, CassandraKeyValueServiceConfig config)
+    static void currentRfOnKeyspaceMatchesDesiredRf(Cassandra.Client client, CassandraKeyValueServiceConfig config)
             throws TException {
         KsDef ks = client.describe_keyspace(config.getKeyspaceOrThrow());
         Set<String> dcs = sanityCheckDatacenters(client, config);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -336,10 +336,10 @@ public final class CassandraVerifier {
         }
     }
 
-    static final FunctionCheckedException<Cassandra.Client, Boolean, UnsupportedOperationException>
+    static final FunctionCheckedException<CassandraClient, Boolean, UnsupportedOperationException>
             underlyingCassandraClusterSupportsCASOperations = client -> {
                 try {
-                    CassandraApiVersion serverVersion = new CassandraApiVersion(client.describe_version());
+                    CassandraApiVersion serverVersion = new CassandraApiVersion(client.rawClient().describe_version());
                     log.debug("Connected cassandra thrift version is: {}",
                             SafeArg.of("cassandraVersion", serverVersion));
                     return serverVersion.supportsCheckAndSet();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -56,8 +56,8 @@ public final class CassandraVerifier {
         // Utility class
     }
 
-    static final FunctionCheckedException<Cassandra.Client, Void, Exception> healthCheck = client -> {
-        client.describe_version();
+    static final FunctionCheckedException<CassandraClient, Void, Exception> healthCheck = client -> {
+        client.rawClient().describe_version();
         return null;
     };
 
@@ -243,13 +243,13 @@ public final class CassandraVerifier {
 
     private static void updateExistingKeyspace(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config)
             throws TException {
-        clientPool.runWithRetry((FunctionCheckedException<Client, Void, TException>) client -> {
-            KsDef originalKsDef = client.describe_keyspace(config.getKeyspaceOrThrow());
+        clientPool.runWithRetry((FunctionCheckedException<CassandraClient, Void, TException>) client -> {
+            KsDef originalKsDef = client.rawClient().describe_keyspace(config.getKeyspaceOrThrow());
             // there was an existing keyspace
             // check and make sure it's definition is up to date with our config
             KsDef modifiedKsDef = originalKsDef.deepCopy();
             checkAndSetReplicationFactor(
-                    client,
+                    client.rawClient(),
                     modifiedKsDef,
                     false,
                     config);
@@ -257,10 +257,10 @@ public final class CassandraVerifier {
             if (!modifiedKsDef.equals(originalKsDef)) {
                 // Can't call system_update_keyspace to update replication factor if CfDefs are set
                 modifiedKsDef.setCf_defs(ImmutableList.of());
-                client.system_update_keyspace(modifiedKsDef);
+                client.rawClient().system_update_keyspace(modifiedKsDef);
                 CassandraKeyValueServices.waitForSchemaVersions(
                         config,
-                        client,
+                        client.rawClient(),
                         "(updating the existing keyspace)");
             }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.CqlResult;
@@ -226,12 +225,12 @@ public class CqlExecutor {
             }
         }
 
-        private FunctionCheckedException<Cassandra.Client, CqlResult, TException> createCqlFunction(String query) {
+        private FunctionCheckedException<CassandraClient, CqlResult, TException> createCqlFunction(String query) {
             ByteBuffer queryBytes = ByteBuffer.wrap(query.getBytes(StandardCharsets.UTF_8));
 
-            return new FunctionCheckedException<Cassandra.Client, CqlResult, TException>() {
+            return new FunctionCheckedException<CassandraClient, CqlResult, TException>() {
                 @Override
-                public CqlResult apply(Cassandra.Client client) throws TException {
+                public CqlResult apply(CassandraClient client) throws TException {
                     return client.execute_cql3_query(queryBytes, Compression.NONE, consistency);
                 }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Heartbeat.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Heartbeat.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.util.List;
 
 import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.UnavailableException;
@@ -68,7 +67,7 @@ class Heartbeat implements Runnable {
         }
     }
 
-    private Void beat(Client client) throws TException {
+    private Void beat(CassandraClient client) throws TException {
         Column ourUpdate = SchemaMutationLock.lockColumnFromIdAndHeartbeat(lockId, heartbeatCount + 1);
 
         List<Column> expected = ImmutableList.of(
@@ -90,7 +89,8 @@ class Heartbeat implements Runnable {
         return null;
     }
 
-    private CASResult writeDdlLockWithCas(Client client, Column ourUpdate, List<Column> expected) throws TException {
+    private CASResult writeDdlLockWithCas(CassandraClient client, Column ourUpdate, List<Column> expected)
+            throws TException {
         try {
             return queryRunner.run(client, lockTable,
                     () -> client.cas(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
@@ -27,7 +27,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnPath;
@@ -175,7 +174,7 @@ final class SchemaMutationLock {
         final long perOperationNodeId = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE - 2);
 
         try {
-            clientPool.runWithRetry((FunctionCheckedException<Client, Void, Exception>) client -> {
+            clientPool.runWithRetry((FunctionCheckedException<CassandraClient, Void, Exception>) client -> {
                 Column ourUpdate = lockColumnFromIdAndHeartbeat(perOperationNodeId, 0);
 
                 List<Column> expected = ImmutableList.of(lockColumnWithValue(GLOBAL_DDL_LOCK_CLEARED_VALUE));
@@ -343,7 +342,7 @@ final class SchemaMutationLock {
         }
     }
 
-    private Optional<Column> queryExistingLockColumn(Client client) throws TException {
+    private Optional<Column> queryExistingLockColumn(CassandraClient client) throws TException {
         TableReference lockTableRef = lockTable.getOnlyTable();
         ColumnPath columnPath = new ColumnPath(lockTableRef.getQualifiedName());
         columnPath.setColumn(getGlobalDdlLockColumnName());
@@ -367,7 +366,7 @@ final class SchemaMutationLock {
     }
 
     private CASResult writeDdlLockWithCas(
-            Client client,
+            CassandraClient client,
             List<Column> expectedLockValue,
             Column newLockValue) throws TException {
         TableReference lockTableRef = lockTable.getOnlyTable();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingQueryRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingQueryRunner.java
@@ -43,7 +43,7 @@ public class TracingQueryRunner {
         V run() throws TException;
     }
 
-    public <V> V run(Cassandra.Client client, Set<TableReference> tableRefs, Action<V> action) throws TException {
+    public <V> V run(CassandraClient client, Set<TableReference> tableRefs, Action<V> action) throws TException {
         if (shouldTraceQuery(tableRefs)) {
             return trace(action, client, tableRefs);
         } else {
@@ -56,12 +56,12 @@ public class TracingQueryRunner {
         }
     }
 
-    public <V> V run(Cassandra.Client client, TableReference tableRef, Action<V> action) throws TException {
+    public <V> V run(CassandraClient client, TableReference tableRef, Action<V> action) throws TException {
         return run(client, ImmutableSet.of(tableRef), action);
     }
 
-    private <V> V trace(Action<V> action, Cassandra.Client client, Set<TableReference> tableRefs) throws TException {
-        ByteBuffer traceId = client.trace_next_query();
+    private <V> V trace(Action<V> action, CassandraClient client, Set<TableReference> tableRefs) throws TException {
+        ByteBuffer traceId = client.rawClient().trace_next_query();
         Stopwatch stopwatch = Stopwatch.createStarted();
         boolean failed = false;
         try {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingQueryRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingQueryRunner.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/paging/RowGetter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/paging/RowGetter.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.keyvalue.cassandra.paging;
 import java.net.InetSocketAddress;
 import java.util.List;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.ColumnParent;
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.KeyRange;
@@ -28,6 +27,7 @@ import org.apache.cassandra.thrift.UnavailableException;
 
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClient;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 import com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner;
@@ -56,9 +56,9 @@ public class RowGetter {
         InetSocketAddress host = clientPool.getRandomHostForKey(keyRange.getStart_key());
         return clientPool.runWithRetryOnHost(
                 host,
-                new FunctionCheckedException<Cassandra.Client, List<KeySlice>, Exception>() {
+                new FunctionCheckedException<CassandraClient, List<KeySlice>, Exception>() {
                     @Override
-                    public List<KeySlice> apply(Cassandra.Client client) throws Exception {
+                    public List<KeySlice> apply(CassandraClient client) throws Exception {
                         try {
                             return queryRunner.run(client, tableRef,
                                     () -> client.get_range_slices(colFam, slicePredicate, keyRange, consistency));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.cassandra.thrift.UnavailableException;
@@ -258,7 +257,7 @@ public class CassandraClientPoolTest {
             int numAttempts) {
         Mockito.verify(cassandraClientPool.getCurrentPools().get(host), Mockito.times(numAttempts))
                 .runWithPooledResource(
-                        Mockito.<FunctionCheckedException<Cassandra.Client, Object, RuntimeException>>any());
+                        Mockito.<FunctionCheckedException<CassandraClient, Object, RuntimeException>>any());
     }
 
     @Test
@@ -338,7 +337,7 @@ public class CassandraClientPoolTest {
     private void setFailureModeForHost(CassandraClientPoolingContainer poolingContainer, Exception failureMode) {
         try {
             when(poolingContainer.runWithPooledResource(
-                    Mockito.<FunctionCheckedException<Cassandra.Client, Object, Exception>>any()))
+                    Mockito.<FunctionCheckedException<CassandraClient, Object, Exception>>any()))
                     .thenThrow(failureMode);
         } catch (Exception e) {
             throw Throwables.propagate(e);
@@ -371,10 +370,10 @@ public class CassandraClientPoolTest {
         }
     }
 
-    private FunctionCheckedException<Cassandra.Client, Void, RuntimeException> noOp() {
-        return new FunctionCheckedException<Cassandra.Client, Void, RuntimeException>() {
+    private FunctionCheckedException<CassandraClient, Void, RuntimeException> noOp() {
+        return new FunctionCheckedException<CassandraClient, Void, RuntimeException>() {
             @Override
-            public Void apply(Cassandra.Client input) throws RuntimeException {
+            public Void apply(CassandraClient input) throws RuntimeException {
                 return null;
             }
 


### PR DESCRIPTION
**Goals (and why)**: Instead of the Cassandra.Client, use a wrapper around it. This allow us to break the Cassandra.Client api by adding or modifying parameters (e.g. using TableReference instead of column_family), and to instrument the interface with tritium.

**Implementation Description (bullets)**: Use the exact same API as Cassandra.Client, as modifications will come in next PRs.

**Where should we start reviewing?**: CassandraClient and CassandraClientImpl.

**Priority (whenever / two weeks / yesterday)**: EOD.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2660)
<!-- Reviewable:end -->
