### PR TITLE
Recording slow range scans in kvs-slow-log

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingIterator.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingIterator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.impl;
+
+import java.util.Collection;
+import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.google.common.base.Stopwatch;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.logging.KvsProfilingLogger;
+import com.palantir.atlasdb.logging.KvsProfilingLogger.LoggingFunction;
+import com.palantir.atlasdb.logging.LoggingArgs;
+import com.palantir.common.base.ClosableIterator;
+
+public class ProfilingIterator<T> implements ClosableIterator<T> {
+    private final ClosableIterator<T> delegate;
+    private final String kvsMethod;
+    private final TableReference tableRef;
+    private final RangeRequest range;
+
+    private ProfilingIterator(ClosableIterator<T> delegate,
+            String kvsMethod, TableReference tableRef, RangeRequest range) {
+        this.delegate = delegate;
+        this.kvsMethod = kvsMethod;
+        this.tableRef = tableRef;
+        this.range = range;
+    }
+
+    public static <T> ClosableIterator<T> wrap(ClosableIterator<T> iterator,
+            String kvsMethod, TableReference tableRef, RangeRequest range) {
+        return new ProfilingIterator<>(iterator, kvsMethod, tableRef, range);
+    }
+
+    private BiConsumer<LoggingFunction, Stopwatch> logMethodAndTimeAndTableRange(
+            String method) {
+        return (logger, stopwatch) ->
+                logger.log("Call to iterator method {} took {} ms. This call is a result of a previous call to KVS.{} "
+                        + "on table {} with range {}.",
+                        LoggingArgs.method(method),
+                        LoggingArgs.durationMillis(stopwatch),
+                        LoggingArgs.method(kvsMethod),
+                        LoggingArgs.tableRef(tableRef),
+                        LoggingArgs.range(tableRef, range));
+    }
+
+    @Override
+    public boolean hasNext() {
+        return KvsProfilingLogger.maybeLog(() -> delegate.hasNext(), logMethodAndTimeAndTableRange("hasNext"));
+    }
+
+    @Override
+    public T next() {
+        return KvsProfilingLogger.maybeLog(() -> delegate.next(), logMethodAndTimeAndTableRange("next"));
+    }
+
+    @Override
+    public void remove() {
+        KvsProfilingLogger.maybeLog(() -> delegate.remove(), logMethodAndTimeAndTableRange("remove"));
+    }
+
+    @Override
+    public void forEachRemaining(Consumer<? super T> action) {
+        KvsProfilingLogger.maybeLog(() -> delegate.forEachRemaining(action),
+                logMethodAndTimeAndTableRange("forEachRemaining"));
+    }
+
+    @Override
+    public void close() {
+        KvsProfilingLogger.maybeLog(() -> delegate.close(), logMethodAndTimeAndTableRange("close"));
+    }
+
+    @Override
+    public <U> ClosableIterator<U> map(Function<T, U> mapper) {
+        return KvsProfilingLogger.maybeLog(() -> ProfilingIterator.wrap(
+                delegate.map(mapper), kvsMethod, tableRef, range), logMethodAndTimeAndTableRange("map"));
+    }
+
+    @Override
+    public <U> ClosableIterator<U> flatMap(Function<T, Collection<U>> mapper) {
+        return KvsProfilingLogger.maybeLog(() -> ProfilingIterator.wrap(
+                delegate.flatMap(mapper), kvsMethod, tableRef, range), logMethodAndTimeAndTableRange("flatMap"));
+    }
+
+    @Override
+    public ClosableIterator<T> stopWhen(Predicate<T> shouldStop) {
+        return KvsProfilingLogger.maybeLog(() -> ProfilingIterator.wrap(
+                delegate.stopWhen(shouldStop), kvsMethod, tableRef, range), logMethodAndTimeAndTableRange("stopWhen"));
+    }
+
+    @Override
+    public Stream<T> stream() {
+        return KvsProfilingLogger.maybeLog(() -> StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(this, 0), false), logMethodAndTimeAndTableRange("stream"));
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -231,14 +231,15 @@ public final class ProfilingKeyValueService implements KeyValueService {
     @Override
     public ClosableIterator<RowResult<Value>> getRange(TableReference tableRef, RangeRequest rangeRequest,
             long timestamp) {
-        return maybeLog(() -> delegate.getRange(tableRef, rangeRequest, timestamp),
-                logTimeAndTableRange("getRange", tableRef, rangeRequest));
+        return maybeLog(() -> ProfilingIterator.wrap(delegate.getRange(tableRef, rangeRequest, timestamp),
+                "getRange", tableRef, rangeRequest), logTimeAndTableRange("getRange", tableRef, rangeRequest));
     }
 
     @Override
     public ClosableIterator<RowResult<Set<Long>>> getRangeOfTimestamps(TableReference tableRef,
             RangeRequest rangeRequest, long timestamp) {
-        return maybeLog(() -> delegate.getRangeOfTimestamps(tableRef, rangeRequest, timestamp),
+        return maybeLog(() -> ProfilingIterator.wrap(delegate.getRangeOfTimestamps(tableRef, rangeRequest, timestamp),
+                "getRangeOfTimestamps", tableRef, rangeRequest),
                 logTimeAndTableRange("getRangeOfTimestamps", tableRef, rangeRequest));
     }
 
@@ -390,7 +391,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
                         LoggingArgs.durationMillis(stopwatch)));
     }
 
-    private  <T> T maybeLog(Supplier<T> action, BiConsumer<LoggingFunction, Stopwatch> logger) {
+    private <T> T maybeLog(Supplier<T> action, BiConsumer<LoggingFunction, Stopwatch> logger) {
         return KvsProfilingLogger.maybeLog(action, logger);
     }
 

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava'
     compile group: 'org.slf4j', name: 'slf4j-api'
     compile project(":commons-executors")
+    compile project(":atlasdb-processors")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
     compile group: 'io.dropwizard.metrics', name: 'metrics-core'

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava'
     compile group: 'org.slf4j', name: 'slf4j-api'
     compile project(":commons-executors")
-    compile project(":atlasdb-processors")
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
     compile group: 'io.dropwizard.metrics', name: 'metrics-core'

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,10 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - Range scan iterators returned by `ProfilingKeyValueService` now log `kvs-slow-log` warnings when the iterator is accessed if applicable.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2663>`__)
+
     *    - |fixed| |metrics|
          - ``MetricsManager`` now logs failures to register metrics at ``WARN`` instead of ``ERROR``, as failure to do so is not necessarily a systemic failure.
            Also, we now log the name of the metric as a Safe argument (previously it was logged as Unsafe).


### PR DESCRIPTION
**Goals (and why)**:
`getRange` requests can return an iterator fast, but actually accessing the iterator may then be slow, which wasn't previously logged.

**Implementation Description (bullets)**:
Wrap the ClosableIterator in a `ProfilingIterator` that logs into kvs-slow-log if calls to its methods are slow.

**Concerns (what feedback would you like?)**:
The way we deal with `stream()` is not ideal, we copy the behaviour from `ClosableIterator` instead of using the delegate. Is there a better way of doing this? Is the approach in general good? 
Note that AutoDelegate does not work with generics :(

**Where should we start reviewing?**:
Tests?

**Priority (whenever / two weeks / yesterday)**:
This week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2664)
<!-- Reviewable:end -->
