### PR TITLE
Refactor/extract metrics from CassandraClientPoolImpl

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -240,7 +240,7 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
     private void registerAggregateMetrics() {
         metricsManager.registerMetric(
                 CassandraClientPool.class, "numBlacklistedHosts",
-                () -> blacklist.size());
+                blacklist::size);
         metricsManager.registerMetric(
                 CassandraClientPool.class, "requestFailureProportion",
                 aggregateMetrics::getExceptionProportion);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -152,7 +152,6 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
     private final ScheduledExecutorService refreshDaemon;
     private final MetricsManager metricsManager = new MetricsManager();
     private final RequestMetrics aggregateMetrics = new RequestMetrics(null);
-    private final Map<InetSocketAddress, RequestMetrics> metricsByHost = new HashMap<>();
     private final InitializingWrapper wrapper = new InitializingWrapper();
 
     private List<InetSocketAddress> cassandraHosts;
@@ -621,10 +620,6 @@ public final class CassandraClientPoolImpl implements CassandraClientPool {
             CassandraClientPoolingContainer hostPool,
             Consumer<RequestMetrics> metricsConsumer) {
         metricsConsumer.accept(aggregateMetrics);
-        RequestMetrics requestMetricsForHost = metricsByHost.get(hostPool.getHost());
-        if (requestMetricsForHost != null) {
-            metricsConsumer.accept(requestMetricsForHost);
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraExpiringKeyValueService.java
@@ -58,8 +58,7 @@ public final class CassandraExpiringKeyValueService extends CassandraKeyValueSer
         CassandraClientPool clientPool =
                 CassandraClientPoolImpl.create(configManager.getConfig(), AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
         CassandraExpiringKeyValueService kvs =
-                new CassandraExpiringKeyValueService(configManager, clientPool, compactionManager, leaderConfig,
-                        AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
+                new CassandraExpiringKeyValueService(configManager, clientPool, compactionManager, leaderConfig);
         kvs.initialize(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
         return kvs;
     }
@@ -68,10 +67,9 @@ public final class CassandraExpiringKeyValueService extends CassandraKeyValueSer
             CassandraKeyValueServiceConfigManager configManager,
             CassandraClientPool clientPool,
             Optional<CassandraJmxCompactionManager> compactionManager,
-            Optional<LeaderConfig> leaderConfig,
-            boolean initializeAsync) {
+            Optional<LeaderConfig> leaderConfig) {
         super(LoggerFactory.getLogger(CassandraKeyValueService.class), configManager, clientPool,
-                compactionManager, leaderConfig, initializeAsync);
+                compactionManager, leaderConfig);
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -263,8 +263,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         Optional<CassandraJmxCompactionManager> compactionManager =
                 CassandraJmxCompaction.createJmxCompactionManager(configManager);
         CassandraKeyValueServiceImpl keyValueService =
-                new CassandraKeyValueServiceImpl(log, configManager, clientPool,
-                        compactionManager, leaderConfig, initializeAsync);
+                new CassandraKeyValueServiceImpl(log, configManager, clientPool, compactionManager, leaderConfig);
         keyValueService.wrapper.initialize(initializeAsync);
         return keyValueService.wrapper.isInitialized() ? keyValueService : keyValueService.wrapper;
     }
@@ -273,8 +272,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                         CassandraKeyValueServiceConfigManager configManager,
                                         CassandraClientPool clientPool,
                                         Optional<CassandraJmxCompactionManager> compactionManager,
-                                        Optional<LeaderConfig> leaderConfig,
-                                        boolean initializeAsync) {
+                                        Optional<LeaderConfig> leaderConfig) {
         super(AbstractKeyValueService.createFixedThreadPool("Atlas Cassandra KVS",
                 configManager.getConfig().poolSize() * configManager.getConfig().servers().size()));
         this.log = log;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolMetrics.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolMetrics.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.pool;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import com.codahale.metrics.Meter;
+import com.google.common.base.Supplier;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer;
+import com.palantir.atlasdb.util.MetricsManager;
+
+public class CassandraClientPoolMetrics {
+    private final MetricsManager metricsManager = new MetricsManager();
+    private final RequestMetrics aggregateMetrics = new RequestMetrics(null);
+    private final Map<InetSocketAddress, RequestMetrics> metricsByHost = new HashMap<>();
+
+    public void deregisterMetrics() {
+        metricsManager.deregisterMetrics();
+    }
+
+    public void registerAggregateMetrics(Supplier<Integer> blacklistSize) {
+        metricsManager.registerMetric(
+                CassandraClientPool.class, "numBlacklistedHosts",
+                () -> blacklistSize);
+        metricsManager.registerMetric(
+                CassandraClientPool.class, "requestFailureProportion",
+                aggregateMetrics::getExceptionProportion);
+        metricsManager.registerMetric(
+                CassandraClientPool.class, "requestConnectionExceptionProportion",
+                aggregateMetrics::getConnectionExceptionProportion);
+    }
+
+    public void recordRequestOnHost(CassandraClientPoolingContainer hostPool) {
+        updateMetricOnAggregateAndHost(hostPool, RequestMetrics::markRequest);
+    }
+
+    public void recordExceptionOnHost(CassandraClientPoolingContainer hostPool) {
+        updateMetricOnAggregateAndHost(hostPool, RequestMetrics::markRequestException);
+    }
+
+    public void recordConnectionExceptionOnHost(CassandraClientPoolingContainer hostPool) {
+        updateMetricOnAggregateAndHost(hostPool, RequestMetrics::markRequestConnectionException);
+    }
+
+    private void updateMetricOnAggregateAndHost(
+            CassandraClientPoolingContainer hostPool,
+            Consumer<RequestMetrics> metricsConsumer) {
+        metricsConsumer.accept(aggregateMetrics);
+        RequestMetrics requestMetricsForHost = metricsByHost.get(hostPool.getHost());
+        if (requestMetricsForHost != null) {
+            metricsConsumer.accept(requestMetricsForHost);
+        }
+    }
+
+    private class RequestMetrics {
+        private final Meter totalRequests;
+        private final Meter totalRequestExceptions;
+        private final Meter totalRequestConnectionExceptions;
+
+        RequestMetrics(String metricPrefix) {
+            totalRequests = metricsManager.registerOrGetMeter(
+                    CassandraClientPool.class, metricPrefix, "requests");
+            totalRequestExceptions = metricsManager.registerOrGetMeter(
+                    CassandraClientPool.class, metricPrefix, "requestExceptions");
+            totalRequestConnectionExceptions = metricsManager.registerOrGetMeter(
+                    CassandraClientPool.class, metricPrefix, "requestConnectionExceptions");
+        }
+
+        void markRequest() {
+            totalRequests.mark();
+        }
+
+        void markRequestException() {
+            totalRequestExceptions.mark();
+        }
+
+        void markRequestConnectionException() {
+            totalRequestConnectionExceptions.mark();
+        }
+
+        // Approximate
+        double getExceptionProportion() {
+            return ((double) totalRequestExceptions.getCount()) / ((double) totalRequests.getCount());
+        }
+
+        // Approximate
+        double getConnectionExceptionProportion() {
+            return ((double) totalRequestConnectionExceptions.getCount()) / ((double) totalRequests.getCount());
+        }
+    }
+}


### PR DESCRIPTION
**Goals (and why)**: Keep shrinking CassandraClientPoolImpl by moving its numerous responsibilities out into separate classes.

**Implementation Description (bullets)**: Moved out the metrics stuff, hopefully didn't break anything.

**Concerns (what feedback would you like?)**: Did I break anything?  I kept in the per host metrics field even though it does nothing.  This makes it easier to add this functionality back later and explains why the metrics are done in a slightly weird way.  Should I just get rid of this and we can figure it out later?

**Where should we start reviewing?**: CassandraClientPoolImpl and CassandraClientPoolMetrics

**Priority (whenever / two weeks / yesterday)**: whenever
