### PR TITLE
[QoS] Estimate the number of read bytes w/ number of rows

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
@@ -67,18 +67,21 @@ public class QosCassandraClient implements CassandraClient {
     public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName, TableReference tableRef,
             List<ByteBuffer> keys, SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        int numberOfQueriedRows = keys.size();
+
         return qosClient.executeRead(
                 () -> client.multiget_slice(kvsMethodName, tableRef, keys, predicate, consistency_level),
-                ThriftQueryWeighers.MULTIGET_SLICE);
+                ThriftQueryWeighers.multigetSlice(numberOfQueriedRows));
     }
 
     @Override
     public List<KeySlice> get_range_slices(String kvsMethodName, TableReference tableRef, SlicePredicate predicate,
             KeyRange range, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        int numberOfQueriedRows = range.count;
         return qosClient.executeRead(
                 () -> client.get_range_slices(kvsMethodName, tableRef, predicate, range, consistency_level),
-                ThriftQueryWeighers.GET_RANGE_SLICES);
+                ThriftQueryWeighers.getRangeSlices(numberOfQueriedRows));
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
@@ -67,11 +67,9 @@ public class QosCassandraClient implements CassandraClient {
     public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName, TableReference tableRef,
             List<ByteBuffer> keys, SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
-        int numberOfQueriedRows = keys.size();
-
         return qosClient.executeRead(
                 () -> client.multiget_slice(kvsMethodName, tableRef, keys, predicate, consistency_level),
-                ThriftQueryWeighers.multigetSlice(numberOfQueriedRows));
+                ThriftQueryWeighers.multigetSlice(keys));
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
@@ -76,10 +76,9 @@ public class QosCassandraClient implements CassandraClient {
     public List<KeySlice> get_range_slices(String kvsMethodName, TableReference tableRef, SlicePredicate predicate,
             KeyRange range, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
-        int numberOfQueriedRows = range.count;
         return qosClient.executeRead(
                 () -> client.get_range_slices(kvsMethodName, tableRef, predicate, range, consistency_level),
-                ThriftQueryWeighers.getRangeSlices(numberOfQueriedRows));
+                ThriftQueryWeighers.getRangeSlices(range));
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftObjectSizeUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftObjectSizeUtils.java
@@ -44,7 +44,7 @@ public final class ThriftObjectSizeUtils {
         // utility class
     }
 
-    public static long getApproximateWriteByteCount(Map<ByteBuffer, Map<String, List<Mutation>>> batchMutateMap) {
+    public static long getApproximateSizeOfMutationMap(Map<ByteBuffer, Map<String, List<Mutation>>> batchMutateMap) {
         long approxBytesForKeys = getCollectionSize(batchMutateMap.keySet(), ThriftObjectSizeUtils::getByteBufferSize);
         long approxBytesForValues = getCollectionSize(batchMutateMap.values(),
                 currentMap -> getCollectionSize(currentMap.keySet(), ThriftObjectSizeUtils::getStringSize)
@@ -53,14 +53,14 @@ public final class ThriftObjectSizeUtils {
         return approxBytesForKeys + approxBytesForValues;
     }
 
-    public static long getApproximateReadByteCount(Map<ByteBuffer, List<ColumnOrSuperColumn>> result) {
+    public static long getApproximateSizeOfColsByKey(Map<ByteBuffer, List<ColumnOrSuperColumn>> result) {
         return getCollectionSize(result.entrySet(),
                 rowResult -> ThriftObjectSizeUtils.getByteBufferSize(rowResult.getKey())
                         + getCollectionSize(rowResult.getValue(),
                         ThriftObjectSizeUtils::getColumnOrSuperColumnSize));
     }
 
-    public static long getApproximateReadByteCount(List<KeySlice> slices) {
+    public static long getApproximateSizeOfKeySlices(List<KeySlice> slices) {
         return getCollectionSize(slices, ThriftObjectSizeUtils::getKeySliceSize);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.Mutation;
 import org.slf4j.Logger;
@@ -55,8 +56,8 @@ public final class ThriftQueryWeighers {
         return readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfColsByKey, Map::size, keys.size());
     }
 
-    static QosClient.QueryWeigher<List<KeySlice>> getRangeSlices(int numberOfQueriedRows) {
-        return readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfKeySlices, List::size, numberOfQueriedRows);
+    static QosClient.QueryWeigher<List<KeySlice>> getRangeSlices(KeyRange keyRange) {
+        return readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfKeySlices, List::size, keyRange.count);
     }
 
     static final QosClient.QueryWeigher<ColumnOrSuperColumn> GET =

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
@@ -51,13 +51,11 @@ public final class ThriftQueryWeighers {
 
     private ThriftQueryWeighers() { }
 
-    static QosClient.QueryWeigher<Map<ByteBuffer, List<ColumnOrSuperColumn>>> multigetSlice(
-            int numberOfQueriedRows) {
-        return readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfColsByKey, Map::size, numberOfQueriedRows);
+    static QosClient.QueryWeigher<Map<ByteBuffer, List<ColumnOrSuperColumn>>> multigetSlice(List<ByteBuffer> keys) {
+        return readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfColsByKey, Map::size, keys.size());
     }
 
-    static QosClient.QueryWeigher<List<KeySlice>> getRangeSlices(
-            int numberOfQueriedRows) {
+    static QosClient.QueryWeigher<List<KeySlice>> getRangeSlices(int numberOfQueriedRows) {
         return readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfKeySlices, List::size, numberOfQueriedRows);
     }
 
@@ -70,8 +68,7 @@ public final class ThriftQueryWeighers {
             // or (key, column, ts) triplets
             readWeigher(ThriftObjectSizeUtils::getCqlResultSize, ignored -> 1, 1);
 
-    static QosClient.QueryWeigher<Void> batchMutate(
-            Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap) {
+    static QosClient.QueryWeigher<Void> batchMutate(Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap) {
         long numRows = mutationMap.size();
         return writeWeigher(numRows, () -> ThriftObjectSizeUtils.getApproximateSizeOfMutationMap(mutationMap));
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
@@ -51,10 +51,10 @@ public final class ThriftQueryWeighers {
     private ThriftQueryWeighers() { }
 
     public static final QosClient.QueryWeigher<Map<ByteBuffer, List<ColumnOrSuperColumn>>> MULTIGET_SLICE =
-            readWeigher(ThriftObjectSizeUtils::getApproximateReadByteCount, Map::size);
+            readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfColsByKey, Map::size);
 
     public static final QosClient.QueryWeigher<List<KeySlice>> GET_RANGE_SLICES =
-            readWeigher(ThriftObjectSizeUtils::getApproximateReadByteCount, List::size);
+            readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfKeySlices, List::size);
 
     public static final QosClient.QueryWeigher<ColumnOrSuperColumn> GET =
             readWeigher(ThriftObjectSizeUtils::getColumnOrSuperColumnSize, ignored -> 1);
@@ -68,7 +68,7 @@ public final class ThriftQueryWeighers {
     public static QosClient.QueryWeigher<Void> batchMutate(
             Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap) {
         long numRows = mutationMap.size();
-        return writeWeigher(numRows, () -> ThriftObjectSizeUtils.getApproximateWriteByteCount(mutationMap));
+        return writeWeigher(numRows, () -> ThriftObjectSizeUtils.getApproximateSizeOfMutationMap(mutationMap));
     }
 
     public static <T> QosClient.QueryWeigher<T> readWeigher(Function<T, Long> bytesRead, Function<T, Integer> numRows) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
@@ -42,28 +42,33 @@ public final class ThriftQueryWeighers {
     private static final Logger log = LoggerFactory.getLogger(CassandraClient.class);
 
     @VisibleForTesting
+    private static final int ESTIMATED_NUM_BYTES_PER_ROW = 100;
     static final QueryWeight DEFAULT_ESTIMATED_WEIGHT = ImmutableQueryWeight.builder()
-            .numBytes(100)
+            .numBytes(ESTIMATED_NUM_BYTES_PER_ROW)
             .numDistinctRows(1)
             .timeTakenNanos(TimeUnit.MILLISECONDS.toNanos(2))
             .build();
 
     private ThriftQueryWeighers() { }
 
-    public static final QosClient.QueryWeigher<Map<ByteBuffer, List<ColumnOrSuperColumn>>> MULTIGET_SLICE =
-            readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfColsByKey, Map::size);
+    public static final QosClient.QueryWeigher<Map<ByteBuffer, List<ColumnOrSuperColumn>>> multigetSlice(
+            int numberOfQueriedRows) {
+        return readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfColsByKey, Map::size, numberOfQueriedRows);
+    }
 
-    public static final QosClient.QueryWeigher<List<KeySlice>> GET_RANGE_SLICES =
-            readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfKeySlices, List::size);
+    public static final QosClient.QueryWeigher<List<KeySlice>> getRangeSlices(
+            int numberOfQueriedRows) {
+        return readWeigher(ThriftObjectSizeUtils::getApproximateSizeOfKeySlices, List::size, numberOfQueriedRows);
+    }
 
     public static final QosClient.QueryWeigher<ColumnOrSuperColumn> GET =
-            readWeigher(ThriftObjectSizeUtils::getColumnOrSuperColumnSize, ignored -> 1);
+            readWeigher(ThriftObjectSizeUtils::getColumnOrSuperColumnSize, ignored -> 1, 1);
 
     public static final QosClient.QueryWeigher<CqlResult> EXECUTE_CQL3_QUERY =
             // TODO(nziebart): we need to inspect the schema to see how many rows there are - a CQL row is NOT a
             // partition. rows here will depend on the type of query executed in CqlExecutor: either (column, ts) pairs,
             // or (key, column, ts) triplets
-            readWeigher(ThriftObjectSizeUtils::getCqlResultSize, ignored -> 1);
+            readWeigher(ThriftObjectSizeUtils::getCqlResultSize, ignored -> 1, 1);
 
     public static QosClient.QueryWeigher<Void> batchMutate(
             Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap) {
@@ -71,11 +76,15 @@ public final class ThriftQueryWeighers {
         return writeWeigher(numRows, () -> ThriftObjectSizeUtils.getApproximateSizeOfMutationMap(mutationMap));
     }
 
-    public static <T> QosClient.QueryWeigher<T> readWeigher(Function<T, Long> bytesRead, Function<T, Integer> numRows) {
+    public static <T> QosClient.QueryWeigher<T> readWeigher(Function<T, Long> bytesRead, Function<T, Integer> numRows,
+            int numberOfQueriedRows) {
         return new QosClient.QueryWeigher<T>() {
             @Override
             public QueryWeight estimate() {
-                return DEFAULT_ESTIMATED_WEIGHT;
+                return ImmutableQueryWeight.builder()
+                        .from(DEFAULT_ESTIMATED_WEIGHT)
+                        .numBytes(ESTIMATED_NUM_BYTES_PER_ROW * numberOfQueriedRows)
+                        .build();
             }
 
             @Override

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/ThriftObjectSizeUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/ThriftObjectSizeUtilsTest.java
@@ -217,7 +217,7 @@ public class ThriftObjectSizeUtilsTest {
                 + Integer.BYTES
                 + EMPTY_COLUMN_OR_SUPERCOLUMN_SIZE;
 
-        assertThat(ThriftObjectSizeUtils.getApproximateWriteByteCount(batchMutateMap)).isEqualTo(expectedSize);
+        assertThat(ThriftObjectSizeUtils.getApproximateSizeOfMutationMap(batchMutateMap)).isEqualTo(expectedSize);
     }
 
     @Test
@@ -233,7 +233,7 @@ public class ThriftObjectSizeUtilsTest {
         long expectedSize = TEST_NAME_BYTES_SIZE
                 + EMPTY_COLUMN_OR_SUPERCOLUMN_SIZE;
 
-        assertThat(ThriftObjectSizeUtils.getApproximateReadByteCount(result)).isEqualTo(expectedSize);
+        assertThat(ThriftObjectSizeUtils.getApproximateSizeOfColsByKey(result)).isEqualTo(expectedSize);
     }
 
     @Test
@@ -246,7 +246,7 @@ public class ThriftObjectSizeUtilsTest {
         long expectedSize = TEST_NAME_BYTES_SIZE
                 + EMPTY_COLUMN_OR_SUPERCOLUMN_SIZE;
 
-        assertThat(ThriftObjectSizeUtils.getApproximateReadByteCount(slices)).isEqualTo(expectedSize);
+        assertThat(ThriftObjectSizeUtils.getApproximateSizeOfKeySlices(slices)).isEqualTo(expectedSize);
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
@@ -57,7 +57,7 @@ public class ThriftQueryWeighersTest {
                 BYTES1, ImmutableList.of(COLUMN_OR_SUPER, COLUMN_OR_SUPER),
                 BYTES2, ImmutableList.of(COLUMN_OR_SUPER));
 
-        long actualNumRows = ThriftQueryWeighers.MULTIGET_SLICE.weighSuccess(result, TIME_TAKEN).numDistinctRows();
+        long actualNumRows = ThriftQueryWeighers.multigetSlice(1).weighSuccess(result, TIME_TAKEN).numDistinctRows();
 
         assertThat(actualNumRows).isEqualTo(2);
     }
@@ -66,7 +66,7 @@ public class ThriftQueryWeighersTest {
     public void rangeSlicesWeigherReturnsCorrectNumRows() {
         List<KeySlice> result = ImmutableList.of(KEY_SLICE, KEY_SLICE, KEY_SLICE);
 
-        long actualNumRows = ThriftQueryWeighers.GET_RANGE_SLICES.weighSuccess(result, TIME_TAKEN).numDistinctRows();
+        long actualNumRows = ThriftQueryWeighers.getRangeSlices(1).weighSuccess(result, TIME_TAKEN).numDistinctRows();
 
         assertThat(actualNumRows).isEqualTo(3);
     }
@@ -103,7 +103,7 @@ public class ThriftQueryWeighersTest {
 
     @Test
     public void multigetSliceWeigherReturnsDefaultEstimateForFailure() {
-        QueryWeight weight = ThriftQueryWeighers.MULTIGET_SLICE.weighFailure(new RuntimeException(), TIME_TAKEN);
+        QueryWeight weight = ThriftQueryWeighers.multigetSlice(1).weighFailure(new RuntimeException(), TIME_TAKEN);
 
         assertThat(weight).isEqualTo(DEFAULT_WEIGHT);
     }
@@ -117,7 +117,7 @@ public class ThriftQueryWeighersTest {
 
     @Test
     public void getRangeSlicesWeigherReturnsDefaultEstimateForFailure() {
-        QueryWeight weight = ThriftQueryWeighers.GET_RANGE_SLICES.weighFailure(new RuntimeException(), TIME_TAKEN);
+        QueryWeight weight = ThriftQueryWeighers.getRangeSlices(1).weighFailure(new RuntimeException(), TIME_TAKEN);
 
         assertThat(weight).isEqualTo(DEFAULT_WEIGHT);
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
@@ -52,6 +52,15 @@ public class ThriftQueryWeighersTest {
             .build();
 
     @Test
+    public void multigetSliceWeigherEstimatesNumberOfBytesBasedOnNumberOfRows() {
+        long numBytesWithOneRow = ThriftQueryWeighers.multigetSlice(1).estimate().numBytes();
+        long numBytesWithTwoRows = ThriftQueryWeighers.multigetSlice(2).estimate().numBytes();
+
+        assertThat(numBytesWithOneRow).isGreaterThan(0L);
+        assertThat(numBytesWithTwoRows).isEqualTo(numBytesWithOneRow * 2);
+    }
+
+    @Test
     public void multigetSliceWeigherReturnsCorrectNumRows() {
         Map<ByteBuffer, List<ColumnOrSuperColumn>> result = ImmutableMap.of(
                 BYTES1, ImmutableList.of(COLUMN_OR_SUPER, COLUMN_OR_SUPER),
@@ -60,6 +69,15 @@ public class ThriftQueryWeighersTest {
         long actualNumRows = ThriftQueryWeighers.multigetSlice(1).weighSuccess(result, TIME_TAKEN).numDistinctRows();
 
         assertThat(actualNumRows).isEqualTo(2);
+    }
+
+    @Test
+    public void rangeSlicesWeigherEstimatesNumberOfBytesBasedOnNumberOfRows() {
+        long numBytesWithOneRow = ThriftQueryWeighers.getRangeSlices(1).estimate().numBytes();
+        long numBytesWithTwoRows = ThriftQueryWeighers.getRangeSlices(2).estimate().numBytes();
+
+        assertThat(numBytesWithOneRow).isGreaterThan(0L);
+        assertThat(numBytesWithTwoRows).isEqualTo(numBytesWithOneRow * 2);
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
@@ -53,8 +53,9 @@ public class ThriftQueryWeighersTest {
 
     @Test
     public void multigetSliceWeigherEstimatesNumberOfBytesBasedOnNumberOfRows() {
-        long numBytesWithOneRow = ThriftQueryWeighers.multigetSlice(1).estimate().numBytes();
-        long numBytesWithTwoRows = ThriftQueryWeighers.multigetSlice(2).estimate().numBytes();
+        long numBytesWithOneRow = ThriftQueryWeighers.multigetSlice(ImmutableList.of(BYTES1)).estimate().numBytes();
+        long numBytesWithTwoRows = ThriftQueryWeighers.multigetSlice(ImmutableList.of(BYTES1, BYTES2)).estimate()
+                .numBytes();
 
         assertThat(numBytesWithOneRow).isGreaterThan(0L);
         assertThat(numBytesWithTwoRows).isEqualTo(numBytesWithOneRow * 2);
@@ -66,7 +67,9 @@ public class ThriftQueryWeighersTest {
                 BYTES1, ImmutableList.of(COLUMN_OR_SUPER, COLUMN_OR_SUPER),
                 BYTES2, ImmutableList.of(COLUMN_OR_SUPER));
 
-        long actualNumRows = ThriftQueryWeighers.multigetSlice(1).weighSuccess(result, TIME_TAKEN).numDistinctRows();
+        long actualNumRows = ThriftQueryWeighers.multigetSlice(ImmutableList.of(BYTES1))
+                .weighSuccess(result, TIME_TAKEN)
+                .numDistinctRows();
 
         assertThat(actualNumRows).isEqualTo(2);
     }
@@ -121,7 +124,8 @@ public class ThriftQueryWeighersTest {
 
     @Test
     public void multigetSliceWeigherReturnsDefaultEstimateForFailure() {
-        QueryWeight weight = ThriftQueryWeighers.multigetSlice(1).weighFailure(new RuntimeException(), TIME_TAKEN);
+        QueryWeight weight = ThriftQueryWeighers.multigetSlice(ImmutableList.of(BYTES1))
+                .weighFailure(new RuntimeException(), TIME_TAKEN);
 
         assertThat(weight).isEqualTo(DEFAULT_WEIGHT);
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighersTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.Mutation;
 import org.junit.Test;
@@ -76,8 +77,8 @@ public class ThriftQueryWeighersTest {
 
     @Test
     public void rangeSlicesWeigherEstimatesNumberOfBytesBasedOnNumberOfRows() {
-        long numBytesWithOneRow = ThriftQueryWeighers.getRangeSlices(1).estimate().numBytes();
-        long numBytesWithTwoRows = ThriftQueryWeighers.getRangeSlices(2).estimate().numBytes();
+        long numBytesWithOneRow = ThriftQueryWeighers.getRangeSlices(new KeyRange(1)).estimate().numBytes();
+        long numBytesWithTwoRows = ThriftQueryWeighers.getRangeSlices(new KeyRange(2)).estimate().numBytes();
 
         assertThat(numBytesWithOneRow).isGreaterThan(0L);
         assertThat(numBytesWithTwoRows).isEqualTo(numBytesWithOneRow * 2);
@@ -87,7 +88,8 @@ public class ThriftQueryWeighersTest {
     public void rangeSlicesWeigherReturnsCorrectNumRows() {
         List<KeySlice> result = ImmutableList.of(KEY_SLICE, KEY_SLICE, KEY_SLICE);
 
-        long actualNumRows = ThriftQueryWeighers.getRangeSlices(1).weighSuccess(result, TIME_TAKEN).numDistinctRows();
+        long actualNumRows = ThriftQueryWeighers.getRangeSlices(new KeyRange(1)).weighSuccess(result, TIME_TAKEN)
+                .numDistinctRows();
 
         assertThat(actualNumRows).isEqualTo(3);
     }
@@ -139,7 +141,8 @@ public class ThriftQueryWeighersTest {
 
     @Test
     public void getRangeSlicesWeigherReturnsDefaultEstimateForFailure() {
-        QueryWeight weight = ThriftQueryWeighers.getRangeSlices(1).weighFailure(new RuntimeException(), TIME_TAKEN);
+        QueryWeight weight = ThriftQueryWeighers.getRangeSlices(new KeyRange(1))
+                .weighFailure(new RuntimeException(), TIME_TAKEN);
 
         assertThat(weight).isEqualTo(DEFAULT_WEIGHT);
     }


### PR DESCRIPTION
**Goals (and why)**: Instead of hard-coding the number of bytes read, use a heuristic that the number of bytes read is `numberOfRows * 100`.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2717)
<!-- Reviewable:end -->
