### PR TITLE
Resume throwing PIEs

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.common.exception.PalantirRuntimeException;
+import com.palantir.exception.PalantirInterruptedException;
 
 public final class Throwables {
 
@@ -112,6 +113,7 @@ public final class Throwables {
     private static RuntimeException createPalantirRuntimeException(String newMessage, Throwable ex) {
         if (ex instanceof InterruptedException || ex instanceof InterruptedIOException) {
             Thread.currentThread().interrupt();
+            return new PalantirInterruptedException(newMessage, ex);
         }
         return new PalantirRuntimeException(newMessage, ex);
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,6 +54,11 @@ develop
          - AtlasDB will now consistently throw an ``AtlasDbDependencyException`` when requests fail due to TimeLock being unavailable.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2677>`__)
 
+    *    - |fixed|
+         - ``Throwables.createPalantirRuntimeException`` once again throws ``PalantirInterruptedException`` if the original exception was either ``InterruptedException`` or ``InterruptedIOException``.
+           This reverts behaviour introduced in 0.67.0, where we instead threw ``PalantirRuntimeException``.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2702>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -41,6 +41,27 @@ Changelog
 develop
 =======
 
+.. replace this with the release date
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |improved| |devbreak|
+         - AtlasDB will now consistently throw an ``AtlasDbDependencyException`` when requests fail due to TimeLock being unavailable.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2677>`__)
+
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
+
+=======
+v0.68.0
+=======
+
+16 November 2017
+
 .. list-table::
     :widths: 5 40
     :header-rows: 1
@@ -51,10 +72,9 @@ develop
     *    - |fixed|
          - HTTP clients for endpoints relating to the Paxos protocols (``PingableLeader``, ``PaxosAcceptor`` and ``PaxosLearner``) now reset themselves after 500 million requests have been executed.
            This was implemented as a workaround for `OkHttp #3670 <https://github.com/square/okhttp/issues/3670>`__ where HTTP/2 connections managed in OkHttp would fail after just over a billion requests owing to an unexpected integer overflow.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2NNN>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2680>`__)
 
-    *    -
-         -
+.. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======
 v0.67.0
@@ -163,10 +183,6 @@ v0.67.0
 
            Note that we also log a warning in these cases, with the message "A single get had quite a few bytes...".
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2671>`__)
-
-    *    - |improved| |devbreak|
-         - AtlasDB will now consistently throw an ``AtlasDbDependencyException`` when requests fail due to TimeLock being unavailable.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2677>`__)
 
     *    - |improved| |devbreak|
          - AtlasDB will now consistently throw a ``InsufficientConsistencyException`` if Cassandra reports an ``UnavailableException``.


### PR DESCRIPTION
**Goals (and why)**: Reverts a change introduced in #2558, which [made large internal product sad](https://github.com/palantir/atlasdb/pull/2558/files#diff-9e2b4fbe70ebe2561ea6337b9050c478L106) 😢  . We now once again throw pies 🤡 .

**Priority (whenever / two weeks / yesterday)**: Today

@datval for SA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2702)
<!-- Reviewable:end -->
