### PR TITLE
Fix StreamingStore cleanup tasks

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -670,7 +670,7 @@ public class StreamStoreRenderer {
                     line(StreamIdxTable, " usersIndex = tables.get", StreamIdxTable, "(t);");
                     line("Set<", StreamIdxRow, "> rows = Sets.newHashSetWithExpectedSize(cells.size());");
                     line("for (Cell cell : cells) {"); {
-                        line("rows.add(", StreamIdxRow, ".of((", StreamId, ") ValueType.", streamIdType.toString(), ".convertToJava(cell.getRowName(), 0)));");
+                        line("rows.add(", StreamIdxRow, ".BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));");
                     } line("}");
                     line("Multimap<", StreamIdxRow, ", ", StreamIdxColumnValue, "> rowsInDb = usersIndex.getRowsMultimap(rows);");
                     line("Set<", StreamId, "> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.keySet().size());");
@@ -739,7 +739,7 @@ public class StreamStoreRenderer {
                     line(StreamMetadataTable, " metaTable = tables.get", StreamMetadataTable, "(t);");
                     line("Collection<", StreamMetadataRow, "> rows = Lists.newArrayListWithCapacity(cells.size());");
                     line("for (Cell cell : cells) {"); {
-                        line("rows.add(", StreamMetadataRow, ".of((", StreamId, ") ValueType.", streamIdType.toString(), ".convertToJava(cell.getRowName(), 0)));");
+                        line("rows.add(", StreamMetadataRow, ".BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));");
                     } line("}");
                     line("Map<", StreamMetadataRow, ", StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);");
                     line("Set<", StreamId, "> toDelete = Sets.newHashSet();");

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestIndexCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestIndexCleanupTask.java
@@ -23,7 +23,7 @@ public class StreamTestIndexCleanupTask implements OnCleanupTask {
         StreamTestStreamIdxTable usersIndex = tables.getStreamTestStreamIdxTable(t);
         Set<StreamTestStreamIdxTable.StreamTestStreamIdxRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
-            rows.add(StreamTestStreamIdxTable.StreamTestStreamIdxRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(StreamTestStreamIdxTable.StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Multimap<StreamTestStreamIdxTable.StreamTestStreamIdxRow, StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue> rowsInDb = usersIndex.getRowsMultimap(rows);
         Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.keySet().size());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemIndexCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemIndexCleanupTask.java
@@ -23,7 +23,7 @@ public class StreamTestMaxMemIndexCleanupTask implements OnCleanupTask {
         StreamTestMaxMemStreamIdxTable usersIndex = tables.getStreamTestMaxMemStreamIdxTable(t);
         Set<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
-            rows.add(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Multimap<StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxTable.StreamTestMaxMemStreamIdxColumnValue> rowsInDb = usersIndex.getRowsMultimap(rows);
         Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.keySet().size());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemMetadataCleanupTask.java
@@ -27,7 +27,7 @@ public class StreamTestMaxMemMetadataCleanupTask implements OnCleanupTask {
         StreamTestMaxMemStreamMetadataTable metaTable = tables.getStreamTestMaxMemStreamMetadataTable(t);
         Collection<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
         for (Cell cell : cells) {
-            rows.add(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Map<StreamTestMaxMemStreamMetadataTable.StreamTestMaxMemStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMetadataCleanupTask.java
@@ -27,7 +27,7 @@ public class StreamTestMetadataCleanupTask implements OnCleanupTask {
         StreamTestStreamMetadataTable metaTable = tables.getStreamTestStreamMetadataTable(t);
         Collection<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
         for (Cell cell : cells) {
-            rows.add(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashIndexCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashIndexCleanupTask.java
@@ -23,7 +23,7 @@ public class StreamTestWithHashIndexCleanupTask implements OnCleanupTask {
         StreamTestWithHashStreamIdxTable usersIndex = tables.getStreamTestWithHashStreamIdxTable(t);
         Set<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
-            rows.add(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Multimap<StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxTable.StreamTestWithHashStreamIdxColumnValue> rowsInDb = usersIndex.getRowsMultimap(rows);
         Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.keySet().size());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashMetadataCleanupTask.java
@@ -27,7 +27,7 @@ public class StreamTestWithHashMetadataCleanupTask implements OnCleanupTask {
         StreamTestWithHashStreamMetadataTable metaTable = tables.getStreamTestWithHashStreamMetadataTable(t);
         Collection<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
         for (Cell cell : cells) {
-            rows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Map<StreamTestWithHashStreamMetadataTable.StreamTestWithHashStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsIndexCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsIndexCleanupTask.java
@@ -23,7 +23,7 @@ public class TestHashComponentsIndexCleanupTask implements OnCleanupTask {
         TestHashComponentsStreamIdxTable usersIndex = tables.getTestHashComponentsStreamIdxTable(t);
         Set<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
-            rows.add(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Multimap<TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxTable.TestHashComponentsStreamIdxColumnValue> rowsInDb = usersIndex.getRowsMultimap(rows);
         Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.keySet().size());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsMetadataCleanupTask.java
@@ -27,7 +27,7 @@ public class TestHashComponentsMetadataCleanupTask implements OnCleanupTask {
         TestHashComponentsStreamMetadataTable metaTable = tables.getTestHashComponentsStreamMetadataTable(t);
         Collection<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
         for (Cell cell : cells) {
-            rows.add(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Map<TestHashComponentsStreamMetadataTable.TestHashComponentsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -65,6 +65,12 @@ develop
            This reverts behaviour introduced in 0.67.0, where we instead threw ``PalantirRuntimeException``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2702>`__)
 
+    *    - |fixed|
+         - Fixes the ability of deleting values from the Streaming Store when configured hash rowComponents.
+           Previously, due to a deserialization bug, we'd not issue delete to the correct rows.
+           If you think you're affected by this bug, please contact the AtlasDB team to migrate off of this behavior.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2736>`__)
+
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 
 =======

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosIndexCleanupTask.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosIndexCleanupTask.java
@@ -23,7 +23,7 @@ public class UserPhotosIndexCleanupTask implements OnCleanupTask {
         UserPhotosStreamIdxTable usersIndex = tables.getUserPhotosStreamIdxTable(t);
         Set<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
         for (Cell cell : cells) {
-            rows.add(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(UserPhotosStreamIdxTable.UserPhotosStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Multimap<UserPhotosStreamIdxTable.UserPhotosStreamIdxRow, UserPhotosStreamIdxTable.UserPhotosStreamIdxColumnValue> rowsInDb = usersIndex.getRowsMultimap(rows);
         Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.keySet().size());

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosMetadataCleanupTask.java
@@ -27,7 +27,7 @@ public class UserPhotosMetadataCleanupTask implements OnCleanupTask {
         UserPhotosStreamMetadataTable metaTable = tables.getUserPhotosStreamMetadataTable(t);
         Collection<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
         for (Cell cell : cells) {
-            rows.add(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow.of((Long) ValueType.VAR_LONG.convertToJava(cell.getRowName(), 0)));
+            rows.add(UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
         }
         Map<UserPhotosStreamMetadataTable.UserPhotosStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
         Set<Long> toDelete = Sets.newHashSet();


### PR DESCRIPTION
**Goals (and why)**: Properly deserialize rows from metadata and index tables on cleanup tasks. This is needed because the row can have two fields when the `.hashFirstRowComponents()` option is used.

The previous code issued deletes to wrong keys, not correctly deleting data.

**Implementation Description (bullets)**: Always `hydrateFromBytes` when deserializing.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2736)
<!-- Reviewable:end -->
