### PR TITLE
Cleanup Requirements, Part 3: Schema Metadata Service

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -83,7 +83,8 @@ public final class AtlasDbConstants {
             NAMESPACE_TABLE,
             PARTITION_MAP_TABLE,
             PERSISTED_LOCKS_TABLE,
-            SWEEP_PROGRESS_TABLE);
+            SWEEP_PROGRESS_TABLE,
+            DEFAULT_SCHEMA_METADATA_TABLE);
 
     /**
      * Tables that must always be on a KVS that supports an atomic putUnlessExists operation.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SchemaMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SchemaMetadata.java
@@ -64,7 +64,9 @@ public abstract class SchemaMetadata implements Persistable {
         message.getTableMetadataList()
                 .forEach(entry -> builder.putSchemaDependentTableMetadata(
                         TableReference.create(
-                                Namespace.create(entry.getTableReference().getNamespace()),
+                                entry.getTableReference().getNamespace().isEmpty() ?
+                                        Namespace.EMPTY_NAMESPACE :
+                                        Namespace.create(entry.getTableReference().getNamespace()),
                                 entry.getTableReference().getTableName()),
                         SchemaDependentTableMetadata.hydrateFromProto(entry.getSchemaDependentTableMetadata())));
         return builder.build();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
@@ -122,6 +122,10 @@ public class Schema {
         this.optionalType = optionalType;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public void addTableDefinition(String tableName, TableDefinition definition) {
         Preconditions.checkArgument(
                 !tableDefinitions.containsKey(tableName) && !indexDefinitions.containsKey(tableName),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -242,7 +242,8 @@ public abstract class TransactionManagers {
         kvs = AtlasDbMetrics.instrument(KeyValueService.class, kvs, MetricRegistry.name(KeyValueService.class));
         kvs = ValidatingQueryRewritingKeyValueService.create(kvs);
 
-        SchemaMetadataService schemaMetadataService = SchemaMetadataServiceImpl.create(kvs, config.initializeAsync());
+        SchemaMetadataService schemaMetadataService = SchemaMetadataServiceImpl.create(rawKvs,
+                config.initializeAsync());
         TransactionManagersInitializer initializer = TransactionManagersInitializer.createInitialTables(
                 kvs,
                 schemas(),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -75,6 +75,8 @@ import com.palantir.atlasdb.qos.client.AtlasDbQosClient;
 import com.palantir.atlasdb.qos.config.QosClientConfig;
 import com.palantir.atlasdb.qos.ratelimit.QosRateLimiters;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
+import com.palantir.atlasdb.schema.metadata.SchemaMetadataService;
+import com.palantir.atlasdb.schema.metadata.SchemaMetadataServiceImpl;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.sweep.AdjustableSweepBatchConfigSource;
@@ -240,9 +242,11 @@ public abstract class TransactionManagers {
         kvs = AtlasDbMetrics.instrument(KeyValueService.class, kvs, MetricRegistry.name(KeyValueService.class));
         kvs = ValidatingQueryRewritingKeyValueService.create(kvs);
 
+        SchemaMetadataService schemaMetadataService = SchemaMetadataServiceImpl.create(kvs, config.initializeAsync());
         TransactionManagersInitializer initializer = TransactionManagersInitializer.createInitialTables(
                 kvs,
                 schemas(),
+                schemaMetadataService,
                 config.initializeAsync());
         PersistentLockService persistentLockService = createAndRegisterPersistentLockService(
                 kvs,

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -40,6 +40,7 @@ dependencies {
   testCompile group: 'org.assertj', name: 'assertj-core'
   testCompile group: 'org.mockito', name: 'mockito-core'
   testCompile group: 'org.hamcrest', name: 'hamcrest-library'
+  testCompile group: 'org.awaitility', name: 'awaitility'
 
   testRuntime group: 'ch.qos.logback', name: 'logback-classic'
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
@@ -22,13 +22,40 @@ import java.util.Optional;
 import com.palantir.atlasdb.schema.SchemaMetadata;
 
 public interface SchemaMetadataService {
+    /**
+     * Returns {@link SchemaMetadata} for the given schema name, provided the service knows it exists.
+     *
+     * @param schemaName name of schema to load metadata for
+     * @return Schema metadata for the given schema name (if present)
+     */
     Optional<SchemaMetadata> loadSchemaMetadata(String schemaName);
 
