### PR TITLE
Revert publish to github from internal build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -63,7 +63,7 @@ test:
 deployment:
   publish-docs:
     branch: develop
-    owner: atlasdb
+    owner: palantir
     commands:
       - ./scripts/circle-ci/publish-github-page.sh
   publish-internal-docs:


### PR DESCRIPTION
**Goals (and why)**: We don't seem to have the creds to publish to github from the internal build, and this broke develop. Reverting for now.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2785)
<!-- Reviewable:end -->
