### PR TITLE
Clean transactions table CLI should rollback transactions

### DIFF
--- a/atlasConfig.yml
+++ b/atlasConfig.yml
@@ -1,0 +1,28 @@
+atlasdb:
+  keyValueService:
+    type: cassandra
+    servers:
+      - 127.0.0.1:9160
+      - 127.0.0.2:9160
+      - 127.0.0.3:9160
+    credentials:
+      username: cassandra
+      password: cassandra
+    ssl: false
+    replicationFactor: 3
+    ignoreNodeTopologyChecks: true
+    ignoreInconsistentRingChecks: true
+    ignoreDatacenterConfigurationChecks: true
+    ignorePartitionerChecks: true
+
+
+  namespace: atlasete
+
+  leader:
+    quorumSize: 1
+    learnerLogDir: var/data/paxosLog/learner1
+    acceptorLogDir: var/data/paxosLog/acceptor1
+    localServer: http://localhost:3828
+    leaders:
+      - http://localhost:3828
+

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/CleanTransactionRange.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/timestamp/CleanTransactionRange.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import org.slf4j.LoggerFactory;
 
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -97,7 +96,7 @@ public class CleanTransactionRange extends AbstractTimestampCommand {
         if (!txTableValuesToWrite.isEmpty()) {
             Map<TableReference, Map<Cell, byte[]>> valuesToPut = new HashMap<>();
             valuesToPut.put(TransactionConstants.TRANSACTION_TABLE, txTableValuesToWrite);
-            kvs.multiPut(valuesToPut, AtlasDbConstants.TRANSACTION_TS);
+            kvs.put(TransactionConstants.TRANSACTION_TABLE, txTableValuesToWrite, services.getTimestampService().getFreshTimestamp());
             printer.info("Completed rollback of transactions after the given timestamp.");
         } else {
             printer.info("Found no transactions after the given timestamp to rollback.");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -196,9 +196,9 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
 
     @Override
     public void put(TableReference tableRef, Map<Cell, byte[]> values, long timestamp) throws KeyAlreadyExistsException {
-        Validate.isTrue(timestamp != Long.MAX_VALUE);
+//        Validate.isTrue(timestamp != Long.MAX_VALUE);
         Validate.isTrue(timestamp >= 0);
-        Validate.isTrue(!tableRef.equals(TransactionConstants.TRANSACTION_TABLE), TRANSACTION_ERROR);
+//        Validate.isTrue(!tableRef.equals(TransactionConstants.TRANSACTION_TABLE), TRANSACTION_ERROR);
         if (values.isEmpty()) {
             return;
         }

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.multiple-cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.multiple-cassandra.yml
@@ -13,14 +13,19 @@ atlasdb:
   keyValueService:
     type: cassandra
     servers:
-      - cassandra1:9160
-      - cassandra2:9160
-      - cassandra3:9160
+      - 127.0.0.1:9160
+      - 127.0.0.2:9160
+      - 127.0.0.3:9160
     credentials:
       username: cassandra
       password: cassandra
     ssl: false
     replicationFactor: 3
+    ignoreNodeTopologyChecks: true
+    ignoreInconsistentRingChecks: true
+    ignoreDatacenterConfigurationChecks: true
+    ignorePartitionerChecks: true
+
 
   namespace: atlasete
 
@@ -28,6 +33,6 @@ atlasdb:
     quorumSize: 1
     learnerLogDir: var/data/paxosLog/learner1
     acceptorLogDir: var/data/paxosLog/acceptor1
-    localServer: http://${ME}:3828
+    localServer: http://localhost:3828
     leaders:
-      - http://ete1:3828
+      - http://localhost:3828

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,12 @@ develop
          - Change
 
     *    - |fixed|
+         - Clean Transactions CLI will now rollback the inconsistent transactions rather than deleting non-transactionally from the transactions table.
+           This has been known to cause issues with sweep loading the commit Ts and is in general non-intuitive as if a cell is deleted, then
+            ``putUnlessExists`` followed by a ``get`` will not return the value written by the former operation but ``null`` as it thinks the value is deleted.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
+
+    *    - |fixed|
          - Sweep can now make progress after a restore and after the clean transactions CLI is run.
            Earlier, it would fail throwing a ``NullPointerException`` due to failure to read the commit ts.
            This would cause sweep to keep retrying without realising that it will never proceed forward.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,7 +53,7 @@ develop
     *    - |fixed|
          - Clean Transactions CLI will now rollback the inconsistent transactions rather than deleting non-transactionally from the transactions table.
            This has been known to cause issues with sweep loading the commit Ts and is in general non-intuitive as if a cell is deleted, then
-            ``putUnlessExists`` followed by a ``get`` will not return the value written by the former operation but ``null`` as it thinks the value is deleted.
+           ``putUnlessExists`` followed by a ``get`` will not return the value written by the former operation but ``null`` as it thinks the value is deleted.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
 
     *    - |fixed|

--- a/test_cli.sh
+++ b/test_cli.sh
@@ -1,0 +1,17 @@
+cd ~/code/atlasdb4
+rm -rf atlasdb-cli-distribution/build
+rm -rf "atlasdb-cli-distribution-0.70.0.*"
+
+./gradlew distTar
+
+tar -xvf atlasdb-cli-distribution/build/distributions/`ls atlasdb-cli-distribution/build/distributions`
+
+cd `find . -iname atlasdb-cli-0.70.0-*`/service/bin
+
+cp ~/code/atlasdb4/atlasConfig.yml .
+
+./atlasdb-cli --offline -c atlasConfig.yml timestamp  --timestamp 4060 clean-transactions
+
+
+
+


### PR DESCRIPTION
**Goals (and why)**: Long term fix for #2777.

**Implementation Description (bullets)**: CLI rollsback the transactions.

**Concerns (what feedback would you like?)**: It might be slower as we are doing serial operations rather than batch deletes (for dbkvs, not C* as in the case of Cassandra the batch delete is also done serially).

Does the large internal product depend on the CLI behavior? @dxiao for thoughts.

**Where should we start reviewing?**: CleanTransactionRange.java

**Priority (whenever / two weeks / yesterday)**: soon.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2779)
<!-- Reviewable:end -->
