### PR TITLE
Fix/timelock healthcheck

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,10 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - The ``LeaderPingHealthCheck`` supplied by ``PaxosLeadershipCreator`` now correctly reports the leadership state of nodes that believe themselves to be the leader.
+           Previously, the health check would ping every *other* node in the cluster, resulting in leader nodess reporting that there are no leaders.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2805>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,7 +52,7 @@ develop
 
     *    - |fixed|
          - The ``LeaderPingHealthCheck`` supplied by ``PaxosLeadershipCreator`` now correctly reports the leadership state of nodes that believe themselves to be the leader.
-           Previously, the health check would ping every *other* node in the cluster, resulting in leader nodess reporting that there are no leaders.
+           Previously, the health check would ping every *other* node in the cluster, resulting in leader nodes reporting that there are no leaders.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2805>`__)
 
 .. <<<<------------------------------------------------------------------------------------------------------------->>>>

--- a/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
+++ b/leader-election-api/src/main/java/com/palantir/leader/LeaderElectionService.java
@@ -73,7 +73,7 @@ public interface LeaderElectionService {
      * Get the set of potential leaders known by this leader election service. This will not do any network
      * calls and is meant to be callable without major performance implications.
      *
-     * @return the set of potential leaders known by this leader election service
+     * @return the set of potential leaders known by this leader election service, including itself
      */
     Set<PingableLeader> getPotentialLeaders();
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -43,8 +43,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 import com.palantir.common.base.Throwables;
 import com.palantir.paxos.CoalescingPaxosLatestRoundVerifier;
@@ -350,7 +352,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
 
     @Override
     public Set<PingableLeader> getPotentialLeaders() {
-        return potentialLeadersToHosts.keySet();
+        return Sets.union(potentialLeadersToHosts.keySet(), ImmutableSet.of(this));
     }
 
     @Override

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -74,7 +74,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
     final PaxosProposer proposer;
     final PaxosLearner knowledge;
 
-    final Map<PingableLeader, HostAndPort> potentialLeadersToHosts;
+    final Map<PingableLeader, HostAndPort> otherPotentialLeadersToHosts;
     final ImmutableList<PaxosAcceptor> acceptors;
     final ImmutableList<PaxosLearner> learners;
 
@@ -91,21 +91,21 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
     @Deprecated // Use PaxosLeaderElectionServiceBuilder instead.
     public PaxosLeaderElectionService(PaxosProposer proposer,
                                       PaxosLearner knowledge,
-                                      Map<PingableLeader, HostAndPort> potentialLeadersToHosts,
+                                      Map<PingableLeader, HostAndPort> otherPotentialLeadersToHosts,
                                       List<PaxosAcceptor> acceptors,
                                       List<PaxosLearner> learners,
                                       ExecutorService executor,
                                       long updatePollingWaitInMs,
                                       long randomWaitBeforeProposingLeadership,
                                       long leaderPingResponseWaitMs) {
-        this(proposer, knowledge, potentialLeadersToHosts, acceptors, learners, executor,
+        this(proposer, knowledge, otherPotentialLeadersToHosts, acceptors, learners, executor,
                 updatePollingWaitInMs, randomWaitBeforeProposingLeadership, leaderPingResponseWaitMs,
                 PaxosLeaderElectionEventRecorder.NO_OP);
     }
 
     PaxosLeaderElectionService(PaxosProposer proposer,
             PaxosLearner knowledge,
-            Map<PingableLeader, HostAndPort> potentialLeadersToHosts,
+            Map<PingableLeader, HostAndPort> otherPotentialLeadersToHosts,
             List<PaxosAcceptor> acceptors,
             List<PaxosLearner> learners,
             ExecutorService executor,
@@ -116,7 +116,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
         this.proposer = proposer;
         this.knowledge = knowledge;
         // XXX This map uses something that may be proxied as a key! Be very careful if making a new map from this.
-        this.potentialLeadersToHosts = Collections.unmodifiableMap(potentialLeadersToHosts);
+        this.otherPotentialLeadersToHosts = Collections.unmodifiableMap(otherPotentialLeadersToHosts);
         this.acceptors = copyOf(acceptors);
         this.learners = copyOf(learners);
         this.executor = executor;
@@ -227,7 +227,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
         if (!maybeLeader.isPresent()) {
             return Optional.empty();
         }
-        return Optional.of(potentialLeadersToHosts.get(maybeLeader.get()));
+        return Optional.of(otherPotentialLeadersToHosts.get(maybeLeader.get()));
     }
 
     private Optional<PingableLeader> getSuspectedLeader(boolean useNetwork) {
@@ -255,7 +255,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
 
         // kick off requests to get leader uuids
         List<Future<Entry<String, PingableLeader>>> allFutures = Lists.newArrayList();
-        for (final PingableLeader potentialLeader : potentialLeadersToHosts.keySet()) {
+        for (final PingableLeader potentialLeader : otherPotentialLeadersToHosts.keySet()) {
             allFutures.add(pingService.submit(() -> new AbstractMap.SimpleEntry<String, PingableLeader>(
                     potentialLeader.getUUID(),
                     potentialLeader)));
@@ -352,7 +352,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
 
     @Override
     public Set<PingableLeader> getPotentialLeaders() {
-        return Sets.union(potentialLeadersToHosts.keySet(), ImmutableSet.of(this));
+        return Sets.union(otherPotentialLeadersToHosts.keySet(), ImmutableSet.of(this));
     }
 
     @Override

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -352,7 +352,7 @@ public class PaxosLeaderElectionService implements PingableLeader, LeaderElectio
 
     @Override
     public Set<PingableLeader> getPotentialLeaders() {
-        return Sets.union(otherPotentialLeadersToHosts.keySet(), ImmutableSet.of(this));
+        return Sets.union(ImmutableSet.of(this), otherPotentialLeadersToHosts.keySet());
     }
 
     @Override

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
@@ -47,6 +47,9 @@ public class PaxosLeaderElectionServiceBuilder {
         return this;
     }
 
+    /**
+     * Mapping containing the host/port information for all nodes in the cluster EXCEPT this one.
+     */
     public PaxosLeaderElectionServiceBuilder potentialLeadersToHosts(
             Map<PingableLeader, HostAndPort> potentialLeadersToHosts) {
         this.potentialLeadersToHosts = potentialLeadersToHosts;

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderElectionServiceTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderElectionServiceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.Executors;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import com.palantir.paxos.PaxosLearner;
+import com.palantir.paxos.PaxosProposer;
+
+public class PaxosLeaderElectionServiceTest {
+    @Test
+    public void weAreOneOfThePotentialLeaders() throws Exception {
+        PingableLeader other = mock(PingableLeader.class);
+        PaxosLeaderElectionService service = new PaxosLeaderElectionServiceBuilder()
+                .proposer(mock(PaxosProposer.class))
+                .knowledge(mock(PaxosLearner.class))
+                .potentialLeadersToHosts(ImmutableMap.of(other, HostAndPort.fromHost("other")))
+                .acceptors(ImmutableList.of())
+                .learners(ImmutableList.of())
+                .executor(Executors.newSingleThreadExecutor())
+                .pingRateMs(0L)
+                .randomWaitBeforeProposingLeadershipMs(0L)
+                .leaderPingResponseWaitMs(0L)
+                .eventRecorder(mock(PaxosLeadershipEventRecorder.class))
+                .build();
+
+        assertThat(service.getPotentialLeaders()).containsExactlyInAnyOrder(other, service);
+    }
+
+}


### PR DESCRIPTION
- [x] smoke testing with timelock test cluster

**Goals (and why)**: Make timelock leader nodes correctly report their health status

**Implementation Description (bullets)**:
- Have PLES.getPotentialLeaders include itself in the result set. This is the set of nodes that are pinged by the LeaderPingHealthCheck.

**Concerns (what feedback would you like?)**:
- I wanted to tet this somewhere like `PaxosTimeLockServerIntegrationTest`, but couldn't figure out how to get to the healthcheck. How hard would it be to add the instrumentation here?

**Where should we start reviewing?**: The test?

**Priority (whenever / two weeks / yesterday)**: Today

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2805)
<!-- Reviewable:end -->
