### PR TITLE
Use SlicePredicate limit 0 when fetching row keys

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCellTimestamps.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCellTimestamps.java
@@ -113,7 +113,7 @@ public class GetCellTimestamps {
 
     private Optional<byte[]> determineSafeRangeEndInclusive(byte[] rangeStart) {
         KeyRange keyRange = new KeyRange().setStart_key(rangeStart).setEnd_key(new byte[0]).setCount(batchHint);
-        SlicePredicate slicePredicate = SlicePredicates.create(SlicePredicates.Range.ALL, SlicePredicates.Limit.of(0));
+        SlicePredicate slicePredicate = SlicePredicates.create(SlicePredicates.Range.ALL, SlicePredicates.Limit.ZERO);
         try {
             List<KeySlice> rows = rowGetter.getRows("getCandidateCellsForSweeping", keyRange, slicePredicate);
             if (rows.isEmpty()) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCellTimestamps.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCellTimestamps.java
@@ -113,7 +113,7 @@ public class GetCellTimestamps {
 
     private Optional<byte[]> determineSafeRangeEndInclusive(byte[] rangeStart) {
         KeyRange keyRange = new KeyRange().setStart_key(rangeStart).setEnd_key(new byte[0]).setCount(batchHint);
-        SlicePredicate slicePredicate = SlicePredicates.create(SlicePredicates.Range.ALL, SlicePredicates.Limit.ONE);
+        SlicePredicate slicePredicate = SlicePredicates.create(SlicePredicates.Range.ALL, SlicePredicates.Limit.of(0));
         try {
             List<KeySlice> rows = rowGetter.getRows("getCandidateCellsForSweeping", keyRange, slicePredicate);
             if (rows.isEmpty()) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/SlicePredicates.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/SlicePredicates.java
@@ -85,6 +85,7 @@ public final class SlicePredicates {
     @Value.Immutable
     public interface Limit {
 
+        Limit ZERO = Limit.of(0);
         Limit ONE = Limit.of(1);
         Limit NO_LIMIT = Limit.of(Integer.MAX_VALUE);
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -70,6 +70,10 @@ develop
     *    - |improved| |devbreak|
          - AtlasDB now wraps ``NotCurrentLeaderException`` in ``AtlasDbDependencyException`` when this exception is thrown by TimeLock.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2716>`__)
+           
+    *    - |improved|
+         - Sweep no longer fetches any values from Cassandra in CONSERVATIVE mode. This results in significantly less data being transferred from Cassandra to the client when sweeping tables with large values, such as stream store tables.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2754>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 


### PR DESCRIPTION
**Goals (and why)**: Avoid fetching any values when fetching row keys. 

**Implementation Description (bullets)**: limit 1 -> limit 0

**Concerns (what feedback would you like?)**:
* Will this actually impact Cassandra's memory usage?
* Can we test the memory footprint of this before merge?

**Where should we start reviewing?**: hmm, I'd probably look at the line deleted and then the line added.

**Priority (whenever / two weeks / yesterday)**: to discuss soon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2754)
<!-- Reviewable:end -->
