### PR TITLE
Clean up verbose exception logging in MetricsManager

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -92,9 +92,10 @@ public class MetricsManager {
                     + " themselves, or if you are trying to use multiple TransactionManagers concurrently in the same"
                     + " JVM (e.g. in a KVS migration). If this is not the case, this is likely to be a product and/or"
                     + " an AtlasDB bug. This is no cause for immediate alarm, but it does mean that your telemetry for"
-                    + " the aforementioned metric may be reported incorrectly.",
-                    SafeArg.of("metricName", fullyQualifiedMetricName),
-                    e);
+                    + " the aforementioned metric may be reported incorrectly. Turn on TRACE logging to see the full"
+                    + " exception.",
+                    SafeArg.of("metricName", fullyQualifiedMetricName));
+            log.trace("Full exception follows:", e);
         }
     }
 


### PR DESCRIPTION
Logging this exception when this fairly innocuous exception
is hit fills error logs with exceptions that can be easily
acted upon. So change this so the exception is only logged
at TRACE.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2743)
<!-- Reviewable:end -->
