### PR TITLE
backoff after sweeping many tombstones

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -681,4 +681,12 @@ public interface KeyValueService extends AutoCloseable {
     default boolean isInitialized() {
         return true;
     }
+
+    /**
+     * Whether or not read performance degrades significantly when many deleted cells are in the requested range.
+     * This is used by sweep to determine if it should wait a while between runs after deleting a large number of cells.
+     */
+    default boolean performanceIsSensitiveToTombstones() {
+        return false;
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -2386,6 +2386,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         return cassandraTables;
     }
 
+    @Override
+    public boolean performanceIsSensitiveToTombstones() {
+        return true;
+    }
+
     /**
      * Does not require all Cassandra nodes to be up and available, works as long as quorum is achieved.
      */

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -64,6 +64,10 @@ develop
          - ``Throwables.createPalantirRuntimeException`` once again throws ``PalantirInterruptedException`` if the original exception was either ``InterruptedException`` or ``InterruptedIOException``.
            This reverts behaviour introduced in 0.67.0, where we instead threw ``PalantirRuntimeException``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2702>`__)
+           
+    *    - |improved|
+         - Sweep now waits 1 day after generating a large number of tombstones before sweeping a table again. This behavior only applies when using Cassandra.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2733>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**:
Addresses https://github.com/palantir/atlasdb/issues/2691

**Implementation Description (bullets)**:
- Wait 1 day after sweeping if we generate more than 1 million tombstones
- Only do this for Cassandra

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2733)
<!-- Reviewable:end -->
