### PR TITLE
Bump guava to 20.0, use getHost() instead of getHostText()

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceCreator.java
@@ -98,7 +98,7 @@ public class ServiceCreator<T> implements Function<ServerListConfig, T> {
                 HostAndPort hostAndPort = HostAndPort.fromString(proxyConfig.hostAndPort()
                         .orElseThrow(() -> new IllegalArgumentException(
                                 "Expected to find proxy hostAndPort configuration for HTTP proxy")));
-                InetSocketAddress addr = new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort());
+                InetSocketAddress addr = new InetSocketAddress(hostAndPort.getHost(), hostAndPort.getPort());
                 return fixedProxySelectorFor(new Proxy(Proxy.Type.HTTP, addr));
             default:
                 // fall through


### PR DESCRIPTION
**Goals (and why)**:

So atlasdb can be used together with guava 22.0+.

Guava 20.0 deprecates `HostAndPort.getHostText()` and adds a replacement - `getHost()`, while guava 22.0 removes `getHostText()` ([deprecation PR](https://github.com/google/guava/commit/b0babb69b05ed4d15cce74635ae96cf8ba78c85f)).
Atlasdb is currently on 18.0, therefore it's necessary to bump to 20.0 so we can use the alternative method.

Please see the same change in http-remoting: https://github.com/palantir/http-remoting/pull/655

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2817)
<!-- Reviewable:end -->
