### PR TITLE
If the loaded commitTs is not the one just written, it is uncommitedTs.

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
@@ -82,8 +82,8 @@ public final class CommitTsLoader {
             return commitTsAfterRollBack;
         } else {
             // This can happen if the clean tx table CLI has rolled-back the transaction at the start ts.
-            log.warn("Did not find a commitTs for startTs {} after rollback. "
-                    + "This is possibly due to a delete for this startTs via the clean transaction table CLI.",
+            log.warn("Did not find a commitTs for startTs {} after a rollback. "
+                    + "This is possibly due to a delete at the above startTs via the clean transaction table CLI.",
                     SafeArg.of("startTs", startTs));
             return TransactionConstants.FAILED_COMMIT_TS;
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
@@ -76,6 +76,12 @@ public final class CommitTsLoader {
                     new TransactionFailedRetriableException(msg, e));
         }
 
-        return transactionService.get(startTs);
+        Long commitTsAfterRollBack = transactionService.get(startTs);
+        if (commitTsAfterRollBack != null) {
+            return commitTsAfterRollBack;
+        } else {
+            // This can happen if the clean tx table CLI has rolled-back the transaction at the start ts.
+            return TransactionConstants.FAILED_COMMIT_TS;
+        }
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
@@ -22,6 +22,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.logsafe.SafeArg;
 
 import gnu.trove.TDecorators;
 import gnu.trove.map.TLongLongMap;
@@ -81,6 +82,9 @@ public final class CommitTsLoader {
             return commitTsAfterRollBack;
         } else {
             // This can happen if the clean tx table CLI has rolled-back the transaction at the start ts.
+            log.warn("Did not find a commitTs for startTs {} after rollback. "
+                    + "This is possibly due to a delete for this startTs via the clean transaction table CLI.",
+                    SafeArg.of("startTs", startTs));
             return TransactionConstants.FAILED_COMMIT_TS;
         }
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
@@ -81,11 +81,11 @@ public class CommitTsLoaderTest {
         verify(mockTransactionService).putUnlessExists(VALID_START_TIMESTAMP, ROLLBACK_TIMESTAMP);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void loadShouldThrowIfANullIsToBeReturned() throws Exception {
         doAnswer((invocation) -> NO_TIMESTAMP)
                 .when(mockTransactionService).get(VALID_START_TIMESTAMP);
 
-        loader.load(VALID_START_TIMESTAMP);
+        assertThat(loader.load(VALID_START_TIMESTAMP)).isEqualTo(ROLLBACK_TIMESTAMP);
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,9 +51,10 @@ develop
          - Change
 
     *    - |fixed|
-         - Sweep can now make progress after a restore and after the clean transactions CLI is run. Earlier, it would fail throwing
-           ``NullPointerException``s due to failure to read the commit ts.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2718>`__)
+         - Sweep can now make progress after a restore and after the clean transactions CLI is run.
+           Earlier, it would fail throwing a ``NullPointerException`` due to failure to read the commit ts.
+           This would cause sweep to keep retrying without realising that it will never proceed forward.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2778>`__)
 
     *    - |new| |logs|
          - Cassandra KVS now records how many writes have been made into each token range for each table.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,11 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Sweep can now make progress after a restore and after the clean transactions CLI is run. Earlier, it would fail throwing
+           ``NullPointerException``s due to failure to read the commit ts.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2718>`__)
+
     *    - |new| |logs|
          - Cassandra KVS now records how many writes have been made into each token range for each table.
            That information is logged at info every time a table is written to more than a threshold of times (currently 100 000 writes).


### PR DESCRIPTION
**Goals (and why)**: 
This is a very simple and quick fix for #2777.

From the sweep logs:
```
java.lang.NullPointerException: {throwable0_message}
	at com.palantir.atlasdb.sweep.CommitTsLoader.loadCacheMissAndPossiblyRollBack(CommitTsLoader.java:79)
	at com.palantir.atlasdb.sweep.CommitTsLoader.load(CommitTsLoader.java:53)
	at com.palantir.atlasdb.sweep.SweepableCellFilter.getCellToSweep(SweepableCellFilter.java:77)
	at com.palantir.atlasdb.sweep.SweepableCellFilter.getCellsToSweep(SweepableCellFilter.java:57)
	at com.google.common.collect.Iterators$7.transform(Iterators.java:750)
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
	at com.palantir.atlasdb.sweep.CellsToSweepPartitioningIterator.computeNext(CellsToSweepPartitioningIterator.java:70)
	at com.palantir.atlasdb.sweep.CellsToSweepPartitioningIterator.computeNext(CellsToSweepPartitioningIterator.java:29)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:145)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:140)
	at com.palantir.atlasdb.sweep.SweepTaskRunner.doRun(SweepTaskRunner.java:179)
	at com.palantir.atlasdb.sweep.SweepTaskRunner.runInternal(SweepTaskRunner.java:137)
	at com.palantir.atlasdb.sweep.SweepTaskRunner.run(SweepTaskRunner.java:103)
	at com.palantir.atlasdb.sweep.SpecificTableSweeper.runOneIteration(SpecificTableSweeper.java:134)
	at com.palantir.atlasdb.sweep.SpecificTableSweeper.runOnceAndSaveResults(SpecificTableSweeper.java:127)
	at com.palantir.atlasdb.sweep.BackgroundSweeperImpl.runOnce(BackgroundSweeperImpl.java:211)
	at com.palantir.atlasdb.sweep.BackgroundSweeperImpl.grabLocksAndRun(BackgroundSweeperImpl.java:183)
	at com.palantir.atlasdb.sweep.BackgroundSweeperImpl.checkConfigAndRunSweep(BackgroundSweeperImpl.java:172)
	at com.palantir.atlasdb.sweep.BackgroundSweeperImpl.run(BackgroundSweeperImpl.java:124)
	at java.lang.Thread.run(Thread.java:748)
```

**Implementation Description (bullets)**:
If we cant read the latest commitTs due to a delete, lets assume its uncommited Ts.

**Concerns (what feedback would you like?)**: Is this enough in the long term? We can eventually fix the behavior on the tx table to not allow the deletes to override future writes, this can be done by deleting at the current ts instead of long.Max.

Planning to smoke test this with clean tx CLI.

**Where should we start reviewing?**: CommitTsLoader.

**Priority (whenever / two weeks / yesterday)**: soon

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2778)
<!-- Reviewable:end -->
