### PR TITLE
use supplier for object size [no release notes]

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ThriftObjectSizeUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ThriftObjectSizeUtils.java
@@ -223,7 +223,7 @@ public final class ThriftObjectSizeUtils {
         return Integer.BYTES;
     }
 
-    private static <T> long getCollectionSize(Collection<T> collection, Function<T, Long> sizeFunction) {
+    public static <T> long getCollectionSize(Collection<T> collection, Function<T, Long> sizeFunction) {
         if (collection == null) {
             return getNullSize();
         }


### PR DESCRIPTION
**Goals (and why)**:
Use a supplier for calculating object sizes, so the try/catch block actually catches exceptions. I believe this was the original intent of this code.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2682)
<!-- Reviewable:end -->
