### PR TITLE
[QoS] Add getNamespace to AtlasDBConfig

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -35,6 +35,8 @@ import com.palantir.exception.NotInitializedException;
 @Value.Immutable
 public abstract class AtlasDbConfig {
 
+    static final String UNSPECIFIED_NAMESPACE = "unspecifed";
+
     public abstract KeyValueServiceConfig keyValueService();
 
     public abstract Optional<LeaderConfig> leader();
@@ -283,6 +285,11 @@ public abstract class AtlasDbConfig {
     }
 
     private void checkNamespaceConfig() {
+        getNamespaceString();
+    }
+
+    @Value.Derived
+    public String getNamespaceString() {
         if (namespace().isPresent()) {
             String namespace = namespace().get();
 
@@ -295,12 +302,13 @@ public abstract class AtlasDbConfig {
                     Preconditions.checkState(client.equals(namespace),
                             "If present, the TimeLock client config should be the same as the"
                                     + " atlas root-level namespace config.")));
+            return namespace;
         } else if (!(keyValueService() instanceof InMemoryAtlasDbConfig)) {
             Preconditions.checkState(keyValueService().namespace().isPresent(),
                     "Either the atlas root-level namespace"
                             + " or the keyspace/dbName/sid config needs to be set.");
 
-            Optional<String> keyValueServiceNamespace = keyValueService().namespace();
+            String keyValueServiceNamespace = keyValueService().namespace().get();
 
             if (timelock().isPresent()) {
                 TimeLockClientConfig timeLockConfig = timelock().get();
@@ -313,17 +321,19 @@ public abstract class AtlasDbConfig {
                 // (C* keyspace / Postgres dbName / Oracle sid). But changing the name of the TimeLock client
                 // will return the timestamp bound store to 0, so we also need to fast forward the new client bound
                 // to a value above of the original bound.
-                Preconditions.checkState(timeLockConfig.client().equals(keyValueServiceNamespace),
+                Preconditions.checkState(timeLockConfig.client().equals(Optional.of(keyValueServiceNamespace)),
                         "AtlasDB refused to start, in order to avoid potential data corruption."
                                 + " Please contact AtlasDB support to remediate this. Specific steps are required;"
                                 + " DO NOT ATTEMPT TO FIX THIS YOURSELF.");
             }
+            return keyValueServiceNamespace;
         } else if (timelock().isPresent()) {
             // Special case - empty timelock and empty namespace/keyspace does not make sense
-            boolean timelockClientNonEmpty = !timelock().get().client().orElse("").isEmpty();
-            Preconditions.checkState(timelockClientNonEmpty,
+            Preconditions.checkState(timelock().get().client().isPresent(),
                     "For InMemoryKVS, the TimeLock client should not be empty");
+            return timelock().get().client().get();
         }
+        return UNSPECIFIED_NAMESPACE;
     }
 
     private boolean areTimeAndLockConfigsAbsent() {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
@@ -24,6 +24,7 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
 
 @JsonSerialize(as = ImmutableTimeLockClientConfig.class)
 @JsonDeserialize(as = ImmutableTimeLockClientConfig.class)
@@ -54,5 +55,11 @@ public abstract class TimeLockClientConfig {
                 .collect(Collectors.toSet());
         return ImmutableServerListConfig.copyOf(serversList())
                 .withServers(serversWithNamespaces);
+    }
+
+    @Value.Check
+    protected final void check() {
+        Preconditions.checkArgument(!client().isPresent() || !client().get().isEmpty(),
+                "Timelock client string cannot be empty");
     }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -58,7 +58,7 @@ public class AtlasDbConfigTest {
     private static final String TEST_NAMESPACE = "client";
     private static final String OTHER_CLIENT = "other-client";
 
-    private static final TimeLockClientConfig TIMELOCK_CONFIG_WITH_EMPTY_CLIENT = ImmutableTimeLockClientConfig
+    private static final TimeLockClientConfig TIMELOCK_CONFIG_WITH_OPTIONAL_EMPTY_CLIENT = ImmutableTimeLockClientConfig
             .builder()
             .client(Optional.empty())
             .serversList(DEFAULT_SERVER_LIST)
@@ -200,7 +200,7 @@ public class AtlasDbConfigTest {
     public void absentNamespaceRequiresTimelockClient() {
         assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
-                .timelock(TIMELOCK_CONFIG_WITH_EMPTY_CLIENT)
+                .timelock(TIMELOCK_CONFIG_WITH_OPTIONAL_EMPTY_CLIENT)
                 .build())
                 .isInstanceOf(IllegalStateException.class)
                 .satisfies((exception) ->
@@ -220,7 +220,7 @@ public class AtlasDbConfigTest {
         AtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .namespace("a client")
                 .keyValueService(KVS_CONFIG_WITHOUT_NAMESPACE)
-                .timelock(TIMELOCK_CONFIG_WITH_EMPTY_CLIENT)
+                .timelock(TIMELOCK_CONFIG_WITH_OPTIONAL_EMPTY_CLIENT)
                 .build();
         assertThat(config.getNamespaceString(), equalTo("a client"));
     }
@@ -257,7 +257,7 @@ public class AtlasDbConfigTest {
         assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
                 .namespace(Optional.empty())
                 .keyValueService(kvsConfig)
-                .timelock(TIMELOCK_CONFIG_WITH_EMPTY_CLIENT)
+                .timelock(TIMELOCK_CONFIG_WITH_OPTIONAL_EMPTY_CLIENT)
                 .build())
                 .isInstanceOf(IllegalStateException.class)
                 .satisfies((exception) ->
@@ -294,7 +294,7 @@ public class AtlasDbConfigTest {
         assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
                 .namespace(TEST_NAMESPACE)
                 .keyValueService(KVS_CONFIG_WITH_OTHER_NAMESPACE)
-                .timelock(TIMELOCK_CONFIG_WITH_EMPTY_CLIENT)
+                .timelock(TIMELOCK_CONFIG_WITH_OPTIONAL_EMPTY_CLIENT)
                 .build())
                 .isInstanceOf(IllegalStateException.class)
                 .satisfies((exception) ->

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.config;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -54,23 +55,25 @@ public class AtlasDbConfigTest {
     private static final Optional<SslConfiguration> OTHER_SSL_CONFIG = Optional.of(mock(SslConfiguration.class));
     private static final Optional<SslConfiguration> NO_SSL_CONFIG = Optional.empty();
 
+    private static final String TEST_NAMESPACE = "client";
+    private static final String OTHER_CLIENT = "other-client";
+
     private static final TimeLockClientConfig TIMELOCK_CONFIG_WITH_EMPTY_CLIENT = ImmutableTimeLockClientConfig
             .builder()
             .client(Optional.empty())
             .serversList(DEFAULT_SERVER_LIST)
             .build();
-
     private static final TimeLockClientConfig TIMELOCK_CONFIG_WITH_OTHER_CLIENT = ImmutableTimeLockClientConfig
             .builder()
-            .client("other-client")
+            .client(OTHER_CLIENT)
             .serversList(DEFAULT_SERVER_LIST)
             .build();
 
     @BeforeClass
     public static void setUp() {
         when(KVS_CONFIG_WITHOUT_NAMESPACE.namespace()).thenReturn(Optional.empty());
-        when(KVS_CONFIG_WITH_OTHER_NAMESPACE.namespace()).thenReturn(Optional.of("other-client"));
-        when(KVS_CONFIG_WITH_NAMESPACE.namespace()).thenReturn(Optional.of("client"));
+        when(KVS_CONFIG_WITH_OTHER_NAMESPACE.namespace()).thenReturn(Optional.of(OTHER_CLIENT));
+        when(KVS_CONFIG_WITH_NAMESPACE.namespace()).thenReturn(Optional.of(TEST_NAMESPACE));
     }
 
     @Test
@@ -92,6 +95,7 @@ public class AtlasDbConfigTest {
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
                 .leader(LEADER_CONFIG)
                 .build();
+        assertThat(config.getNamespaceString(), equalTo(TEST_NAMESPACE));
         assertThat(config, not(nullValue()));
     }
 
@@ -101,6 +105,7 @@ public class AtlasDbConfigTest {
                 .keyValueService(KVS_CONFIG_WITH_NAMESPACE)
                 .timelock(TIMELOCK_CONFIG)
                 .build();
+        assertThat(config.getNamespaceString(), equalTo(TEST_NAMESPACE));
         assertThat(config, not(nullValue()));
     }
 
@@ -111,6 +116,7 @@ public class AtlasDbConfigTest {
                 .lock(DEFAULT_SERVER_LIST)
                 .timestamp(DEFAULT_SERVER_LIST)
                 .build();
+        assertThat(config.getNamespaceString(), equalTo(TEST_NAMESPACE));
         assertThat(config, not(nullValue()));
     }
 
@@ -211,11 +217,12 @@ public class AtlasDbConfigTest {
 
     @Test
     public void namespaceAcceptsEmptyKvsNamespaceAndTimelockClient() {
-        ImmutableAtlasDbConfig.builder()
+        AtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .namespace("a client")
                 .keyValueService(KVS_CONFIG_WITHOUT_NAMESPACE)
                 .timelock(TIMELOCK_CONFIG_WITH_EMPTY_CLIENT)
                 .build();
+        assertThat(config.getNamespaceString(), equalTo("a client"));
     }
 
     @Test
@@ -223,10 +230,11 @@ public class AtlasDbConfigTest {
         InMemoryAtlasDbConfig kvsConfig = new InMemoryAtlasDbConfig();
         assertFalse("This test assumes the InMemoryAtlasDbConfig has no namespace by default",
                 kvsConfig.namespace().isPresent());
-        ImmutableAtlasDbConfig.builder()
+        ImmutableAtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .namespace(Optional.empty())
                 .keyValueService(kvsConfig)
                 .build();
+        assertThat(config.getNamespaceString(), equalTo(AtlasDbConfig.UNSPECIFIED_NAMESPACE));
     }
 
     @Test
@@ -234,10 +242,11 @@ public class AtlasDbConfigTest {
         InMemoryAtlasDbConfig kvsConfig = new InMemoryAtlasDbConfig();
         assertFalse("This test assumes the InMemoryAtlasDbConfig has no namespace by default",
                 kvsConfig.namespace().isPresent());
-        ImmutableAtlasDbConfig.builder()
+        AtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .namespace("clive")
                 .keyValueService(kvsConfig)
                 .build();
+        assertThat(config.getNamespaceString(), equalTo("clive"));
     }
 
     @Test
@@ -261,16 +270,17 @@ public class AtlasDbConfigTest {
         InMemoryAtlasDbConfig kvsConfig = new InMemoryAtlasDbConfig();
         assertFalse("This test assumes the InMemoryAtlasDbConfig has no namespace by default",
                 kvsConfig.namespace().isPresent());
-        ImmutableAtlasDbConfig.builder()
+        ImmutableAtlasDbConfig config = ImmutableAtlasDbConfig.builder()
                 .keyValueService(kvsConfig)
                 .timelock(TIMELOCK_CONFIG_WITH_OTHER_CLIENT)
                 .build();
+        assertThat(config.getNamespaceString(), equalTo(OTHER_CLIENT));
     }
 
     @Test
     public void namespaceAndTimelockClientShouldMatch() {
         assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
-                .namespace("client")
+                .namespace(TEST_NAMESPACE)
                 .keyValueService(KVS_CONFIG_WITHOUT_NAMESPACE)
                 .timelock(TIMELOCK_CONFIG_WITH_OTHER_CLIENT)
                 .build())
@@ -282,7 +292,7 @@ public class AtlasDbConfigTest {
     @Test
     public void namespaceAndKvsNamespaceShouldMatch() {
         assertThatThrownBy(() -> ImmutableAtlasDbConfig.builder()
-                .namespace("client")
+                .namespace(TEST_NAMESPACE)
                 .keyValueService(KVS_CONFIG_WITH_OTHER_NAMESPACE)
                 .timelock(TIMELOCK_CONFIG_WITH_EMPTY_CLIENT)
                 .build())
@@ -299,6 +309,7 @@ public class AtlasDbConfigTest {
                 .build();
         AtlasDbConfig withSsl = AtlasDbConfigs.addFallbackSslConfigurationToAtlasDbConfig(withoutSsl, SSL_CONFIG);
         assertThat(withSsl.leader().get().sslConfiguration(), is(SSL_CONFIG));
+        assertThat(withoutSsl.getNamespaceString(), equalTo(TEST_NAMESPACE));
     }
 
     @Test
@@ -310,6 +321,7 @@ public class AtlasDbConfigTest {
                 .build();
         AtlasDbConfig withSsl = AtlasDbConfigs.addFallbackSslConfigurationToAtlasDbConfig(withoutSsl, SSL_CONFIG);
         assertThat(withSsl.lock().get().sslConfiguration(), is(SSL_CONFIG));
+        assertThat(withoutSsl.getNamespaceString(), equalTo(TEST_NAMESPACE));
     }
 
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TimeLockClientConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TimeLockClientConfigTest.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.config;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertThat;
@@ -72,6 +73,18 @@ public class TimeLockClientConfigTest {
         ImmutableTimeLockClientConfig.builder()
                 .serversList(SERVERS_LIST)
                 .build();
+    }
+
+    @Test
+    public void tmelockClientCannotBeAnEmptyString() {
+        assertThatThrownBy(() -> ImmutableTimeLockClientConfig
+                .builder()
+                .client("")
+                .serversList(SERVERS_LIST)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .satisfies((exception) ->
+                        assertThat(exception.getMessage(), containsString("Timelock client string cannot be empty")));
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**: Add getNamespace so that the `QosClient` can use it. See #2650.

**Priority (whenever / two weeks / yesterday)**: Soon, small PR. Will cherry-pick and continue on the QoS client stuff, so not really blocking.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2661)
<!-- Reviewable:end -->