+    /**
+     * Stores {@link SchemaMetadata} for the given schema.
+     *
+     * @param schemaName name of schema to store metadata for
+     * @param schemaMetadata schema metadata to be stored
+     */
     void putSchemaMetadata(String schemaName, SchemaMetadata schemaMetadata);
 
+    /**
+     * Returns {@link SchemaMetadata} for all schemas known by this service.
+     * This query may be costly on some implementations if many schemas are present.
+     *
+     * @return Map of Schema Name to Schema Metadata for the relevant schema
+     */
     Map<String, SchemaMetadata> getAllSchemaMetadata();
 
+    /**
+     * Removes {@link SchemaMetadata} for the given schema name, provided it exists.
+     * This method is idempotent - it will not throw even if the provided schema name does not exist in this service.
+     *
+     * @param schemaName name of schema to delete metadata for
+     */
     void decommissionSchema(String schemaName);
 
+    /**
+     * @return true iff the Schema Metadata Service has completed initialization and is prepared to service requests
+     */
     boolean isInitialized();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
@@ -55,6 +55,13 @@ public interface SchemaMetadataService {
     void deleteSchemaMetadata(String schemaName);
 
     /**
+     * Returns true if and only if the Schema Metadata Service has completed its initialization, and is prepared
+     * to service requests.
+     *
+     * Note that this does not guarantee that requests can actually be serviced. For example, if the schema metadata
+     * service was able to start but then the key value service became unavailable, calls to other methods will
+     * still fail even though this method can return true.
+     *
      * @return true iff the Schema Metadata Service has completed initialization and is prepared to service requests
      */
     boolean isInitialized();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
@@ -17,15 +17,16 @@
 package com.palantir.atlasdb.schema.metadata;
 
 import java.util.Map;
+import java.util.Optional;
 
 import com.palantir.atlasdb.schema.SchemaMetadata;
 
 public interface SchemaMetadataService {
-    SchemaMetadata loadSchemaMetadata(String schemaName);
+    Optional<SchemaMetadata> loadSchemaMetadata(String schemaName);
 
     void putSchemaMetadata(String schemaName, SchemaMetadata schemaMetadata);
 
-    Map<String, SchemaMetadata> getAllSchemaMetadata(String schemaName);
+    Map<String, SchemaMetadata> getAllSchemaMetadata();
 
     void decommissionSchema(String schemaName);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
@@ -52,7 +52,7 @@ public interface SchemaMetadataService {
      *
      * @param schemaName name of schema to delete metadata for
      */
-    void decommissionSchema(String schemaName);
+    void deleteSchemaMetadata(String schemaName);
 
     /**
      * @return true iff the Schema Metadata Service has completed initialization and is prepared to service requests

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.metadata;
+
+import java.util.Map;
+
+import com.palantir.atlasdb.schema.SchemaMetadata;
+
+public interface SchemaMetadataService {
+    SchemaMetadata loadSchemaMetadata(String schemaName);
+
+    void putSchemaMetadata(String schemaName, SchemaMetadata schemaMetadata);
+
+    Map<String, SchemaMetadata> getAllSchemaMetadata(String schemaName);
+
+    void decommissionSchema(String schemaName);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataService.java
@@ -29,4 +29,6 @@ public interface SchemaMetadataService {
     Map<String, SchemaMetadata> getAllSchemaMetadata();
 
     void decommissionSchema(String schemaName);
+
+    boolean isInitialized();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
@@ -133,7 +133,7 @@ public final class SchemaMetadataServiceImpl implements SchemaMetadataService {
     }
 
     @Override
-    public void decommissionSchema(String schemaName) {
+    public void deleteSchemaMetadata(String schemaName) {
         keyValueService.delete(AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
                 ImmutableMultimap.of(createCellForGivenSchemaName(schemaName), 0L));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
@@ -136,6 +136,11 @@ public class SchemaMetadataServiceImpl implements SchemaMetadataService {
                 ImmutableMultimap.of(createCellForGivenSchemaName(schemaName), 0L));
     }
 
+    @Override
+    public boolean isInitialized() {
+        return keyValueService.isInitialized();
+    }
+
     private Cell createCellForGivenSchemaName(String schemaName) {
         return Cell.create(PtBytes.toBytes(schemaName), COLUMN_NAME);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.metadata;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Iterables;
+import com.palantir.async.initializer.AsyncInitializer;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.schema.ImmutableSchemaMetadata;
+import com.palantir.atlasdb.schema.SchemaMetadata;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.processors.AutoDelegate;
+
+@AutoDelegate(typeToExtend = SchemaMetadataService.class)
+public class SchemaMetadataServiceImpl implements SchemaMetadataService {
+    @VisibleForTesting
+    class InitializingWrapper extends AsyncInitializer implements AutoDelegate_SchemaMetadataService {
+        @Override
+        public SchemaMetadataService delegate() {
+            checkInitialized();
+            return SchemaMetadataServiceImpl.this;
+        }
+
+        @Override
+        protected void tryInitialize() {
+            SchemaMetadataServiceImpl.this.tryInitialize();
+        }
+
+        @Override
+        protected String getInitializingClassName() {
+            return SchemaMetadataService.class.getSimpleName();
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(SchemaMetadataServiceImpl.class);
+
+    private static final long QUERY_TIMESTAMP = 1L;
+    private static final byte[] COLUMN_NAME = PtBytes.toBytes("m");
+
+    private final KeyValueService keyValueService;
+    private final InitializingWrapper wrapper = new InitializingWrapper();
+
+    private SchemaMetadataServiceImpl(KeyValueService keyValueService) {
+        this.keyValueService = keyValueService;
+    }
+
+    public static SchemaMetadataService create(KeyValueService keyValueService, boolean initializeAsync) {
+        SchemaMetadataServiceImpl metadataService = new SchemaMetadataServiceImpl(keyValueService);
+        metadataService.wrapper.initialize(initializeAsync);
+        return metadataService.wrapper.isInitialized() ? metadataService : metadataService.wrapper;
+    }
+
+    protected void initialize(boolean asyncInitialize) {
+        wrapper.initialize(asyncInitialize);
+    }
+
+    private void tryInitialize() {
+        keyValueService.createTable(
+                AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);
+    }
+
+    @Override
+    public SchemaMetadata loadSchemaMetadata(String schemaName) {
+        return loadMetadataCellFromKeyValueService(schemaName)
+                .map(SchemaMetadata.HYDRATOR::hydrateFromBytes)
+                .orElse(ImmutableSchemaMetadata.builder().build());
+    }
+
+    @Override
+    public void putSchemaMetadata(String schemaName, SchemaMetadata schemaMetadata) {
+        byte[] serializedMetadata = schemaMetadata.persistToBytes();
+        while (!Thread.currentThread().isInterrupted()) {
+            Optional<byte[]> existingMetadata = loadMetadataCellFromKeyValueService(schemaName);
+            CheckAndSetRequest request = existingMetadata.map(existingData -> CheckAndSetRequest.singleCell(
+                    AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
+                    createCellForGivenSchemaName(schemaName),
+                    existingData,
+                    serializedMetadata))
+                    .orElse(CheckAndSetRequest.newCell(
+                            AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
+                            createCellForGivenSchemaName(schemaName),
+                            serializedMetadata));
+            try {
+                keyValueService.checkAndSet(request);
+                return;
+            } catch (CheckAndSetException e) {
+                log.info("Failed to update the schema metadata: {}. Retrying.",
+                        UnsafeArg.of("attemptedUpdate", request));
+            }
+        }
+    }
+
+    @Override
+    public Map<String, SchemaMetadata> getAllSchemaMetadata(String schemaName) {
+        // RangeRequest here is ok as the table is small
+        return keyValueService.getRange(AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
+                RangeRequest.all(),
+                QUERY_TIMESTAMP).stream()
+                .collect(Collectors.toMap(
+                        result -> PtBytes.toString(result.getRowName()),
+                        result -> SchemaMetadata.HYDRATOR.hydrateFromBytes(result.getOnlyColumnValue().getContents())
+                ));
+    }
+
+    @Override
+    public void decommissionSchema(String schemaName) {
+        keyValueService.delete(AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
+                ImmutableMultimap.of(createCellForGivenSchemaName(schemaName), QUERY_TIMESTAMP));
+    }
+
+    private Cell createCellForGivenSchemaName(String schemaName) {
+        return Cell.create(PtBytes.toBytes(schemaName), COLUMN_NAME);
+    }
+
+    private Optional<byte[]> loadMetadataCellFromKeyValueService(String schemaName) {
+        Map<Cell, Value> kvsData = keyValueService.get(AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
+                ImmutableMap.of(createCellForGivenSchemaName(schemaName), QUERY_TIMESTAMP));
+        return kvsData.isEmpty() ?
+                Optional.empty() :
+                Optional.of(Iterables.getOnlyElement(kvsData.values()).getContents());
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
@@ -41,7 +41,7 @@ import com.palantir.logsafe.UnsafeArg;
 import com.palantir.processors.AutoDelegate;
 
 @AutoDelegate(typeToExtend = SchemaMetadataService.class)
-public class SchemaMetadataServiceImpl implements SchemaMetadataService {
+public final class SchemaMetadataServiceImpl implements SchemaMetadataService {
     @VisibleForTesting
     class InitializingWrapper extends AsyncInitializer implements AutoDelegate_SchemaMetadataService {
         @Override
@@ -150,8 +150,8 @@ public class SchemaMetadataServiceImpl implements SchemaMetadataService {
     private Optional<byte[]> loadMetadataCellFromKeyValueService(String schemaName) {
         Map<Cell, Value> kvsData = keyValueService.get(AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
                 ImmutableMap.of(createCellForGivenSchemaName(schemaName), QUERY_TIMESTAMP));
-        return kvsData.isEmpty() ?
-                Optional.empty() :
-                Optional.of(Iterables.getOnlyElement(kvsData.values()).getContents());
+        return kvsData.isEmpty()
+                ? Optional.empty()
+                : Optional.of(Iterables.getOnlyElement(kvsData.values()).getContents());
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
@@ -36,7 +36,6 @@ import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.schema.ImmutableSchemaMetadata;
 import com.palantir.atlasdb.schema.SchemaMetadata;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.processors.AutoDelegate;
@@ -90,10 +89,9 @@ public class SchemaMetadataServiceImpl implements SchemaMetadataService {
     }
 
     @Override
-    public SchemaMetadata loadSchemaMetadata(String schemaName) {
+    public Optional<SchemaMetadata> loadSchemaMetadata(String schemaName) {
         return loadMetadataCellFromKeyValueService(schemaName)
-                .map(SchemaMetadata.HYDRATOR::hydrateFromBytes)
-                .orElse(ImmutableSchemaMetadata.builder().build());
+                .map(SchemaMetadata.HYDRATOR::hydrateFromBytes);
     }
 
     @Override
@@ -121,7 +119,7 @@ public class SchemaMetadataServiceImpl implements SchemaMetadataService {
     }
 
     @Override
-    public Map<String, SchemaMetadata> getAllSchemaMetadata(String schemaName) {
+    public Map<String, SchemaMetadata> getAllSchemaMetadata() {
         // RangeRequest here is ok as the table is small
         return keyValueService.getRange(AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
                 RangeRequest.all(),
@@ -135,7 +133,7 @@ public class SchemaMetadataServiceImpl implements SchemaMetadataService {
     @Override
     public void decommissionSchema(String schemaName) {
         keyValueService.delete(AtlasDbConstants.DEFAULT_SCHEMA_METADATA_TABLE,
-                ImmutableMultimap.of(createCellForGivenSchemaName(schemaName), QUERY_TIMESTAMP));
+                ImmutableMultimap.of(createCellForGivenSchemaName(schemaName), 0L));
     }
 
     private Cell createCellForGivenSchemaName(String schemaName) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/schema/metadata/SchemaMetadataServiceImpl.java
@@ -110,6 +110,8 @@ public class SchemaMetadataServiceImpl implements SchemaMetadataService {
                             serializedMetadata));
             try {
                 keyValueService.checkAndSet(request);
+                log.info("Successfully updated the schema metadata to {}.",
+                        UnsafeArg.of("committedUpdate", request));
                 return;
             } catch (CheckAndSetException e) {
                 log.info("Failed to update the schema metadata: {}. Retrying.",

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/metadata/SchemaMetadataServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/metadata/SchemaMetadataServiceImplTest.java
@@ -50,7 +50,7 @@ public class SchemaMetadataServiceImplTest {
             ImmutableSchemaMetadata.builder().putSchemaDependentTableMetadata(
                     TableReference.create(Namespace.EMPTY_NAMESPACE, "tableOne"),
                     ImmutableSchemaDependentTableMetadata.builder().cleanupRequirement(
-                            SchemaMetadataPersistence.CleanupRequirement.ARBITRARY_SYNC).build()).build();
+                            SchemaMetadataPersistence.CleanupRequirement.NOT_NEEDED).build()).build();
 
     private final String SCHEMA_NAME_TWO = "two";
     private final SchemaMetadata SCHEMA_METADATA_TWO =

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/metadata/SchemaMetadataServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/metadata/SchemaMetadataServiceImplTest.java
@@ -33,12 +33,14 @@ import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.ForwardingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
-import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
 import com.palantir.atlasdb.schema.ImmutableSchemaDependentTableMetadata;
 import com.palantir.atlasdb.schema.ImmutableSchemaMetadata;
 import com.palantir.atlasdb.schema.SchemaMetadata;
+import com.palantir.atlasdb.schema.cleanup.ImmutableStreamStoreCleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.NullCleanupMetadata;
 import com.palantir.atlasdb.schema.metadata.SchemaMetadataService;
 import com.palantir.atlasdb.schema.metadata.SchemaMetadataServiceImpl;
+import com.palantir.atlasdb.table.description.ValueType;
 
 public class SchemaMetadataServiceImplTest {
     private final SchemaMetadataService SCHEMA_METADATA_SERVICE = SchemaMetadataServiceImpl.create(
@@ -49,15 +51,17 @@ public class SchemaMetadataServiceImplTest {
     private final SchemaMetadata SCHEMA_METADATA_ONE =
             ImmutableSchemaMetadata.builder().putSchemaDependentTableMetadata(
                     TableReference.create(Namespace.EMPTY_NAMESPACE, "tableOne"),
-                    ImmutableSchemaDependentTableMetadata.builder().cleanupRequirement(
-                            SchemaMetadataPersistence.CleanupRequirement.NOT_NEEDED).build()).build();
+                    ImmutableSchemaDependentTableMetadata.builder().cleanupMetadata(new NullCleanupMetadata()).build()).build();
 
     private final String SCHEMA_NAME_TWO = "two";
     private final SchemaMetadata SCHEMA_METADATA_TWO =
             ImmutableSchemaMetadata.builder().putSchemaDependentTableMetadata(
                     TableReference.create(Namespace.EMPTY_NAMESPACE, "tableTwo"),
-                    ImmutableSchemaDependentTableMetadata.builder().cleanupRequirement(
-                            SchemaMetadataPersistence.CleanupRequirement.ARBITRARY_ASYNC).build()).build();
+                    ImmutableSchemaDependentTableMetadata.builder().cleanupMetadata(
+                            ImmutableStreamStoreCleanupMetadata.builder()
+                                    .numHashedRowComponents(1)
+                                    .streamIdType(ValueType.VAR_LONG)
+                                    .build()).build()).build();
 
     @Test
     public void retrievesStoredMetadata() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/metadata/SchemaMetadataServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/metadata/SchemaMetadataServiceImplTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
+import com.palantir.atlasdb.schema.ImmutableSchemaDependentTableMetadata;
+import com.palantir.atlasdb.schema.ImmutableSchemaMetadata;
+import com.palantir.atlasdb.schema.SchemaMetadata;
+import com.palantir.atlasdb.schema.metadata.SchemaMetadataService;
+import com.palantir.atlasdb.schema.metadata.SchemaMetadataServiceImpl;
+
+public class SchemaMetadataServiceImplTest {
+    private final SchemaMetadataService SCHEMA_METADATA_SERVICE = SchemaMetadataServiceImpl.create(
+            new InMemoryKeyValueService(true),
+            false);
+
+    private final String SCHEMA_NAME_ONE = "one";
+    private final SchemaMetadata SCHEMA_METADATA_ONE =
+            ImmutableSchemaMetadata.builder().putSchemaDependentTableMetadata(
+                    TableReference.create(Namespace.EMPTY_NAMESPACE, "tableOne"),
+                    ImmutableSchemaDependentTableMetadata.builder().cleanupRequirement(
+                            SchemaMetadataPersistence.CleanupRequirement.ARBITRARY_SYNC).build()).build();
+
+    private final String SCHEMA_NAME_TWO = "two";
+    private final SchemaMetadata SCHEMA_METADATA_TWO =
+            ImmutableSchemaMetadata.builder().putSchemaDependentTableMetadata(
+                    TableReference.create(Namespace.EMPTY_NAMESPACE, "tableTwo"),
+                    ImmutableSchemaDependentTableMetadata.builder().cleanupRequirement(
+                            SchemaMetadataPersistence.CleanupRequirement.ARBITRARY_ASYNC).build()).build();
+
+    @Test
+    public void retrievesStoredMetadata() {
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE);
+        assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata(SCHEMA_NAME_ONE)).contains(SCHEMA_METADATA_ONE);
+    }
+
+    @Test
+    public void returnsOptionalIfNoMetadataPresent() {
+        assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata("should not exist")).isEmpty();
+    }
+
+    @Test
+    public void overwritesPreviouslyStoredMetadata() {
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE);
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_TWO);
+        assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata(SCHEMA_NAME_ONE)).contains(SCHEMA_METADATA_TWO);
+    }
+
+    @Test
+    public void storesDistinctMetadataForDifferentSchemas() {
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE);
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_TWO, SCHEMA_METADATA_TWO);
+        assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata(SCHEMA_NAME_ONE)).contains(SCHEMA_METADATA_ONE);
+        assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata(SCHEMA_NAME_TWO)).contains(SCHEMA_METADATA_TWO);
+    }
+
+    @Test
+    public void getAllMetadataReturnsKnownPairs() {
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE);
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_TWO, SCHEMA_METADATA_TWO);
+
+        Map<String, SchemaMetadata> expected = ImmutableMap.of(
+                SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE, SCHEMA_NAME_TWO, SCHEMA_METADATA_TWO);
+        assertThat(SCHEMA_METADATA_SERVICE.getAllSchemaMetadata()).isEqualTo(expected);
+    }
+
+    @Test
+    public void getAllMetadataReturnsNothingIfNoDataKnown() {
+        assertThat(SCHEMA_METADATA_SERVICE.getAllSchemaMetadata()).isEmpty();
+    }
+
+    @Test
+    public void canDecommissionSchema() {
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE);
+        SCHEMA_METADATA_SERVICE.decommissionSchema(SCHEMA_NAME_ONE);
+        assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata(SCHEMA_NAME_ONE)).isEmpty();
+    }
+
+    @Test
+    public void canDecommissionAndRecommissionSchema() {
+        IntStream.range(0, 10)
+                .forEach(index -> {
+                    SchemaMetadata metadataToPut = index % 2 == 0 ? SCHEMA_METADATA_ONE : SCHEMA_METADATA_TWO;
+                    SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_ONE, metadataToPut);
+                    assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata(SCHEMA_NAME_ONE))
+                            .contains(metadataToPut);
+                    SCHEMA_METADATA_SERVICE.decommissionSchema(SCHEMA_NAME_ONE);
+                    assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata(SCHEMA_NAME_ONE)).isEmpty();
+                });
+    }
+
+    @Test
+    public void canDecommissionSchemaThatIsNotPresent() {
+        SCHEMA_METADATA_SERVICE.decommissionSchema("should not exist");
+        // pass
+    }
+
+    @Test
+    public void decommissionIsIdempotent() {
+        SCHEMA_METADATA_SERVICE.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE);
+        SCHEMA_METADATA_SERVICE.decommissionSchema(SCHEMA_NAME_ONE);
+        SCHEMA_METADATA_SERVICE.decommissionSchema(SCHEMA_NAME_ONE);
+        assertThat(SCHEMA_METADATA_SERVICE.loadSchemaMetadata(SCHEMA_NAME_ONE)).isEmpty();
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/metadata/SchemaMetadataServiceImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/metadata/SchemaMetadataServiceImplTest.java
@@ -108,36 +108,36 @@ public class SchemaMetadataServiceImplTest {
     }
 
     @Test
-    public void canDecommissionSchema() {
+    public void canDeleteSchemaMetadata() {
         schemaMetadataService.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE);
-        schemaMetadataService.decommissionSchema(SCHEMA_NAME_ONE);
+        schemaMetadataService.deleteSchemaMetadata(SCHEMA_NAME_ONE);
         assertThat(schemaMetadataService.loadSchemaMetadata(SCHEMA_NAME_ONE)).isEmpty();
     }
 
     @Test
-    public void canDecommissionAndRecommissionSchema() {
+    public void canDeleteAndRestoreSchemaMetadata() {
         IntStream.range(0, 10)
                 .forEach(index -> {
                     SchemaMetadata metadataToPut = index % 2 == 0 ? SCHEMA_METADATA_ONE : SCHEMA_METADATA_TWO;
                     schemaMetadataService.putSchemaMetadata(SCHEMA_NAME_ONE, metadataToPut);
                     assertThat(schemaMetadataService.loadSchemaMetadata(SCHEMA_NAME_ONE))
                             .contains(metadataToPut);
-                    schemaMetadataService.decommissionSchema(SCHEMA_NAME_ONE);
+                    schemaMetadataService.deleteSchemaMetadata(SCHEMA_NAME_ONE);
                     assertThat(schemaMetadataService.loadSchemaMetadata(SCHEMA_NAME_ONE)).isEmpty();
                 });
     }
 
     @Test
-    public void canDecommissionSchemaThatIsNotPresent() {
-        schemaMetadataService.decommissionSchema("should not exist");
+    public void canDeleteSchemaMetadataThatIsNotPresent() {
+        schemaMetadataService.deleteSchemaMetadata("should not exist");
         // pass
     }
 
     @Test
-    public void decommissionIsIdempotent() {
+    public void deleteIsIdempotent() {
         schemaMetadataService.putSchemaMetadata(SCHEMA_NAME_ONE, SCHEMA_METADATA_ONE);
-        schemaMetadataService.decommissionSchema(SCHEMA_NAME_ONE);
-        schemaMetadataService.decommissionSchema(SCHEMA_NAME_ONE);
+        schemaMetadataService.deleteSchemaMetadata(SCHEMA_NAME_ONE);
+        schemaMetadataService.deleteSchemaMetadata(SCHEMA_NAME_ONE);
         assertThat(schemaMetadataService.loadSchemaMetadata(SCHEMA_NAME_ONE)).isEmpty();
     }
 


### PR DESCRIPTION
**Goals (and why)**:
- Provide an interface for actually storing metadata about a schema, which will eventually be readable by an external service.
- Support async initialization, since this depends on the underlying KVS.

**Implementation Description (bullets)**:
- The "schema" for this service (which uses a table backed by check and set) uses the schema name as its row name, and stores a serialized protobuf of the metadata.
- The service delegates to the appropriate calls on the raw KVS.

**Concerns (what feedback would you like?)**:
- Pitfalls with concurrency / if nodes disagree on schemas would be the main concerns here.
- Is exposing `getName()` on a schema a bad thing?
- What if we have schemas that have name clashes being registered at the same time?

**Where should we start reviewing?**: `SchemaMetadataService` and its tests.

**Priority (whenever / two weeks / yesterday)**: tail end of this week?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2748)
<!-- Reviewable:end -->
