### PR TITLE
Shortened sweep progress table name

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -31,7 +31,7 @@ public class AtlasDbConstants {
     public static final TableReference PERSISTED_LOCKS_TABLE = TableReference.createWithEmptyNamespace(
             "_persisted_locks");
     public static final TableReference SWEEP_PROGRESS_TABLE = TableReference.createWithEmptyNamespace(
-            "_sweep_progress_0_39_fixed");
+            "_sweep_progress1_5");
 
     public static final TableReference DEFAULT_METADATA_TABLE = TableReference.createWithEmptyNamespace("_metadata");
     public static final TableReference DEFAULT_ORACLE_METADATA_TABLE = TableReference.createWithEmptyNamespace("atlasdb_metadata");


### PR DESCRIPTION
**Goals (and why)**:
Large internal product has it's own tablemapping logic that doesn't deal with the sweep progress table, and we hit `ORA-00972: identifier is too long`. This should fix it.

**Priority (whenever / two weeks / yesterday)**:
Now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2795)
<!-- Reviewable:end -->
