### PR TITLE
Pull out basics of the CassandraClientPool blacklist

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -41,7 +41,6 @@ import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
@@ -160,15 +159,14 @@ public class CassandraClientPoolIntegrationTest {
 
     @Test
     public void testPoolGivenNoOptionTalksToBlacklistedHosts() {
-        clientPool.blacklistedHosts.putAll(
-                Maps.transformValues(clientPool.getCurrentPools(), clientPoolContainer -> Long.MAX_VALUE));
+        clientPool.getBlacklist().addAll(clientPool.getCurrentPools().keySet());
         try {
             clientPool.run(describeRing);
         } catch (Exception e) {
             fail("Should have been allowed to attempt forward progress after blacklisting all hosts in pool.");
         }
 
-        clientPool.blacklistedHosts.clear();
+        clientPool.getBlacklist().removeAll();
     }
 
     private FunctionCheckedException<CassandraClient, List<TokenRange>, Exception> describeRing =

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Blacklist.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/Blacklist.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Maps;
+import com.palantir.logsafe.SafeArg;
+
+public class Blacklist {
+    private static final Logger log = LoggerFactory.getLogger(CassandraClientPool.class);
+
+    private Map<InetSocketAddress, Long> blacklistedHosts = Maps.newConcurrentMap();
+
+    public Map<InetSocketAddress, Long> getBlacklistedHosts() {
+        return blacklistedHosts;
+    }
+
+    // TODO (gsheasby): Why did we blacklist this host?
+    public void add(InetSocketAddress badHost) {
+        blacklistedHosts.put(badHost, System.currentTimeMillis());
+        log.warn("Blacklisted host '{}'", SafeArg.of("badHost", CassandraLogHelper.host(badHost)));
+    }
+
+    public void addAll(Set<InetSocketAddress> hosts) {
+        hosts.forEach(this::add);
+    }
+
+    public boolean contains(InetSocketAddress specifiedHost) {
+        return blacklistedHosts.containsKey(specifiedHost);
+    }
+
+    public void remove(InetSocketAddress removedServerAddress) {
+        blacklistedHosts.remove(removedServerAddress);
+    }
+
+    public void removeAll() {
+        blacklistedHosts.clear();
+    }
+
+    public int size() {
+        return blacklistedHosts.size();
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -412,7 +412,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                     + "live hosts that claim ownership of the given range. Falling back to choosing a random live node."
                     + " Current host blacklist is {}."
                     + " Current state logged at TRACE",
-                    SafeArg.of("blacklistedHosts", CassandraLogHelper.blacklistedHosts(blacklist.getBlacklistedHosts())));
+                    SafeArg.of("blacklistedHosts", CassandraLogHelper.blacklistedHosts(blacklist)));
             log.trace("Current ring view is: {}.",
                     SafeArg.of("tokenMap", CassandraLogHelper.tokenMap(tokenMap)));
             return getRandomGoodHost().getHost();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -143,8 +143,8 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
     static final int MAX_TRIES_TOTAL = 6;
     @VisibleForTesting
     volatile RangeMap<LightweightOppToken, List<InetSocketAddress>> tokenMap = ImmutableRangeMap.of();
-    @VisibleForTesting
-    Map<InetSocketAddress, Long> blacklistedHosts = Maps.newConcurrentMap();
+
+    private Blacklist blacklist = new Blacklist();
 
     private final CassandraKeyValueServiceConfig config;
     private final Map<InetSocketAddress, CassandraClientPoolingContainer> currentPools = Maps.newConcurrentMap();
@@ -229,6 +229,11 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
         metricsManager.deregisterMetrics();
     }
 
