### PR TITLE
avoid tombstoned rows

### DIFF
--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownGetTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownGetTest.java
@@ -112,7 +112,7 @@ public class OneNodeDownGetTest {
                 OneNodeDownTestSuite.TEST_TABLE, range, Long.MAX_VALUE);
         assertThatThrownBy(() -> it.next())
                 .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessage("This operation requires all Cassandra nodes to be up and available.");
+                .hasMessageContaining("requires all Cassandra nodes to be up and available.");
     }
 
     @Test
@@ -120,6 +120,6 @@ public class OneNodeDownGetTest {
         assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.getAllTimestamps(OneNodeDownTestSuite.TEST_TABLE,
                 ImmutableSet.of(OneNodeDownTestSuite.CELL_1_1), Long.MAX_VALUE))
                 .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessage("This get operation requires ALL Cassandra nodes to be up and available.");
+                .hasMessageContaining("requires ALL Cassandra nodes to be up and available.");
     }
 }

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownGetTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownGetTest.java
@@ -43,6 +43,7 @@ import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 
 public class OneNodeDownGetTest {
+    private static final String REQUIRES_ALL_CASSANDRA_NODES = "requires ALL Cassandra nodes to be up and available.";
 
     ImmutableMap<Cell, Value> expectedRow = ImmutableMap.of(
             OneNodeDownTestSuite.CELL_1_1, OneNodeDownTestSuite.DEFAULT_VALUE,
@@ -112,7 +113,7 @@ public class OneNodeDownGetTest {
                 OneNodeDownTestSuite.TEST_TABLE, range, Long.MAX_VALUE);
         assertThatThrownBy(() -> it.next())
                 .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessageContaining("requires all Cassandra nodes to be up and available.");
+                .hasMessageContaining(REQUIRES_ALL_CASSANDRA_NODES);
     }
 
     @Test
@@ -120,6 +121,6 @@ public class OneNodeDownGetTest {
         assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.getAllTimestamps(OneNodeDownTestSuite.TEST_TABLE,
                 ImmutableSet.of(OneNodeDownTestSuite.CELL_1_1), Long.MAX_VALUE))
                 .isExactlyInstanceOf(InsufficientConsistencyException.class)
-                .hasMessageContaining("requires ALL Cassandra nodes to be up and available.");
+                .hasMessageContaining(REQUIRES_ALL_CASSANDRA_NODES);
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1486,10 +1486,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             String kvsMethodName,
             TableReference tableRef,
             CandidateCellForSweepingRequest request) {
+        RowGetter rowGetter = new RowGetter(clientPool, queryRunner, ConsistencyLevel.ALL, tableRef);
         return new CandidateRowsForSweepingIterator(
                 (iteratorTableRef, cells, maxTimestampExclusive) ->
                         get(kvsMethodName, iteratorTableRef, cells, maxTimestampExclusive),
-                newInstrumentedCqlExecutor(),
+                newInstrumentedCqlExecutor(), rowGetter,
                 tableRef, request);
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
@@ -39,5 +39,6 @@ public interface CqlExecutor {
     List<CellWithTimestamp> getTimestamps(
             TableReference tableRef,
             byte[] startRowInclusive,
+            byte[] endRowInclusive,
             int limit);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
@@ -59,12 +59,15 @@ public class CqlExecutorImpl implements CqlExecutor {
     public List<CellWithTimestamp> getTimestamps(
             TableReference tableRef,
             byte[] startRowInclusive,
+            byte[] endRowInclusive,
             int limit) {
-        String selQuery = "SELECT key, column1, column2 FROM %s WHERE token(key) >= token(%s) LIMIT %s;";
+        String selQuery = "SELECT key, column1, column2 FROM %s"
+                + " WHERE token(key) >= token(%s) AND token(key) <= token(%s) LIMIT %s;";
         CqlQuery query = new CqlQuery(
                 selQuery,
                 CqlQueryUtils.quotedTableName(tableRef),
                 CqlQueryUtils.key(startRowInclusive),
+                CqlQueryUtils.key(endRowInclusive),
                 CqlQueryUtils.limit(limit));
 
         return executeAndGetCells(query, startRowInclusive, CqlQueryUtils::getCellFromRow);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/CandidateRowsForSweepingIterator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/CandidateRowsForSweepingIterator.java
@@ -24,6 +24,7 @@ import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.CqlExecutor;
+import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
 import com.palantir.common.base.ClosableIterator;
 
 public class CandidateRowsForSweepingIterator extends AbstractIterator<List<CandidateRowForSweeping>>
@@ -31,6 +32,7 @@ public class CandidateRowsForSweepingIterator extends AbstractIterator<List<Cand
 
     private final ValuesLoader valuesLoader;
     private final CqlExecutor cqlExecutor;
+    private final RowGetter rowGetter;
     private final TableReference table;
     private final CandidateCellForSweepingRequest request;
 
@@ -39,10 +41,12 @@ public class CandidateRowsForSweepingIterator extends AbstractIterator<List<Cand
     public CandidateRowsForSweepingIterator(
             ValuesLoader valuesLoader,
             CqlExecutor cqlExecutor,
+            RowGetter rowGetter,
             TableReference table,
             CandidateCellForSweepingRequest request) {
         this.valuesLoader = valuesLoader;
         this.cqlExecutor = cqlExecutor;
+        this.rowGetter = rowGetter;
         this.table = table;
         this.request = request;
 
@@ -63,7 +67,7 @@ public class CandidateRowsForSweepingIterator extends AbstractIterator<List<Cand
     }
 
     private List<CandidateRowForSweeping> getCandidateCellsForSweepingBatch() {
-        return new GetCandidateRowsForSweeping(valuesLoader, cqlExecutor, table,
+        return new GetCandidateRowsForSweeping(valuesLoader, cqlExecutor, rowGetter, table,
                 request.withStartRow(nextStartRow)).execute();
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCandidateRowsForSweeping.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCandidateRowsForSweeping.java
@@ -31,6 +31,7 @@ import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.CqlExecutor;
+import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
 
 public class GetCandidateRowsForSweeping {
 
@@ -39,6 +40,7 @@ public class GetCandidateRowsForSweeping {
 
     private final ValuesLoader valuesLoader;
     private final CqlExecutor cqlExecutor;
+    private final RowGetter rowGetter;
     private final TableReference table;
     private final CandidateCellForSweepingRequest request;
     private final int timestampsBatchSize;
@@ -50,10 +52,12 @@ public class GetCandidateRowsForSweeping {
     public GetCandidateRowsForSweeping(
             ValuesLoader valuesLoader,
             CqlExecutor cqlExecutor,
+            RowGetter rowGetter,
             TableReference table,
             CandidateCellForSweepingRequest request) {
         this.table = table;
         this.cqlExecutor = cqlExecutor;
+        this.rowGetter = rowGetter;
         this.request = request;
         this.valuesLoader = valuesLoader;
 
@@ -74,8 +78,8 @@ public class GetCandidateRowsForSweeping {
     }
 
     private void fetchCellTimestamps() {
-        cellTimestamps = new GetCellTimestamps(cqlExecutor, table, request.startRowInclusive(), timestampsBatchSize)
-                .execute();
+        cellTimestamps = new GetCellTimestamps(cqlExecutor, rowGetter, table, request.startRowInclusive(),
+                timestampsBatchSize).execute();
     }
 
     public void findCellsWithEmptyValuesIfNeeded() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCellTimestamps.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCellTimestamps.java
@@ -20,29 +20,42 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import org.apache.cassandra.thrift.KeyRange;
+import org.apache.cassandra.thrift.KeySlice;
+import org.apache.cassandra.thrift.SlicePredicate;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.CqlExecutor;
+import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
+import com.palantir.atlasdb.keyvalue.cassandra.thrift.SlicePredicates;
+import com.palantir.common.base.Throwables;
 
 public class GetCellTimestamps {
 
+    private final RowGetter rowGetter;
     private final CqlExecutor cqlExecutor;
     private final TableReference tableRef;
     private final byte[] startRowInclusive;
     private final int batchHint;
 
+    private byte[] endRowInclusive;
+
     private final Collection<CellWithTimestamp> timestamps = Lists.newArrayList();
 
     public GetCellTimestamps(
             CqlExecutor cqlExecutor,
+            RowGetter rowGetter,
             TableReference tableRef,
             byte[] startRowInclusive,
             int batchHint) {
         this.cqlExecutor = cqlExecutor;
+        this.rowGetter = rowGetter;
         this.tableRef = tableRef;
         this.startRowInclusive = startRowInclusive;
         this.batchHint = batchHint;
@@ -63,14 +76,51 @@ public class GetCellTimestamps {
      * row.
      */
     private void fetchBatchOfTimestamps() {
-        fetchAllTimestampsBeginningAtStartRow();
+        fetchBatchOfTimestampsBeginningAtStartRow();
+
         fetchRemainingTimestampsForLastRow();
     }
 
-    private void fetchAllTimestampsBeginningAtStartRow() {
-        List<CellWithTimestamp> batch = cqlExecutor.getTimestamps(tableRef, startRowInclusive, batchHint);
+    /**
+     * The complexity in this method is due to a desire to avoid scanning over large numbers of tombstoned rows.
+     * <p>
+     * Details: An unbounded CQL query will scan over an unbounded number of tombstoned rows in an attempt to find
+     * either the end of the table, or the desired number of results. This can lead to timeouts if there are large
+     * segments of tombstoned rows (which can happen with THOROUGH sweep). Thrift, on the other hand, will actually
+     * return the tombstoned rows (they will just be empty KeySlices), which allows us to page over them. So, we first
+     * execute a thrift range scan to determine an upper bound on the CQL range scan, and page over the data until we
+     * find some live cells.
+     * <p>
+     * This is a hack (and a perf hit) until we have a better solution to avoid scanning massive numbers of
+     * tombstones (ideally this will involve catching some exception and reducing the range appropriately).
+     */
+    private void fetchBatchOfTimestampsBeginningAtStartRow() {
+        Optional<byte[]> rangeEnd;
+        for (byte[] rangeStart = startRowInclusive; timestamps.isEmpty(); rangeStart = rangeEnd.get()) {
+            rangeEnd = determineSafeRangeEnd(rangeStart);
+            if (!rangeEnd.isPresent()) {
+                return;
+            }
 
-        timestamps.addAll(batch);
+            List<CellWithTimestamp> batch = cqlExecutor.getTimestamps(tableRef, rangeStart, rangeEnd.get(), batchHint);
+            timestamps.addAll(batch);
+        }
+    }
+
+    private Optional<byte[]> determineSafeRangeEnd(byte[] rangeStart) {
+        KeyRange keyRange = new KeyRange().setStart_key(rangeStart).setEnd_key(new byte[0]).setCount(batchHint);
+        SlicePredicate slicePredicate = SlicePredicates.create(SlicePredicates.Range.ALL, SlicePredicates.Limit.ONE);
+        try {
+            List<KeySlice> rows = rowGetter.getRows("getCandidateCellsForSweeping", keyRange, slicePredicate);
+            if (rows.isEmpty()) {
+                return Optional.empty();
+            } else {
+                return Optional.of(Iterables.getLast(rows).getKey());
+            }
+        } catch (Exception e) {
+            // TODO(nziebart): handle QoS exceptions here
+            throw Throwables.throwUncheckedException(e);
+        }
     }
 
     private void fetchRemainingTimestampsForLastRow() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -44,6 +44,7 @@ public class CqlExecutorTest {
 
     private static final TableReference TABLE_REF = TableReference.create(Namespace.create("foo"), "bar");
     private static final byte[] ROW = {0x01, 0x02};
+    private static final byte[] END_ROW = {0x05, 0x09};
     private static final byte[] COLUMN = {0x03, 0x04};
     private static final long TIMESTAMP = 123L;
     private static final int LIMIT = 100;
@@ -60,9 +61,10 @@ public class CqlExecutorTest {
 
     @Test
     public void getTimestamps() {
-        String expected = "SELECT key, column1, column2 FROM \"foo__bar\" WHERE token(key) >= token(0x0102) LIMIT 100;";
+        String expected = "SELECT key, column1, column2 FROM \"foo__bar\""
+                + " WHERE token(key) >= token(0x0102) AND token(key) <= token(0x0509) LIMIT 100;";
 
-        executor.getTimestamps(TABLE_REF, ROW, LIMIT);
+        executor.getTimestamps(TABLE_REF, ROW, END_ROW, LIMIT);
 
         verify(queryExecutor).execute(argThat(cqlQueryMatcher(expected)), eq(ROW));
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -48,6 +48,12 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - We now avoid Cassandra timeouts caused by running unbounded CQL range scans during sweep.
+           In order to assign a bound, we prefetch row keys using thrift, and use these bounds to page internally through rows.
+           This issue affected thoroughly swept tables, which could accumulate many rows entirely made up of tombstones.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2732>`__)
+
     *    - |new| |metrics|
          - We now record metrics for most cases where cells fetched from Cassandra are post-filtered before returning to the client.
            The new metrics are called ``notLatestVisibleValueCellFilterCount``, ``commitTsGreaterThatTxTsCellFilterCount``,


### PR DESCRIPTION
**Goals (and why)**:
Addresses part of https://github.com/palantir/atlasdb/issues/2691 by paging over tombstones, rather than making Cassandra do an unbounded range scan.

**Implementation Description (bullets)**:
- Impose an upper bound on the CQL range scan used for sweep.
- Use thrift to determine a safe upper bound (see comments in `GetCellTimestamps` for an explanation of why this works.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2732)
<!-- Reviewable:end -->
