### PR TITLE
Cleanup Queues, Part 1: Schema Definition

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/CleanupSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/CleanupSchema.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema;
+
+import java.io.File;
+
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.schema.queue.SequentialTables;
+import com.palantir.atlasdb.table.description.OptionalType;
+import com.palantir.atlasdb.table.description.Schema;
+
+public enum CleanupSchema implements AtlasSchema {
+    INSTANCE;
+
+    private static final Namespace NAMESPACE = Namespace.create("cleanup");
+    private static final Schema SCHEMA = generateSchema();
+
+    private static Schema generateSchema() {
+        Schema schema = new Schema("Cleanup",
+                CleanupSchema.class.getPackage().getName() + ".generated",
+                NAMESPACE,
+                OptionalType.JAVA8);
+
+        SequentialTables.addSequentialTableDefinitions(schema, "cleanup");
+
+        schema.validate();
+        return schema;
+    }
+
+    @Override
+    public Namespace getNamespace() {
+        return NAMESPACE;
+    }
+
+    @Override
+    public Schema getLatestSchema() {
+        return SCHEMA;
+    }
+
+    public static void main(String[] args) throws Exception {
+        SCHEMA.renderTables(new File("src/main/java"));
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CleanupQueueTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CleanupQueueTable.java
@@ -1,0 +1,805 @@
+package com.palantir.atlasdb.schema.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedExpiringSet;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class CleanupQueueTable implements
+        AtlasDbDynamicMutablePersistentTable<CleanupQueueTable.CleanupQueueRow,
+                                                CleanupQueueTable.CleanupQueueColumn,
+                                                CleanupQueueTable.CleanupQueueColumnValue,
+                                                CleanupQueueTable.CleanupQueueRowResult> {
+    private final Transaction t;
+    private final List<CleanupQueueTrigger> triggers;
+    private final static String rawTableName = "cleanup_queue";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = ColumnSelection.all();
+
+    static CleanupQueueTable of(Transaction t, Namespace namespace) {
+        return new CleanupQueueTable(t, namespace, ImmutableList.<CleanupQueueTrigger>of());
+    }
+
+    static CleanupQueueTable of(Transaction t, Namespace namespace, CleanupQueueTrigger trigger, CleanupQueueTrigger... triggers) {
+        return new CleanupQueueTable(t, namespace, ImmutableList.<CleanupQueueTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static CleanupQueueTable of(Transaction t, Namespace namespace, List<CleanupQueueTrigger> triggers) {
+        return new CleanupQueueTable(t, namespace, triggers);
+    }
+
+    private CleanupQueueTable(Transaction t, Namespace namespace, List<CleanupQueueTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * CleanupQueueRow {
+     *   {@literal byte[] queueKey};
+     * }
+     * </pre>
+     */
+    public static final class CleanupQueueRow implements Persistable, Comparable<CleanupQueueRow> {
+        private final byte[] queueKey;
+
+        public static CleanupQueueRow of(byte[] queueKey) {
+            return new CleanupQueueRow(queueKey);
+        }
+
+        private CleanupQueueRow(byte[] queueKey) {
+            this.queueKey = queueKey;
+        }
+
+        public byte[] getQueueKey() {
+            return queueKey;
+        }
+
+        public static Function<CleanupQueueRow, byte[]> getQueueKeyFun() {
+            return new Function<CleanupQueueRow, byte[]>() {
+                @Override
+                public byte[] apply(CleanupQueueRow row) {
+                    return row.queueKey;
+                }
+            };
+        }
+
+        public static Function<byte[], CleanupQueueRow> fromQueueKeyFun() {
+            return new Function<byte[], CleanupQueueRow>() {
+                @Override
+                public CleanupQueueRow apply(byte[] row) {
+                    return CleanupQueueRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] queueKeyBytes = queueKey;
+            return EncodingUtils.add(queueKeyBytes);
+        }
+
+        public static final Hydrator<CleanupQueueRow> BYTES_HYDRATOR = new Hydrator<CleanupQueueRow>() {
+            @Override
+            public CleanupQueueRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                byte[] queueKey = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
+                __index += 0;
+                return new CleanupQueueRow(queueKey);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("queueKey", queueKey)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            CleanupQueueRow other = (CleanupQueueRow) obj;
+            return Arrays.equals(queueKey, other.queueKey);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(queueKey);
+        }
+
+        @Override
+        public int compareTo(CleanupQueueRow o) {
+            return ComparisonChain.start()
+                .compare(this.queueKey, o.queueKey, UnsignedBytes.lexicographicalComparator())
+                .result();
+        }
+    }
+
+    /**
+     * <pre>
+     * CleanupQueueColumn {
+     *   {@literal Long offset};
+     * }
+     * </pre>
+     */
+    public static final class CleanupQueueColumn implements Persistable, Comparable<CleanupQueueColumn> {
+        private final long offset;
+
+        public static CleanupQueueColumn of(long offset) {
+            return new CleanupQueueColumn(offset);
+        }
+
+        private CleanupQueueColumn(long offset) {
+            this.offset = offset;
+        }
+
+        public long getOffset() {
+            return offset;
+        }
+
+        public static Function<CleanupQueueColumn, Long> getOffsetFun() {
+            return new Function<CleanupQueueColumn, Long>() {
+                @Override
+                public Long apply(CleanupQueueColumn row) {
+                    return row.offset;
+                }
+            };
+        }
+
+        public static Function<Long, CleanupQueueColumn> fromOffsetFun() {
+            return new Function<Long, CleanupQueueColumn>() {
+                @Override
+                public CleanupQueueColumn apply(Long row) {
+                    return CleanupQueueColumn.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] offsetBytes = EncodingUtils.encodeUnsignedVarLong(offset);
+            return EncodingUtils.add(offsetBytes);
+        }
+
+        public static final Hydrator<CleanupQueueColumn> BYTES_HYDRATOR = new Hydrator<CleanupQueueColumn>() {
+            @Override
+            public CleanupQueueColumn hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long offset = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                __index += EncodingUtils.sizeOfUnsignedVarLong(offset);
+                return new CleanupQueueColumn(offset);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("offset", offset)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            CleanupQueueColumn other = (CleanupQueueColumn) obj;
+            return Objects.equal(offset, other.offset);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(offset);
+        }
+
+        @Override
+        public int compareTo(CleanupQueueColumn o) {
+            return ComparisonChain.start()
+                .compare(this.offset, o.offset)
+                .result();
+        }
+    }
+
+    public interface CleanupQueueTrigger {
+        public void putCleanupQueue(Multimap<CleanupQueueRow, ? extends CleanupQueueColumnValue> newRows);
+    }
+
+    /**
+     * <pre>
+     * Column name description {
+     *   {@literal Long offset};
+     * }
+     * Column value description {
+     *   type: byte[];
+     * }
+     * </pre>
+     */
+    public static final class CleanupQueueColumnValue implements ColumnValue<byte[]> {
+        private final CleanupQueueColumn columnName;
+        private final byte[] value;
+
+        public static CleanupQueueColumnValue of(CleanupQueueColumn columnName, byte[] value) {
+            return new CleanupQueueColumnValue(columnName, value);
+        }
+
+        private CleanupQueueColumnValue(CleanupQueueColumn columnName, byte[] value) {
+            this.columnName = columnName;
+            this.value = value;
+        }
+
+        public CleanupQueueColumn getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public byte[] getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return columnName.persistToBytes();
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = value;
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        public static byte[] hydrateValue(byte[] bytes) {
+            bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+            return EncodingUtils.getBytesFromOffsetToEnd(bytes, 0);
+        }
+
+        public static Function<CleanupQueueColumnValue, CleanupQueueColumn> getColumnNameFun() {
+            return new Function<CleanupQueueColumnValue, CleanupQueueColumn>() {
+                @Override
+                public CleanupQueueColumn apply(CleanupQueueColumnValue columnValue) {
+                    return columnValue.getColumnName();
+                }
+            };
+        }
+
+        public static Function<CleanupQueueColumnValue, byte[]> getValueFun() {
+            return new Function<CleanupQueueColumnValue, byte[]>() {
+                @Override
+                public byte[] apply(CleanupQueueColumnValue columnValue) {
+                    return columnValue.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("ColumnName", this.columnName)
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public static final class CleanupQueueRowResult implements TypedRowResult {
+        private final CleanupQueueRow rowName;
+        private final ImmutableSet<CleanupQueueColumnValue> columnValues;
+
+        public static CleanupQueueRowResult of(RowResult<byte[]> rowResult) {
+            CleanupQueueRow rowName = CleanupQueueRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<CleanupQueueColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                CleanupQueueColumn col = CleanupQueueColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                byte[] value = CleanupQueueColumnValue.hydrateValue(e.getValue());
+                columnValues.add(CleanupQueueColumnValue.of(col, value));
+            }
+            return new CleanupQueueRowResult(rowName, ImmutableSet.copyOf(columnValues));
+        }
+
+        private CleanupQueueRowResult(CleanupQueueRow rowName, ImmutableSet<CleanupQueueColumnValue> columnValues) {
+            this.rowName = rowName;
+            this.columnValues = columnValues;
+        }
+
+        @Override
+        public CleanupQueueRow getRowName() {
+            return rowName;
+        }
+
+        public Set<CleanupQueueColumnValue> getColumnValues() {
+            return columnValues;
+        }
+
+        public static Function<CleanupQueueRowResult, CleanupQueueRow> getRowNameFun() {
+            return new Function<CleanupQueueRowResult, CleanupQueueRow>() {
+                @Override
+                public CleanupQueueRow apply(CleanupQueueRowResult rowResult) {
+                    return rowResult.rowName;
+                }
+            };
+        }
+
+        public static Function<CleanupQueueRowResult, ImmutableSet<CleanupQueueColumnValue>> getColumnValuesFun() {
+            return new Function<CleanupQueueRowResult, ImmutableSet<CleanupQueueColumnValue>>() {
+                @Override
+                public ImmutableSet<CleanupQueueColumnValue> apply(CleanupQueueRowResult rowResult) {
+                    return rowResult.columnValues;
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("ColumnValues", getColumnValues())
+                .toString();
+        }
+    }
+
+    @Override
+    public void delete(CleanupQueueRow row, CleanupQueueColumn column) {
+        delete(ImmutableMultimap.of(row, column));
+    }
+
+    @Override
+    public void delete(Iterable<CleanupQueueRow> rows) {
+        Multimap<CleanupQueueRow, CleanupQueueColumn> toRemove = HashMultimap.create();
+        Multimap<CleanupQueueRow, CleanupQueueColumnValue> result = getRowsMultimap(rows);
+        for (Entry<CleanupQueueRow, CleanupQueueColumnValue> e : result.entries()) {
+            toRemove.put(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toRemove);
+    }
+
+    @Override
+    public void delete(Multimap<CleanupQueueRow, CleanupQueueColumn> values) {
+        t.delete(tableRef, ColumnValues.toCells(values));
+    }
+
+    @Override
+    public void put(CleanupQueueRow rowName, Iterable<CleanupQueueColumnValue> values) {
+        put(ImmutableMultimap.<CleanupQueueRow, CleanupQueueColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(CleanupQueueRow rowName, CleanupQueueColumnValue... values) {
+        put(ImmutableMultimap.<CleanupQueueRow, CleanupQueueColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(Multimap<CleanupQueueRow, ? extends CleanupQueueColumnValue> values) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(values));
+        for (CleanupQueueTrigger trigger : triggers) {
+            trigger.putCleanupQueue(values);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(CleanupQueueRow rowName, Iterable<CleanupQueueColumnValue> values) {
+        putUnlessExists(ImmutableMultimap.<CleanupQueueRow, CleanupQueueColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(CleanupQueueRow rowName, CleanupQueueColumnValue... values) {
+        putUnlessExists(ImmutableMultimap.<CleanupQueueRow, CleanupQueueColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<CleanupQueueRow, ? extends CleanupQueueColumnValue> rows) {
+        Multimap<CleanupQueueRow, CleanupQueueColumn> toGet = Multimaps.transformValues(rows, CleanupQueueColumnValue.getColumnNameFun());
+        Multimap<CleanupQueueRow, CleanupQueueColumnValue> existing = get(toGet);
+        Multimap<CleanupQueueRow, CleanupQueueColumnValue> toPut = HashMultimap.create();
+        for (Entry<CleanupQueueRow, ? extends CleanupQueueColumnValue> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    @Override
+    public void touch(Multimap<CleanupQueueRow, CleanupQueueColumn> values) {
+        Multimap<CleanupQueueRow, CleanupQueueColumnValue> currentValues = get(values);
+        put(currentValues);
+        Multimap<CleanupQueueRow, CleanupQueueColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<CleanupQueueRow, CleanupQueueColumnValue> e : currentValues.entries()) {
+            toDelete.remove(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toDelete);
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<CleanupQueueColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
+    }
+
+    public static ColumnSelection getColumnSelection(CleanupQueueColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    @Override
+    public Multimap<CleanupQueueRow, CleanupQueueColumnValue> get(Multimap<CleanupQueueRow, CleanupQueueColumn> cells) {
+        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
+        Multimap<CleanupQueueRow, CleanupQueueColumnValue> rowMap = HashMultimap.create();
+        for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
+            if (e.getValue().length > 0) {
+                CleanupQueueRow row = CleanupQueueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                CleanupQueueColumn col = CleanupQueueColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                byte[] val = CleanupQueueColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, CleanupQueueColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public List<CleanupQueueColumnValue> getRowColumns(CleanupQueueRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<CleanupQueueColumnValue> getRowColumns(CleanupQueueRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<CleanupQueueColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                CleanupQueueColumn col = CleanupQueueColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                byte[] val = CleanupQueueColumnValue.hydrateValue(e.getValue());
+                ret.add(CleanupQueueColumnValue.of(col, val));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<CleanupQueueRow, CleanupQueueColumnValue> getRowsMultimap(Iterable<CleanupQueueRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<CleanupQueueRow, CleanupQueueColumnValue> getRowsMultimap(Iterable<CleanupQueueRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<CleanupQueueRow, CleanupQueueColumnValue> getRowsMultimapInternal(Iterable<CleanupQueueRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<CleanupQueueRow, CleanupQueueColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<CleanupQueueRow, CleanupQueueColumnValue> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            CleanupQueueRow row = CleanupQueueRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                CleanupQueueColumn col = CleanupQueueColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                byte[] val = CleanupQueueColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, CleanupQueueColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<CleanupQueueRow, BatchingVisitable<CleanupQueueColumnValue>> getRowsColumnRange(Iterable<CleanupQueueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<CleanupQueueRow, BatchingVisitable<CleanupQueueColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            CleanupQueueRow row = CleanupQueueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<CleanupQueueColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                CleanupQueueColumn col = CleanupQueueColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                byte[] val = CleanupQueueColumnValue.hydrateValue(result.getValue());
+                return CleanupQueueColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<CleanupQueueRow, CleanupQueueColumnValue>> getRowsColumnRange(Iterable<CleanupQueueRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            CleanupQueueRow row = CleanupQueueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            CleanupQueueColumn col = CleanupQueueColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            byte[] val = CleanupQueueColumnValue.hydrateValue(e.getValue());
+            CleanupQueueColumnValue colValue = CleanupQueueColumnValue.of(col, val);
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<CleanupQueueRowResult> getRange(RangeRequest range) {
+        if (range.getColumnNames().isEmpty()) {
+            range = range.getBuilder().retainColumns(allColumns).build();
+        }
+        return BatchingVisitables.transform(t.getRange(tableRef, range), new Function<RowResult<byte[]>, CleanupQueueRowResult>() {
+            @Override
+            public CleanupQueueRowResult apply(RowResult<byte[]> input) {
+                return CleanupQueueRowResult.of(input);
+            }
+        });
+    }
+
+    @Deprecated
+    public IterableView<BatchingVisitable<CleanupQueueRowResult>> getRanges(Iterable<RangeRequest> ranges) {
+        Iterable<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRanges(tableRef, ranges);
+        return IterableView.of(rangeResults).transform(
+                new Function<BatchingVisitable<RowResult<byte[]>>, BatchingVisitable<CleanupQueueRowResult>>() {
+            @Override
+            public BatchingVisitable<CleanupQueueRowResult> apply(BatchingVisitable<RowResult<byte[]>> visitable) {
+                return BatchingVisitables.transform(visitable, new Function<RowResult<byte[]>, CleanupQueueRowResult>() {
+                    @Override
+                    public CleanupQueueRowResult apply(RowResult<byte[]> row) {
+                        return CleanupQueueRowResult.of(row);
+                    }
+                });
+            }
+        });
+    }
+
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   int concurrencyLevel,
+                                   BiFunction<RangeRequest, BatchingVisitable<CleanupQueueRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges, concurrencyLevel,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CleanupQueueRowResult::of)));
+    }
+
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   BiFunction<RangeRequest, BatchingVisitable<CleanupQueueRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, CleanupQueueRowResult::of)));
+    }
+
+    public Stream<BatchingVisitable<CleanupQueueRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
+        Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
+        return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, CleanupQueueRowResult::of));
+    }
+
+    public void deleteRange(RangeRequest range) {
+        deleteRanges(ImmutableSet.of(range));
+    }
+
+    public void deleteRanges(Iterable<RangeRequest> ranges) {
+        BatchingVisitables.concat(getRanges(ranges)).batchAccept(1000, new AbortingVisitor<List<CleanupQueueRowResult>, RuntimeException>() {
+            @Override
+            public boolean visit(List<CleanupQueueRowResult> rowResults) {
+                Multimap<CleanupQueueRow, CleanupQueueColumn> toRemove = HashMultimap.create();
+                for (CleanupQueueRowResult rowResult : rowResults) {
+                    for (CleanupQueueColumnValue columnValue : rowResult.getColumnValues()) {
+                        toRemove.put(rowResult.getRowName(), columnValue.getColumnName());
+                    }
+                }
+                delete(toRemove);
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutableExpiringTable}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutableExpiringTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedExpiringSet}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "UXEDnkLHMhcx+iZjpyK8hg==";
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CleanupReadOffsetsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CleanupReadOffsetsTable.java
@@ -1,0 +1,693 @@
+package com.palantir.atlasdb.schema.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedExpiringSet;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class CleanupReadOffsetsTable implements
+        AtlasDbMutablePersistentTable<CleanupReadOffsetsTable.CleanupReadOffsetsRow,
+                                         CleanupReadOffsetsTable.CleanupReadOffsetsNamedColumnValue<?>,
+                                         CleanupReadOffsetsTable.CleanupReadOffsetsRowResult>,
+        AtlasDbNamedMutableTable<CleanupReadOffsetsTable.CleanupReadOffsetsRow,
+                                    CleanupReadOffsetsTable.CleanupReadOffsetsNamedColumnValue<?>,
+                                    CleanupReadOffsetsTable.CleanupReadOffsetsRowResult> {
+    private final Transaction t;
+    private final List<CleanupReadOffsetsTrigger> triggers;
+    private final static String rawTableName = "cleanup_read_offsets";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(CleanupReadOffsetsNamedColumn.values());
+
+    static CleanupReadOffsetsTable of(Transaction t, Namespace namespace) {
+        return new CleanupReadOffsetsTable(t, namespace, ImmutableList.<CleanupReadOffsetsTrigger>of());
+    }
+
+    static CleanupReadOffsetsTable of(Transaction t, Namespace namespace, CleanupReadOffsetsTrigger trigger, CleanupReadOffsetsTrigger... triggers) {
+        return new CleanupReadOffsetsTable(t, namespace, ImmutableList.<CleanupReadOffsetsTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static CleanupReadOffsetsTable of(Transaction t, Namespace namespace, List<CleanupReadOffsetsTrigger> triggers) {
+        return new CleanupReadOffsetsTable(t, namespace, triggers);
+    }
+
+    private CleanupReadOffsetsTable(Transaction t, Namespace namespace, List<CleanupReadOffsetsTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * CleanupReadOffsetsRow {
+     *   {@literal String fullTableName};
+     * }
+     * </pre>
+     */
+    public static final class CleanupReadOffsetsRow implements Persistable, Comparable<CleanupReadOffsetsRow> {
+        private final String fullTableName;
+
+        public static CleanupReadOffsetsRow of(String fullTableName) {
+            return new CleanupReadOffsetsRow(fullTableName);
+        }
+
+        private CleanupReadOffsetsRow(String fullTableName) {
+            this.fullTableName = fullTableName;
+        }
+
+        public String getFullTableName() {
+            return fullTableName;
+        }
+
+        public static Function<CleanupReadOffsetsRow, String> getFullTableNameFun() {
+            return new Function<CleanupReadOffsetsRow, String>() {
+                @Override
+                public String apply(CleanupReadOffsetsRow row) {
+                    return row.fullTableName;
+                }
+            };
+        }
+
+        public static Function<String, CleanupReadOffsetsRow> fromFullTableNameFun() {
+            return new Function<String, CleanupReadOffsetsRow>() {
+                @Override
+                public CleanupReadOffsetsRow apply(String row) {
+                    return CleanupReadOffsetsRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] fullTableNameBytes = PtBytes.toBytes(fullTableName);
+            return EncodingUtils.add(fullTableNameBytes);
+        }
+
+        public static final Hydrator<CleanupReadOffsetsRow> BYTES_HYDRATOR = new Hydrator<CleanupReadOffsetsRow>() {
+            @Override
+            public CleanupReadOffsetsRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                String fullTableName = PtBytes.toString(__input, __index, __input.length-__index);
+                __index += 0;
+                return new CleanupReadOffsetsRow(fullTableName);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("fullTableName", fullTableName)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            CleanupReadOffsetsRow other = (CleanupReadOffsetsRow) obj;
+            return Objects.equal(fullTableName, other.fullTableName);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(fullTableName);
+        }
+
+        @Override
+        public int compareTo(CleanupReadOffsetsRow o) {
+            return ComparisonChain.start()
+                .compare(this.fullTableName, o.fullTableName)
+                .result();
+        }
+    }
+
+    public interface CleanupReadOffsetsNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class Offset implements CleanupReadOffsetsNamedColumnValue<Long> {
+        private final Long value;
+
+        public static Offset of(Long value) {
+            return new Offset(value);
+        }
+
+        private Offset(Long value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "offset";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "o";
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("o");
+        }
+
+        public static final Hydrator<Offset> BYTES_HYDRATOR = new Hydrator<Offset>() {
+            @Override
+            public Offset hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                return of(EncodingUtils.decodeUnsignedVarLong(bytes, 0));
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface CleanupReadOffsetsTrigger {
+        public void putCleanupReadOffsets(Multimap<CleanupReadOffsetsRow, ? extends CleanupReadOffsetsNamedColumnValue<?>> newRows);
+    }
+
+    public static final class CleanupReadOffsetsRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static CleanupReadOffsetsRowResult of(RowResult<byte[]> row) {
+            return new CleanupReadOffsetsRowResult(row);
+        }
+
+        private CleanupReadOffsetsRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public CleanupReadOffsetsRow getRowName() {
+            return CleanupReadOffsetsRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<CleanupReadOffsetsRowResult, CleanupReadOffsetsRow> getRowNameFun() {
+            return new Function<CleanupReadOffsetsRowResult, CleanupReadOffsetsRow>() {
+                @Override
+                public CleanupReadOffsetsRow apply(CleanupReadOffsetsRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, CleanupReadOffsetsRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, CleanupReadOffsetsRowResult>() {
+                @Override
+                public CleanupReadOffsetsRowResult apply(RowResult<byte[]> rowResult) {
+                    return new CleanupReadOffsetsRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasOffset() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("o"));
+        }
+
+        public Long getOffset() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("o"));
+            if (bytes == null) {
+                return null;
+            }
+            Offset value = Offset.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<CleanupReadOffsetsRowResult, Long> getOffsetFun() {
+            return new Function<CleanupReadOffsetsRowResult, Long>() {
+                @Override
+                public Long apply(CleanupReadOffsetsRowResult rowResult) {
+                    return rowResult.getOffset();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Offset", getOffset())
+                .toString();
+        }
+    }
+
+    public enum CleanupReadOffsetsNamedColumn {
+        OFFSET {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("o");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<CleanupReadOffsetsNamedColumn, byte[]> toShortName() {
+            return new Function<CleanupReadOffsetsNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(CleanupReadOffsetsNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<CleanupReadOffsetsNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, CleanupReadOffsetsNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(CleanupReadOffsetsNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends CleanupReadOffsetsNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends CleanupReadOffsetsNamedColumnValue<?>>>builder()
+                .put("o", Offset.BYTES_HYDRATOR)
+                .build();
+
+    public Map<CleanupReadOffsetsRow, Long> getOffsets(Collection<CleanupReadOffsetsRow> rows) {
+        Map<Cell, CleanupReadOffsetsRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (CleanupReadOffsetsRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("o")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<CleanupReadOffsetsRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            Long val = Offset.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putOffset(CleanupReadOffsetsRow row, Long value) {
+        put(ImmutableMultimap.of(row, Offset.of(value)));
+    }
+
+    public void putOffset(Map<CleanupReadOffsetsRow, Long> map) {
+        Map<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<CleanupReadOffsetsRow, Long> e : map.entrySet()) {
+            toPut.put(e.getKey(), Offset.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    public void putOffsetUnlessExists(CleanupReadOffsetsRow row, Long value) {
+        putUnlessExists(ImmutableMultimap.of(row, Offset.of(value)));
+    }
+
+    public void putOffsetUnlessExists(Map<CleanupReadOffsetsRow, Long> map) {
+        Map<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<CleanupReadOffsetsRow, Long> e : map.entrySet()) {
+            toPut.put(e.getKey(), Offset.of(e.getValue()));
+        }
+        putUnlessExists(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<CleanupReadOffsetsRow, ? extends CleanupReadOffsetsNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (CleanupReadOffsetsTrigger trigger : triggers) {
+            trigger.putCleanupReadOffsets(rows);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<CleanupReadOffsetsRow, ? extends CleanupReadOffsetsNamedColumnValue<?>> rows) {
+        Multimap<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<CleanupReadOffsetsRow, ? extends CleanupReadOffsetsNamedColumnValue<?>> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    public void deleteOffset(CleanupReadOffsetsRow row) {
+        deleteOffset(ImmutableSet.of(row));
+    }
+
+    public void deleteOffset(Iterable<CleanupReadOffsetsRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("o");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(CleanupReadOffsetsRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<CleanupReadOffsetsRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("o")));
+        t.delete(tableRef, cells);
+    }
+
+    public Optional<CleanupReadOffsetsRowResult> getRow(CleanupReadOffsetsRow row) {
+        return getRow(row, allColumns);
+    }
+
+    public Optional<CleanupReadOffsetsRowResult> getRow(CleanupReadOffsetsRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(CleanupReadOffsetsRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<CleanupReadOffsetsRowResult> getRows(Iterable<CleanupReadOffsetsRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<CleanupReadOffsetsRowResult> getRows(Iterable<CleanupReadOffsetsRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<CleanupReadOffsetsRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(CleanupReadOffsetsRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<CleanupReadOffsetsNamedColumnValue<?>> getRowColumns(CleanupReadOffsetsRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<CleanupReadOffsetsNamedColumnValue<?>> getRowColumns(CleanupReadOffsetsRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<CleanupReadOffsetsNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> getRowsMultimap(Iterable<CleanupReadOffsetsRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> getRowsMultimap(Iterable<CleanupReadOffsetsRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> getRowsMultimapInternal(Iterable<CleanupReadOffsetsRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            CleanupReadOffsetsRow row = CleanupReadOffsetsRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<CleanupReadOffsetsRow, BatchingVisitable<CleanupReadOffsetsNamedColumnValue<?>>> getRowsColumnRange(Iterable<CleanupReadOffsetsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<CleanupReadOffsetsRow, BatchingVisitable<CleanupReadOffsetsNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            CleanupReadOffsetsRow row = CleanupReadOffsetsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<CleanupReadOffsetsNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<CleanupReadOffsetsRow, CleanupReadOffsetsNamedColumnValue<?>>> getRowsColumnRange(Iterable<CleanupReadOffsetsRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            CleanupReadOffsetsRow row = CleanupReadOffsetsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            CleanupReadOffsetsNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<CleanupReadOffsetsRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<CleanupReadOffsetsRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, CleanupReadOffsetsRowResult>() {
+            @Override
+            public CleanupReadOffsetsRowResult apply(RowResult<byte[]> input) {
+                return CleanupReadOffsetsRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutableExpiringTable}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutableExpiringTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedExpiringSet}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "zX/4GQebz3UbxIy4HnAQ/w==";
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CleanupTableFactory.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CleanupTableFactory.java
@@ -1,0 +1,78 @@
+package com.palantir.atlasdb.schema.generated;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.table.generation.Triggers;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
+public final class CleanupTableFactory {
+    private static final Namespace defaultNamespace = Namespace.create("cleanup", Namespace.UNCHECKED_NAME);
+
+    private final List<Function<? super Transaction, SharedTriggers>> sharedTriggers;
+
+    private final Namespace namespace;
+
+    private CleanupTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+            Namespace namespace) {
+        this.sharedTriggers = sharedTriggers;
+        this.namespace = namespace;
+    }
+
+    public static CleanupTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+            Namespace namespace) {
+        return new CleanupTableFactory(sharedTriggers, namespace);
+    }
+
+    public static CleanupTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+        return new CleanupTableFactory(sharedTriggers, defaultNamespace);
+    }
+
+    public static CleanupTableFactory of(Namespace namespace) {
+        return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), namespace);
+    }
+
+    public static CleanupTableFactory of() {
+        return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
+    }
+
+    public CleanupQueueTable getCleanupQueueTable(Transaction t,
+            CleanupQueueTable.CleanupQueueTrigger... triggers) {
+        return CleanupQueueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public CleanupReadOffsetsTable getCleanupReadOffsetsTable(Transaction t,
+            CleanupReadOffsetsTable.CleanupReadOffsetsTrigger... triggers) {
+        return CleanupReadOffsetsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public CleanupWriteOffsetsTable getCleanupWriteOffsetsTable(Transaction t,
+            CleanupWriteOffsetsTable.CleanupWriteOffsetsTrigger... triggers) {
+        return CleanupWriteOffsetsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public interface SharedTriggers extends CleanupQueueTable.CleanupQueueTrigger, CleanupReadOffsetsTable.CleanupReadOffsetsTrigger, CleanupWriteOffsetsTable.CleanupWriteOffsetsTrigger {
+    }
+
+    public abstract static class NullSharedTriggers implements SharedTriggers {
+        @Override
+        public void putCleanupQueue(Multimap<CleanupQueueTable.CleanupQueueRow, ? extends CleanupQueueTable.CleanupQueueColumnValue> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putCleanupReadOffsets(Multimap<CleanupReadOffsetsTable.CleanupReadOffsetsRow, ? extends CleanupReadOffsetsTable.CleanupReadOffsetsNamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putCleanupWriteOffsets(Multimap<CleanupWriteOffsetsTable.CleanupWriteOffsetsRow, ? extends CleanupWriteOffsetsTable.CleanupWriteOffsetsNamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CleanupWriteOffsetsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CleanupWriteOffsetsTable.java
@@ -1,0 +1,693 @@
+package com.palantir.atlasdb.schema.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutableExpiringTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedExpiringSet;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class CleanupWriteOffsetsTable implements
+        AtlasDbMutablePersistentTable<CleanupWriteOffsetsTable.CleanupWriteOffsetsRow,
+                                         CleanupWriteOffsetsTable.CleanupWriteOffsetsNamedColumnValue<?>,
+                                         CleanupWriteOffsetsTable.CleanupWriteOffsetsRowResult>,
+        AtlasDbNamedMutableTable<CleanupWriteOffsetsTable.CleanupWriteOffsetsRow,
+                                    CleanupWriteOffsetsTable.CleanupWriteOffsetsNamedColumnValue<?>,
+                                    CleanupWriteOffsetsTable.CleanupWriteOffsetsRowResult> {
+    private final Transaction t;
+    private final List<CleanupWriteOffsetsTrigger> triggers;
+    private final static String rawTableName = "cleanup_write_offsets";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(CleanupWriteOffsetsNamedColumn.values());
+
+    static CleanupWriteOffsetsTable of(Transaction t, Namespace namespace) {
+        return new CleanupWriteOffsetsTable(t, namespace, ImmutableList.<CleanupWriteOffsetsTrigger>of());
+    }
+
+    static CleanupWriteOffsetsTable of(Transaction t, Namespace namespace, CleanupWriteOffsetsTrigger trigger, CleanupWriteOffsetsTrigger... triggers) {
+        return new CleanupWriteOffsetsTable(t, namespace, ImmutableList.<CleanupWriteOffsetsTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static CleanupWriteOffsetsTable of(Transaction t, Namespace namespace, List<CleanupWriteOffsetsTrigger> triggers) {
+        return new CleanupWriteOffsetsTable(t, namespace, triggers);
+    }
+
+    private CleanupWriteOffsetsTable(Transaction t, Namespace namespace, List<CleanupWriteOffsetsTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * CleanupWriteOffsetsRow {
+     *   {@literal String fullTableName};
+     * }
+     * </pre>
+     */
+    public static final class CleanupWriteOffsetsRow implements Persistable, Comparable<CleanupWriteOffsetsRow> {
+        private final String fullTableName;
+
+        public static CleanupWriteOffsetsRow of(String fullTableName) {
+            return new CleanupWriteOffsetsRow(fullTableName);
+        }
+
+        private CleanupWriteOffsetsRow(String fullTableName) {
+            this.fullTableName = fullTableName;
+        }
+
+        public String getFullTableName() {
+            return fullTableName;
+        }
+
+        public static Function<CleanupWriteOffsetsRow, String> getFullTableNameFun() {
+            return new Function<CleanupWriteOffsetsRow, String>() {
+                @Override
+                public String apply(CleanupWriteOffsetsRow row) {
+                    return row.fullTableName;
+                }
+            };
+        }
+
+        public static Function<String, CleanupWriteOffsetsRow> fromFullTableNameFun() {
+            return new Function<String, CleanupWriteOffsetsRow>() {
+                @Override
+                public CleanupWriteOffsetsRow apply(String row) {
+                    return CleanupWriteOffsetsRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] fullTableNameBytes = PtBytes.toBytes(fullTableName);
+            return EncodingUtils.add(fullTableNameBytes);
+        }
+
+        public static final Hydrator<CleanupWriteOffsetsRow> BYTES_HYDRATOR = new Hydrator<CleanupWriteOffsetsRow>() {
+            @Override
+            public CleanupWriteOffsetsRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                String fullTableName = PtBytes.toString(__input, __index, __input.length-__index);
+                __index += 0;
+                return new CleanupWriteOffsetsRow(fullTableName);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("fullTableName", fullTableName)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            CleanupWriteOffsetsRow other = (CleanupWriteOffsetsRow) obj;
+            return Objects.equal(fullTableName, other.fullTableName);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(fullTableName);
+        }
+
+        @Override
+        public int compareTo(CleanupWriteOffsetsRow o) {
+            return ComparisonChain.start()
+                .compare(this.fullTableName, o.fullTableName)
+                .result();
+        }
+    }
+
+    public interface CleanupWriteOffsetsNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class Offset implements CleanupWriteOffsetsNamedColumnValue<Long> {
+        private final Long value;
+
+        public static Offset of(Long value) {
+            return new Offset(value);
+        }
+
+        private Offset(Long value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "offset";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "o";
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("o");
+        }
+
+        public static final Hydrator<Offset> BYTES_HYDRATOR = new Hydrator<Offset>() {
+            @Override
+            public Offset hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                return of(EncodingUtils.decodeUnsignedVarLong(bytes, 0));
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface CleanupWriteOffsetsTrigger {
+        public void putCleanupWriteOffsets(Multimap<CleanupWriteOffsetsRow, ? extends CleanupWriteOffsetsNamedColumnValue<?>> newRows);
+    }
+
+    public static final class CleanupWriteOffsetsRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static CleanupWriteOffsetsRowResult of(RowResult<byte[]> row) {
+            return new CleanupWriteOffsetsRowResult(row);
+        }
+
+        private CleanupWriteOffsetsRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public CleanupWriteOffsetsRow getRowName() {
+            return CleanupWriteOffsetsRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<CleanupWriteOffsetsRowResult, CleanupWriteOffsetsRow> getRowNameFun() {
+            return new Function<CleanupWriteOffsetsRowResult, CleanupWriteOffsetsRow>() {
+                @Override
+                public CleanupWriteOffsetsRow apply(CleanupWriteOffsetsRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, CleanupWriteOffsetsRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, CleanupWriteOffsetsRowResult>() {
+                @Override
+                public CleanupWriteOffsetsRowResult apply(RowResult<byte[]> rowResult) {
+                    return new CleanupWriteOffsetsRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasOffset() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("o"));
+        }
+
+        public Long getOffset() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("o"));
+            if (bytes == null) {
+                return null;
+            }
+            Offset value = Offset.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<CleanupWriteOffsetsRowResult, Long> getOffsetFun() {
+            return new Function<CleanupWriteOffsetsRowResult, Long>() {
+                @Override
+                public Long apply(CleanupWriteOffsetsRowResult rowResult) {
+                    return rowResult.getOffset();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Offset", getOffset())
+                .toString();
+        }
+    }
+
+    public enum CleanupWriteOffsetsNamedColumn {
+        OFFSET {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("o");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<CleanupWriteOffsetsNamedColumn, byte[]> toShortName() {
+            return new Function<CleanupWriteOffsetsNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(CleanupWriteOffsetsNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<CleanupWriteOffsetsNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, CleanupWriteOffsetsNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(CleanupWriteOffsetsNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends CleanupWriteOffsetsNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends CleanupWriteOffsetsNamedColumnValue<?>>>builder()
+                .put("o", Offset.BYTES_HYDRATOR)
+                .build();
+
+    public Map<CleanupWriteOffsetsRow, Long> getOffsets(Collection<CleanupWriteOffsetsRow> rows) {
+        Map<Cell, CleanupWriteOffsetsRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (CleanupWriteOffsetsRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("o")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<CleanupWriteOffsetsRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            Long val = Offset.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putOffset(CleanupWriteOffsetsRow row, Long value) {
+        put(ImmutableMultimap.of(row, Offset.of(value)));
+    }
+
+    public void putOffset(Map<CleanupWriteOffsetsRow, Long> map) {
+        Map<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<CleanupWriteOffsetsRow, Long> e : map.entrySet()) {
+            toPut.put(e.getKey(), Offset.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    public void putOffsetUnlessExists(CleanupWriteOffsetsRow row, Long value) {
+        putUnlessExists(ImmutableMultimap.of(row, Offset.of(value)));
+    }
+
+    public void putOffsetUnlessExists(Map<CleanupWriteOffsetsRow, Long> map) {
+        Map<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<CleanupWriteOffsetsRow, Long> e : map.entrySet()) {
+            toPut.put(e.getKey(), Offset.of(e.getValue()));
+        }
+        putUnlessExists(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<CleanupWriteOffsetsRow, ? extends CleanupWriteOffsetsNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (CleanupWriteOffsetsTrigger trigger : triggers) {
+            trigger.putCleanupWriteOffsets(rows);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<CleanupWriteOffsetsRow, ? extends CleanupWriteOffsetsNamedColumnValue<?>> rows) {
+        Multimap<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<CleanupWriteOffsetsRow, ? extends CleanupWriteOffsetsNamedColumnValue<?>> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    public void deleteOffset(CleanupWriteOffsetsRow row) {
+        deleteOffset(ImmutableSet.of(row));
+    }
+
+    public void deleteOffset(Iterable<CleanupWriteOffsetsRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("o");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(CleanupWriteOffsetsRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<CleanupWriteOffsetsRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("o")));
+        t.delete(tableRef, cells);
+    }
+
+    public Optional<CleanupWriteOffsetsRowResult> getRow(CleanupWriteOffsetsRow row) {
+        return getRow(row, allColumns);
+    }
+
+    public Optional<CleanupWriteOffsetsRowResult> getRow(CleanupWriteOffsetsRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(CleanupWriteOffsetsRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<CleanupWriteOffsetsRowResult> getRows(Iterable<CleanupWriteOffsetsRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<CleanupWriteOffsetsRowResult> getRows(Iterable<CleanupWriteOffsetsRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<CleanupWriteOffsetsRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(CleanupWriteOffsetsRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<CleanupWriteOffsetsNamedColumnValue<?>> getRowColumns(CleanupWriteOffsetsRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<CleanupWriteOffsetsNamedColumnValue<?>> getRowColumns(CleanupWriteOffsetsRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<CleanupWriteOffsetsNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> getRowsMultimap(Iterable<CleanupWriteOffsetsRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> getRowsMultimap(Iterable<CleanupWriteOffsetsRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> getRowsMultimapInternal(Iterable<CleanupWriteOffsetsRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            CleanupWriteOffsetsRow row = CleanupWriteOffsetsRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<CleanupWriteOffsetsRow, BatchingVisitable<CleanupWriteOffsetsNamedColumnValue<?>>> getRowsColumnRange(Iterable<CleanupWriteOffsetsRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<CleanupWriteOffsetsRow, BatchingVisitable<CleanupWriteOffsetsNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            CleanupWriteOffsetsRow row = CleanupWriteOffsetsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<CleanupWriteOffsetsNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<CleanupWriteOffsetsRow, CleanupWriteOffsetsNamedColumnValue<?>>> getRowsColumnRange(Iterable<CleanupWriteOffsetsRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            CleanupWriteOffsetsRow row = CleanupWriteOffsetsRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            CleanupWriteOffsetsNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<CleanupWriteOffsetsRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<CleanupWriteOffsetsRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, CleanupWriteOffsetsRowResult>() {
+            @Override
+            public CleanupWriteOffsetsRowResult apply(RowResult<byte[]> input) {
+                return CleanupWriteOffsetsRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutableExpiringTable}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutableExpiringTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedExpiringSet}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "RTRqpnF8GTtDV5dbA+/j1w==";
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/queue/SequentialTables.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/queue/SequentialTables.java
@@ -36,20 +36,21 @@ public class SequentialTables {
     private static TableDefinition getSequentialTableDefinition() {
         return new TableDefinition() {{
             allSafeForLoggingByDefault();
+            conflictHandler(ConflictHandler.IGNORE_ALL); // Offsets are unique
             rowName();
                 rowComponent("queue_key", ValueType.BLOB);
                 rangeScanAllowed();
             dynamicColumns();
                 columnComponent("offset", ValueType.VAR_LONG);
                 value(ValueType.BLOB);
-            sweepStrategy(TableMetadataPersistence.SweepStrategy.THOROUGH);
+            sweepStrategy(TableMetadataPersistence.SweepStrategy.THOROUGH); // Needed to avoid cruft
         }};
     }
 
     private static TableDefinition getOffsetTableDefinition() {
         return new TableDefinition() {{
             allSafeForLoggingByDefault();
-            conflictHandler(ConflictHandler.SERIALIZABLE);
+            conflictHandler(ConflictHandler.RETRY_ON_WRITE_WRITE);
             rowName();
                 rowComponent("full_table_name", ValueType.STRING);
             columns();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/queue/SequentialTables.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/queue/SequentialTables.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.queue;
+
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.atlasdb.table.description.Schema;
+import com.palantir.atlasdb.table.description.TableDefinition;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+
+public class SequentialTables {
+    private SequentialTables() {
+        // utility
+    }
+
+    public static void addSequentialTableDefinitions(Schema schema, String sequentialTablePrefix) {
+        schema.addTableDefinition(sequentialTablePrefix + "_queue", getSequentialTableDefinition());
+        schema.addTableDefinition(sequentialTablePrefix + "_read_offsets", getOffsetTableDefinition());
+        schema.addTableDefinition(sequentialTablePrefix + "_write_offsets", getOffsetTableDefinition());
+    }
+
+    private static TableDefinition getSequentialTableDefinition() {
+        return new TableDefinition() {{
+            allSafeForLoggingByDefault();
+            rowName();
+                rowComponent("queue_key", ValueType.BLOB);
+                rangeScanAllowed();
+            dynamicColumns();
+                columnComponent("offset", ValueType.VAR_LONG);
+                value(ValueType.BLOB);
+            sweepStrategy(TableMetadataPersistence.SweepStrategy.THOROUGH);
+        }};
+    }
+
+    private static TableDefinition getOffsetTableDefinition() {
+        return new TableDefinition() {{
+            allSafeForLoggingByDefault();
+            conflictHandler(ConflictHandler.SERIALIZABLE);
+            rowName();
+                rowComponent("full_table_name", ValueType.STRING);
+            columns();
+                column("offset", "o", ValueType.VAR_LONG);
+        }};
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/queue/SequentialTables.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/queue/SequentialTables.java
@@ -38,8 +38,8 @@ public class SequentialTables {
             allSafeForLoggingByDefault();
             conflictHandler(ConflictHandler.IGNORE_ALL); // Offsets are unique
             rowName();
+                hashFirstRowComponent(); // Can still find all queues by virtue of the offset table
                 rowComponent("queue_key", ValueType.BLOB);
-                rangeScanAllowed();
             dynamicColumns();
                 columnComponent("offset", ValueType.VAR_LONG);
                 value(ValueType.BLOB);


### PR DESCRIPTION
**Goals (and why)**:
- Part 1 of building a cleanup queue, to be used by Sweep for async cleanup tasks, and possibly later on for other internal uses e.g. targeted sweep.

**Implementation Description (bullets)**:
- Implement a generator for queue-like tables.
- Implement a Cleanup Schema, which uses this generator in a pretty bare form.

**Concerns (what feedback would you like?)**:
- The lines in `getSequentialTableDefinition` probably need to be reviewed very closely, as there are a number of trade-offs and assumptions I've made there.
- We're using blobs for the row key and values. I intend them to be this way so that I can write arbitrary things there (Part 2 will include a protobuf for a cell batch).

**Where should we start reviewing?**:`SequentialTables`, then `CleanupSchema`. The rest is generated.

**Priority (whenever / two weeks / yesterday)**: one week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2768)
<!-- Reviewable:end -->
