### PR TITLE
Propagate top-level KVS method names to CassandraClient

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -43,28 +43,42 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 public interface CassandraClient {
     Cassandra.Client rawClient();
 
-    Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName, TableReference tableRef,
+    Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName,
+            TableReference tableRef,
             List<ByteBuffer> keys,
             SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
-    List<KeySlice> get_range_slices(TableReference tableRef, SlicePredicate predicate, KeyRange range,
+    List<KeySlice> get_range_slices(String kvsMethodName,
+            TableReference tableRef,
+            SlicePredicate predicate,
+            KeyRange range,
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
-    void batch_mutate(Map<ByteBuffer,Map<String,List<Mutation>>> mutation_map, ConsistencyLevel consistency_level)
+    void batch_mutate(String kvsMethodName,
+            Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
+            ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
-    ColumnOrSuperColumn get(TableReference tableReference, ByteBuffer key,
-            byte[] column, ConsistencyLevel consistency_level)
+    ColumnOrSuperColumn get(TableReference tableReference,
+            ByteBuffer key,
+            byte[] column,
+            ConsistencyLevel consistency_level)
             throws InvalidRequestException, NotFoundException, UnavailableException, TimedOutException,
             org.apache.thrift.TException;
 
-    CASResult cas(TableReference tableReference, ByteBuffer key, List<Column> expected, List<Column> updates,
-            ConsistencyLevel serial_consistency_level, ConsistencyLevel commit_consistency_level)
+    CASResult cas(TableReference tableReference,
+            ByteBuffer key,
+            List<Column> expected,
+            List<Column> updates,
+            ConsistencyLevel serial_consistency_level,
+            ConsistencyLevel commit_consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
 
-    CqlResult execute_cql3_query(ByteBuffer query, Compression compression, ConsistencyLevel consistency)
+    CqlResult execute_cql3_query(ByteBuffer query,
+            Compression compression,
+            ConsistencyLevel consistency)
             throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException,
             org.apache.thrift.TException;
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -43,7 +43,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 public interface CassandraClient {
     Cassandra.Client rawClient();
 
-    Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(TableReference tableRef,
+    Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName, TableReference tableRef,
             List<ByteBuffer> keys,
             SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -89,6 +89,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
     }
 
     private CassandraClient instrumentClient(Client client) {
+        // TODO(ssouza): use the kvsMethodName to tag the timers.
         return AtlasDbMetrics.instrument(CassandraClient.class, new CassandraClientImpl(client));
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -58,15 +58,19 @@ public class CassandraClientImpl implements CassandraClient {
 
     @Override
     public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(
-            String kvsMethodName, TableReference tableRef, List<ByteBuffer> keys,
-            SlicePredicate predicate, ConsistencyLevel consistency_level)
+            String kvsMethodName,
+            TableReference tableRef,
+            List<ByteBuffer> keys,
+            SlicePredicate predicate,
+            ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         ColumnParent colFam = getColumnParent(tableRef);
         return client.multiget_slice(keys, colFam, predicate, consistency_level);
     }
 
     @Override
-    public List<KeySlice> get_range_slices(TableReference tableRef,
+    public List<KeySlice> get_range_slices(String kvsMethodName,
+            TableReference tableRef,
             SlicePredicate predicate,
             KeyRange range,
             ConsistencyLevel consistency_level)
@@ -76,7 +80,8 @@ public class CassandraClientImpl implements CassandraClient {
     }
 
     @Override
-    public void batch_mutate(Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
+    public void batch_mutate(String kvsMethodName,
+            Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         client.batch_mutate(mutation_map, consistency_level);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -58,7 +58,7 @@ public class CassandraClientImpl implements CassandraClient {
 
     @Override
     public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(
-            TableReference tableRef, List<ByteBuffer> keys,
+            String kvsMethodName, TableReference tableRef, List<ByteBuffer> keys,
             SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         ColumnParent colFam = getColumnParent(tableRef);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
@@ -73,20 +73,14 @@ public final class CassandraExpiringKeyValueService extends CassandraKeyValueSer
 
     @Override
     public void put(TableReference tableRef, Map<Cell, byte[]> values, long timestamp, long time, TimeUnit unit) {
-        try {
-            putInternal(
-                    tableRef,
-                    KeyValueServices.toConstantTimestampValues(values.entrySet(), timestamp),
-                    CassandraKeyValueServices.convertTtl(time, unit));
-        } catch (Exception e) {
-            throw Throwables.throwUncheckedException(e);
-        }
+        expiringPut("put", tableRef, values, timestamp, time, unit);
     }
 
     @Override
     public void putWithTimestamps(TableReference tableRef, Multimap<Cell, Value> values, long time, TimeUnit unit) {
         try {
-            putInternal(tableRef, values.entries(), CassandraKeyValueServices.convertTtl(time, unit));
+            putInternal("putWithTimestamps", tableRef, values.entries(),
+                    CassandraKeyValueServices.convertTtl(time, unit));
         } catch (Exception e) {
             throw Throwables.throwUncheckedException(e);
         }
@@ -112,7 +106,7 @@ public final class CassandraExpiringKeyValueService extends CassandraKeyValueSer
             for (final List<Entry<Cell, byte[]>> p : partitions) {
                 callables.add(() -> {
                     Thread.currentThread().setName("Atlas expiry multiPut of " + p.size() + " cells into " + table);
-                    put(table, Maps2.fromEntries(p), timestamp, time, unit);
+                    expiringPut("multiPut", table, Maps2.fromEntries(p), timestamp, time, unit);
                     return null;
                 });
             }
@@ -135,4 +129,15 @@ public final class CassandraExpiringKeyValueService extends CassandraKeyValueSer
         }
     }
 
+    private void expiringPut(String kvsMethodName, TableReference tableRef, Map<Cell, byte[]> values, long timestamp,
+            long time, TimeUnit unit) {
+        try {
+            putInternal(kvsMethodName,
+                    tableRef,
+                    KeyValueServices.toConstantTimestampValues(values.entrySet(), timestamp),
+                    CassandraKeyValueServices.convertTtl(time, unit));
+        } catch (Exception e) {
+            throw Throwables.throwUncheckedException(e);
+        }
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -448,12 +448,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                                 List<ByteBuffer> rowNames = wrap(batch);
 
-                                Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal(
+                                Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal("getRows",
                                         client,
                                         tableRef,
                                         rowNames,
-                                        pred,
-                                        readConsistency);
+                                        pred, readConsistency);
                                 Map<Cell, Value> ret = Maps.newHashMapWithExpectedSize(batch.size());
                                 new ValueExtractor(ret).extractResults(results, startTs, ColumnSelection.all());
                                 return ret;
@@ -502,7 +501,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         }
 
         StartTsResultsCollector collector = new StartTsResultsCollector(startTs);
-        loadWithTs(tableRef, cells, startTs, false, collector, readConsistency);
+        loadWithTs("getRows", tableRef, cells, startTs, false, collector, readConsistency);
         return collector.getCollectedResults();
     }
 
@@ -532,7 +531,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         try {
             Long firstTs = timestampByCell.values().iterator().next();
             if (Iterables.all(timestampByCell.values(), Predicates.equalTo(firstTs))) {
-                return get(tableRef, timestampByCell.keySet(), firstTs);
+                return get("get", tableRef, timestampByCell.keySet(), firstTs);
             }
 
             SetMultimap<Long, Cell> cellsByTs = Multimaps.invertFrom(
@@ -540,7 +539,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             Builder<Cell, Value> builder = ImmutableMap.builder();
             for (long ts : cellsByTs.keySet()) {
                 StartTsResultsCollector collector = new StartTsResultsCollector(ts);
-                loadWithTs(tableRef, cellsByTs.get(ts), ts, false, collector, readConsistency);
+                loadWithTs("get", tableRef, cellsByTs.get(ts), ts, false, collector, readConsistency);
                 builder.putAll(collector.getCollectedResults());
             }
             return builder.build();
@@ -549,18 +548,20 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         }
     }
 
-    private Map<Cell, Value> get(TableReference tableRef, Set<Cell> cells, long maxTimestampExclusive) {
+    private Map<Cell, Value> get(String kvsMethodName, TableReference tableRef, Set<Cell> cells,
+            long maxTimestampExclusive) {
         StartTsResultsCollector collector = new StartTsResultsCollector(maxTimestampExclusive);
-        loadWithTs(tableRef, cells, maxTimestampExclusive, false, collector, readConsistency);
+        loadWithTs(kvsMethodName, tableRef, cells, maxTimestampExclusive, false, collector, readConsistency);
         return collector.getCollectedResults();
     }
 
-    private void loadWithTs(TableReference tableRef,
-                            Set<Cell> cells,
-                            long startTs,
-                            boolean loadAllTs,
-                            ThreadSafeResultVisitor visitor,
-                            ConsistencyLevel consistency) {
+    private void loadWithTs(String kvsMethodName,
+            TableReference tableRef,
+            Set<Cell> cells,
+            long startTs,
+            boolean loadAllTs,
+            ThreadSafeResultVisitor visitor,
+            ConsistencyLevel consistency) {
         Map<InetSocketAddress, List<Cell>> hostsAndCells =  partitionByHost(cells, Cells.getRowFunction());
         int totalPartitions = hostsAndCells.keySet().size();
 
@@ -584,7 +585,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         SafeArg.of("ipPort", hostAndCells.getKey()));
             }
 
-            tasks.addAll(getLoadWithTsTasksForSingleHost(hostAndCells.getKey(),
+            tasks.addAll(getLoadWithTsTasksForSingleHost(kvsMethodName,
+                    hostAndCells.getKey(),
                     tableRef,
                     hostAndCells.getValue(),
                     startTs,
@@ -596,7 +598,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     // TODO(unknown): after cassandra api change: handle different column select per row
-    private List<Callable<Void>> getLoadWithTsTasksForSingleHost(final InetSocketAddress host,
+    private List<Callable<Void>> getLoadWithTsTasksForSingleHost(final String kvsMethodName,
+                                                                 final InetSocketAddress host,
                                                                  final TableReference tableRef,
                                                                  final Collection<Cell> cells,
                                                                  final long startTs,
@@ -646,7 +649,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                 }
 
                                 Map<ByteBuffer, List<ColumnOrSuperColumn>> results =
-                                        multigetInternal(client, tableRef, rowNames, predicate, consistency);
+                                        multigetInternal(kvsMethodName, client, tableRef, rowNames, predicate,
+                                                consistency);
                                 visitor.visit(results);
                                 return null;
                             }
@@ -791,7 +795,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                             SlicePredicate pred = SlicePredicates.create(range, limit);
 
                             Map<ByteBuffer, List<ColumnOrSuperColumn>> results =
-                                    multigetInternal(client, tableRef, wrap(rows), pred, readConsistency);
+                                    multigetInternal("getRowsColumnRange", client, tableRef, wrap(rows), pred,
+                                            readConsistency);
 
                             RowColumnRangeExtractor extractor = new RowColumnRangeExtractor();
                             extractor.extractResults(rows, results, startTs);
@@ -846,8 +851,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                         ByteBuffer rowByteBuffer = ByteBuffer.wrap(row);
 
-                        Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal(client, tableRef,
-                                ImmutableList.of(rowByteBuffer), pred, readConsistency);
+                        Map<ByteBuffer, List<ColumnOrSuperColumn>> results = multigetInternal("getRowsColumnRange",
+                                client, tableRef, ImmutableList.of(rowByteBuffer), pred, readConsistency);
 
                         if (results.isEmpty()) {
                             return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
@@ -1193,14 +1198,15 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private Map<ByteBuffer, List<ColumnOrSuperColumn>> multigetInternal(
+            String kvsMethodName,
             CassandraClient client,
             TableReference tableRef,
             List<ByteBuffer> rowNames,
             SlicePredicate pred,
             ConsistencyLevel consistency) throws TException {
         try {
-            return queryRunner.run(client, tableRef, () -> client.multiget_slice(tableRef, rowNames, pred,
-                    consistency));
+            return queryRunner.run(client, tableRef, () -> client.multiget_slice(kvsMethodName, tableRef, rowNames,
+                    pred, consistency));
         } catch (UnavailableException e) {
             throw new InsufficientConsistencyException(
                     "This get operation requires " + consistency + " Cassandra nodes to be up and available.", e);
@@ -1448,7 +1454,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 .addTimestampsToIgnore()
                 .shouldCheckIfLatestValueIsEmpty(false)
                 .build();
-        return getCandidateRowsForSweeping(tableRef, request)
+        return getCandidateRowsForSweeping("getRangeOfTimestamps", tableRef, request)
                 .flatMap(rows -> rows)
                 .map(row -> row.toRowResult())
                 .stopWhen(rowResult -> !rangeRequest.inRange(rowResult.getRowName()));
@@ -1458,7 +1464,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     public ClosableIterator<List<CandidateCellForSweeping>> getCandidateCellsForSweeping(
             TableReference tableRef,
             CandidateCellForSweepingRequest request) {
-        return getCandidateRowsForSweeping(tableRef, request)
+        return getCandidateRowsForSweeping("getCandidateCellsForSweeping", tableRef, request)
                 .map(rows -> rows.stream()
                         .map(CandidateRowForSweeping::cells)
                         .flatMap(List::stream)
@@ -1466,9 +1472,13 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private ClosableIterator<List<CandidateRowForSweeping>> getCandidateRowsForSweeping(
+            String kvsMethodName,
             TableReference tableRef,
             CandidateCellForSweepingRequest request) {
-        return new CandidateRowsForSweepingIterator(this::get, new CqlExecutor(clientPool, ConsistencyLevel.ALL),
+        return new CandidateRowsForSweepingIterator(
+                (iteratorTableRef, cells, maxTimestampExclusive) ->
+                        get(kvsMethodName, iteratorTableRef, cells, maxTimestampExclusive),
+                new CqlExecutor(clientPool, ConsistencyLevel.ALL),
                 tableRef, request);
     }
 
@@ -2064,7 +2074,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     @Override
     public Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> cells, long ts) {
         AllTimestampsCollector collector = new AllTimestampsCollector();
-        loadWithTs(tableRef, cells, ts, true, collector, deleteConsistency);
+        loadWithTs("getAllTimestamps", tableRef, cells, ts, true, collector, deleteConsistency);
         return collector.getCollectedResults();
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -452,7 +452,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                         client,
                                         tableRef,
                                         rowNames,
-                                        pred, readConsistency);
+                                        pred,
+                                        readConsistency);
                                 Map<Cell, Value> ret = Maps.newHashMapWithExpectedSize(batch.size());
                                 new ValueExtractor(ret).extractResults(results, startTs, ColumnSelection.all());
                                 return ret;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/paging/CassandraRangePagingIterable.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/paging/CassandraRangePagingIterable.java
@@ -91,7 +91,7 @@ public class CassandraRangePagingIterable<T>
 
     private List<KeySlice> getRows(byte[] startKey) throws Exception {
         KeyRange keyRange = getKeyRange(startKey, rangeRequest.getEndExclusive());
-        return rowGetter.getRows(keyRange, slicePredicate);
+        return rowGetter.getRows("getRange", keyRange, slicePredicate);
     }
 
     private Map<ByteBuffer, List<ColumnOrSuperColumn>> getColumns(List<KeySlice> firstPage) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/paging/RowGetter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/paging/RowGetter.java
@@ -49,7 +49,9 @@ public class RowGetter {
         this.tableRef = tableRef;
     }
 
-    public List<KeySlice> getRows(KeyRange keyRange, SlicePredicate slicePredicate) throws Exception {
+    public List<KeySlice> getRows(String kvsMethodName, KeyRange keyRange, SlicePredicate slicePredicate)
+            throws Exception {
+
         InetSocketAddress host = clientPool.getRandomHostForKey(keyRange.getStart_key());
         return clientPool.runWithRetryOnHost(
                 host,
@@ -58,7 +60,11 @@ public class RowGetter {
                     public List<KeySlice> apply(CassandraClient client) throws Exception {
                         try {
                             return queryRunner.run(client, tableRef,
-                                    () -> client.get_range_slices(tableRef, slicePredicate, keyRange, consistency));
+                                    () -> client.get_range_slices(kvsMethodName,
+                                            tableRef,
+                                            slicePredicate,
+                                            keyRange,
+                                            consistency));
                         } catch (UnavailableException e) {
                             throw new InsufficientConsistencyException("get_range_slices requires " + consistency
                                     + " Cassandra nodes to be up and available.", e);


### PR DESCRIPTION
**Goals (and why)**: In order to disambiguate the top-level kvs calls that originated the downstream CassandraClient calls, propagate the kvs method names to CassandraClient impl.

**Priority (whenever / two weeks / yesterday)**: EOW.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2669)
<!-- Reviewable:end -->
