### PR TITLE
(further) expose KVS health

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ClusterAvailabilityStatus.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ClusterAvailabilityStatus.java
@@ -16,8 +16,18 @@
 package com.palantir.atlasdb.keyvalue.api;
 
 public enum ClusterAvailabilityStatus {
-    TERMINAL,
-    NO_QUORUM_AVAILABLE,
-    QUORUM_AVAILABLE,
-    ALL_AVAILABLE
+    TERMINAL(false),
+    NO_QUORUM_AVAILABLE(false),
+    QUORUM_AVAILABLE(true),
+    ALL_AVAILABLE(true);
+
+    private final boolean isHealthy;
+
+    ClusterAvailabilityStatus(boolean isHealthy) {
+        this.isHealthy = isHealthy;
+    }
+
+    public boolean isHealthy() {
+        return isHealthy;
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ClusterAvailabilityStatus.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ClusterAvailabilityStatus.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.keyvalue.api;
 public enum ClusterAvailabilityStatus {
     TERMINAL(false),
     NO_QUORUM_AVAILABLE(false),
-    QUORUM_AVAILABLE(true),
+    QUORUM_AVAILABLE(false),
     ALL_AVAILABLE(true);
 
     private final boolean isHealthy;

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -29,6 +29,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.annotation.NonIdempotent;
 import com.palantir.common.base.ClosableIterator;
@@ -655,8 +656,16 @@ public interface KeyValueService extends AutoCloseable {
     void compactInternally(TableReference tableRef);
 
     /**
-     * Checks if the KVS has a quorum available to successfully perform reads/writes.
-     *
+     * Provides a {@link ClusterAvailabilityStatus}, indicating the current availability of the key value store.
+     * This can be used to infer product health - in the usual, conservative case, products can call
+     * {@link ClusterAvailabilityStatus#isHealthy()}, which returns true only if all KVS nodes are up.
+     * <p>
+     * Products that use AtlasDB only for reads and writes (no schema mutations or deletes, including having sweep and
+     * scrub disabled) can also treat {@link ClusterAvailabilityStatus#QUORUM_AVAILABLE} as healthy.
+     * <p>
+     * If you have access to a {@link com.palantir.atlasdb.transaction.api.TransactionManager}, then it is recommended
+     * to use its availability indicator, {@link TransactionManager#getKeyValueServiceStatus()}, instead of this one.
+     * <p>
      * This call must be implemented so that it completes synchronously.
      */
     @POST

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatus.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatus.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.transaction.api;
 public enum KeyValueServiceStatus {
     TERMINAL(false),
     UNHEALTHY(false),
-    HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES(true),
+    HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES(false),
     HEALTHY_ALL_OPERATIONS(true);
 
     private final boolean isHealthy;

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatus.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatus.java
@@ -16,8 +16,8 @@
 package com.palantir.atlasdb.transaction.api;
 
 public enum KeyValueServiceStatus {
-    TERMINAL(true),
-    UNHEALTHY(true),
+    TERMINAL(false),
+    UNHEALTHY(false),
     HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES(true),
     HEALTHY_ALL_OPERATIONS(true);
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatus.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatus.java
@@ -16,8 +16,18 @@
 package com.palantir.atlasdb.transaction.api;
 
 public enum KeyValueServiceStatus {
-    TERMINAL,
-    UNHEALTHY,
-    HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES,
-    HEALTHY_ALL_OPERATIONS
+    TERMINAL(true),
+    UNHEALTHY(true),
+    HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES(true),
+    HEALTHY_ALL_OPERATIONS(true);
+
+    private final boolean isHealthy;
+
+    KeyValueServiceStatus(boolean isHealthy) {
+        this.isHealthy = isHealthy;
+    }
+
+    public boolean isHealthy() {
+        return isHealthy;
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -126,9 +126,15 @@ public interface TransactionManager extends AutoCloseable {
     long getImmutableTimestamp();
 
     /**
-     * Return the {@link KeyValueServiceStatus} depending on the availability of the underlying key-value store.
-     *
-     * @return status of the key value service, can be used by the application to decide its own health
+     * Provides a {@link KeyValueServiceStatus}, indicating the current availability of the key value store.
+     * This can be used to infer product health - in the usual, conservative case, products can call
+     * {@link KeyValueServiceStatus#isHealthy()}, which returns true only if all KVS nodes are up.
+     * <p>
+     * Products that use AtlasDB only for reads and writes (no schema mutations or deletes, including having sweep and
+     * scrub disabled) can also treat {@link KeyValueServiceStatus#HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES} as
+     * healthy.
+     * <p>
+     * This call must be implemented so that it completes synchronously.
      */
     KeyValueServiceStatus getKeyValueServiceStatus();
 

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/ClusterAvailabilityStatusTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/ClusterAvailabilityStatusTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ClusterAvailabilityStatusTest {
+    @Test
+    public void allAvailableMeansHealthy() {
+        assertTrue(ClusterAvailabilityStatus.ALL_AVAILABLE.isHealthy());
+    }
+    @Test
+    public void quorumAvailableMeansHealthy() {
+        assertTrue(ClusterAvailabilityStatus.QUORUM_AVAILABLE.isHealthy());
+    }
+
+    @Test
+    public void noQuorumMeansNotHealthy() {
+        assertFalse(ClusterAvailabilityStatus.NO_QUORUM_AVAILABLE.isHealthy());
+    }
+
+    @Test
+    public void terminalMeansNotHealthy() {
+        assertFalse(ClusterAvailabilityStatus.TERMINAL.isHealthy());
+    }
+}

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/ClusterAvailabilityStatusTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/ClusterAvailabilityStatusTest.java
@@ -26,9 +26,10 @@ public class ClusterAvailabilityStatusTest {
     public void allAvailableMeansHealthy() {
         assertTrue(ClusterAvailabilityStatus.ALL_AVAILABLE.isHealthy());
     }
+
     @Test
-    public void quorumAvailableMeansHealthy() {
-        assertTrue(ClusterAvailabilityStatus.QUORUM_AVAILABLE.isHealthy());
+    public void quorumAvailableMeansNotHealthy() {
+        assertFalse(ClusterAvailabilityStatus.QUORUM_AVAILABLE.isHealthy());
     }
 
     @Test

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatusTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatusTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.api;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class KeyValueServiceStatusTest {
+    @Test
+    public void allOperationsMeansHealthy() {
+        assertTrue(KeyValueServiceStatus.HEALTHY_ALL_OPERATIONS.isHealthy());
+    }
+    @Test
+    public void mostOperationsMeansHealthy() {
+        assertTrue(KeyValueServiceStatus.HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES.isHealthy());
+    }
+
+    @Test
+    public void unhealthyMeansNotHealthy() { // well, obviously
+        assertFalse(KeyValueServiceStatus.UNHEALTHY.isHealthy());
+    }
+
+    @Test
+    public void terminalMeansNotHealthy() {
+        assertFalse(KeyValueServiceStatus.TERMINAL.isHealthy());
+    }
+}

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatusTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/transaction/api/KeyValueServiceStatusTest.java
@@ -27,8 +27,8 @@ public class KeyValueServiceStatusTest {
         assertTrue(KeyValueServiceStatus.HEALTHY_ALL_OPERATIONS.isHealthy());
     }
     @Test
-    public void mostOperationsMeansHealthy() {
-        assertTrue(KeyValueServiceStatus.HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES.isHealthy());
+    public void mostOperationsMeansNotHealthy() {
+        assertFalse(KeyValueServiceStatus.HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES.isHealthy());
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -49,8 +49,9 @@ develop
          - Change
 
     *    - |improved|
-         - Applications can now easily determine whether their AtlasDB cluster is healthy by querying either
-           ``TransactionManager.getKeyValueServiceStatus().isHealthy()`` or ``KeyValueService.getClusterAvailabilityStatus.isHealthy()``.
+         - Applications can now easily determine whether their AtlasDB cluster is healthy by querying ``TransactionManager.getKeyValueServiceStatus().isHealthy()``.
+           This returns true only if all key value service nodes are up; applications that do not perform schema mutations or deletes (including sweep or scrub) can
+           also treat ``KeyValueServiceStatus.HEALTHY_BUT_NO_SCHEMA_MUTATIONS_OR_DELETES`` as a healthy state.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2678>`__)
 
     *    - |fixed| |metrics|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,11 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - Applications can now easily determine whether their AtlasDB cluster is healthy by querying either
+           ``TransactionManager.getKeyValueServiceStatus().isHealthy()`` or ``KeyValueService.getClusterAvailabilityStatus.isHealthy()``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2678>`__)
+
     *    - |fixed| |metrics|
          - ``MetricsManager`` now logs failures to register metrics at ``WARN`` instead of ``ERROR``, as failure to do so is not necessarily a systemic failure.
            Also, we now log the name of the metric as a Safe argument (previously it was logged as Unsafe).


### PR DESCRIPTION
**Goals (and why)**: Allow products to use a simple boolean method to determine if AtlasDB is healthy.

**Implementation Description (bullets)**: Add a boolean `isHealthy` to the two existing healthcheck enums.

**Concerns (what feedback would you like?)**: Is this really it?

**Where should we start reviewing?**: Anywhere really

**Priority (whenever / two weeks / yesterday)**: by Wednesday 15th

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2678)
<!-- Reviewable:end -->
