### PR TITLE
[QoS] Don't rate limit CAS

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
@@ -106,10 +106,8 @@ public class QosCassandraClient implements CassandraClient {
     public CASResult cas(TableReference tableReference, ByteBuffer key, List<Column> expected, List<Column> updates,
             ConsistencyLevel serial_consistency_level, ConsistencyLevel commit_consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
-        return qosClient.executeWrite(
-                () -> client.cas(tableReference, key, expected, updates, serial_consistency_level,
-                commit_consistency_level),
-                ThriftQueryWeighers.cas(updates));
+        // CAS is intentionally not rate limited, until we have a concept of priority
+        return client.cas(tableReference, key, expected, updates, serial_consistency_level, commit_consistency_level);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
@@ -23,8 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.KeySlice;
@@ -71,13 +69,6 @@ public final class ThriftQueryWeighers {
             Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap) {
         long numRows = mutationMap.size();
         return writeWeigher(numRows, () -> ThriftObjectSizeUtils.getApproximateWriteByteCount(mutationMap));
-    }
-
-    public static QosClient.QueryWeigher<CASResult> cas(List<Column> updates) {
-        // TODO(nziebart): technically CAS involves both reads and writes; currently we are just counting it as a read
-        // Also, it should probably be counted as multiple rows, since Paxos negotiations trigger serial writes
-        long numRows = 1;
-        return writeWeigher(numRows, () -> ThriftObjectSizeUtils.getCasByteCount(updates));
     }
 
     public static <T> QosClient.QueryWeigher<T> readWeigher(Function<T, Long> bytesRead, Function<T, Integer> numRows) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/QosCassandraClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/QosCassandraClientTest.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 
 import javax.naming.LimitExceededException;
 
+import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.KeyRange;
@@ -89,6 +90,14 @@ public class QosCassandraClientTest {
         client.get_range_slices("get", TEST_TABLE, SLICE_PREDICATE, new KeyRange(), ConsistencyLevel.ANY);
 
         verify(qosClient, times(1)).executeRead(any(), any());
+        verifyNoMoreInteractions(qosClient);
+    }
+
+    @Test
+    public void casDoesNotCheckLimit() throws TException, LimitExceededException {
+        client.cas(TEST_TABLE, ByteBuffer.allocate(1), ImmutableList.of(new Column()), ImmutableList.of(new Column()),
+                ConsistencyLevel.SERIAL, ConsistencyLevel.SERIAL);
+
         verifyNoMoreInteractions(qosClient);
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.cassandra.thrift.CASResult;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.CqlResult;
@@ -88,14 +87,6 @@ public class ThriftQueryWeighersTest {
     }
 
     @Test
-    public void casQueryWeigherReturnsOneRowAlways() {
-        long actualNumRows = ThriftQueryWeighers.cas(ImmutableList.of(COLUMN, COLUMN)).weighSuccess(new CASResult(true),
-                TIME_TAKEN).numDistinctRows();
-
-        assertThat(actualNumRows).isEqualTo(1);
-    }
-
-    @Test
     public void batchMutateWeigherReturnsCorrectNumRows() {
         Map<ByteBuffer, Map<String, List<Mutation>>> mutations = ImmutableMap.of(
                 BYTES1, ImmutableMap.of(
@@ -137,19 +128,6 @@ public class ThriftQueryWeighersTest {
                 BYTES1, ImmutableMap.of("foo", ImmutableList.of(MUTATION, MUTATION)));
 
         QosClient.QueryWeigher<Void> weigher = ThriftQueryWeighers.batchMutate(mutations);
-
-        QueryWeight expected = ImmutableQueryWeight.builder()
-                .from(weigher.estimate())
-                .timeTakenNanos(TIME_TAKEN)
-                .build();
-        QueryWeight actual = weigher.weighFailure(new RuntimeException(), TIME_TAKEN);
-
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    public void casWeigherReturnsEstimateForFailure() {
-        QosClient.QueryWeigher<CASResult> weigher = ThriftQueryWeighers.cas(ImmutableList.of(COLUMN, COLUMN));
 
         QueryWeight expected = ImmutableQueryWeight.builder()
                 .from(weigher.estimate())


### PR DESCRIPTION
**Goals (and why)**:
Don't limit CAS operations. These are required to commit transactions, and have effectively a constant weight. Further, adding sleep time between writing and committing increases the chance that readers will see the data before it's committed, and have to block.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2711)
<!-- Reviewable:end -->
