### PR TITLE
Feature/use shared metric registries everywhere

### DIFF
--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
-import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 
@@ -46,7 +45,6 @@ public class AtlasDbMetricsTest {
 
     @Test
     public void metricsIsDefaultWhenNotSet() {
-        AtlasDbMetrics.metrics.set(null);
         assertThat(AtlasDbMetrics.getMetricRegistry(),
                 is(equalTo(SharedMetricRegistries.getOrCreate(AtlasDbMetrics.DEFAULT_REGISTRY_NAME))));
     }
@@ -61,7 +59,7 @@ public class AtlasDbMetricsTest {
 
     @Test(expected = NullPointerException.class)
     public void nullMetricsCannotBeSet() {
-        AtlasDbMetrics.setMetricRegistries(null, null);
+        AtlasDbMetrics.setMetricRegistries(null, new DefaultTaggedMetricRegistry());
     }
 
     @Test(expected = NullPointerException.class)

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/AtlasDbMetricsTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
-import com.palantir.tritium.metrics.MetricRegistries;
 
 public class AtlasDbMetricsTest {
 
@@ -82,7 +81,7 @@ public class AtlasDbMetricsTest {
     }
 
     private MetricRegistry setMetricRegistry() {
-        MetricRegistry metrics = MetricRegistries.createWithHdrHistogramReservoirs();
+        MetricRegistry metrics = SharedMetricRegistries.getOrCreate("AtlasDbTest");
         AtlasDbMetrics.setMetricRegistry(metrics);
         return metrics;
     }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricsRule.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricsRule.java
@@ -39,6 +39,7 @@ public class MetricsRule extends ExternalResource {
             ConsoleReporter reporter = ConsoleReporter.forRegistry(metrics).build();
             reporter.report();
             reporter.close();
+            SharedMetricRegistries.remove("AtlasDbTest");
         }
     }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricsRule.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/util/MetricsRule.java
@@ -19,14 +19,14 @@ import org.junit.rules.ExternalResource;
 
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
-import com.palantir.tritium.metrics.MetricRegistries;
+import com.codahale.metrics.SharedMetricRegistries;
 
 public class MetricsRule extends ExternalResource {
 
     @Override
     protected void before() throws Throwable {
         super.before();
-        AtlasDbMetrics.setMetricRegistry(MetricRegistries.createWithHdrHistogramReservoirs());
+        AtlasDbMetrics.setMetricRegistry(SharedMetricRegistries.getOrCreate("AtlasDbTest"));
     }
 
     @Override

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/TransactionManagersTest.java
@@ -162,7 +162,7 @@ public class TransactionManagersTest {
     public void setup() throws JsonProcessingException {
         // Change code to run synchronously, but with a timeout in case something's gone horribly wrong
         originalAsyncMethod = TransactionManagers.runAsync;
-        TransactionManagers.runAsync = task -> Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(task::run);
+        TransactionManagers.runAsync = task -> Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(task::run);
 
         availableServer.stubFor(LEADER_UUID_MAPPING.willReturn(aResponse().withStatus(200).withBody(
                 ("\"" + UUID.randomUUID().toString() + "\"").getBytes())));

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
@@ -37,7 +38,6 @@ import com.palantir.atlasdb.todo.TodoClient;
 import com.palantir.atlasdb.todo.TodoSchema;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.remoting3.servers.jersey.HttpRemotingJerseyFeature;
-import com.palantir.tritium.metrics.MetricRegistries;
 
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
@@ -59,7 +59,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
 
     @Override
     public void initialize(Bootstrap<AtlasDbEteConfiguration> bootstrap) {
-        bootstrap.setMetricRegistry(MetricRegistries.createWithHdrHistogramReservoirs());
+        bootstrap.setMetricRegistry(SharedMetricRegistries.getOrCreate("AtlasDbTest"));
         enableEnvironmentVariablesInConfig(bootstrap);
         bootstrap.addBundle(new AtlasDbBundle<>());
         bootstrap.getObjectMapper().registerModule(new Jdk8Module());

--- a/atlasdb-service-server/src/main/java/com/palantir/atlasdb/server/AtlasDbServiceServer.java
+++ b/atlasdb-service-server/src/main/java/com/palantir/atlasdb/server/AtlasDbServiceServer.java
@@ -15,13 +15,13 @@
  */
 package com.palantir.atlasdb.server;
 
+import com.codahale.metrics.SharedMetricRegistries;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.impl.AtlasDbServiceImpl;
 import com.palantir.atlasdb.impl.TableMetadataCache;
 import com.palantir.atlasdb.jackson.AtlasJacksonModule;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
-import com.palantir.tritium.metrics.MetricRegistries;
 
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
@@ -36,7 +36,7 @@ public class AtlasDbServiceServer extends Application<AtlasDbServiceServerConfig
     @Override
     public void initialize(Bootstrap<AtlasDbServiceServerConfiguration> bootstrap) {
         super.initialize(bootstrap);
-        bootstrap.setMetricRegistry(MetricRegistries.createWithHdrHistogramReservoirs());
+        bootstrap.setMetricRegistry(SharedMetricRegistries.getOrCreate("AtlasDbTest"));
     }
 
     @Override

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.timelock;
 
+import java.util.UUID;
 import java.util.function.Consumer;
 
 import com.codahale.metrics.MetricRegistry;
@@ -44,7 +45,8 @@ public class TimeLockServerLauncher extends Application<TimeLockServerConfigurat
 
     @Override
     public void initialize(Bootstrap<TimeLockServerConfiguration> bootstrap) {
-        MetricRegistry metricRegistry = SharedMetricRegistries.getOrCreate("AtlasDbTest");
+        MetricRegistry metricRegistry = SharedMetricRegistries
+                .getOrCreate("AtlasDbTest" + UUID.randomUUID().toString());
         TaggedMetricRegistry taggedMetricRegistry = new DefaultTaggedMetricRegistry();
         AtlasDbMetrics.setMetricRegistries(metricRegistry, taggedMetricRegistry);
         bootstrap.setMetricRegistry(metricRegistry);

--- a/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
+++ b/timelock-server/src/main/java/com/palantir/atlasdb/timelock/TimeLockServerLauncher.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.timelock;
 import java.util.function.Consumer;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.palantir.atlasdb.timelock.config.CombinedTimeLockServerConfiguration;
 import com.palantir.atlasdb.timelock.config.TimeLockConfigMigrator;
@@ -26,12 +27,14 @@ import com.palantir.atlasdb.timelock.logging.NonBlockingFileAppenderFactory;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.remoting3.servers.jersey.HttpRemotingJerseyFeature;
 import com.palantir.timelock.paxos.TimeLockAgent;
-import com.palantir.tritium.metrics.MetricRegistries;
 
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
+/**
+ * Provides a way of launching an embedded TimeLock server using Dropwizard. Should only be used in tests.
+ */
 public class TimeLockServerLauncher extends Application<TimeLockServerConfiguration> {
     public static void main(String[] args) throws Exception {
         new TimeLockServerLauncher().run(args);
@@ -39,7 +42,7 @@ public class TimeLockServerLauncher extends Application<TimeLockServerConfigurat
 
     @Override
     public void initialize(Bootstrap<TimeLockServerConfiguration> bootstrap) {
-        MetricRegistry metricRegistry = MetricRegistries.createWithHdrHistogramReservoirs();
+        MetricRegistry metricRegistry = SharedMetricRegistries.getOrCreate("AtlasDbTest");
         AtlasDbMetrics.setMetricRegistry(metricRegistry);
         bootstrap.setMetricRegistry(metricRegistry);
         bootstrap.getObjectMapper().registerSubtypes(NonBlockingFileAppenderFactory.class);


### PR DESCRIPTION
**Goals (and why)**: Fixes #2694. We already use `SharedMetricRegistries.create` in production code, so this PR just makes the test code (and `TimeLockServerLauncher`) match this.

**Concerns (what feedback would you like?)**: Do we need to do anything else discussed on #2694. In particular, should we hook into a Tritium method that will eventually use exponentially decaying reservoirs, or is this handled for us already when we create new metrics?

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2728)
<!-- Reviewable:end -->
