### PR TITLE
Nziebart/fix compression block size

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
@@ -78,11 +78,10 @@ public class StreamStoreDefinitionBuilder {
     }
 
     /**
-     * For Cassandra, this increases the sstable compression block size (which correspondingly increases the minimum
-     * amount of bytes that must be read from disk for any read). This increases the efficiency of database-side
-     * compression. However, it's recommended to use {@link #compressStreamInClient()} instead, because that will
-     * compress before sending the data over the network to Cassandra.
+     * @deprecated use {@link #compressStreamInClient()} instead, because that will compress before sending the data
+     * over the network to Cassandra.
      */
+    @Deprecated
     public StreamStoreDefinitionBuilder compressBlocksInDb() {
         streamTables.forEach((tableName, streamTableBuilder) -> streamTableBuilder.compressBlocksInDb());
         return this;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
@@ -77,6 +77,12 @@ public class StreamStoreDefinitionBuilder {
         return this;
     }
 
+    /**
+     * For Cassandra, this increases the sstable compression block size (which correspondingly increases the minimum
+     * amount of bytes that must be read from disk for any read). This increases the efficiency of database-side
+     * compression. However, it's recommended to use {@link #compressStreamInClient()} instead, because that will
+     * compress before sending the data over the network to Cassandra.
+     */
     public StreamStoreDefinitionBuilder compressBlocksInDb() {
         streamTables.forEach((tableName, streamTableBuilder) -> streamTableBuilder.compressBlocksInDb());
         return this;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableDefinitionBuilder.java
@@ -159,7 +159,8 @@ public class StreamTableDefinitionBuilder {
                 }
                 if (dbSideCompressionForBlocks) {
                     int streamStoreValueSizeKB = GenericStreamStore.BLOCK_SIZE_IN_BYTES / 1_000;
-                    int compressionBlockSizeKB = highestPowerOfTwoLessThanOrEqualTo(streamStoreValueSizeKB / 2);
+                    int expectedAverageValueSizeKB = streamStoreValueSizeKB / 2;
+                    int compressionBlockSizeKB = highestPowerOfTwoLessThanOrEqualTo(expectedAverageValueSizeKB);
                     explicitCompressionBlockSizeKB(compressionBlockSizeKB);
                 }
                 ignoreHotspottingChecks();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableDefinitionBuilder.java
@@ -142,30 +142,28 @@ public class StreamTableDefinitionBuilder {
             }};
 
         case VALUE:
-            return new TableDefinition() {
-                {
-                    javaTableName(streamTableType.getJavaClassName(prefix));
-                    rowName();
+            return new TableDefinition() {{
+                javaTableName(streamTableType.getJavaClassName(prefix));
+                rowName();
                     hashFirstNRowComponents(numberOfComponentsHashed);
-                    rowComponent("id", idType);
-                    rowComponent("block_id", ValueType.VAR_LONG);
-                    columns();
-                    column("value", "v", ValueType.BLOB);
-                    conflictHandler(ConflictHandler.IGNORE_ALL);
-                    maxValueSize(GenericStreamStore.BLOCK_SIZE_IN_BYTES);
-                    cachePriority(CachePriority.COLD);
-                    expirationStrategy(expirationStrategy);
-                    if (appendHeavyAndReadLight) {
-                        appendHeavyAndReadLight();
-                    }
-                    if (dbSideCompressionForBlocks) {
-                        int streamStoreValueSizeKB = GenericStreamStore.BLOCK_SIZE_IN_BYTES / 1_000;
-                        int compressionBlockSizeKB = highestPowerOfTwoLessThanOrEqualTo(streamStoreValueSizeKB / 2);
-                        explicitCompressionBlockSizeKB(compressionBlockSizeKB);
-                    }
-                    ignoreHotspottingChecks();
+                    rowComponent("id",              idType);
+                    rowComponent("block_id",        ValueType.VAR_LONG);
+                columns();
+                    column("value", "v",            ValueType.BLOB);
+                conflictHandler(ConflictHandler.IGNORE_ALL);
+                maxValueSize(GenericStreamStore.BLOCK_SIZE_IN_BYTES);
+                cachePriority(CachePriority.COLD);
+                expirationStrategy(expirationStrategy);
+                if (appendHeavyAndReadLight) {
+                    appendHeavyAndReadLight();
                 }
-            };
+                if (dbSideCompressionForBlocks) {
+                    int streamStoreValueSizeKB = GenericStreamStore.BLOCK_SIZE_IN_BYTES / 1_000;
+                    int compressionBlockSizeKB = highestPowerOfTwoLessThanOrEqualTo(streamStoreValueSizeKB / 2);
+                    explicitCompressionBlockSizeKB(compressionBlockSizeKB);
+                }
+                ignoreHotspottingChecks();
+            }};
 
         default:
             throw new IllegalStateException("Incorrectly supplied stream table type");

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -62,6 +62,11 @@ develop
            ``TransactionManagers.config().userAgent().metricRegistry().taggedMetricRegistry()``.
            This avoid runtime errors due to failure to specify all required arguments.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2720>`__)
+           
+    *    - |fixed|
+         - Fixed a bug where setting ``compressBlocksInDb` for stream store definitions would result in a much bigger than intended block size.
+           This option is also deprecated, as we recommend ``compressStreamsInClient`` instead.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2752>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**:
Fix a bug when calculating compression block size: we currently pass the size in bytes rather than KB, so it's 1000x bigger than it should be

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2752)
<!-- Reviewable:end -->
