### PR TITLE
Publish releases and docs through the internal build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -63,7 +63,7 @@ test:
 deployment:
   publish-docs:
     branch: develop
-    owner: palantir
+    owner: atlasdb
     commands:
       - ./scripts/circle-ci/publish-github-page.sh
   publish-internal-docs:
@@ -73,6 +73,6 @@ deployment:
       - curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH
   bintray:
     tag: /[0-9]+(\.[0-9]+){2}(-alpha|-beta|-rc[0-9]+)?(\+[0-9]{3})?/
-    owner: palantir
+    owner: atlasdb
     commands:
       - ./gradlew bintrayUpload -x check

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,7 +52,7 @@ develop
 
     *    - |improved|
          - AtlasDB publish of new releases is now done through the internal circle build. Before it was done via the external circle build.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2778>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2783>`__)
 
     *    - |fixed|
          - Sweep can now make progress after a restore and after the clean transactions CLI is run.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - AtlasDB publish of new releases is now done through the internal circle build. Before it was done via the external circle build.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2778>`__)
+
     *    - |fixed|
          - Sweep can now make progress after a restore and after the clean transactions CLI is run.
            Earlier, it would fail throwing a ``NullPointerException`` due to failure to read the commit ts.


### PR DESCRIPTION
**Goals (and why)**: The external build is flaky, takes longer and consumes shared resources. Let's move the remaining bits that are done there to the internal build.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2783)
<!-- Reviewable:end -->
