### PR TITLE
Pull MutationMap creation out of CKVSImpl

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1186,7 +1186,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                      ConsistencyLevel consistency) throws TException {
         try {
             return queryRunner.run(client, tableRefs, () -> {
-                client.batch_mutate(kvsMethodName, map.get(), consistency);
+                client.batch_mutate(kvsMethodName, map.toMap(), consistency);
                 return null;
             });
         } catch (UnavailableException e) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1052,10 +1052,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         Mutation mutation = new Mutation();
                         mutation.setColumn_or_supercolumn(colOrSup);
 
-                        // TODO maybe pass cell to mutation map?
-                        ByteBuffer rowName = ByteBuffer.wrap(cell.getRowName());
-
-                        map.addMutationForRow(rowName, tableRef, mutation);
+                        map.addMutationForCell(cell, tableRef, mutation);
                     }
                     batchMutateInternal(kvsMethodName, client, tableRef, map.get(), writeConsistency);
                 }
@@ -1158,9 +1155,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             Mutation mutation = new Mutation();
             mutation.setColumn_or_supercolumn(colOrSup);
 
-            ByteBuffer rowName = ByteBuffer.wrap(cell.getRowName());
-
-            mutationMap.addMutationForRow(rowName, tableCellAndValue.tableRef, mutation);
+            mutationMap.addMutationForCell(cell, tableCellAndValue.tableRef, mutation);
         }
         return mutationMap;
     }
@@ -1358,8 +1353,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                             del.setTimestamp(Long.MAX_VALUE);
                             Mutation mutation = new Mutation();
                             mutation.setDeletion(del);
-                            ByteBuffer rowName = ByteBuffer.wrap(cellVersions.getKey().getRowName());
-                            mutationMap.addMutationForRow(rowName, tableRef, mutation);
+
+                            mutationMap.addMutationForCell(cellVersions.getKey(), tableRef, mutation);
                             mapIndex++;
                             numVersions += cellVersions.getValue().size();
                         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/MutationMap.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/MutationMap.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.thrift.Mutation;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
 
@@ -34,7 +35,8 @@ public class MutationMap {
         this.mutationMap = Maps.newHashMap();
     }
 
-    public void addMutationForRow(ByteBuffer rowName, TableReference tableRef, Mutation mutation) {
+    public void addMutationForCell(Cell cell, TableReference tableRef, Mutation mutation) {
+        ByteBuffer rowName = ByteBuffer.wrap(cell.getRowName());
         Map<String, List<Mutation>> rowPuts = mutationMap.computeIfAbsent(rowName, row -> Maps.newHashMap());
 
         List<Mutation> tableMutations = rowPuts.computeIfAbsent(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/MutationMap.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/MutationMap.java
@@ -56,6 +56,8 @@ public class MutationMap {
     }
 
     /**
+     * Gets the MutationMap's internal map object, for use by Thrift's batch_mutate API.
+     *
      * @return a reference to (not a copy of) the map wrapped by the MutationMap object
      */
     public Map<ByteBuffer, Map<String, List<Mutation>>> toMap() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/MutationMap.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/MutationMap.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.thrift;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cassandra.thrift.Mutation;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
+
+public class MutationMap {
+    private final Map<ByteBuffer, Map<String, List<Mutation>>> mutationMap;
+
+    public MutationMap() {
+        this.mutationMap = Maps.newHashMap();
+    }
+
+    public void addMutationForRow(ByteBuffer rowName, TableReference tableRef, Mutation mutation) {
+        Map<String, List<Mutation>> rowPuts = mutationMap.computeIfAbsent(rowName, row -> Maps.newHashMap());
+
+        List<Mutation> tableMutations = rowPuts.computeIfAbsent(
+                AbstractKeyValueService.internalTableName(tableRef),
+                k -> Lists.newArrayList());
+
+        tableMutations.add(mutation);
+    }
+
+    public Map<ByteBuffer, Map<String, List<Mutation>>> get() {
+        return mutationMap;
+    }
+}


### PR DESCRIPTION
**Goals (and why)**: Extract some duplicated plumbing code from CKVS. This can later be combined with some of the work in #2787 to provide a single area for "I'm building a horrible data structure for Thrift" type code to live.

**Implementation Description (bullets)**:
* Create `MutationMap` class to wrap the Map-Map-List
* Made each instance where there was a `Map<ByteBuffer, Map<String, List<Mutation>>>` use `MutationMap` instead

**Concerns (what feedback would you like?)**: I ran out of time to write specific tests for `MutationMap`. Should I do so now?

**Where should we start reviewing?**: commit by commit

**Priority (whenever / two weeks / yesterday)**: this year?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2814)
<!-- Reviewable:end -->
