### PR TITLE
[TTT] Document Hikari connection parameters

### DIFF
--- a/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
@@ -39,7 +39,7 @@ A minimal AtlasDB configuration for running against postgres will look like :
         type: postgres
         host: dbhost
         port: 5432
-        dbName: my-unique-db-name # must be unique per product 
+        dbName: my-unique-db-name # must be unique per product
         dbLogin: palantir
         dbPassword: palantir
 
@@ -60,8 +60,64 @@ A minimal AtlasDB configuration for running against postgres will look like :
 
 For more details on the leader block, see :ref:`Leader Configuration <leader-config>`.
 
-Connection parameters
----------------------
+Hikari Connection parameters
+----------------------------
+
+We also provide the following options, which are mapped to `Hikari connection options <https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby>`__:
+
+.. list-table::
+    :widths: 20 20 20 80
+    :header-rows: 1
+
+    *    - Option
+         - Default
+         - Hikari config equivalent
+         - Description
+
+    *    - ``minConnections``
+         - 8
+         - ``minimumIdle``
+         - The number of connections in an idle Hikari pool.
+
+    *    - ``maxConnections``
+         - 256
+         - ``maximumPoolSize``
+         - The maximum size the pool is allowed to reach.
+
+    *    - ``maxConnectionAge``
+         - 1000
+         - ``maxLifetime``
+         - The maximum lifetime, in seconds, of a connection in the pool. ``maxLifetime`` is in ``ms``, so we multiply the provided value by 1000.
+
+    *    - ``maxIdleTime``
+         - 600
+         - ``idleTimeout``
+         - The maximum time, in seconds, a connection may sit idle in the pool. ``idleTimeout`` is in ``ms``, so we multiply the provided value by 1000.
+
+    *    - ``unreturnedConnectionTimeout``
+         - 0 (Disabled)
+         - ``leakDetectionThreshold``
+         - The time that a connection can be out of the pool before a message indicating a possible connection leak is logged. Lowest acceptable value is 2000 (ms).
+
+    *    - ``checkoutTimeout``
+         - 30000
+         - ``connectionTimeout``
+         - The maximum time, in milliseconds, we wait for a connection from the pool.
+
+For example, to double the size of the connection pool, apply the following configuration:
+
+.. code-block:: yaml
+
+  atlasdb:
+    keyValueService:
+      # as above - skipped for brevity
+      connection:
+        # as above - skipped for brevity
+        minConnections: 16
+        maxConnections: 512
+
+JDBC Connection parameters
+--------------------------
 
 If you would like to customise the JDBC connection parameters, for example if you are experiencing performance issues, then you may supply them under the ``connection`` section of the ``keyValueService`` config.
 An example is shown below; for full documentation on which parameters are available, check out `the JDBC docs <https://jdbc.postgresql.org/documentation/head/connect.html>`__.

--- a/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
+++ b/docs/source/configuration/key_value_service_configs/postgres_key_value_service_config.rst
@@ -85,7 +85,7 @@ We also provide the following options, which are mapped to `Hikari connection op
          - The maximum size the pool is allowed to reach.
 
     *    - ``maxConnectionAge``
-         - 1000
+         - 1800
          - ``maxLifetime``
          - The maximum lifetime, in seconds, of a connection in the pool. ``maxLifetime`` is in ``ms``, so we multiply the provided value by 1000.
 
@@ -102,7 +102,7 @@ We also provide the following options, which are mapped to `Hikari connection op
     *    - ``checkoutTimeout``
          - 30000
          - ``connectionTimeout``
-         - The maximum time, in milliseconds, we wait for a connection from the pool.
+         - The maximum time, **in milliseconds**, we wait for a connection from the pool.
 
 For example, to double the size of the connection pool, apply the following configuration:
 


### PR DESCRIPTION
**Goals (and why)**: Fixes #2704, adding a list of Hikari parameters that can be specified.

**Implementation Description (bullets)**: Added a table in docs.

**Concerns (what feedback would you like?)**: We also have ``socketTimeoutSeconds`` and ``connectionTimeoutSeconds``, which are passed to Postgres/Oracle configuration directly (not used by Hikari). I should probably also document these, but how?

**Where should we start reviewing?**: One docs file

**Priority (whenever / two weeks / yesterday)**: Today (TTT)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2726)
<!-- Reviewable:end -->
