### PR TITLE
[TTT] Async Lock Advisory Locks, Part 1: Parameterising Pre Commit Checks

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockPreCommitCheck.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockPreCommitCheck.java
@@ -46,15 +46,16 @@ final class AdvisoryLockPreCommitCheck {
 
     public static final AdvisoryLockPreCommitCheck NO_OP = new AdvisoryLockPreCommitCheck(() -> { });
 
-    public static AdvisoryLockPreCommitCheck forLockServiceLocks(Iterable<LockRefreshToken> tokens,
+    public static AdvisoryLockPreCommitCheck forLockServiceLocks(
+            Iterable<LockRefreshToken> tokens,
             LockService lockService) {
         return getLockServiceBasedPreCommitCheck(lockService::refreshLockRefreshTokens, ImmutableSet.copyOf(tokens));
     }
 
     public static AdvisoryLockPreCommitCheck forAsyncLockServiceLocks(
-            Set<LockToken> lockTokens,
+            Iterable<LockToken> lockTokens,
             TimelockService timelockService) {
-        return getLockServiceBasedPreCommitCheck(timelockService::refreshLockLeases, lockTokens);
+        return getLockServiceBasedPreCommitCheck(timelockService::refreshLockLeases, ImmutableSet.copyOf(lockTokens));
     }
 
     private static <T> AdvisoryLockPreCommitCheck getLockServiceBasedPreCommitCheck(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockPreCommitCheck.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockPreCommitCheck.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Set;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +27,8 @@ import com.google.common.collect.Sets;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockService;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.UnsafeArg;
 
 /**
@@ -45,14 +48,25 @@ final class AdvisoryLockPreCommitCheck {
 
     public static AdvisoryLockPreCommitCheck forLockServiceLocks(Iterable<LockRefreshToken> tokens,
             LockService lockService) {
-        Set<LockRefreshToken> toRefresh = ImmutableSet.copyOf(tokens);
+        return getLockServiceBasedPreCommitCheck(lockService::refreshLockRefreshTokens, ImmutableSet.copyOf(tokens));
+    }
+
+    public static AdvisoryLockPreCommitCheck forAsyncLockServiceLocks(
+            Set<LockToken> lockTokens,
+            TimelockService timelockService) {
+        return getLockServiceBasedPreCommitCheck(timelockService::refreshLockLeases, lockTokens);
+    }
+
+    private static <T> AdvisoryLockPreCommitCheck getLockServiceBasedPreCommitCheck(
+            Function<Set<T>, Set<T>> refreshingFunction,
+            Set<T> toRefresh) {
         if (toRefresh.isEmpty()) {
             return NO_OP;
         }
 
         return new AdvisoryLockPreCommitCheck(() -> {
-            Set<LockRefreshToken> refreshed = lockService.refreshLockRefreshTokens(toRefresh);
-            Set<LockRefreshToken> notRefreshed = Sets.difference(toRefresh, refreshed).immutableCopy();
+            Set<T> refreshed = refreshingFunction.apply(toRefresh);
+            Set<T> notRefreshed = Sets.difference(toRefresh, refreshed);
             if (!notRefreshed.isEmpty()) {
                 log.warn("Lock service locks were no longer valid at commit time",
                         UnsafeArg.of("invalidTokens", notRefreshed));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockPreCommitCheckTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockPreCommitCheckTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
+import com.palantir.lock.LockRefreshToken;
+import com.palantir.lock.LockService;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
+
+public class AdvisoryLockPreCommitCheckTest {
+    private static final LockRefreshToken TOKEN_1 = new LockRefreshToken(new BigInteger("1"), Long.MAX_VALUE);
+    private static final LockRefreshToken TOKEN_2 = new LockRefreshToken(new BigInteger("2"), Long.MAX_VALUE);
+    private static final List<LockRefreshToken> TOKENS = ImmutableList.of(TOKEN_1, TOKEN_2);
+
+    private static final LockToken TOKEN_V2_1 = LockToken.of(UUID.randomUUID());
+    private static final LockToken TOKEN_V2_2 = LockToken.of(UUID.randomUUID());
+    private static final List<LockToken> TOKENS_V2 = ImmutableList.of(TOKEN_V2_1, TOKEN_V2_2);
+
+    @Test
+    @SuppressWarnings("unchecked") // we know throughout that we refer to Iterables of LockRefreshToken
+    public void checkPassesIfLegacyLocksAreRefreshed() throws InterruptedException {
+        LockService happyLockService = mock(LockService.class);
+        when(happyLockService.refreshLockRefreshTokens(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
+
+        AdvisoryLockPreCommitCheck.forLockServiceLocks(TOKENS, happyLockService).throwIfLocksExpired();
+
+        // We need to check that the element contains-exactly-in-any-order the same elements
+        // but eq is too strong, because the check is allowed to (and does!) wrap the tokens in a different collection.
+        ArgumentCaptor<Iterable> captor = ArgumentCaptor.forClass(Iterable.class);
+        verify(happyLockService).refreshLockRefreshTokens(captor.capture());
+        assertThat((Iterable<LockRefreshToken>) captor.getValue()).hasSameElementsAs(TOKENS);
+    }
+
+    @Test
+    public void checkFailsIfOnlySomeLegacyLocksAreRefreshed() {
+        LockService lockService = mock(LockService.class);
+        when(lockService.refreshLockRefreshTokens(any())).thenReturn(ImmutableSet.of(TOKEN_1));
+
+        assertThatThrownBy(AdvisoryLockPreCommitCheck.forLockServiceLocks(TOKENS, lockService)::throwIfLocksExpired)
+                .isInstanceOf(TransactionLockTimeoutException.class);
+    }
+
+    @Test
+    public void checkFailsIfNoLegacyLocksAreRefreshed() {
+        LockService sadLockService = mock(LockService.class);
+        when(sadLockService.refreshLockRefreshTokens(any())).thenReturn(ImmutableSet.of());
+
+        assertThatThrownBy(AdvisoryLockPreCommitCheck.forLockServiceLocks(TOKENS, sadLockService)::throwIfLocksExpired)
+                .isInstanceOf(TransactionLockTimeoutException.class);
+    }
+
+    @Test
+    public void checkDelegatesAndFailsOnlyWhenChecked() {
+        LockService sadLockService = mock(LockService.class);
+        when(sadLockService.refreshLockRefreshTokens(any())).thenReturn(ImmutableSet.of());
+
+        AdvisoryLockPreCommitCheck preCommitCheck = AdvisoryLockPreCommitCheck.forLockServiceLocks(
+                TOKENS, sadLockService);
+
+        verify(sadLockService, never()).refreshLockRefreshTokens(any());
+        try {
+            preCommitCheck.throwIfLocksExpired();
+        } catch (Exception e) {
+            // expected
+        }
+        verify(sadLockService).refreshLockRefreshTokens(any());
+    }
+
+    @Test
+    public void propagatesExceptionsIfLockServiceThrows() {
+        IllegalStateException exception = new IllegalStateException("something bad");
+        LockService lockService = mock(LockService.class);
+        when(lockService.refreshLockRefreshTokens(any())).thenThrow(exception);
+
+        assertThatThrownBy(AdvisoryLockPreCommitCheck.forLockServiceLocks(TOKENS, lockService)::throwIfLocksExpired)
+                .isInstanceOf(IllegalStateException.class)
+                .isNotInstanceOf(TransactionLockTimeoutException.class);
+    }
+
+    @Test
+    public void doesNotDelegateCheckIfNoLegacyLockTokensAreSupplied() {
+        LockService lockService = mock(LockService.class);
+        AdvisoryLockPreCommitCheck.forLockServiceLocks(ImmutableList.of(), lockService).throwIfLocksExpired();
+        verifyNoMoreInteractions(lockService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked") // we know throughout that we refer to Sets of LockRefreshToken
+    public void checkPassesIfAsyncLocksAreRefreshed() {
+        TimelockService timelockService = mock(TimelockService.class);
+        when(timelockService.refreshLockLeases(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
+
+        AdvisoryLockPreCommitCheck.forAsyncLockServiceLocks(TOKENS_V2, timelockService).throwIfLocksExpired();
+
+        // We need to check that the element contains-exactly-in-any-order the same elements
+        // but eq is too strong, because the check is allowed to (and does!) wrap the tokens in a different collection.
+        ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
+        verify(timelockService).refreshLockLeases(captor.capture());
+        assertThat((Set<LockToken>) captor.getValue()).hasSameElementsAs(TOKENS_V2);
+    }
+
+    @Test
+    public void checkFailsIfOnlySomeAsyncLocksAreRefreshed() {
+        TimelockService timelockService = mock(TimelockService.class);
+        when(timelockService.refreshLockLeases(any())).thenReturn(ImmutableSet.of(TOKEN_V2_1));
+
+        assertThatThrownBy(
+                AdvisoryLockPreCommitCheck.forAsyncLockServiceLocks(TOKENS_V2, timelockService)::throwIfLocksExpired)
+                .isInstanceOf(TransactionLockTimeoutException.class);
+    }
+
+    @Test
+    public void checkFailsIfNoAsyncLocksAreRefreshed() {
+        TimelockService timelockService = mock(TimelockService.class);
+        when(timelockService.refreshLockLeases(any())).thenReturn(ImmutableSet.of());
+
+        assertThatThrownBy(
+                AdvisoryLockPreCommitCheck.forAsyncLockServiceLocks(TOKENS_V2, timelockService)::throwIfLocksExpired)
+                .isInstanceOf(TransactionLockTimeoutException.class);
+    }
+
+    @Test
+    public void propagatesExceptionsIfAsyncLockServiceThrows() {
+        IllegalStateException exception = new IllegalStateException("something bad");
+        TimelockService timelockService = mock(TimelockService.class);
+        when(timelockService.refreshLockLeases(any())).thenThrow(exception);
+
+        assertThatThrownBy(
+                AdvisoryLockPreCommitCheck.forAsyncLockServiceLocks(TOKENS_V2, timelockService)::throwIfLocksExpired)
+                .isInstanceOf(IllegalStateException.class)
+                .isNotInstanceOf(TransactionLockTimeoutException.class);
+    }
+
+    @Test
+    public void doesNotDelegateCheckIfNoAsyncLockTokensAreSupplied() {
+        LockService lockService = mock(LockService.class);
+        AdvisoryLockPreCommitCheck.forLockServiceLocks(ImmutableList.of(), lockService).throwIfLocksExpired();
+        verifyNoMoreInteractions(lockService);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Build infrastructure for moving users of advisory locking (including possible future internal AtlasDB queues) to use the async lock service
- Add tests for the pre commit check logic

**Implementation Description (bullets)**:
- refactor pre-commit checks, adding an async lock option

**Concerns (what feedback would you like?)**:
- nothing specifically. I don't really like the unchecked stuff in AdvisoryLockPreCommitCheckTest, but I don't want to make the test stronger than it needs to be either.

**Where should we start reviewing?**: `AdvisoryLockPreCommitCheck.java`

**Priority (whenever / two weeks / yesterday)**: two weeks?