+    @VisibleForTesting
+    Blacklist getBlacklist() {
+        return blacklist;
+    }
+
     @Override
     public Map<InetSocketAddress, CassandraClientPoolingContainer> getCurrentPools() {
         return currentPools;
@@ -237,7 +242,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
     private void registerAggregateMetrics() {
         metricsManager.registerMetric(
                 CassandraClientPool.class, "numBlacklistedHosts",
-                () -> blacklistedHosts.size());
+                () -> blacklist.size());
         metricsManager.registerMetric(
                 CassandraClientPool.class, "requestFailureProportion",
                 aggregateMetrics::getExceptionProportion);
@@ -296,7 +301,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
 
     @VisibleForTesting
     void removePool(InetSocketAddress removedServerAddress) {
-        blacklistedHosts.remove(removedServerAddress);
+        blacklist.remove(removedServerAddress);
         try {
             currentPools.get(removedServerAddress).shutdownPooling();
         } catch (Exception e) {
@@ -312,7 +317,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
             StringBuilder currentState = new StringBuilder();
             currentState.append(
                     String.format("POOL STATUS: Current blacklist = %s,%n current hosts in pool = %s%n",
-                    blacklistedHosts.keySet().toString(), currentPools.keySet().toString()));
+                    blacklist.getBlacklistedHosts().keySet().toString(), currentPools.keySet().toString()));
             for (Entry<InetSocketAddress, CassandraClientPoolingContainer> entry : currentPools.entrySet()) {
                 int activeCheckouts = entry.getValue().getActiveCheckouts();
                 int totalAllowed = entry.getValue().getPoolSize();
@@ -329,23 +334,17 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
 
     private void checkAndUpdateBlacklist() {
         // Check blacklist and re-integrate or continue to wait as necessary
-        for (Map.Entry<InetSocketAddress, Long> blacklistedEntry : blacklistedHosts.entrySet()) {
+        for (Map.Entry<InetSocketAddress, Long> blacklistedEntry : blacklist.getBlacklistedHosts().entrySet()) {
             long backoffTimeMillis = TimeUnit.SECONDS.toMillis(config.unresponsiveHostBackoffTimeSeconds());
             if (blacklistedEntry.getValue() + backoffTimeMillis < System.currentTimeMillis()) {
                 InetSocketAddress host = blacklistedEntry.getKey();
                 if (isHostHealthy(host)) {
-                    blacklistedHosts.remove(host);
+                    blacklist.remove(host);
                     log.info("Added host {} back into the pool after a waiting period and successful health check.",
                             SafeArg.of("host", CassandraLogHelper.host(host)));
                 }
             }
         }
-    }
-
-    // TODO (gsheasby): Why did we blacklist this host?
-    private void addToBlacklist(InetSocketAddress badHost) {
-        blacklistedHosts.put(badHost, System.currentTimeMillis());
-        log.warn("Blacklisted host '{}'", SafeArg.of("badHost", CassandraLogHelper.host(badHost)));
     }
 
     private boolean isHostHealthy(InetSocketAddress host) {
@@ -381,7 +380,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
             return Optional.empty();
         }
 
-        Set<InetSocketAddress> livingHosts = Sets.difference(filteredHosts, blacklistedHosts.keySet());
+        Set<InetSocketAddress> livingHosts = Sets.difference(filteredHosts, blacklist.getBlacklistedHosts().keySet());
         if (livingHosts.isEmpty()) {
             log.warn("There are no known live hosts in the connection pool matching the predicate. We're choosing"
                     + " one at random in a last-ditch attempt at forward progress.");
@@ -406,14 +405,14 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
 
         Set<InetSocketAddress> liveOwnerHosts = Sets.difference(
                 ImmutableSet.copyOf(hostsForKey),
-                blacklistedHosts.keySet());
+                blacklist.getBlacklistedHosts().keySet());
 
         if (liveOwnerHosts.isEmpty()) {
             log.warn("Perf / cluster stability issue. Token aware query routing has failed because there are no known "
                     + "live hosts that claim ownership of the given range. Falling back to choosing a random live node."
                     + " Current host blacklist is {}."
                     + " Current state logged at TRACE",
-                    SafeArg.of("blacklistedHosts", CassandraLogHelper.blacklistedHosts(blacklistedHosts)));
+                    SafeArg.of("blacklistedHosts", CassandraLogHelper.blacklistedHosts(blacklist.getBlacklistedHosts())));
             log.trace("Current ring view is: {}.",
                     SafeArg.of("tokenMap", CassandraLogHelper.tokenMap(tokenMap)));
             return getRandomGoodHost().getHost();
@@ -448,7 +447,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                 atLeastOneHostResponded = true;
             } catch (Exception e) {
                 completelyUnresponsiveHosts.put(host, e);
-                addToBlacklist(host);
+                blacklist.add(host);
             }
 
             if (thisHostResponded) {
@@ -578,7 +577,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
             }
             CassandraClientPoolingContainer hostPool = currentPools.get(specifiedHost);
 
-            if (blacklistedHosts.containsKey(specifiedHost) || hostPool == null || shouldRetryOnDifferentHost) {
+            if (blacklist.contains(specifiedHost) || hostPool == null || shouldRetryOnDifferentHost) {
                 InetSocketAddress previousHostPool = hostPool == null ? specifiedHost : hostPool.getHost();
                 Optional<CassandraClientPoolingContainer> hostPoolCandidate
                         = getRandomGoodHostForPredicate(address -> !triedHosts.contains(address));
@@ -698,7 +697,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
                             ex);
                 }
                 if (isConnectionException(ex) && numTries >= MAX_TRIES_SAME_HOST) {
-                    addToBlacklist(host);
+                    blacklist.add(host);
                 }
             }
         } else {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -19,7 +19,6 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -38,8 +37,8 @@ final class CassandraLogHelper {
         return host.getHostString();
     }
 
-    static List<String> blacklistedHosts(Map<InetSocketAddress, Long> blacklistedHosts) {
-        return blacklistedHosts.entrySet().stream()
+    static List<String> blacklistedHosts(Blacklist blacklist) {
+        return blacklist.getBlacklistedHosts().entrySet().stream()
                 .map(blacklistedHostToBlacklistTime -> String.format("host: %s was blacklisted at %s",
                         host(blacklistedHostToBlacklistTime.getKey()),
                         blacklistedHostToBlacklistTime.getValue().longValue()))

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -130,7 +130,7 @@ public class CassandraClientPoolTest {
     public void shouldNotReturnHostsNotMatchingPredicateEvenWithNodeFailure() {
         CassandraClientPoolImpl cassandraClientPool = clientPoolWithServersInCurrentPool(
                 ImmutableSet.of(HOST_1, HOST_2));
-        cassandraClientPool.blacklistedHosts.put(HOST_1, System.currentTimeMillis());
+        cassandraClientPool.getBlacklist().add(HOST_1);
         Optional<CassandraClientPoolingContainer> container
                 = cassandraClientPool.getRandomGoodHostForPredicate(address -> address.equals(HOST_1));
         assertContainerHasHostOne(container);


### PR DESCRIPTION
**Goals (and why)**: Ultimate goal is allow us to configure the backoff and retry behaviour in the CassandraClientPool.  First step is refactoring this out to allow things to be customised.  This PR just starts pulling out some blacklist stuff.

**Implementation Description (bullets)**: Hide the blacklist in its own class.

**Concerns (what feedback would you like?)**: I know there's lots more refactorings here, all I'm concerned about is whether I've accidentally changed behaviour.

**Where should we start reviewing?**: CassandraClientPoolImpl

**Priority (whenever / two weeks / yesterday)**: a few days

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2701)
<!-- Reviewable:end -->
