### PR TITLE
Disable sweep during KVS Migrations

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
@@ -156,7 +156,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
     public AtlasDbServices connectFromServices() throws IOException {
         AtlasDbConfig fromConfig = AtlasDbConfigs.load(fromConfigFile, configRoot);
         ServicesConfigModule scm = ServicesConfigModule.create(
-                makeOfflineIfNecessary(fromConfig), AtlasDbRuntimeConfig.withoutSweep());
+                makeOfflineIfNecessary(fromConfig), AtlasDbRuntimeConfig.withSweepDisabled());
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }
 
@@ -165,7 +165,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
                 ? AtlasDbConfigs.load(toConfigFile, configRoot)
                 : AtlasDbConfigs.loadFromString(inlineConfig, null);
         ServicesConfigModule scm = ServicesConfigModule.create(
-                makeOfflineIfNecessary(toConfig), AtlasDbRuntimeConfig.withoutSweep());
+                makeOfflineIfNecessary(toConfig), AtlasDbRuntimeConfig.withSweepDisabled());
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }
 

--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/KvsMigrationCommand.java
@@ -156,7 +156,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
     public AtlasDbServices connectFromServices() throws IOException {
         AtlasDbConfig fromConfig = AtlasDbConfigs.load(fromConfigFile, configRoot);
         ServicesConfigModule scm = ServicesConfigModule.create(
-                makeOfflineIfNecessary(fromConfig), AtlasDbRuntimeConfig.defaultRuntimeConfig());
+                makeOfflineIfNecessary(fromConfig), AtlasDbRuntimeConfig.withoutSweep());
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }
 
@@ -165,7 +165,7 @@ public class KvsMigrationCommand implements Callable<Integer> {
                 ? AtlasDbConfigs.load(toConfigFile, configRoot)
                 : AtlasDbConfigs.loadFromString(inlineConfig, null);
         ServicesConfigModule scm = ServicesConfigModule.create(
-                makeOfflineIfNecessary(toConfig), AtlasDbRuntimeConfig.defaultRuntimeConfig());
+                makeOfflineIfNecessary(toConfig), AtlasDbRuntimeConfig.withoutSweep());
         return DaggerAtlasDbServices.builder().servicesConfigModule(scm).build();
     }
 

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.cli.command;
 
+import static org.junit.Assert.assertFalse;
+
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -42,6 +44,16 @@ public class TestKvsMigrationCommand {
         String[] initArgs = new String[] { "migrate", "-fc", filePath, "-mc", filePath };
         String[] fullArgs = ObjectArrays.concat(initArgs, args, String.class);
         return AbstractTestRunner.buildCommand(KvsMigrationCommand.class, fullArgs);
+    }
+
+    @Test
+    public void doesNotSweepDuringMigration() throws Exception {
+        KvsMigrationCommand cmd = getCommand(new String[] { "-smv" });
+        AtlasDbServices fromServices = cmd.connectFromServices();
+        assertFalse(fromServices.getAtlasDbRuntimeConfig().sweep().enabled());
+
+        AtlasDbServices toServices = cmd.connectToServices();
+        assertFalse(toServices.getAtlasDbRuntimeConfig().sweep().enabled());
     }
 
     @Test

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -78,7 +78,7 @@ public abstract class AtlasDbRuntimeConfig {
         return ImmutableAtlasDbRuntimeConfig.builder().build();
     }
 
-    public static ImmutableAtlasDbRuntimeConfig withoutSweep() {
+    public static ImmutableAtlasDbRuntimeConfig withSweepDisabled() {
         return ImmutableAtlasDbRuntimeConfig.builder().sweep(SweepConfig.disabled()).build();
     }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -77,4 +77,8 @@ public abstract class AtlasDbRuntimeConfig {
     public static ImmutableAtlasDbRuntimeConfig defaultRuntimeConfig() {
         return ImmutableAtlasDbRuntimeConfig.builder().build();
     }
+
+    public static ImmutableAtlasDbRuntimeConfig withoutSweep() {
+        return ImmutableAtlasDbRuntimeConfig.builder().sweep(SweepConfig.disabled()).build();
+    }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/SweepConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/SweepConfig.java
@@ -77,4 +77,8 @@ public abstract class SweepConfig {
                 .deleteBatchHint(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
                 .build();
     }
+
+    public static SweepConfig disabled() {
+        return ImmutableSweepConfig.builder().enabled(false).build();
+    }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.config;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class AtlasDbRuntimeConfigTest {
+    @Test
+    public void configHasSweepEnabledByDefault() {
+        AtlasDbRuntimeConfig config = AtlasDbRuntimeConfig.defaultRuntimeConfig();
+        assertTrue(config.sweep().enabled());
+    }
+
+    @Test
+    public void configWithoutSweepHasSweepDisabled() throws Exception {
+        AtlasDbRuntimeConfig config = AtlasDbRuntimeConfig.withoutSweep();
+        assertFalse(config.sweep().enabled());
+    }
+}

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigTest.java
@@ -30,7 +30,7 @@ public class AtlasDbRuntimeConfigTest {
 
     @Test
     public void configWithoutSweepHasSweepDisabled() throws Exception {
-        AtlasDbRuntimeConfig config = AtlasDbRuntimeConfig.withoutSweep();
+        AtlasDbRuntimeConfig config = AtlasDbRuntimeConfig.withSweepDisabled();
         assertFalse(config.sweep().enabled());
     }
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/AtlasDbServices.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/AtlasDbServices.java
@@ -19,6 +19,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import com.palantir.atlasdb.config.AtlasDbConfig;
+import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -35,6 +36,8 @@ import dagger.Component;
 public abstract class AtlasDbServices implements AutoCloseable {
 
     public abstract AtlasDbConfig getAtlasDbConfig();
+
+    public abstract AtlasDbRuntimeConfig getAtlasDbRuntimeConfig();
 
     public abstract TimelockService getTimelockService();
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,10 @@ develop
            This would cause sweep to keep retrying without realising that it will never proceed forward.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2778>`__)
 
+    *    - |fixed|
+         - Sweep will no longer run during KVS Migrations.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2784>`__)
+
     *    - |new| |logs|
          - Cassandra KVS now records how many writes have been made into each token range for each table.
            That information is logged at info every time a table is written to more than a threshold of times (currently 100 000 writes).


### PR DESCRIPTION
**Goals (and why)**:
Having sweep run during migrations can cause confusion, and lead to
inconsistencies as the sweep priority table will change and may say
that a table has been swept after we have copied it in an unswept state
(or vice versa).

Fixes #2209

**Implementation Description (bullets)**:
* Hard coded the config for both `fromServices` and `toServices` to have sweep disabled, creating new factory methods for a few config objects.

**Concerns (what feedback would you like?)**:
* I assumed that the runtime config takes precedence over the (deprecated) value in `AtlasDbConfig`. Is this correct?

**Where should we start reviewing?**: KvsMigrationCommand

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2784)
<!-- Reviewable:end -->
