### PR TITLE
Cleanup Requirements, Part 2: Computation from Schemas

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -42,6 +42,8 @@ public final class AtlasDbConstants {
     public static final TableReference DEFAULT_METADATA_TABLE = TableReference.createWithEmptyNamespace("_metadata");
     public static final TableReference DEFAULT_ORACLE_METADATA_TABLE = TableReference.createWithEmptyNamespace(
             "atlasdb_metadata");
+    public static final TableReference DEFAULT_SCHEMA_METADATA_TABLE = TableReference.createWithEmptyNamespace(
+            "_schema_metadata");
 
     public static final String PRIMARY_KEY_CONSTRAINT_PREFIX = "pk_";
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinition.java
@@ -37,6 +37,7 @@ public class StreamStoreDefinition {
     private final String longName;
     private final ValueType idType;
     private final boolean compressStream;
+    private final int numberOfRowComponentsHashed;
 
     private int inMemoryThreshold;
 
@@ -46,17 +47,27 @@ public class StreamStoreDefinition {
             String longName,
             ValueType idType,
             int inMemoryThreshold,
-            boolean compressStream) {
+            boolean compressStream,
+            int numberOfRowComponentsHashed) {
         this.streamStoreTables = streamStoreTables;
         this.shortName = shortName;
         this.longName = longName;
         this.idType = idType;
         this.inMemoryThreshold = inMemoryThreshold;
         this.compressStream = compressStream;
+        this.numberOfRowComponentsHashed = numberOfRowComponentsHashed;
     }
 
     public Map<String, TableDefinition> getTables() {
         return streamStoreTables;
+    }
+
+    public ValueType getIdType() {
+        return idType;
+    }
+
+    public int getNumberOfRowComponentsHashed() {
+        return numberOfRowComponentsHashed;
     }
 
     public StreamStoreRenderer getRenderer(String packageName, String name) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
@@ -33,6 +33,7 @@ public class StreamStoreDefinitionBuilder {
             Maps.newHashMapWithExpectedSize(StreamTableType.values().length);
     private int inMemoryThreshold = AtlasDbConstants.DEFAULT_STREAM_IN_MEMORY_THRESHOLD;
     private boolean compressStream;
+    private int numberOfRowComponentsHashed = 0;
 
     /**
      * @param shortName The prefix of the table names in the DB.
@@ -75,6 +76,7 @@ public class StreamStoreDefinitionBuilder {
                         + "StreamStore internal tables use at most two row components.");
         streamTables.forEach((tableName, streamTableBuilder) ->
                 streamTableBuilder.hashFirstNRowComponents(numberOfComponentsHashed));
+        numberOfRowComponentsHashed = numberOfComponentsHashed;
         return this;
     }
 
@@ -123,7 +125,8 @@ public class StreamStoreDefinitionBuilder {
                 longName,
                 valueType,
                 inMemoryThreshold,
-                compressStream);
+                compressStream,
+                numberOfRowComponentsHashed);
     }
 
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -44,11 +45,21 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
+import com.palantir.atlasdb.schema.ImmutableSchemaDependentTableMetadata;
+import com.palantir.atlasdb.schema.ImmutableSchemaMetadata;
+import com.palantir.atlasdb.schema.SchemaDependentTableMetadata;
+import com.palantir.atlasdb.schema.SchemaMetadata;
+import com.palantir.atlasdb.schema.cleanup.ArbitraryCleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.CleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.ImmutableStreamStoreCleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.NullCleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
 import com.palantir.atlasdb.schema.stream.StreamStoreDefinition;
 import com.palantir.atlasdb.table.description.IndexDefinition.IndexType;
 import com.palantir.atlasdb.table.description.render.StreamStoreRenderer;
@@ -77,7 +88,6 @@ public class Schema {
     private boolean ignoreTableNameLengthChecks = false;
 
     private final Multimap<String, Supplier<OnCleanupTask>> cleanupTasks = ArrayListMultimap.create();
-    private final Map<String, TableDefinition> tempTableDefinitions = Maps.newHashMap();
     private final Map<String, TableDefinition> tableDefinitions = Maps.newHashMap();
     private final Map<String, IndexDefinition> indexDefinitions = Maps.newHashMap();
     private final List<StreamStoreRenderer> streamStoreRenderers = Lists.newArrayList();
@@ -85,6 +95,10 @@ public class Schema {
     // N.B., the following is a list multimap because we want to preserve order
     // for code generation purposes.
     private final ListMultimap<String, String> indexesByTable = ArrayListMultimap.create();
+
+    // Used to determine cleanup metadata.
+    private final Set<String> tablesWithCustomCleanupTasks = Sets.newHashSet();
+    private final Map<String, StreamStoreCleanupMetadata> streamStoreCleanupMetadata = Maps.newHashMap();
 
     /** Creates a new schema, using Guava Optionals. */
     public Schema(Namespace namespace) {
@@ -193,6 +207,15 @@ public class Schema {
         StreamStoreRenderer renderer = streamStoreDefinition.getRenderer(packageName, name);
         Multimap<String, Supplier<OnCleanupTask>> streamStoreCleanupTasks = streamStoreDefinition.getCleanupTasks(
                 packageName, name, renderer, namespace);
+
+        StreamStoreCleanupMetadata metadata = ImmutableStreamStoreCleanupMetadata.builder()
+                .numHashedRowComponents(streamStoreDefinition.getNumberOfRowComponentsHashed())
+                .streamIdType(streamStoreDefinition.getIdType())
+                .build();
+        streamStoreDefinition.getTables().forEach(
+                (tableName, definition) -> {
+                    streamStoreCleanupMetadata.put(tableName, metadata);
+                });
 
         cleanupTasks.putAll(streamStoreCleanupTasks);
         streamStoreRenderers.add(renderer);
@@ -333,15 +356,6 @@ public class Schema {
                         tableRendererV2.getClassName(rawTableName, table));
             }
         }
-        for (Entry<String, TableDefinition> entry : tempTableDefinitions.entrySet()) {
-            String rawTableName = entry.getKey();
-            TableDefinition table = entry.getValue();
-            emit(srcDir,
-                 tableRenderer.render(rawTableName, table, ImmutableSortedSet.<IndexMetadata>of()),
-                 packageName,
-                 tableRenderer.getClassName(rawTableName, table));
-        }
-
         for (StreamStoreRenderer renderer : streamStoreRenderers) {
             emit(srcDir,
                  renderer.renderStreamStore(),
@@ -389,10 +403,11 @@ public class Schema {
     }
 
     public void addCleanupTask(String rawTableName, OnCleanupTask task) {
-        cleanupTasks.put(rawTableName, Suppliers.ofInstance(task));
+        addCleanupTask(rawTableName, Suppliers.ofInstance(task));
     }
 
     public void addCleanupTask(String rawTableName, Supplier<OnCleanupTask> task) {
+        tablesWithCustomCleanupTasks.add(rawTableName);
         cleanupTasks.put(rawTableName, task);
     }
 
@@ -406,5 +421,38 @@ public class Schema {
 
     public void ignoreTableNameLengthChecks() {
         ignoreTableNameLengthChecks = true;
+    }
+
+    public SchemaMetadata getSchemaMetadata() {
+        ImmutableSchemaMetadata.Builder builder = ImmutableSchemaMetadata.builder();
+
+        Map<TableReference, SchemaDependentTableMetadata> tableMetadatas =
+                Stream.of(tableDefinitions, indexDefinitions)
+                        .map(Map::keySet)
+                        .map(Set::stream)
+                        .flatMap(x -> x)
+                        .collect(Collectors.toMap(
+                                tableName -> TableReference.create(namespace, tableName),
+                                this::constructSchemaDependentTableMetadata));
+        builder.putAllSchemaDependentTableMetadata(tableMetadatas);
+
+        return builder.build();
+    }
+
+    private SchemaDependentTableMetadata constructSchemaDependentTableMetadata(String tableName) {
+        return ImmutableSchemaDependentTableMetadata.builder()
+                .cleanupMetadata(getCleanupMetadata(tableName))
+                .build();
+    }
+
+    private CleanupMetadata getCleanupMetadata(String tableName) {
+        if (!cleanupTasks.containsKey(tableName)) {
+            return new NullCleanupMetadata();
+        }
+        if (!tablesWithCustomCleanupTasks.contains(tableName) && streamStoreCleanupMetadata.containsKey(tableName)) {
+            // Stream store Index or Metadata table with no custom cleanup task.
+            return streamStoreCleanupMetadata.get(tableName);
+        }
+        return new ArbitraryCleanupMetadata();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
@@ -213,9 +213,7 @@ public class Schema {
                 .streamIdType(streamStoreDefinition.getIdType())
                 .build();
         streamStoreDefinition.getTables().forEach(
-                (tableName, definition) -> {
-                    streamStoreCleanupMetadata.put(tableName, metadata);
-                });
+                (tableName, definition) -> streamStoreCleanupMetadata.put(tableName, metadata));
 
         cleanupTasks.putAll(streamStoreCleanupTasks);
         streamStoreRenderers.add(renderer);
@@ -402,6 +400,7 @@ public class Schema {
         }
     }
 
+    // Cannot be removed, as it is used by the large internal product
     public void addCleanupTask(String rawTableName, OnCleanupTask task) {
         addCleanupTask(rawTableName, Suppliers.ofInstance(task));
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableDefinition.java
@@ -197,6 +197,12 @@ public class TableDefinition extends AbstractDefinition {
         ignoreHotspottingChecks = true;
     }
 
+    /**
+     * Returns the number of components to hash as a prefix to row keys.
+     */
+    public int getNumberOfComponentsHashed() {
+        return numberOfComponentsHashed;
+    }
 
     public void rowComponent(String componentName, ValueType valueType) {
         rowComponent(componentName, valueType, defaultNamedComponentLogSafety);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemaTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemaTest.java
@@ -204,14 +204,14 @@ public class SchemaTest {
     @Test
     public void simpleTablesHaveNullCleanupMetadata() {
         Schema schema = getSchemaWithSimpleTestTable();
-        assertOnCleanupMetadataInSchema(schema, TABLE_REF, NULL_CLEANUP_METADATA_ASSERTION);
+        assertCleanupMetadataInSchemaSatisfies(schema, TABLE_REF, NULL_CLEANUP_METADATA_ASSERTION);
     }
 
     @Test
     public void tablesWithCustomCleanupTaskHaveArbitraryCleanupMetadata() {
         Schema schema = getSchemaWithSimpleTestTable();
         schema.addCleanupTask(TEST_TABLE_NAME, () -> (tx, cells) -> false);
-        assertOnCleanupMetadataInSchema(schema, TABLE_REF, ARBITRARY_CLEANUP_METADATA_ASSERTION);
+        assertCleanupMetadataInSchemaSatisfies(schema, TABLE_REF, ARBITRARY_CLEANUP_METADATA_ASSERTION);
     }
 
     @Test
@@ -220,7 +220,7 @@ public class SchemaTest {
 
         addTestIndexDefinition(schema);
 
-        assertOnCleanupMetadataInSchema(schema, INDEX_TABLE_REF, NULL_CLEANUP_METADATA_ASSERTION);
+        assertCleanupMetadataInSchemaSatisfies(schema, INDEX_TABLE_REF, NULL_CLEANUP_METADATA_ASSERTION);
     }
 
     @Test
@@ -230,7 +230,7 @@ public class SchemaTest {
         addTestIndexDefinition(schema);
         schema.addCleanupTask(TEST_INDEX_NAME, () -> (tx, cells) -> false);
 
-        assertOnCleanupMetadataInSchema(schema, INDEX_TABLE_REF, ARBITRARY_CLEANUP_METADATA_ASSERTION);
+        assertCleanupMetadataInSchemaSatisfies(schema, INDEX_TABLE_REF, ARBITRARY_CLEANUP_METADATA_ASSERTION);
     }
 
     @Test
@@ -240,7 +240,7 @@ public class SchemaTest {
 
         addTestIndexDefinition(schema);
 
-        assertOnCleanupMetadataInSchema(schema, INDEX_TABLE_REF, NULL_CLEANUP_METADATA_ASSERTION);
+        assertCleanupMetadataInSchemaSatisfies(schema, INDEX_TABLE_REF, NULL_CLEANUP_METADATA_ASSERTION);
     }
 
     @Test
@@ -297,19 +297,19 @@ public class SchemaTest {
         schema.addCleanupTask(StreamTableType.HASH.getTableName(shortName), () -> (cells, tx) -> false);
         schema.addCleanupTask(StreamTableType.INDEX.getTableName(shortName), () -> (cells, tx) -> false);
 
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 StreamTableType.VALUE.getTableName(shortName),
                 NULL_CLEANUP_METADATA_ASSERTION);
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 StreamTableType.HASH.getTableName(shortName),
                 ARBITRARY_CLEANUP_METADATA_ASSERTION);
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 StreamTableType.METADATA.getTableName(shortName),
                 getStreamStoreMetadataAssertion(2, ValueType.VAR_SIGNED_LONG));
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 StreamTableType.INDEX.getTableName(shortName),
                 ARBITRARY_CLEANUP_METADATA_ASSERTION);
@@ -327,17 +327,17 @@ public class SchemaTest {
         schema.addIndexDefinition(TEST_TABLE_NAME, indexDefinition);
     }
 
-    private void assertOnCleanupMetadataInSchema(
+    private void assertCleanupMetadataInSchemaSatisfies(
             Schema schema,
             String tableName,
             Consumer<CleanupMetadata> verification) {
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 TableReference.create(Namespace.EMPTY_NAMESPACE, tableName),
                 verification);
     }
 
-    private void assertOnCleanupMetadataInSchema(
+    private void assertCleanupMetadataInSchemaSatisfies(
             Schema schema,
             TableReference tableReference,
             Consumer<CleanupMetadata> verification) {
@@ -352,19 +352,19 @@ public class SchemaTest {
             String streamStoreShortName,
             int numComponentsHashed,
             ValueType idType) {
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 StreamTableType.VALUE.getTableName(streamStoreShortName),
                 NULL_CLEANUP_METADATA_ASSERTION);
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 StreamTableType.HASH.getTableName(streamStoreShortName),
                 NULL_CLEANUP_METADATA_ASSERTION);
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 StreamTableType.METADATA.getTableName(streamStoreShortName),
                 getStreamStoreMetadataAssertion(numComponentsHashed, idType));
-        assertOnCleanupMetadataInSchema(
+        assertCleanupMetadataInSchemaSatisfies(
                 schema,
                 StreamTableType.INDEX.getTableName(streamStoreShortName),
                 getStreamStoreMetadataAssertion(numComponentsHashed, idType));

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemaTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemaTest.java
@@ -247,7 +247,7 @@ public class SchemaTest {
     public void streamStoreMetadataGeneratedCorrectlyForSimpleStreamStore() {
         Schema schema = new Schema("Table", TEST_PACKAGE, Namespace.EMPTY_NAMESPACE);
         String shortName = "f";
-        String longName = "floccinaucinihilipilification";
+        String longName = "Floccinaucinihilipilification";
 
         schema.addStreamStoreDefinition(
                 new StreamStoreDefinitionBuilder(shortName, longName, ValueType.VAR_LONG)
@@ -260,7 +260,7 @@ public class SchemaTest {
     public void streamStoreMetadataGeneratedCorrectlyForStreamStoreWithHashFirstRowComponent() {
         Schema schema = new Schema("Table", TEST_PACKAGE, Namespace.EMPTY_NAMESPACE);
         String shortName = "a";
-        String longName = "antidisestablishmentarianism";
+        String longName = "Antidisestablishmentarianism";
 
         schema.addStreamStoreDefinition(
                 new StreamStoreDefinitionBuilder(shortName, longName, ValueType.FIXED_LONG)
@@ -274,7 +274,7 @@ public class SchemaTest {
     public void streamStoreMetadataGeneratedCorrectlyForStreamStoreWithHashRowComponents() {
         Schema schema = new Schema("Table", TEST_PACKAGE, Namespace.EMPTY_NAMESPACE);
         String shortName = "p";
-        String longName = "pneumonoultramicroscopicsilicovolcanoconiosis";
+        String longName = "Pneumonoultramicroscopicsilicovolcanoconiosis";
 
         schema.addStreamStoreDefinition(
                 new StreamStoreDefinitionBuilder(shortName, longName, ValueType.FIXED_LONG_LITTLE_ENDIAN)
@@ -288,7 +288,7 @@ public class SchemaTest {
     public void streamStoreTablesSupportAdditionalCleanupTasks() {
         Schema schema = new Schema("Table", TEST_PACKAGE, Namespace.EMPTY_NAMESPACE);
         String shortName = "l";
-        String longName = "llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch";
+        String longName = "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch";
 
         schema.addStreamStoreDefinition(
                 new StreamStoreDefinitionBuilder(shortName, longName, ValueType.VAR_SIGNED_LONG)


### PR DESCRIPTION
**Goals (and why)**:
- Determine the cleanup requirements for tables automatically from a schema definition. Part of broader Sweep work.

**Implementation Description (bullets)**:
- Compute the cleanup requirements from schemas. We don't use the special-cased stream store yet. Basically, if a user puts an *unspecified* cleanup task (or one specified as SYNC) we return SYNC; if a user puts a known ASYNC task we return ASYNC; if a table is a StreamStore metadata or index table then we return ASYNC (unless the user also added a SYNC task); otherwise we return NONE.

**Concerns (what feedback would you like?)**:
- Don't really like relying on the ordering of the enum
- Is the logic for addition correct? 

**Where should we start reviewing?**: `Schema.java`, though really most of this not-large PR is tests.

**Priority (whenever / two weeks / yesterday)**: this week?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2747)
<!-- Reviewable:end -->
