### PR TITLE
Publish internal docs from internal circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,6 +66,11 @@ deployment:
     owner: palantir
     commands:
       - ./scripts/circle-ci/publish-github-page.sh
+  publish-internal-docs:
+      branch: develop
+      owner: atlasdb
+      commands:
+        - ./scripts/circle-ci/publish-docs.sh
   bintray:
     tag: /[0-9]+(\.[0-9]+){2}(-alpha|-beta|-rc[0-9]+)?(\+[0-9]{3})?/
     owner: palantir

--- a/scripts/circle-ci/publish-docs.sh
+++ b/scripts/circle-ci/publish-docs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# TODO(ssouza): merge this file and publish-github-page.sh
+
+set -x -e
+
+# Just-in-time install of sphinx so that docs build
+sudo -H pip install --disable-pip-version-check --upgrade sphinx sphinx_rtd_theme requests recommonmark
+
+# Clone gh-pages into build
+cd docs/
+rm -rf build/
+git clone git@github.com:palantir/atlasdb.git -b gh-pages build
+
+# Rebuild the docs into the repo
+make html || { echo "doc build failed, build should not pass"; exit 1; }
+
+cd build/
+# Just to report status of repo in the build output
+git status
+git config user.email "pd-atlasdb-team@palantir.com"
+git config user.name $CIRCLE_PROJECT_USERNAME
+
+# Add and commmit changes to gh-pages
+git add .
+
+if ! git commit -m "circle-publish: [skip ci] from $CIRCLE_BRANCH by build $CIRCLE_BUILD_NUM, can be found at $CIRCLE_BUILD_URL"; then
+    echo "no docs changes, skipping deployment";
+    exit 0;
+fi
+
+cd ..
+curl -s --fail $DOCS_URL | bash -s -- -r requirements.txt $CIRCLE_BRANCH


### PR DESCRIPTION
Title says it all. Note that the `publish-docs.sh` script is mostly a copy of `publish-github-page.sh`, and I intend to merge the two when we move all the publishing infrastructure to the internal build.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2713)
<!-- Reviewable:end -->
