### PR TITLE
Publish internal and external docs on same circle rule

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -65,8 +65,8 @@ deployment:
     branch: develop
     owner: atlasdb
     commands:
-      - ./scripts/circle-ci/publish-github-page.sh
-      - curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH
+      - ./scripts/circle-ci/publish-github-page.sh                                    # This command publishes the external docs.
+      - curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH # This command publishes the internal docs.
   bintray:
     tag: /[0-9]+(\.[0-9]+){2}(-alpha|-beta|-rc[0-9]+)?(\+[0-9]{3})?/
     owner: atlasdb

--- a/circle.yml
+++ b/circle.yml
@@ -66,10 +66,6 @@ deployment:
     owner: atlasdb
     commands:
       - ./scripts/circle-ci/publish-github-page.sh
-  publish-internal-docs:
-    branch: develop
-    owner: atlasdb
-    commands:
       - curl -s --fail $DOCS_URL | bash -s -- -r docs/requirements.txt $CIRCLE_BRANCH
   bintray:
     tag: /[0-9]+(\.[0-9]+){2}(-alpha|-beta|-rc[0-9]+)?(\+[0-9]{3})?/


### PR DESCRIPTION
**Goals (and why)**: If we have two rules matching the branch, Circle just seems to run the first one. Internal docs were out of date for a few versions.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2790)
<!-- Reviewable:end -->
