### PR TITLE
Targeted Sweep Part 3 - Sweep Queue Processor

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CandidateCellForSweepingRequest.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CandidateCellForSweepingRequest.java
@@ -42,9 +42,8 @@ public interface CandidateCellForSweepingRequest {
     boolean ignoreGarbageCollectionSentinels();
 
     default boolean shouldSweep(long timestamp) {
-        if (ignoreGarbageCollectionSentinels()
-                && timestamp == com.palantir.atlasdb.keyvalue.api.Value.INVALID_VALUE_TIMESTAMP) {
-            return false;
+        if (timestamp == com.palantir.atlasdb.keyvalue.api.Value.INVALID_VALUE_TIMESTAMP) {
+            return ignoreGarbageCollectionSentinels();
         }
 
         return timestamp < maxTimestampExclusive();

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CandidateCellForSweepingRequest.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/CandidateCellForSweepingRequest.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.keyvalue.api;
 
 import java.util.OptionalInt;
-import java.util.Set;
 
 import org.immutables.value.Value;
 
@@ -37,9 +36,19 @@ public interface CandidateCellForSweepingRequest {
     boolean shouldCheckIfLatestValueIsEmpty();
 
     /*
-     *  In practice, this is the empty set if for the THOROUGH sweep strategy and { -1 } for CONSERVATIVE.
+     *  Whether GC sentinels (values written at timestamp -1) should be swept. In practice, this is true for the
+     *  THOROUGH sweep strategy and false for CONSERVATIVE.
      */
-    Set<Long> timestampsToIgnore();
+    boolean ignoreGarbageCollectionSentinels();
+
+    default boolean shouldSweep(long timestamp) {
+        if (ignoreGarbageCollectionSentinels()
+                && timestamp == com.palantir.atlasdb.keyvalue.api.Value.INVALID_VALUE_TIMESTAMP) {
+            return false;
+        }
+
+        return timestamp < maxTimestampExclusive();
+    }
 
     default CandidateCellForSweepingRequest withStartRow(byte[] startRow) {
         return ImmutableCandidateCellForSweepingRequest.builder()

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -374,6 +374,17 @@ public interface KeyValueService extends AutoCloseable {
     void deleteRange(@QueryParam("tableRef") TableReference tableRef, RangeRequest range);
 
     /**
+     * For each cell, deletes all timestamps prior to the associated maximum timestamp, excluding garbage collection
+     * sentinels. Depending on the implementation, this may result in a range tombstone in the underlying KVS.
+     */
+    @POST
+    @Path("delete-all-timestamps")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Idempotent
+    void deleteAllTimestamps(@QueryParam("tableRef") TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell);
+
+    /**
      * Truncate a table in the key-value store.
      * <p>
      * This is preferred to dropping and re-adding a table, as live schema changes can

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Value.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/Value.java
@@ -60,6 +60,10 @@ public final class Value implements Serializable {
         return contents.length == 0;
     }
 
+    public static boolean isTombstone(byte[] value) {
+        return value.length == 0;
+    }
+
     /**
      * The timestamp of the value.
      */

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
@@ -72,7 +72,7 @@ public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends Abst
         insertMultipleValues(numInsertions);
 
         long sweepTimestamp = numInsertions + 1;
-        SweepResults results = completeSweep(sweepTimestamp);
+        SweepResults results = completeSweep(sweepTimestamp).get();
         Assert.assertEquals(numInsertions - 1, results.getStaleValuesDeleted());
     }
 
@@ -85,7 +85,7 @@ public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends Abst
             put("row", "col2", "value", ts + 5);
         }
 
-        SweepResults results = completeSweep(350);
+        SweepResults results = completeSweep(350).get();
         Assert.assertEquals(28, results.getStaleValuesDeleted());
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTargetedSweepIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTargetedSweepIntegrationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
+import com.palantir.atlasdb.containers.CassandraContainer;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.SweepResults;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.sweep.AbstractSweepTest;
+import com.palantir.atlasdb.sweep.queue.BackgroundSweepQueueProcessor;
+import com.palantir.atlasdb.sweep.queue.SweepTimestampProvider;
+import com.palantir.atlasdb.sweep.queue.test.InMemorySweepQueue;
+import com.palantir.atlasdb.sweep.queue.test.InMemorySweepQueueProcessorFactory;
+
+public class CassandraTargetedSweepIntegrationTest extends AbstractSweepTest {
+
+    private SweepTimestampProvider timestamps = mock(SweepTimestampProvider.class);
+    private BackgroundSweepQueueProcessor processor;
+
+    @Before
+    public void setup() {
+        super.setup();
+
+        InMemorySweepQueue.clear();
+        InMemorySweepQueueProcessorFactory factory = new InMemorySweepQueueProcessorFactory(kvs, ssm, timestamps);
+        processor = new BackgroundSweepQueueProcessor(kvs, factory::getProcessorForTable);
+    }
+
+    @Override
+    protected KeyValueService getKeyValueService() {
+        CassandraKeyValueServiceConfig config = CassandraContainer.KVS_CONFIG;
+
+        return CassandraKeyValueServiceImpl.create(
+                CassandraKeyValueServiceConfigManager.createSimpleManager(config), CassandraContainer.LEADER_CONFIG);
+    }
+
+    @Override
+    protected Optional<SweepResults> completeSweep(TableReference tableReference, long ts) {
+        when(timestamps.getSweepTimestamp(any())).thenReturn(ts);
+        processor.sweepOneBatchForAllTable();
+        return Optional.empty();
+    }
+
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -2068,7 +2068,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                 .add(mutation);
                     });
 
-                    batchMutateInternal("delete", client, tableRef, mutationsByRowByTable, deleteConsistency);
+                    batchMutateInternal("deleteAllTimestamps", client, tableRef, mutationsByRowByTable,
+                            deleteConsistency);
 
                     return null;
                 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/CellWithTimestamps.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/CellWithTimestamps.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra.sweep;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.immutables.value.Value;
@@ -45,11 +45,10 @@ public interface CellWithTimestamps {
     }
 
     default CandidateCellForSweeping toSweepCandidate(
-            long maxTimestampExclusive,
-            Set<Long> timestampsToIgnore,
+            Predicate<Long> shouldSweepTimestampPredicate,
             boolean latestValueEmpty) {
         List<Long> filteredTimestamps = sortedTimestamps().stream()
-                .filter(ts -> ts < maxTimestampExclusive && !timestampsToIgnore.contains(ts))
+                .filter(shouldSweepTimestampPredicate)
                 .collect(Collectors.toList());
         return ImmutableCandidateCellForSweeping.builder()
                 .cell(cell())
@@ -57,5 +56,7 @@ public interface CellWithTimestamps {
                 .isLatestValueEmpty(latestValueEmpty)
                 .build();
     }
+
+
 
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCandidateRowsForSweeping.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/GetCandidateRowsForSweeping.java
@@ -96,8 +96,7 @@ public class GetCandidateRowsForSweeping {
     private List<CandidateRowForSweeping> convertToOrderedSweepCandidateRows() {
         Map<ByteBuffer, List<CandidateCellForSweeping>> cellsByRow = cellTimestamps.stream()
                 .map(cell -> cell.toSweepCandidate(
-                        request.maxTimestampExclusive(),
-                        request.timestampsToIgnore(),
+                        request::shouldSweep,
                         cellsWithEmptyValues.contains(cell.cell())))
                 .collect(Collectors.groupingBy(
                         cell -> ByteBuffer.wrap(cell.cell().getRowName()),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
@@ -25,6 +25,7 @@ public final class Mutations {
 
     public static Mutation rangeTombstoneForColumn(byte[] columnName, long maxTimestampExclusive) {
         Deletion deletion = new Deletion()
+                .setTimestamp(Long.MAX_VALUE)
                 .setPredicate(SlicePredicates.rangeTombstoneForColumn(columnName, maxTimestampExclusive));
 
         return new Mutation().setDeletion(deletion);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra.thrift;
+
+import org.apache.cassandra.thrift.Deletion;
+import org.apache.cassandra.thrift.Mutation;
+
+public final class Mutations {
+
+    private Mutations() { }
+
+    public static Mutation rangeTombstoneForColumn(byte[] columnName, long maxTimestampExclusive) {
+        Deletion deletion = new Deletion()
+                .setPredicate(SlicePredicates.rangeTombstoneForColumn(columnName, maxTimestampExclusive));
+
+        return new Mutation().setDeletion(deletion);
+    }
+
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/SlicePredicates.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/SlicePredicates.java
@@ -35,6 +35,14 @@ public final class SlicePredicates {
                 Limit.ONE);
     }
 
+    public static SlicePredicate rangeTombstoneForColumn(byte[] columnName, long maxTimestampExclusive) {
+        return create(
+                Range.of(
+                        Range.startOfColumn(columnName, maxTimestampExclusive),
+                        Range.endOfColumnExcludingSentinels(columnName)),
+                Limit.NO_LIMIT);
+    }
+
     public static SlicePredicate create(Range range, Limit limit) {
         SliceRange slice = new SliceRange(
                 range.start(),
@@ -58,7 +66,7 @@ public final class SlicePredicates {
 
         static Range singleColumn(byte[] columnName, long maxTimestampExclusive) {
             ByteBuffer start = startOfColumn(columnName, maxTimestampExclusive);
-            ByteBuffer end = endOfColumn(columnName);
+            ByteBuffer end = endOfColumnIncludingSentinels(columnName);
             return of(start, end);
         }
 
@@ -68,10 +76,16 @@ public final class SlicePredicates {
                     maxTimestampExclusive - 1);
         }
 
-        static ByteBuffer endOfColumn(byte[] columnName) {
+        static ByteBuffer endOfColumnIncludingSentinels(byte[] columnName) {
             return CassandraKeyValueServices.makeCompositeBuffer(
                     columnName,
                     -1);
+        }
+
+        static ByteBuffer endOfColumnExcludingSentinels(byte[] columnName) {
+            return CassandraKeyValueServices.makeCompositeBuffer(
+                    columnName,
+                    0);
         }
 
         static Range of(ByteBuffer startInclusive, ByteBuffer endInclusive) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -131,6 +131,12 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        delegate1.deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell);
+        delegate2.deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell);
+    }
+
+    @Override
     public void truncateTable(TableReference tableRef) {
         delegate1.truncateTable(tableRef);
         delegate2.truncateTable(tableRef);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
@@ -76,6 +76,11 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     }
 
     @Override
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        delegate().deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell);
+    }
+
+    @Override
     public Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> keys, long timestamp) {
         return delegate().getAllTimestamps(tableRef, keys, timestamp);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -164,6 +164,12 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        maybeLog(() -> delegate.deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell),
+                logTimeAndTable("deleteAllTimestamps", tableRef));
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         maybeLog(() -> delegate.dropTable(tableRef),
                 logTimeAndTable("dropTable", tableRef));

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -158,6 +158,15 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        //noinspection unused - try-with-resources closes trace
+        try (CloseableTrace trace = startLocalTrace("deleteAllTimestamps({})",
+                LoggingArgs.safeTableOrPlaceholder(tableRef))) {
+            delegate().deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell);
+        }
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTrace trace = startLocalTrace("dropTable({})",

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -116,7 +116,7 @@ public class ReadTransaction extends ForwardingTransaction {
     }
 
     private void checkTableName(TableReference tableRef) {
-        SweepStrategy sweepStrategy = sweepStrategies.sweepStrategyForTable(tableRef);
+        SweepStrategy sweepStrategy = sweepStrategies.get().get(tableRef);
         if (sweepStrategy == SweepStrategy.THOROUGH) {
             throw new IllegalStateException(
                     "Cannot read from a table with a thorough sweep strategy in a read only transaction.");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ReadTransaction.java
@@ -116,7 +116,7 @@ public class ReadTransaction extends ForwardingTransaction {
     }
 
     private void checkTableName(TableReference tableRef) {
-        SweepStrategy sweepStrategy = sweepStrategies.get().get(tableRef);
+        SweepStrategy sweepStrategy = sweepStrategies.sweepStrategyForTable(tableRef);
         if (sweepStrategy == SweepStrategy.THOROUGH) {
             throw new IllegalStateException(
                     "Cannot read from a table with a thorough sweep strategy in a read only transaction.");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManager.java
@@ -27,8 +27,8 @@ public class SweepStrategyManager {
         this.supplier = supplier;
     }
 
-    public Map<TableReference, SweepStrategy> get() {
-        return supplier.get();
+    public SweepStrategy sweepStrategyForTable(TableReference table) {
+        return supplier.get().getOrDefault(table, SweepStrategy.CONSERVATIVE);
     }
 
     public void recompute() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/SweepStrategyManager.java
@@ -27,8 +27,8 @@ public class SweepStrategyManager {
         this.supplier = supplier;
     }
 
-    public SweepStrategy sweepStrategyForTable(TableReference table) {
-        return supplier.get().getOrDefault(table, SweepStrategy.CONSERVATIVE);
+    public Map<TableReference, SweepStrategy> get() {
+        return supplier.get();
     }
 
     public void recompute() {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
@@ -68,11 +68,10 @@ public class ReadTransactionShould {
     public void setUp() throws Exception {
         delegateTransaction = Mockito.mock(AbstractTransaction.class);
         SweepStrategyManager sweepStrategies = Mockito.mock(SweepStrategyManager.class);
-        when(sweepStrategies.get()).thenReturn(ImmutableMap.of(
-                DUMMY_CONSERVATIVE_TABLE,
-                TableMetadataPersistence.SweepStrategy.CONSERVATIVE,
-                DUMMY_THOROUGH_TABLE,
-                TableMetadataPersistence.SweepStrategy.THOROUGH));
+        when(sweepStrategies.sweepStrategyForTable(DUMMY_CONSERVATIVE_TABLE)).thenReturn(
+                TableMetadataPersistence.SweepStrategy.CONSERVATIVE);
+        when(sweepStrategies.sweepStrategyForTable(DUMMY_THOROUGH_TABLE)).thenReturn(
+                TableMetadataPersistence.SweepStrategy.THOROUGH);
         readTransaction = new ReadTransaction(delegateTransaction, sweepStrategies);
     }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/ReadTransactionShould.java
@@ -68,10 +68,11 @@ public class ReadTransactionShould {
     public void setUp() throws Exception {
         delegateTransaction = Mockito.mock(AbstractTransaction.class);
         SweepStrategyManager sweepStrategies = Mockito.mock(SweepStrategyManager.class);
-        when(sweepStrategies.sweepStrategyForTable(DUMMY_CONSERVATIVE_TABLE)).thenReturn(
-                TableMetadataPersistence.SweepStrategy.CONSERVATIVE);
-        when(sweepStrategies.sweepStrategyForTable(DUMMY_THOROUGH_TABLE)).thenReturn(
-                TableMetadataPersistence.SweepStrategy.THOROUGH);
+        when(sweepStrategies.get()).thenReturn(ImmutableMap.of(
+                DUMMY_CONSERVATIVE_TABLE,
+                TableMetadataPersistence.SweepStrategy.CONSERVATIVE,
+                DUMMY_THOROUGH_TABLE,
+                TableMetadataPersistence.SweepStrategy.THOROUGH));
         readTransaction = new ReadTransaction(delegateTransaction, sweepStrategies);
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -85,10 +85,10 @@ import com.palantir.atlasdb.sweep.NoOpBackgroundSweeperPerformanceLogger;
 import com.palantir.atlasdb.sweep.PersistentLockManager;
 import com.palantir.atlasdb.sweep.SpecificTableSweeper;
 import com.palantir.atlasdb.sweep.SweepBatchConfig;
+import com.palantir.atlasdb.sweep.SweepMetrics;
 import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.sweep.SweeperServiceImpl;
-import com.palantir.atlasdb.sweep.metrics.SweepMetricsManager;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
@@ -281,7 +281,7 @@ public abstract class TransactionManagers {
                 config.keyValueService().defaultGetRangesConcurrency(),
                 config.initializeAsync(),
                 () -> runtimeConfigSupplier.get().getTimestampCacheSize(),
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
 
         PersistentLockManager persistentLockManager = new PersistentLockManager(
                 persistentLockService,
@@ -355,7 +355,7 @@ public abstract class TransactionManagers {
         AdjustableSweepBatchConfigSource sweepBatchConfigSource = AdjustableSweepBatchConfigSource.create(() ->
                 getSweepBatchConfig(runtimeConfigSupplier.get().sweep(), config.keyValueService()));
 
-        SweepMetricsManager sweepMetricsManager = new SweepMetricsManager();
+        SweepMetrics sweepMetrics = new SweepMetrics();
 
         SpecificTableSweeper specificTableSweeper = initializeSweepEndpoint(
                 env,
@@ -363,7 +363,7 @@ public abstract class TransactionManagers {
                 transactionManager,
                 sweepRunner,
                 sweepPerfLogger,
-                sweepMetricsManager,
+                sweepMetrics,
                 config.initializeAsync(),
                 sweepBatchConfigSource);
 
@@ -384,7 +384,7 @@ public abstract class TransactionManagers {
             SerializableTransactionManager transactionManager,
             SweepTaskRunner sweepRunner,
             BackgroundSweeperPerformanceLogger sweepPerfLogger,
-            SweepMetricsManager sweepMetricsManager,
+            SweepMetrics sweepMetrics,
             boolean initializeAsync,
             AdjustableSweepBatchConfigSource sweepBatchConfigSource) {
         SpecificTableSweeper specificTableSweeper = SpecificTableSweeper.create(
@@ -393,7 +393,7 @@ public abstract class TransactionManagers {
                 sweepRunner,
                 SweepTableFactory.of(),
                 sweepPerfLogger,
-                sweepMetricsManager,
+                sweepMetrics,
                 initializeAsync);
         env.accept(new SweeperServiceImpl(specificTableSweeper, sweepBatchConfigSource));
         return specificTableSweeper;

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -88,6 +88,7 @@ import com.palantir.atlasdb.sweep.SweepBatchConfig;
 import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.sweep.SweeperServiceImpl;
 import com.palantir.atlasdb.sweep.metrics.SweepMetricsManager;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
@@ -279,7 +280,8 @@ public abstract class TransactionManagers {
                 config.keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.keyValueService().defaultGetRangesConcurrency(),
                 config.initializeAsync(),
-                () -> runtimeConfigSupplier.get().getTimestampCacheSize());
+                () -> runtimeConfigSupplier.get().getTimestampCacheSize(),
+                SweepQueueWriter.NO_OP);
 
         PersistentLockManager persistentLockManager = new PersistentLockManager(
                 persistentLockService,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -85,9 +85,9 @@ import com.palantir.atlasdb.sweep.NoOpBackgroundSweeperPerformanceLogger;
 import com.palantir.atlasdb.sweep.PersistentLockManager;
 import com.palantir.atlasdb.sweep.SpecificTableSweeper;
 import com.palantir.atlasdb.sweep.SweepBatchConfig;
-import com.palantir.atlasdb.sweep.SweepMetrics;
 import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.sweep.SweeperServiceImpl;
+import com.palantir.atlasdb.sweep.metrics.SweepMetricsManager;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -355,7 +355,7 @@ public abstract class TransactionManagers {
         AdjustableSweepBatchConfigSource sweepBatchConfigSource = AdjustableSweepBatchConfigSource.create(() ->
                 getSweepBatchConfig(runtimeConfigSupplier.get().sweep(), config.keyValueService()));
 
-        SweepMetrics sweepMetrics = new SweepMetrics();
+        SweepMetricsManager sweepMetrics = new SweepMetricsManager();
 
         SpecificTableSweeper specificTableSweeper = initializeSweepEndpoint(
                 env,
@@ -384,7 +384,7 @@ public abstract class TransactionManagers {
             SerializableTransactionManager transactionManager,
             SweepTaskRunner sweepRunner,
             BackgroundSweeperPerformanceLogger sweepPerfLogger,
-            SweepMetrics sweepMetrics,
+            SweepMetricsManager sweepMetrics,
             boolean initializeAsync,
             AdjustableSweepBatchConfigSource sweepBatchConfigSource) {
         SpecificTableSweeper specificTableSweeper = SpecificTableSweeper.create(

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -102,7 +103,8 @@ public class TransactionManagerModule {
                 config.allowAccessToHiddenTables(),
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
-                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
+                SweepQueueWriter.NO_OP);
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -104,7 +104,7 @@ public class TransactionManagerModule {
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -30,7 +30,7 @@ import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
 import com.palantir.atlasdb.services.ServicesConfig;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -110,7 +110,7 @@ public class TestTransactionManagerModule {
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
     }
 
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -30,6 +30,7 @@ import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
 import com.palantir.atlasdb.services.ServicesConfig;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
@@ -108,7 +109,8 @@ public class TestTransactionManagerModule {
                 config.allowAccessToHiddenTables(),
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
-                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency());
+                config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
+                SweepQueueWriter.NO_OP);
     }
 
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/sweep/SweepQueryHelpers.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/sweep/SweepQueryHelpers.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.sweep;
 
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
+import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.FullQuery;
 
 public final class SweepQueryHelpers {
@@ -24,9 +25,8 @@ public final class SweepQueryHelpers {
 
     public static void appendIgnoredTimestampPredicate(CandidateCellForSweepingRequest request,
                                                        FullQuery.Builder builder) {
-        for (long ts : request.timestampsToIgnore()) {
-            // In practice this will always be -1, so we don't bother with binds
-            builder.append(" AND ts <> ").append(String.valueOf(ts));
+        if (request.ignoreGarbageCollectionSentinels()) {
+            builder.append(" AND ts <> ").append(String.valueOf(Value.INVALID_VALUE_TIMESTAMP));
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -115,6 +115,15 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        try {
+            delegate().deleteAllTimestamps(tableMapper.getMappedTableName(tableRef), maxTimestampExclusiveByCell);
+        } catch (TableMappingNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         dropTables(ImmutableSet.of(tableRef));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -135,6 +135,11 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        getDelegate(tableRef).deleteAllTimestamps(tableRef, maxTimestampExclusiveByCell);
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         getDelegate(tableRef).dropTable(tableRef);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -39,6 +39,7 @@ import com.palantir.atlasdb.qos.QosClient;
 import com.palantir.atlasdb.schema.AtlasSchema;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.table.description.Schemas;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -185,7 +186,8 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
                 cleaner,
                 DEFAULT_MAX_CONCURRENT_RANGES,
                 DEFAULT_GET_RANGES_CONCURRENCY,
-                () -> DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> DEFAULT_TIMESTAMP_CACHE_SIZE,
+                MultiTableSweepQueueWriter.NO_OP);
         cleaner.start(ret);
         return ret;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -132,7 +132,7 @@ public class SweepTaskRunner {
                     LoggingArgs.tableRef("tableRef", tableRef));
             return SweepResults.createEmptySweepResultWithNoMoreToSweep();
         }
-        SweepStrategy sweepStrategy = sweepStrategyManager.sweepStrategyForTable(tableRef);
+        SweepStrategy sweepStrategy = sweepStrategyManager.get().getOrDefault(tableRef, SweepStrategy.CONSERVATIVE);
         Optional<Sweeper> sweeper = Sweeper.of(sweepStrategy);
         if (!sweeper.isPresent()) {
             return SweepResults.createEmptySweepResultWithNoMoreToSweep();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -168,7 +168,7 @@ public class SweepTaskRunner {
                 .batchSizeHint(batchConfig.candidateBatchSize())
                 .maxTimestampExclusive(sweepTs)
                 .shouldCheckIfLatestValueIsEmpty(sweeper.shouldSweepLastCommitted())
-                .timestampsToIgnore(sweeper.getTimestampsToIgnore())
+                .ignoreGarbageCollectionSentinels(!sweeper.shouldAddSentinels())
                 .build();
 
         SweepableCellFilter sweepableCellFilter = new SweepableCellFilter(transactionService, sweeper, sweepTs);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -132,7 +132,7 @@ public class SweepTaskRunner {
                     LoggingArgs.tableRef("tableRef", tableRef));
             return SweepResults.createEmptySweepResultWithNoMoreToSweep();
         }
-        SweepStrategy sweepStrategy = sweepStrategyManager.get().getOrDefault(tableRef, SweepStrategy.CONSERVATIVE);
+        SweepStrategy sweepStrategy = sweepStrategyManager.sweepStrategyForTable(tableRef);
         Optional<Sweeper> sweeper = Sweeper.of(sweepStrategy);
         if (!sweeper.isPresent()) {
             return SweepResults.createEmptySweepResultWithNoMoreToSweep();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/Sweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/Sweeper.java
@@ -16,42 +16,31 @@
 package com.palantir.atlasdb.sweep;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.LongSupplier;
 
-import com.google.common.collect.ImmutableSet;
-import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 
 public enum Sweeper {
     CONSERVATIVE((unreadableTs, immutableTs) -> Math.min(unreadableTs.getAsLong(), immutableTs.getAsLong()),
-                 ImmutableSet.of(Value.INVALID_VALUE_TIMESTAMP),
                  false,
                  true),
     THOROUGH((unreadableTs, immutableTs) -> immutableTs.getAsLong(),
-            ImmutableSet.of(),
              true,
              false);
 
     private final SweepTimestampSupplier sweepTimestampSupplier;
-    private final Set<Long> timestampsToIgnore;
     private final boolean shouldSweepLastCommitted;
     private final boolean shouldAddSentinels;
 
-    Sweeper(SweepTimestampSupplier sweepTimestampSupplier, Set<Long> timestampsToIgnore,
+    Sweeper(SweepTimestampSupplier sweepTimestampSupplier,
             boolean shouldSweepLastCommitted, boolean shouldAddSentinels) {
         this.sweepTimestampSupplier = sweepTimestampSupplier;
-        this.timestampsToIgnore = timestampsToIgnore;
         this.shouldSweepLastCommitted = shouldSweepLastCommitted;
         this.shouldAddSentinels = shouldAddSentinels;
     }
 
     public SweepTimestampSupplier getSweepTimestampSupplier() {
         return sweepTimestampSupplier;
-    }
-
-    public Set<Long> getTimestampsToIgnore() {
-        return timestampsToIgnore;
     }
 
     public boolean shouldSweepLastCommitted() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/BackgroundSweepQueueProcessor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/BackgroundSweepQueueProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.logging.LoggingArgs;
+
+public class BackgroundSweepQueueProcessor {
+
+    private final Logger log = LoggerFactory.getLogger(BackgroundSweepQueueProcessor.class);
+
+    private final KeyValueService kvs;
+    private final Function<TableReference, SweepQueueProcessor> processorFactory;
+
+    public BackgroundSweepQueueProcessor(
+            KeyValueService kvs,
+            Function<TableReference, SweepQueueProcessor> processorFactory) {
+        this.kvs = kvs;
+        this.processorFactory = processorFactory;
+    }
+
+    public void sweepOneBatchForAllTable() {
+        for (TableReference table : kvs.getAllTableNames()) {
+            trySweepOneBatch(table);
+        }
+    }
+
+    // visible for testing
+    public void trySweepOneBatch(TableReference table) {
+        try {
+            processorFactory.apply(table).processNextBatch();
+        } catch (Exception ex) {
+            log.warn("error while processing sweep queue for table {}", LoggingArgs.tableRef(table));
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/MultiTableSweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/MultiTableSweepQueueWriter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+
+/**
+ * Adds {@link WriteInfo}s to a global queue to be swept.
+ */
+public interface MultiTableSweepQueueWriter {
+
+    MultiTableSweepQueueWriter NO_OP = (table, writes) -> { };
+
+    default void enqueue(Map<TableReference, ? extends Map<Cell, byte[]>> writesByTable, long timestamp) {
+        writesByTable.forEach((table, writes) -> enqueue(table, writes, timestamp));
+    }
+
+    default void enqueue(TableReference table, Map<Cell, byte[]> writes, long timestamp) {
+        enqueue(table, writes.entrySet().stream()
+                .map(entry -> ImmutableWriteInfo.builder()
+                        .cell(entry.getKey())
+                        .isTombstone(Value.isTombstone(entry.getValue()))
+                        .timestamp(timestamp)
+                        .build())
+                .collect(Collectors.toList()));
+    }
+
+    void enqueue(TableReference table, Collection<WriteInfo> writes);
+
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDeleter.java
@@ -18,8 +18,10 @@ package com.palantir.atlasdb.sweep.queue;
 
 import java.util.Collection;
 
-public interface SweepQueueWriter {
+public interface SweepDeleter {
 
-    void enqueue(Collection<WriteInfo> writes);
+    SweepDeleter NO_OP = writes -> { };
+
+    void sweep(Collection<WriteInfo> writes);
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDeleterImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDeleterImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.sweep.Sweeper;
+
+public class SweepDeleterImpl implements SweepDeleter {
+
+    private final TableReference table;
+    private final KeyValueService kvs;
+    private final Sweeper sweeper;
+
+    public SweepDeleterImpl(TableReference table, KeyValueService kvs, Sweeper sweeper) {
+        this.table = table;
+        this.kvs = kvs;
+        this.sweeper = sweeper;
+    }
+
+    @Override
+    public void sweep(Collection<WriteInfo> writes) {
+        Map<Cell, Long> maxTimestampByCell = getMaxDeletionTimestamps(writes);
+
+        if (sweeper.shouldAddSentinels()) {
+            kvs.addGarbageCollectionSentinelValues(table, maxTimestampByCell.keySet());
+        }
+
+        kvs.deleteAllTimestamps(table, maxTimestampByCell);
+    }
+
+    private Map<Cell, Long> getMaxDeletionTimestamps(Collection<WriteInfo> writes) {
+        Map<Cell, Long> deleteTimestampByCell = Maps.newHashMap();
+
+        for (WriteInfo write : writes) {
+            deleteTimestampByCell.merge(write.cell(), write.timestampToDeleteAtExclusive(sweeper), Long::max);
+        }
+
+        return deleteTimestampByCell;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueProcessor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueProcessor.java
@@ -16,10 +16,25 @@
 
 package com.palantir.atlasdb.sweep.queue;
 
-import java.util.Collection;
+import java.util.function.Supplier;
 
-public interface SweepQueueWriter {
+public class SweepQueueProcessor {
 
-    void enqueue(Collection<WriteInfo> writes);
+    private final Supplier<Long> sweepTimestamp;
+    private final SweepQueueReader reader;
+    private final SweepDeleter deleter;
+
+    public SweepQueueProcessor(
+            Supplier<Long> sweepTimestamp,
+            SweepQueueReader reader,
+            SweepDeleter deleter) {
+        this.sweepTimestamp = sweepTimestamp;
+        this.reader = reader;
+        this.deleter = deleter;
+    }
+
+    public void processNextBatch() {
+        reader.consumeNextBatch(deleter::sweep, sweepTimestamp.get());
+    }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
@@ -17,9 +17,14 @@
 package com.palantir.atlasdb.sweep.queue;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 
-public interface SweepQueueWriter {
+public interface SweepQueueReader {
 
-    void enqueue(Collection<WriteInfo> writes);
+    // Passes the next batch of writes to the given consumer. If the consumer returns without throwing,
+    // the batch is considered consumed, and future invocations of this method will consume only newer writes.
+    // On the other hand, if the consumer fails by throwing an exception, the same batch will be consumed
+    // on the next invocation.
+    void consumeNextBatch(Consumer<Collection<WriteInfo>> consumer, long maxTimestampExclusive);
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueWriter.java
@@ -24,7 +24,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 
 /**
- * Adds {@link Write}s to a global queue to be swept.
+ * Adds {@link WriteInfo}s to a global queue to be swept.
  */
 public interface SweepQueueWriter {
 
@@ -36,7 +36,7 @@ public interface SweepQueueWriter {
 
     default void enqueue(TableReference table, Map<Cell, byte[]> writes, long timestamp) {
         enqueue(table, writes.entrySet().stream()
-                .map(entry -> ImmutableWrite.builder()
+                .map(entry -> ImmutableWriteInfo.builder()
                         .cell(entry.getKey())
                         .isTombstone(Value.isTombstone(entry.getValue()))
                         .timestamp(timestamp)
@@ -44,6 +44,6 @@ public interface SweepQueueWriter {
                 .collect(Collectors.toList()));
     }
 
-    void enqueue(TableReference table, Iterable<Write> writes);
+    void enqueue(TableReference table, Iterable<WriteInfo> writes);
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueWriter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+
+public interface SweepQueueWriter {
+
+    SweepQueueWriter NO_OP = (table, writes) -> { };
+
+    default void enqueue(Map<TableReference, ? extends Map<Cell, byte[]>> writesByTable, long timestamp) {
+        writesByTable.forEach((table, writes) -> enqueue(table, writes, timestamp));
+    }
+
+    default void enqueue(TableReference table, Map<Cell, byte[]> writes, long timestamp) {
+        enqueue(table, writes.entrySet().stream()
+                .map(entry -> ImmutableWrite.builder()
+                        .cell(entry.getKey())
+                        .isTombstone(Value.isTombstone(entry.getValue()))
+                        .timestamp(timestamp)
+                        .build())
+                .collect(Collectors.toList()));
+    }
+
+    void enqueue(TableReference table, Iterable<Write> writes);
+
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueWriter.java
@@ -23,6 +23,9 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 
+/**
+ * Adds {@link Write}s to a global queue to be swept.
+ */
 public interface SweepQueueWriter {
 
     SweepQueueWriter NO_OP = (table, writes) -> { };

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepTimestampProvider.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepTimestampProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import java.util.function.LongSupplier;
+
+import com.palantir.atlasdb.sweep.Sweeper;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+
+public class SweepTimestampProvider {
+
+    private final LongSupplier immutableTimestamp;
+    private final LongSupplier unreadableTimestamp;
+
+    public static SweepTimestampProvider create(TransactionManager txnManager) {
+        return new SweepTimestampProvider(txnManager::getImmutableTimestamp, txnManager::getUnreadableTimestamp);
+    }
+
+    public SweepTimestampProvider(LongSupplier immutableTimestamp, LongSupplier unreadableTimestamp) {
+        this.immutableTimestamp = immutableTimestamp;
+        this.unreadableTimestamp = unreadableTimestamp;
+    }
+
+    public long getSweepTimestamp(Sweeper sweeper) {
+        return sweeper.getSweepTimestampSupplier().getSweepTimestamp(immutableTimestamp, unreadableTimestamp);
+    }
+
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/Write.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/Write.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+
+@Value.Immutable
+@JsonSerialize(as=ImmutableWrite.class)
+@JsonDeserialize(as=ImmutableWrite.class)
+public interface Write {
+
+    @JsonProperty("ts")
+    long timestamp();
+
+    @JsonProperty("c")
+    Cell cell();
+
+    @JsonProperty("d")
+    boolean isTombstone();
+
+    static Write of(Cell cell, boolean isTombstone, long timestamp) {
+        return ImmutableWrite.builder().cell(cell).isTombstone(isTombstone).timestamp(timestamp).build();
+    }
+
+
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/Write.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/Write.java
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 
+/**
+ * Contains information about a committed write, for use by the sweep queue.
+ */
 @Value.Immutable
 @JsonSerialize(as=ImmutableWrite.class)
 @JsonDeserialize(as=ImmutableWrite.class)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/Write.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/Write.java
@@ -27,8 +27,8 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
  * Contains information about a committed write, for use by the sweep queue.
  */
 @Value.Immutable
-@JsonSerialize(as=ImmutableWrite.class)
-@JsonDeserialize(as=ImmutableWrite.class)
+@JsonSerialize(as = ImmutableWrite.class)
+@JsonDeserialize(as = ImmutableWrite.class)
 public interface Write {
 
     @JsonProperty("ts")
@@ -43,6 +43,5 @@ public interface Write {
     static Write of(Cell cell, boolean isTombstone, long timestamp) {
         return ImmutableWrite.builder().cell(cell).isTombstone(isTombstone).timestamp(timestamp).build();
     }
-
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfo.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfo.java
@@ -27,9 +27,9 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
  * Contains information about a committed write, for use by the sweep queue.
  */
 @Value.Immutable
-@JsonSerialize(as = ImmutableWrite.class)
-@JsonDeserialize(as = ImmutableWrite.class)
-public interface Write {
+@JsonSerialize(as = ImmutableWriteInfo.class)
+@JsonDeserialize(as = ImmutableWriteInfo.class)
+public interface WriteInfo {
 
     @JsonProperty("ts")
     long timestamp();
@@ -40,8 +40,8 @@ public interface Write {
     @JsonProperty("d")
     boolean isTombstone();
 
-    static Write of(Cell cell, boolean isTombstone, long timestamp) {
-        return ImmutableWrite.builder().cell(cell).isTombstone(isTombstone).timestamp(timestamp).build();
+    static WriteInfo of(Cell cell, boolean isTombstone, long timestamp) {
+        return ImmutableWriteInfo.builder().cell(cell).isTombstone(isTombstone).timestamp(timestamp).build();
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfo.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfo.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.sweep.Sweeper;
 
 /**
  * Contains information about a committed write, for use by the sweep queue.
@@ -39,6 +40,14 @@ public interface WriteInfo {
 
     @JsonProperty("d")
     boolean isTombstone();
+
+    default long timestampToDeleteAtExclusive(Sweeper sweeper) {
+        if (sweeper.shouldSweepLastCommitted() && isTombstone()) {
+            return timestamp() + 1L;
+        }
+
+        return timestamp();
+    }
 
     static WriteInfo of(Cell cell, boolean isTombstone, long timestamp) {
         return ImmutableWriteInfo.builder().cell(cell).isTombstone(isTombstone).timestamp(timestamp).build();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/test/InMemorySweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/test/InMemorySweepQueue.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue.test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.function.Consumer;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.PeekingIterator;
+import com.google.common.collect.Queues;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.SweepQueueReader;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.WriteInfo;
+
+/**
+ * In memory implementation of the sweep queue. Only intended to be used for testing.
+ * TODO(nziebart): remove this once we have an implementation that uses the KVS.
+ */
+public final class InMemorySweepQueue implements SweepQueueReader, SweepQueueWriter {
+
+    private static final Map<TableReference, InMemorySweepQueue> instancesByTable = Maps.newConcurrentMap();
+
+    private Queue<WriteInfo> writes = Queues.newArrayDeque();
+
+    public static InMemorySweepQueue instanceForTable(TableReference table) {
+        return instancesByTable.computeIfAbsent(table, ignored -> new InMemorySweepQueue());
+    }
+
+    public static MultiTableSweepQueueWriter writer() {
+        return (table, writes) -> instanceForTable(table).enqueue(writes);
+    }
+
+    private InMemorySweepQueue() {
+
+    }
+
+    public static void clear() {
+        instancesByTable.clear();
+    }
+
+    public synchronized void consumeNextBatch(
+            Consumer<Collection<WriteInfo>> consumer,
+            long maxTimestampExclusive) {
+        List<WriteInfo> batch = getNextBatch(maxTimestampExclusive);
+
+        consumer.accept(batch);
+
+        writes.removeAll(batch);
+    }
+
+    private List<WriteInfo> getNextBatch(long maxTimestampExclusive) {
+        List<WriteInfo> batch = Lists.newArrayList();
+        PeekingIterator<WriteInfo> iterator = Iterators.peekingIterator(writes.iterator());
+
+        while (iterator.hasNext() && iterator.peek().timestamp() < maxTimestampExclusive) {
+            batch.add(iterator.next());
+        }
+        return batch;
+    }
+
+    public synchronized void enqueue(Collection<WriteInfo> newWrites) {
+        writes.addAll(newWrites);
+    }
+
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/test/InMemorySweepQueueProcessorFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/test/InMemorySweepQueueProcessorFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue.test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.sweep.Sweeper;
+import com.palantir.atlasdb.sweep.queue.SweepDeleter;
+import com.palantir.atlasdb.sweep.queue.SweepDeleterImpl;
+import com.palantir.atlasdb.sweep.queue.SweepQueueProcessor;
+import com.palantir.atlasdb.sweep.queue.SweepTimestampProvider;
+import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
+
+public class InMemorySweepQueueProcessorFactory {
+
+    private final KeyValueService kvs;
+    private final SweepStrategyManager sweepStrategyManager;
+    private final SweepTimestampProvider sweepTimestamps;
+
+    private final Map<TableReference, SweepQueueProcessor> processorsByTable = Maps.newConcurrentMap();
+
+    public InMemorySweepQueueProcessorFactory(
+            KeyValueService kvs,
+            SweepStrategyManager sweepStrategyManager,
+            SweepTimestampProvider sweepTimestamps) {
+        this.kvs = kvs;
+        this.sweepStrategyManager = sweepStrategyManager;
+        this.sweepTimestamps = sweepTimestamps;
+    }
+
+    public SweepQueueProcessor getProcessorForTable(
+            TableReference table) {
+        return processorsByTable.computeIfAbsent(table, this::createProcessorForTable);
+    }
+
+    private SweepQueueProcessor createProcessorForTable(TableReference table) {
+        InMemorySweepQueue queue = InMemorySweepQueue.instanceForTable(table);
+        Optional<Sweeper> sweeper = Sweeper.of(sweepStrategyManager.get().get(table));
+        Preconditions.checkState(sweeper.isPresent(), "Sweep strategy is NONE for table " + table);
+
+        SweepDeleter deleter = new SweepDeleterImpl(table, kvs, sweeper.get());
+        return new SweepQueueProcessor(() -> sweepTimestamps.getSweepTimestamp(sweeper.get()), queue, deleter);
+    }
+
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -718,7 +718,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                 lockAcquireTimeoutMs,
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                (writes, ts) -> { }) {
+                SweepQueueWriter.NO_OP) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -62,6 +62,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -119,7 +120,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    TimestampCache timestampCache,
                                    long lockAcquireTimeoutMs,
                                    ExecutorService getRangesExecutor,
-                                   int defaultGetRangesConcurrency) {
+                                   int defaultGetRangesConcurrency,
+                                   SweepQueueWriter sweepQueue) {
         super(keyValueService,
               timelockService,
               transactionService,
@@ -137,7 +139,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               timestampCache,
               lockAcquireTimeoutMs,
               getRangesExecutor,
-              defaultGetRangesConcurrency);
+              defaultGetRangesConcurrency,
+              sweepQueue);
     }
 
     @Override
@@ -714,7 +717,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs,
                 getRangesExecutor,
-                defaultGetRangesConcurrency) {
+                defaultGetRangesConcurrency,
+                (writes, ts) -> { }) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -62,7 +62,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -121,7 +121,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    long lockAcquireTimeoutMs,
                                    ExecutorService getRangesExecutor,
                                    int defaultGetRangesConcurrency,
-                                   SweepQueueWriter sweepQueue) {
+                                   MultiTableSweepQueueWriter sweepQueue) {
         super(keyValueService,
               timelockService,
               transactionService,
@@ -718,7 +718,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                 lockAcquireTimeoutMs,
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                SweepQueueWriter.NO_OP) {
+                MultiTableSweepQueueWriter.NO_OP) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -23,6 +23,7 @@ import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTracker;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -88,7 +89,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
     // TODO(ssouza): it's hard to change the interface of STM with this.
     // We should extract interfaces and delete this hack.
     protected SerializableTransactionManager() {
-        this(null, null, null, null, null, null, null, null, null, () -> 1L, false, null, 1, 1);
+        this(null, null, null, null, null, null, null, null, null, () -> 1L, false, null, 1, 1, SweepQueueWriter.NO_OP);
     }
 
     public static SerializableTransactionManager create(KeyValueService keyValueService,
@@ -105,7 +106,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             boolean initializeAsync,
-            Supplier<Long> timestampCacheSize) {
+            Supplier<Long> timestampCacheSize,
+            SweepQueueWriter sweepQueueWriter) {
         TimestampTracker timestampTracker = TimestampTrackerImpl.createWithDefaultTrackers(
                 timelockService, cleaner, initializeAsync);
         SerializableTransactionManager serializableTransactionManager = new SerializableTransactionManager(
@@ -122,7 +124,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 lockAcquireTimeoutMs,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                sweepQueueWriter);
 
         return initializeAsync
                 ? new InitializeCheckingWrapper(serializableTransactionManager, initializationPrerequisite)
@@ -154,7 +157,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                SweepQueueWriter.NO_OP);
     }
 
     /**
@@ -190,7 +194,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 allowHiddenTableAccess,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 concurrentGetRangesThreadPoolSize,
-                defaultGetRangesConcurrency
+                defaultGetRangesConcurrency,
+                SweepQueueWriter.NO_OP
         );
     }
 
@@ -208,7 +213,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             boolean allowHiddenTableAccess,
             Supplier<Long> lockAcquireTimeoutMs,
             int concurrentGetRangesThreadPoolSize,
-            int defaultGetRangesConcurrency) {
+            int defaultGetRangesConcurrency,
+            SweepQueueWriter sweepQueueWriter) {
         super(
                 keyValueService,
                 timelockService,
@@ -223,7 +229,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 timestampTracker,
                 concurrentGetRangesThreadPoolSize,
                 defaultGetRangesConcurrency,
-                timestampCacheSize);
+                timestampCacheSize,
+                sweepQueueWriter);
     }
 
     @Override
@@ -249,7 +256,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 timestampValidationReadCache,
                 lockAcquireTimeoutMs.get(),
                 getRangesExecutor,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                sweepQueueWriter);
     }
 
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -781,7 +781,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     private boolean isValidationNecessary(TableReference tableRef) {
-        return sweepStrategyManager.sweepStrategyForTable(tableRef) == SweepStrategy.THOROUGH;
+        return sweepStrategyManager.get().get(tableRef) == SweepStrategy.THOROUGH;
     }
 
     private List<Entry<Cell, byte[]>> getPostFilteredWithLocalWrites(final TableReference tableRef,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -101,7 +101,7 @@ import com.palantir.atlasdb.keyvalue.impl.RowResults;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.logging.LoggingArgs.SafeAndUnsafeTableReferences;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.description.exceptions.AtlasDbConstraintException;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
@@ -184,7 +184,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     private final Supplier<Long> startTimestamp;
     private static final MetricsManager metricsManager = new MetricsManager();
 
-    private final SweepQueueWriter sweepQueue;
+    private final MultiTableSweepQueueWriter sweepQueue;
 
     protected final long immutableTimestamp;
     protected final Optional<LockToken> immutableTimestampLock;
@@ -239,7 +239,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                                long lockAcquireTimeoutMs,
                                ExecutorService getRangesExecutor,
                                int defaultGetRangesConcurrency,
-                               SweepQueueWriter sweepQueue) {
+                               MultiTableSweepQueueWriter sweepQueue) {
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.defaultTransactionService = transactionService;
@@ -274,7 +274,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                         TimestampCache timestampValidationReadCache,
                         ExecutorService getRangesExecutor,
                         int defaultGetRangesConcurrency,
-                        SweepQueueWriter sweepQueue) {
+                        MultiTableSweepQueueWriter sweepQueue) {
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.defaultTransactionService = transactionService;
@@ -325,7 +325,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         this.lockAcquireTimeoutMs = lockAcquireTimeoutMs;
         this.getRangesExecutor = getRangesExecutor;
         this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
-        this.sweepQueue = SweepQueueWriter.NO_OP;
+        this.sweepQueue = MultiTableSweepQueueWriter.NO_OP;
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -200,7 +200,7 @@ import com.palantir.timestamp.TimestampService;
                 lockAcquireTimeoutMs.get(),
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                sweepQueueWriter::enqueue);
+                sweepQueueWriter);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -36,7 +36,7 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTracker;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.KeyValueServiceStatus;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionTask;
@@ -73,7 +73,7 @@ import com.palantir.timestamp.TimestampService;
     final ExecutorService getRangesExecutor;
     final TimestampTracker timestampTracker;
     final int defaultGetRangesConcurrency;
-    final SweepQueueWriter sweepQueueWriter;
+    final MultiTableSweepQueueWriter sweepQueueWriter;
 
     final List<Runnable> closingCallbacks;
     final AtomicBoolean isClosed;
@@ -93,7 +93,7 @@ import com.palantir.timestamp.TimestampService;
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             Supplier<Long> timestampCacheSize,
-            SweepQueueWriter sweepQueueWriter) {
+            MultiTableSweepQueueWriter sweepQueueWriter) {
         super(timestampCacheSize);
 
         this.keyValueService = keyValueService;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -28,6 +28,7 @@ import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.lock.v2.TimelockService;
 
 public class SerializableTransactionManagerTest {
@@ -56,7 +57,8 @@ public class SerializableTransactionManagerTest {
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 true, // initializeAsync
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+                SweepQueueWriter.NO_OP);
 
         when(mockKvs.isInitialized()).thenReturn(true);
         when(mockTimelockService.isInitialized()).thenReturn(true);
@@ -116,7 +118,8 @@ public class SerializableTransactionManagerTest {
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 false, // initializeAsync
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+                SweepQueueWriter.NO_OP);
 
         when(mockKvs.isInitialized()).thenReturn(false);
         when(mockTimelockService.isInitialized()).thenReturn(false);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -28,7 +28,7 @@ import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.lock.v2.TimelockService;
 
 public class SerializableTransactionManagerTest {
@@ -58,7 +58,7 @@ public class SerializableTransactionManagerTest {
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 true, // initializeAsync
                 () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
 
         when(mockKvs.isInitialized()).thenReturn(true);
         when(mockTimelockService.isInitialized()).thenReturn(true);
@@ -119,7 +119,7 @@ public class SerializableTransactionManagerTest {
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 false, // initializeAsync
                 () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
 
         when(mockKvs.isInitialized()).thenReturn(false);
         when(mockTimelockService.isInitialized()).thenReturn(false);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -33,7 +33,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.lock.CloseableLockService;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
@@ -61,7 +61,7 @@ public class SnapshotTransactionManagerTest {
             TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
             TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
             () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
-            SweepQueueWriter.NO_OP);
+            MultiTableSweepQueueWriter.NO_OP);
 
     @Test
     public void isAlwaysInitialized() {
@@ -104,7 +104,7 @@ public class SnapshotTransactionManagerTest {
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
         newTransactionManager.close(); // should not throw
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -33,6 +33,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.lock.CloseableLockService;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
@@ -59,7 +60,8 @@ public class SnapshotTransactionManagerTest {
             TimestampTrackerImpl.createNoOpTracker(),
             TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
             TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
-            () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+            () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+            SweepQueueWriter.NO_OP);
 
     @Test
     public void isAlwaysInitialized() {
@@ -101,7 +103,8 @@ public class SnapshotTransactionManagerTest {
                 TimestampTrackerImpl.createNoOpTracker(),
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+                SweepQueueWriter.NO_OP);
         newTransactionManager.close(); // should not throw
     }
 

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -124,6 +124,7 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.GetCandidateCellsForSweepingShim;
 import com.palantir.atlasdb.keyvalue.impl.KeyValueServices;
 import com.palantir.atlasdb.keyvalue.jdbc.impl.MultiTimestampPutBatch;
@@ -686,6 +687,11 @@ public class JdbcKeyValueService implements KeyValueService {
                 delete(tableRef, cellsToDelete);
             }
         }
+    }
+
+    @Override
+    public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        AbstractKeyValueService.deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell);
     }
 
     @Override

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetCandidateCellsForSweepingBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/KvsGetCandidateCellsForSweepingBenchmarks.java
@@ -27,7 +27,6 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
@@ -35,7 +34,6 @@ import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.performance.benchmarks.table.ConsecutiveNarrowTable;
 import com.palantir.atlasdb.performance.benchmarks.table.VeryWideRowTable;
 import com.palantir.common.base.ClosableIterator;
@@ -98,7 +96,7 @@ public class KvsGetCandidateCellsForSweepingBenchmarks {
                     .batchSizeHint(1000)
                     .maxTimestampExclusive(Long.MAX_VALUE)
                     .shouldCheckIfLatestValueIsEmpty(thorough)
-                    .timestampsToIgnore(thorough ? ImmutableSet.of() : ImmutableSet.of(Value.INVALID_VALUE_TIMESTAMP))
+                    .ignoreGarbageCollectionSentinels(!thorough)
                     .build();
         try (ClosableIterator<List<CandidateCellForSweeping>> iter = kvs.getCandidateCellsForSweeping(
                     tableRef, request)) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractGetCandidateCellsForSweepingTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractGetCandidateCellsForSweepingTest.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -42,7 +41,6 @@ import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweeping;
 import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 
 public abstract class AbstractGetCandidateCellsForSweepingTest {
@@ -216,7 +214,7 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
                         .startRowInclusive(PtBytes.EMPTY_BYTE_ARRAY)
                         .maxTimestampExclusive(40L)
                         .shouldCheckIfLatestValueIsEmpty(checkIfLatestValueIsEmpty)
-                        .addTimestampsToIgnore(Value.INVALID_VALUE_TIMESTAMP)
+                        .ignoreGarbageCollectionSentinels(true)
                         .batchSizeHint(1)
                         .build());
         assertEquals(expectedCells,
@@ -240,7 +238,7 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
                 .startRowInclusive(startRow)
                 .maxTimestampExclusive(sweepTs)
                 .shouldCheckIfLatestValueIsEmpty(false)
-                .addTimestampsToIgnore(Value.INVALID_VALUE_TIMESTAMP)
+                .ignoreGarbageCollectionSentinels(true)
                 .batchSizeHint(batchSizeHint)
                 .build();
     }
@@ -250,7 +248,7 @@ public abstract class AbstractGetCandidateCellsForSweepingTest {
                 .startRowInclusive(startRow)
                 .maxTimestampExclusive(sweepTs)
                 .shouldCheckIfLatestValueIsEmpty(true)
-                .timestampsToIgnore(ImmutableSet.of())
+                .ignoreGarbageCollectionSentinels(false)
                 .batchSizeHint(batchSizeHint)
                 .build();
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.impl;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -1020,6 +1021,92 @@ public abstract class AbstractKeyValueServiceTest {
         setupTestRowsZeroOneAndTwoAndDeleteFrom(PtBytes.toBytes("a"),
                 PtBytes.toBytes("a"));
         checkThatTableIsNowOnly(row0, row1, row2);
+    }
+
+    @Test
+    public void deleteTimestampRangesIgnoresEmptyMap() {
+        keyValueService.deleteAllTimestamps(TEST_TABLE, ImmutableMap.of());
+    }
+
+    @Test
+    public void deleteTimestampRangesDeletesForSingleColumn() {
+        Cell row0col0 = Cell.create(row0, column0);
+        long ts1 = 5L;
+        long ts2 = 10L;
+        long latestTs = 15L;
+
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value00), ts1);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value01), ts2);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value10), latestTs);
+
+        keyValueService.deleteAllTimestamps(TEST_TABLE, ImmutableMap.of(row0col0, latestTs));
+
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col0), Long.MAX_VALUE).asMap().get(
+                row0col0), contains(latestTs));
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row0col0, Long.MAX_VALUE)).get(row0col0),
+                equalTo(Value.create(value10, latestTs)));
+    }
+
+    @Test
+    public void deleteTimestampRangesDeletesMultipleColumnsAcrossMultipleRows() {
+        Cell row0col0 = Cell.create(row0, column0);
+        Cell row0col1 = Cell.create(row0, column1);
+        Cell row1col0 = Cell.create(row1, column0);
+
+        long ts1Col0 = 5L;
+        long ts2Col0 = 10L;
+        long latestTsCol0 = 15L;
+
+        long ts1Col1 = 2L;
+        long ts2Col1 = 3L;
+        long latestTsCol1 = 4L;
+
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value00), ts1Col0);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value01), ts2Col0);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value10), latestTsCol0);
+
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row1col0, value00), ts1Col0);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row1col0, value01), ts2Col0);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row1col0, value10), latestTsCol0);
+
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col1, value00), ts1Col1);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col1, value01), ts2Col1);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col1, value10), latestTsCol1);
+
+        keyValueService.deleteAllTimestamps(TEST_TABLE, ImmutableMap.of(
+                row0col0, latestTsCol0,
+                row0col1, latestTsCol1,
+                row1col0, latestTsCol0));
+
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col0), Long.MAX_VALUE).asMap().get(
+                row0col0), contains(latestTsCol0));
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col1), Long.MAX_VALUE).asMap().get(
+                row0col1), contains(latestTsCol1));
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row1col0), Long.MAX_VALUE).asMap().get(
+                row1col0), contains(latestTsCol0));
+
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row0col0, Long.MAX_VALUE)).get(row0col0),
+                equalTo(Value.create(value10, latestTsCol0)));
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row0col1, Long.MAX_VALUE)).get(row0col1),
+                equalTo(Value.create(value10, latestTsCol1)));
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row1col0, Long.MAX_VALUE)).get(row1col0),
+                equalTo(Value.create(value10, latestTsCol0)));
+    }
+
+    @Test
+    public void deleteTimestampRangesLeavesSentinels() {
+        Cell row0col0 = Cell.create(row0, column0);
+        long latestTs = 15L;
+
+        keyValueService.addGarbageCollectionSentinelValues(TEST_TABLE, ImmutableSet.of(row0col0));
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value10), latestTs);
+
+        keyValueService.deleteAllTimestamps(TEST_TABLE, ImmutableMap.of(row0col0, latestTs));
+
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col0), Long.MAX_VALUE).asMap()
+                .get(row0col0), contains(Value.INVALID_VALUE_TIMESTAMP, latestTs));
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row0col0, Value.INVALID_VALUE_TIMESTAMP + 1L))
+                        .get(row0col0), equalTo(Value.create(new byte[0], Value.INVALID_VALUE_TIMESTAMP)));
     }
 
     private void setupTestRowsZeroOneAndTwoAndDeleteFrom(byte[] start, byte[] end) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -25,363 +25,42 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ImmutableSweepResults;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
-import com.palantir.atlasdb.table.description.TableDefinition;
-import com.palantir.atlasdb.table.description.ValueType;
-import com.palantir.atlasdb.transaction.api.ConflictHandler;
-import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
-import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
-import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
-import com.palantir.atlasdb.transaction.service.TransactionService;
-import com.palantir.atlasdb.transaction.service.TransactionServices;
-import com.palantir.timestamp.InMemoryTimestampService;
-import com.palantir.timestamp.TimestampService;
 
-public abstract class AbstractSweepTaskRunnerTest {
-    private static final String FULL_TABLE_NAME = "test_table.xyz_atlasdb_sweeper_test";
-    protected static final TableReference TABLE_NAME = TableReference.createFromFullyQualifiedName(FULL_TABLE_NAME);
-    private static final String COL = "c";
+public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
     protected static final int DEFAULT_BATCH_SIZE = 1000;
 
-    private static final List<Cell> SMALL_LIST_OF_CELLS = Lists.newArrayList();
-    private static final List<Cell> BIG_LIST_OF_CELLS = Lists.newArrayList();
-
-    static {
-        for (int i = 0; i < 10; i++) {
-            String colName = String.format("c%d", i);
-            BIG_LIST_OF_CELLS.add(
-                    Cell.create("row".getBytes(StandardCharsets.UTF_8), colName.getBytes(StandardCharsets.UTF_8)));
-        }
-        SMALL_LIST_OF_CELLS.addAll(BIG_LIST_OF_CELLS.subList(0, 4));
-    }
-
-    protected KeyValueService kvs;
-    protected final AtomicLong sweepTimestamp = new AtomicLong();
     protected SweepTaskRunner sweepRunner;
-    protected LockAwareTransactionManager txManager;
-    protected TransactionService txService;
-    protected PersistentLockManager persistentLockManager;
-    protected SweepStrategyManager ssm;
     protected LongSupplier tsSupplier;
+    protected final AtomicLong sweepTimestamp = new AtomicLong();
 
     @Before
     public void setup() {
-        TimestampService tsService = new InMemoryTimestampService();
-        kvs = SweepStatsKeyValueService.create(getKeyValueService(), tsService);
-        ssm = SweepStrategyManagers.createDefault(kvs);
-        txService = TransactionServices.createTransactionService(kvs);
-        txManager = SweepTestUtils.setupTxManager(kvs, tsService, ssm, txService);
+        super.setup();
         tsSupplier = sweepTimestamp::get;
-        persistentLockManager = new PersistentLockManager(
-                SweepTestUtils.getPersistentLockService(kvs),
-                AtlasDbConstants.DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS);
+
         CellsSweeper cellsSweeper = new CellsSweeper(txManager, kvs, persistentLockManager, ImmutableList.of());
         sweepRunner = new SweepTaskRunner(kvs, tsSupplier, tsSupplier, txService, ssm, cellsSweeper);
-    }
-
-    @After
-    public void close() {
-        kvs.close();
-    }
-
-    /**
-     * Called once before each test.
-     *
-     * @return the KVS used for testing
-     */
-    protected abstract KeyValueService getKeyValueService();
-
-    @Test(timeout = 50000)
-    public void testSweepOneConservative() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putIntoDefaultColumn("foo", "baz", 100);
-        SweepResults results = completeSweep(175);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
-        assertEquals("baz", getFromDefaultColumn("foo", 150));
-        assertEquals("", getFromDefaultColumn("foo", 80));
-        assertEquals(ImmutableSet.of(-1L, 100L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testDontSweepLatestConservative() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("foo", "bar", 50);
-        SweepResults results = completeSweep(75);
-        assertEquals(0, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-        assertEquals("bar", getFromDefaultColumn("foo", 150));
-        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepUncommittedConservative() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putUncommitted("foo", "baz", 100);
-        SweepResults results = completeSweep(175);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
-        assertEquals("bar", getFromDefaultColumn("foo", 750));
-        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepManyValuesConservative() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putUncommitted("foo", "bad", 75);
-        putIntoDefaultColumn("foo", "baz", 100);
-        putIntoDefaultColumn("foo", "buzz", 125);
-        putUncommitted("foo", "foo", 150);
-        SweepResults results = completeSweep(175);
-        assertEquals(4, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
-        assertEquals("buzz", getFromDefaultColumn("foo", 200));
-        assertEquals("", getFromDefaultColumn("foo", 124));
-        assertEquals(ImmutableSet.of(-1L, 125L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepManyRowsConservative() {
-        testSweepManyRows(SweepStrategy.CONSERVATIVE);
-    }
-
-    @Test(timeout = 50000)
-    public void testDontSweepFutureConservative() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putUncommitted("foo", "bad", 75);
-        putIntoDefaultColumn("foo", "baz", 100);
-        putIntoDefaultColumn("foo", "buzz", 125);
-        putUncommitted("foo", "foo", 150);
-        SweepResults results = completeSweep(110);
-        assertEquals(2, results.getStaleValuesDeleted());
-        // Future timestamps don't count towards the examined count
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(3);
-        assertEquals(ImmutableSet.of(-1L, 100L, 125L, 150L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepOneThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putIntoDefaultColumn("foo", "baz", 100);
-        SweepResults results = completeSweep(175);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
-        assertEquals("baz", getFromDefaultColumn("foo", 150));
-        assertNull(getFromDefaultColumn("foo", 80));
-        assertEquals(ImmutableSet.of(100L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testDontSweepLatestThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "bar", 50);
-        SweepResults results = completeSweep(75);
-        assertEquals(0, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-        assertEquals("bar", getFromDefaultColumn("foo", 150));
-        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepLatestDeletedMultiRowThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "", 50);
-        put("foo-2", "other", "womp", 60);
-        SweepResults results = completeSweep(75);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-
-        assertNull(getFromDefaultColumn("foo", 150));
-        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepLatestDeletedMultiColThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        put("foo", "other column", "other value", 40);
-        putIntoDefaultColumn("foo", "", 50);
-        SweepResults results = completeSweep(75);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-
-        // The default column had its only value deleted
-        assertNull(getFromDefaultColumn("foo", 150));
-        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
-
-        // The other column was unaffected
-        assertEquals("other value", get("foo", "other column", 150));
-        assertEquals(ImmutableSet.of(40L), getAllTs("foo", "other column"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepLatestDeletedMultiValConservative() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("foo", "old value", 40);
-        putIntoDefaultColumn("foo", "", 50);
-        SweepResults results = completeSweep(75);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-        assertEquals("", getFromDefaultColumn("foo", 150));
-        assertEquals(ImmutableSet.of(-1L, 50L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepLatestNotDeletedMultiValThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "old value", 40);
-        putIntoDefaultColumn("foo", "new value", 50);
-        SweepResults results = completeSweep(75);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-        assertEquals("new value", getFromDefaultColumn("foo", 150));
-        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepLatestDeletedMultiValThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "old value", 40);
-        putIntoDefaultColumn("foo", "", 50);
-        SweepResults results = completeSweep(75);
-        assertEquals(2, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-        assertNull(getFromDefaultColumn("foo", 150));
-        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
-
-        // The second sweep has no cells to examine
-        SweepResults secondSweep = completeSweep(75);
-        assertEquals(0, secondSweep.getStaleValuesDeleted());
-        assertEquals(0, secondSweep.getCellTsPairsExamined());
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepLatestDeletedThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "", 50);
-        SweepResults results = completeSweep(75);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-        assertNull(getFromDefaultColumn("foo", 150));
-        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepUncommittedThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putUncommitted("foo", "baz", 100);
-        SweepResults results = completeSweep(175);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
-        assertEquals("bar", getFromDefaultColumn("foo", 750));
-        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepManyValuesThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putUncommitted("foo", "bad", 75);
-        putIntoDefaultColumn("foo", "baz", 100);
-        putIntoDefaultColumn("foo", "buzz", 125);
-        putUncommitted("foo", "foo", 150);
-        SweepResults results = completeSweep(175);
-        assertEquals(4, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
-        assertEquals("buzz", getFromDefaultColumn("foo", 200));
-        assertNull(getFromDefaultColumn("foo", 124));
-        assertEquals(ImmutableSet.of(125L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepManyRowsThorough() {
-        testSweepManyRows(SweepStrategy.THOROUGH);
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepManyLatestDeletedThorough1() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putUncommitted("foo", "bad", 75);
-        putIntoDefaultColumn("foo", "baz", 100);
-        putIntoDefaultColumn("foo", "", 125);
-        putUncommitted("foo", "foo", 150);
-        putIntoDefaultColumn("zzz", "bar", 51);
-
-        SweepResults results = completeSweep(175);
-        assertEquals(4, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(6);
-        assertEquals("", getFromDefaultColumn("foo", 200));
-        assertEquals(ImmutableSet.of(125L), getAllTsFromDefaultColumn("foo"));
-
-        results = completeSweep(175);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
-        assertNull(getFromDefaultColumn("foo", 200));
-        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepManyLatestDeletedThorough2() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putUncommitted("foo", "bad", 75);
-        putIntoDefaultColumn("foo", "baz", 100);
-        putIntoDefaultColumn("foo", "foo", 125);
-        putUncommitted("foo", "", 150);
-        SweepResults results = completeSweep(175);
-        assertEquals(4, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
-        assertEquals("foo", getFromDefaultColumn("foo", 200));
-        assertEquals(ImmutableSet.of(125L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testDontSweepFutureThorough() {
-        createTable(SweepStrategy.THOROUGH);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putUncommitted("foo", "bad", 75);
-        putIntoDefaultColumn("foo", "baz", 100);
-        putIntoDefaultColumn("foo", "buzz", 125);
-        putUncommitted("foo", "foo", 150);
-        SweepResults results = completeSweep(110);
-        assertEquals(2, results.getStaleValuesDeleted());
-        // Future timestamps don't count towards the examined count
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(3);
-        assertEquals(ImmutableSet.of(100L, 125L, 150L), getAllTsFromDefaultColumn("foo"));
     }
 
     @Test(timeout = 50000)
@@ -400,69 +79,8 @@ public abstract class AbstractSweepTaskRunnerTest {
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
                 PtBytes.EMPTY_BYTE_ARRAY);
-        assertEmptyResultWithNoMoreToSweep(results);
+        assertEquals(SweepResults.createEmptySweepResult(), results);
         assertEquals(ImmutableSet.of(50L, 75L, 100L, 125L, 150L), getAllTsFromDefaultColumn("foo"));
-    }
-
-    @Test(timeout = 50000)
-    public void testSweeperFailsHalfwayThroughOnDeleteTable() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putIntoDefaultColumn("foo2", "bang", 75);
-        putIntoDefaultColumn("foo3", "baz", 100);
-        putIntoDefaultColumn("foo4", "buzz", 125);
-        byte[] nextStartRow = partialSweep(150).getNextStartRow().get();
-
-        kvs.dropTable(TABLE_NAME);
-
-        SweepResults results = sweepRunner.run(
-                TABLE_NAME,
-                ImmutableSweepBatchConfig.builder()
-                        .deleteBatchSize(DEFAULT_BATCH_SIZE)
-                        .candidateBatchSize(DEFAULT_BATCH_SIZE)
-                        .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
-                        .build(),
-                nextStartRow);
-        assertEmptyResultWithNoMoreToSweep(results);
-    }
-
-    @Test
-    public void testSweepTimers() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("foo", "bar", 50);
-        putIntoDefaultColumn("foo2", "bang", 75);
-        putIntoDefaultColumn("foo3", "baz", 100);
-        putIntoDefaultColumn("foo4", "buzz", 125);
-        SweepResults sweepResults = partialSweep(150);
-
-        assertTimeSweepStartedWithinDeltaOfSystemTime(sweepResults);
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepingAlreadySweptTable() {
-        createTable(SweepStrategy.CONSERVATIVE);
-        putIntoDefaultColumn("row", "val", 10);
-        putIntoDefaultColumn("row", "val", 20);
-
-        SweepResults results = completeSweep(30);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
-
-        results = completeSweep(40);
-        assertEquals(0, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
-    }
-
-    @Test(timeout = 50000)
-    public void testSweepOnMixedCaseTable() {
-        TableReference mixedCaseTable = TableReference.create(Namespace.create("someNamespace"), "someTable");
-        createTable(mixedCaseTable, SweepStrategy.CONSERVATIVE);
-        put(mixedCaseTable, "row", "col", "val", 10);
-        put(mixedCaseTable, "row", "col", "val", 20);
-
-        SweepResults results = completeSweep(mixedCaseTable, 30);
-        assertEquals(1, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
     }
 
     @Test(timeout = 50000)
@@ -515,17 +133,123 @@ public abstract class AbstractSweepTaskRunnerTest {
         assertThat(sweptCells.get(sweptCells.size() - 1).size()).isLessThanOrEqualTo(2 * deleteBatchSize);
     }
 
-    private void putTwoValuesInEachCell(List<Cell> cells) {
+    @Test(timeout = 50000)
+    public void testSweepUncommittedConservative() {
         createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putUncommitted("foo", "baz", 100);
+        SweepResults results = completeSweep(175).get();
+        assertEquals(1, results.getStaleValuesDeleted());
+        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
+        assertEquals("bar", getFromDefaultColumn("foo", 750));
+        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
+    }
 
-        int ts = 1;
-        for (Cell cell : cells) {
-            put(cell, "val1", ts);
-            put(cell, "val2", ts + 5);
-            ts += 10;
-        }
+    @Test(timeout = 50000)
+    public void testSweepManyValuesThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putUncommitted("foo", "bad", 75);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "buzz", 125);
+        putUncommitted("foo", "foo", 150);
+        SweepResults results = completeSweep(175).get();
+        assertEquals(4, results.getStaleValuesDeleted());
+        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
+        assertEquals("buzz", getFromDefaultColumn("foo", 200));
+        assertNull(getFromDefaultColumn("foo", 124));
+        assertEquals(ImmutableSet.of(125L), getAllTsFromDefaultColumn("foo"));
+    }
 
-        sweepTimestamp.set(ts);
+    @Test(timeout = 50000)
+    public void testSweepManyValuesIncludingUncommittedConservative() {
+        createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putUncommitted("foo", "bad", 75);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "buzz", 125);
+        putUncommitted("foo", "foo", 150);
+        SweepResults results = completeSweep(175).get();
+        assertEquals(4, results.getStaleValuesDeleted());
+        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
+        assertEquals("buzz", getFromDefaultColumn("foo", 200));
+        assertEquals("", getFromDefaultColumn("foo", 124));
+        assertEquals(ImmutableSet.of(-1L, 125L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepUncommittedThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putUncommitted("foo", "baz", 100);
+        SweepResults results = completeSweep(175).get();
+        assertEquals(1, results.getStaleValuesDeleted());
+        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
+        assertEquals("bar", getFromDefaultColumn("foo", 750));
+        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweeperFailsHalfwayThroughOnDeleteTable() {
+        createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putIntoDefaultColumn("foo2", "bang", 75);
+        putIntoDefaultColumn("foo3", "baz", 100);
+        putIntoDefaultColumn("foo4", "buzz", 125);
+        byte[] nextStartRow = partialSweep(150).getNextStartRow().get();
+
+        kvs.dropTable(TABLE_NAME);
+
+        SweepResults results = sweepRunner.run(
+                TABLE_NAME,
+                ImmutableSweepBatchConfig.builder()
+                        .deleteBatchSize(DEFAULT_BATCH_SIZE)
+                        .candidateBatchSize(DEFAULT_BATCH_SIZE)
+                        .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
+                        .build(),
+                nextStartRow);
+        assertEquals(SweepResults.createEmptySweepResult(), results);
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepManyLatestDeletedThoroughIncludingUncommitted1() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putUncommitted("foo", "bad", 75);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "", 125);
+        putUncommitted("foo", "foo", 150);
+        putIntoDefaultColumn("zzz", "bar", 51);
+
+        SweepResults results = completeSweep(175).get();
+        assertEquals(4, results.getStaleValuesDeleted());
+        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(6);
+        // this check is a nuance of SweepTaskRunner: the value at timestamp 125 is actually eligible for deletion,
+        // but we don't delete it on the first pass due to the later uncommitted value. below we sweep again and make
+        // sure it's deleted
+        assertEquals("", getFromDefaultColumn("foo", 200));
+        assertEquals(ImmutableSet.of(125L), getAllTsFromDefaultColumn("foo"));
+
+        results = completeSweep(175).get();
+        assertEquals(1, results.getStaleValuesDeleted());
+        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
+        assertNull(getFromDefaultColumn("foo", 200));
+        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepManyLatestDeletedThoroughIncludingUncommitted2() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putUncommitted("foo", "bad", 75);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "foo", 125);
+        putUncommitted("foo", "", 150);
+        SweepResults results = completeSweep(175).get();
+        //        assertEquals(4, results.getStaleValuesDeleted());
+        //        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
+        assertEquals("foo", getFromDefaultColumn("foo", 200));
+        assertEquals(ImmutableSet.of(125L), getAllTsFromDefaultColumn("foo"));
     }
 
     @SuppressWarnings("unchecked")
@@ -549,27 +273,15 @@ public abstract class AbstractSweepTaskRunnerTest {
         return sweptCells;
     }
 
-    private void testSweepManyRows(SweepStrategy strategy) {
-        createTable(strategy);
-        putIntoDefaultColumn("foo", "bar1", 5);
-        putIntoDefaultColumn("foo", "bar2", 10);
-        putIntoDefaultColumn("baz", "bar3", 15);
-        putIntoDefaultColumn("baz", "bar4", 20);
-        SweepResults results = completeSweep(175);
-        assertEquals(2, results.getStaleValuesDeleted());
-        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(4);
-    }
-
-    protected SweepResults completeSweep(long ts) {
+    protected Optional<SweepResults> completeSweep(long ts) {
         return completeSweep(TABLE_NAME, ts);
     }
 
-    protected SweepResults completeSweep(TableReference tableReference, long ts) {
+    protected Optional<SweepResults> completeSweep(TableReference tableReference, long ts) {
         sweepTimestamp.set(ts);
         byte[] startRow = PtBytes.EMPTY_BYTE_ARRAY;
         long totalStaleValuesDeleted = 0;
         long totalCellsExamined = 0;
-        long totalTime = 0;
         for (int run = 0; run < 100; ++run) {
             SweepResults results = sweepRunner.run(
                     tableReference,
@@ -579,19 +291,16 @@ public abstract class AbstractSweepTaskRunnerTest {
                             .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                             .build(),
                     startRow);
-            assertEquals(ts, results.getMinSweptTimestamp());
+            assertEquals(ts, results.getSweptTimestamp());
             assertArrayEquals(startRow, results.getPreviousStartRow().orElse(null));
             totalStaleValuesDeleted += results.getStaleValuesDeleted();
             totalCellsExamined += results.getCellTsPairsExamined();
-            totalTime += results.getTimeInMillis();
             if (!results.getNextStartRow().isPresent()) {
-                return ImmutableSweepResults.builder()
+                return Optional.of(ImmutableSweepResults.builder()
                         .staleValuesDeleted(totalStaleValuesDeleted)
                         .cellTsPairsExamined(totalCellsExamined)
-                        .minSweptTimestamp(ts)
-                        .timeInMillis(totalTime)
-                        .timeSweepStarted(0L)
-                        .build();
+                        .sweptTimestamp(ts)
+                        .build());
             }
             startRow = results.getNextStartRow().get();
         }
@@ -613,95 +322,5 @@ public abstract class AbstractSweepTaskRunnerTest {
         assertTrue(results.getNextStartRow().isPresent());
         return results;
     }
-
-    private String getFromDefaultColumn(String row, long ts) {
-        return get(row, COL, ts);
-    }
-
-    private String get(String row, String column, long ts) {
-        Cell cell = Cell.create(row.getBytes(StandardCharsets.UTF_8), column.getBytes(StandardCharsets.UTF_8));
-        Value val = kvs.get(TABLE_NAME, ImmutableMap.of(cell, ts)).get(cell);
-        return val == null ? null : new String(val.getContents(), StandardCharsets.UTF_8);
-    }
-
-    private Set<Long> getAllTsFromDefaultColumn(String row) {
-        return getAllTs(row, COL);
-    }
-
-    private Set<Long> getAllTs(String row, String column) {
-        Cell cell = Cell.create(row.getBytes(StandardCharsets.UTF_8), column.getBytes(StandardCharsets.UTF_8));
-        return ImmutableSet.copyOf(kvs.getAllTimestamps(TABLE_NAME, ImmutableSet.of(cell), Long.MAX_VALUE).get(cell));
-    }
-
-    protected void putIntoDefaultColumn(final String row, final String val, final long ts) {
-        put(row, COL, val, ts);
-    }
-
-    protected void put(final String row, final String column, final String val, final long ts) {
-        put(TABLE_NAME, row, column, val, ts);
-    }
-
-    protected void put(final TableReference tableRef,
-            final String row,
-            final String column,
-            final String val,
-            final long ts) {
-        Cell cell = Cell.create(row.getBytes(StandardCharsets.UTF_8), column.getBytes(StandardCharsets.UTF_8));
-        put(tableRef, cell, val, ts);
-    }
-
-    protected void put(Cell cell, final String val, final long ts) {
-        put(TABLE_NAME, cell, val, ts);
-    }
-
-    protected void put(final TableReference tableRef, Cell cell, final String val, final long ts) {
-        kvs.put(tableRef, ImmutableMap.of(cell, val.getBytes(StandardCharsets.UTF_8)), ts);
-        putTimestampIntoTransactionTable(ts);
-    }
-
-    private void putTimestampIntoTransactionTable(long ts) {
-        txService.putUnlessExists(ts, ts);
-    }
-
-    private void putUncommitted(final String row, final String val, final long ts) {
-        Cell cell = Cell.create(row.getBytes(StandardCharsets.UTF_8), COL.getBytes(StandardCharsets.UTF_8));
-        kvs.put(TABLE_NAME, ImmutableMap.of(cell, val.getBytes(StandardCharsets.UTF_8)), ts);
-    }
-
-    protected void createTable(SweepStrategy sweepStrategy) {
-        createTable(TABLE_NAME, sweepStrategy);
-    }
-
-    protected void createTable(TableReference tableReference, SweepStrategy sweepStrategy) {
-        kvs.createTable(tableReference,
-                new TableDefinition() {
-                    {
-                        rowName();
-                        rowComponent("row", ValueType.BLOB);
-                        columns();
-                        column("col", COL, ValueType.BLOB);
-                        conflictHandler(ConflictHandler.IGNORE_ALL);
-                        sweepStrategy(sweepStrategy);
-                    }
-                }.toTableMetadata().persistToBytes()
-        );
-    }
-
-    private void assertEmptyResultWithNoMoreToSweep(SweepResults results) {
-        assertTimeSweepStartedWithinDeltaOfSystemTime(results);
-        assertThat(results.getTimeInMillis()).isLessThanOrEqualTo(1000L);
-        assertThat(results.getTimeInMillis()).isGreaterThanOrEqualTo(0L);
-        assertEquals(results, SweepResults.builder()
-                .from(SweepResults.createEmptySweepResultWithNoMoreToSweep())
-                .timeSweepStarted(results.getTimeSweepStarted())
-                .timeInMillis(results.getTimeInMillis())
-                .build());
-    }
-
-    private void assertTimeSweepStartedWithinDeltaOfSystemTime(SweepResults results) {
-        assertThat(results.getTimeSweepStarted() + results.getTimeInMillis())
-                .isLessThanOrEqualTo(System.currentTimeMillis());
-        assertThat(results.getTimeSweepStarted() + results.getTimeInMillis())
-                .isGreaterThan(System.currentTimeMillis() - 1000L);
-    }
 }
+

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
                 PtBytes.EMPTY_BYTE_ARRAY);
-        assertEquals(SweepResults.createEmptySweepResult(), results);
+        assertEquals(SweepResults.createEmptySweepResult(Optional.empty()), results);
         assertEquals(ImmutableSet.of(50L, 75L, 100L, 125L, 150L), getAllTsFromDefaultColumn("foo"));
     }
 
@@ -208,7 +208,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
                 nextStartRow);
-        assertEquals(SweepResults.createEmptySweepResult(), results);
+        assertEquals(SweepResults.createEmptySweepResult(Optional.empty()), results);
     }
 
     @Test(timeout = 50000)
@@ -246,8 +246,8 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
         putIntoDefaultColumn("foo", "foo", 125);
         putUncommitted("foo", "", 150);
         SweepResults results = completeSweep(175).get();
-        //        assertEquals(4, results.getStaleValuesDeleted());
-        //        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
+        assertEquals(4, results.getStaleValuesDeleted());
+        assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
         assertEquals("foo", getFromDefaultColumn("foo", 200));
         assertEquals(ImmutableSet.of(125L), getAllTsFromDefaultColumn("foo"));
     }
@@ -255,6 +255,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
     @SuppressWarnings("unchecked")
     private List<List<Cell>> runSweep(CellsSweeper cellsSweeper, SweepTaskRunner spiedSweepRunner,
             int maxCellTsPairsToExamine, int candidateBatchSize, int deleteBatchSize) {
+        sweepTimestamp.set(Long.MAX_VALUE);
         List<List<Cell>> sweptCells = Lists.newArrayList();
 
         doAnswer((invocationOnMock) -> {
@@ -291,7 +292,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                             .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                             .build(),
                     startRow);
-            assertEquals(ts, results.getSweptTimestamp());
+            assertEquals(ts, results.getMinSweptTimestamp());
             assertArrayEquals(startRow, results.getPreviousStartRow().orElse(null));
             totalStaleValuesDeleted += results.getStaleValuesDeleted();
             totalCellsExamined += results.getCellTsPairsExamined();
@@ -299,7 +300,9 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                 return Optional.of(ImmutableSweepResults.builder()
                         .staleValuesDeleted(totalStaleValuesDeleted)
                         .cellTsPairsExamined(totalCellsExamined)
-                        .sweptTimestamp(ts)
+                        .timeInMillis(1)
+                        .timeSweepStarted(1)
+                        .minSweptTimestamp(ts)
                         .build());
             }
             startRow = results.getNextStartRow().get();

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTest.java
@@ -144,8 +144,8 @@ public abstract class AbstractSweepTest {
 
         Optional<SweepResults> optResults = completeSweep(175);
         optResults.ifPresent(results -> {
-            assertEquals(4, results.getStaleValuesDeleted());
-            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
+            assertEquals(2, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(3);
         });
 
         assertEquals("buzz", getFromDefaultColumn("foo", 200));
@@ -331,8 +331,8 @@ public abstract class AbstractSweepTest {
 
         Optional<SweepResults> optResults = completeSweep(175);
         optResults.ifPresent(results -> {
-            assertEquals(4, results.getStaleValuesDeleted());
-            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(6);
+            assertEquals(3, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(4);
         });
 
         assertNull(getFromDefaultColumn("foo", 200));
@@ -348,8 +348,8 @@ public abstract class AbstractSweepTest {
 
         Optional<SweepResults> optResults = completeSweep(175);
         optResults.ifPresent(results -> {
-            assertEquals(4, results.getStaleValuesDeleted());
-            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
+            assertEquals(2, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(3);
         });
 
         assertEquals("foo", getFromDefaultColumn("foo", 200));

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTest.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.SweepResults;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
+import com.palantir.atlasdb.sweep.queue.test.InMemorySweepQueue;
+import com.palantir.atlasdb.table.description.TableDefinition;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
+import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
+import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionServices;
+import com.palantir.timestamp.InMemoryTimestampService;
+import com.palantir.timestamp.TimestampService;
+
+public abstract class AbstractSweepTest {
+    protected static final String FULL_TABLE_NAME = "test_table.xyz_atlasdb_sweeper_test";
+    protected static final TableReference TABLE_NAME = TableReference.createFromFullyQualifiedName(FULL_TABLE_NAME);
+    protected static final String COL = "c";
+
+    protected static final List<Cell> SMALL_LIST_OF_CELLS = Lists.newArrayList();
+    protected static final List<Cell> BIG_LIST_OF_CELLS = Lists.newArrayList();
+
+    static {
+        for (int i = 0; i < 10; i++) {
+            String colName = String.format("c%d", i);
+            BIG_LIST_OF_CELLS.add(
+                    Cell.create("row".getBytes(StandardCharsets.UTF_8), colName.getBytes(StandardCharsets.UTF_8)));
+        }
+        SMALL_LIST_OF_CELLS.addAll(BIG_LIST_OF_CELLS.subList(0, 4));
+    }
+
+    protected KeyValueService kvs;
+    protected LockAwareTransactionManager txManager;
+    protected TransactionService txService;
+    protected SweepStrategyManager ssm;
+    protected PersistentLockManager persistentLockManager;
+
+    /**
+     * Called once before each test.
+     *
+     * @return the KVS used for testing
+     */
+    protected abstract KeyValueService getKeyValueService();
+
+    @Before
+    public void setup() {
+        TimestampService tsService = new InMemoryTimestampService();
+        kvs = SweepStatsKeyValueService.create(getKeyValueService(), tsService);
+        ssm = SweepStrategyManagers.createDefault(kvs);
+        txService = TransactionServices.createTransactionService(kvs);
+        txManager = SweepTestUtils.setupTxManager(kvs, tsService, ssm, txService);
+        persistentLockManager = new PersistentLockManager(
+                SweepTestUtils.getPersistentLockService(kvs),
+                AtlasDbConstants.DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS);
+        InMemorySweepQueue.clear();
+    }
+
+    @After
+    public void close() {
+        kvs.close();
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepOneConservative() {
+        createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putIntoDefaultColumn("foo", "baz", 100);
+
+        Optional<SweepResults> optResults = completeSweep(175);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
+        });
+
+        assertEquals("baz", getFromDefaultColumn("foo", 150));
+        assertEquals("", getFromDefaultColumn("foo", 80));
+        assertEquals(ImmutableSet.of(-1L, 100L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testDontSweepLatestConservative() {
+        createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("foo", "bar", 50);
+
+        Optional<SweepResults> optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(0, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+
+        assertEquals("bar", getFromDefaultColumn("foo", 150));
+        assertEqualsDisregardingExtraSentinels(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepManyValuesConservative() {
+        createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "buzz", 125);
+
+        Optional<SweepResults> optResults = completeSweep(175);
+        optResults.ifPresent(results -> {
+            assertEquals(4, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
+        });
+
+        assertEquals("buzz", getFromDefaultColumn("foo", 200));
+        assertEquals("", getFromDefaultColumn("foo", 124));
+        assertEquals(ImmutableSet.of(-1L, 125L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepManyRowsConservative() {
+        testSweepManyRows(SweepStrategy.CONSERVATIVE);
+    }
+
+    @Test(timeout = 50000)
+    public void testDontSweepFutureConservative() {
+        createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putUncommitted("foo", "bad", 75);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "buzz", 125);
+        putUncommitted("foo", "foo", 150);
+
+        Optional<SweepResults> optResults = completeSweep(110);
+        optResults.ifPresent(results -> {
+            assertEquals(2, results.getStaleValuesDeleted());
+            // Future timestamps don't count towards the examined count
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(3);
+        });
+
+        assertEquals(ImmutableSet.of(-1L, 100L, 125L, 150L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepOneThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putIntoDefaultColumn("foo", "baz", 100);
+
+        Optional<SweepResults> optResults = completeSweep(175);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
+        });
+
+        assertEquals("baz", getFromDefaultColumn("foo", 150));
+        assertNull(getFromDefaultColumn("foo", 80));
+        assertEquals(ImmutableSet.of(100L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testDontSweepLatestThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+
+        Optional<SweepResults> optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(0, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+
+        assertEquals("bar", getFromDefaultColumn("foo", 150));
+        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepLatestDeletedMultiRowThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "", 50);
+        put("foo-2", "other", "womp", 60);
+
+        Optional<SweepResults> optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+
+        assertNull(getFromDefaultColumn("foo", 150));
+        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepLatestDeletedMultiColThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        put("foo", "other column", "other value", 40);
+        putIntoDefaultColumn("foo", "", 50);
+
+        Optional<SweepResults> optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+
+        // The default column had its only value deleted
+        assertNull(getFromDefaultColumn("foo", 150));
+        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
+
+        // The other column was unaffected
+        assertEquals("other value", get("foo", "other column", 150));
+        assertEquals(ImmutableSet.of(40L), getAllTs("foo", "other column"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepLatestDeletedMultiValConservative() {
+        createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("foo", "old value", 40);
+        putIntoDefaultColumn("foo", "", 50);
+
+        Optional<SweepResults> optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+
+        assertEquals("", getFromDefaultColumn("foo", 150));
+        assertEquals(ImmutableSet.of(-1L, 50L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepLatestNotDeletedMultiValThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "old value", 40);
+        putIntoDefaultColumn("foo", "new value", 50);
+
+        Optional<SweepResults> optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+
+        assertEquals("new value", getFromDefaultColumn("foo", 150));
+        assertEquals(ImmutableSet.of(50L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepLatestDeletedMultiValThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "old value", 40);
+        putIntoDefaultColumn("foo", "", 50);
+
+        Optional<SweepResults> optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(2, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+
+        assertNull(getFromDefaultColumn("foo", 150));
+        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
+
+        // The second sweep has no cells to examine
+        optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(0, results.getStaleValuesDeleted());
+            assertEquals(0, results.getCellTsPairsExamined());
+        });
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepLatestDeletedThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "", 50);
+
+        Optional<SweepResults> optResults = completeSweep(75);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+
+        assertNull(getFromDefaultColumn("foo", 150));
+        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepManyRowsThorough() {
+        testSweepManyRows(SweepStrategy.THOROUGH);
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepManyLatestDeletedThorough1() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "", 125);
+        putIntoDefaultColumn("zzz", "bar", 51);
+
+        Optional<SweepResults> optResults = completeSweep(175);
+        optResults.ifPresent(results -> {
+            assertEquals(4, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(6);
+        });
+
+        assertNull(getFromDefaultColumn("foo", 200));
+        assertEquals(ImmutableSet.of(), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepManyLatestDeletedThorough2() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "foo", 125);
+
+        Optional<SweepResults> optResults = completeSweep(175);
+        optResults.ifPresent(results -> {
+            assertEquals(4, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(5);
+        });
+
+        assertEquals("foo", getFromDefaultColumn("foo", 200));
+        assertEquals(ImmutableSet.of(125L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testDontSweepFutureThorough() {
+        createTable(SweepStrategy.THOROUGH);
+        putIntoDefaultColumn("foo", "bar", 50);
+        putUncommitted("foo", "bad", 75);
+        putIntoDefaultColumn("foo", "baz", 100);
+        putIntoDefaultColumn("foo", "buzz", 125);
+        putUncommitted("foo", "foo", 150);
+
+        Optional<SweepResults> optResults = completeSweep(110);
+        optResults.ifPresent(results -> {
+            assertEquals(2, results.getStaleValuesDeleted());
+            // Future timestamps don't count towards the examined count
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(3);
+        });
+
+        assertEquals(ImmutableSet.of(100L, 125L, 150L), getAllTsFromDefaultColumn("foo"));
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepingAlreadySweptTable() {
+        createTable(SweepStrategy.CONSERVATIVE);
+        putIntoDefaultColumn("row", "val", 10);
+        putIntoDefaultColumn("row", "val", 20);
+
+        Optional<SweepResults> optResults = completeSweep(30);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
+        });
+
+        optResults = completeSweep(40);
+        optResults.ifPresent(results -> {
+            assertEquals(0, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(1);
+        });
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepOnMixedCaseTable() {
+        TableReference mixedCaseTable = TableReference.create(Namespace.create("someNamespace"), "someTable");
+        createTable(mixedCaseTable, SweepStrategy.CONSERVATIVE);
+        put(mixedCaseTable, "row", "col", "val", 10);
+        put(mixedCaseTable, "row", "col", "val", 20);
+
+        Optional<SweepResults> optResults = completeSweep(mixedCaseTable, 30);
+        optResults.ifPresent(results -> {
+            assertEquals(1, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(2);
+        });
+    }
+
+    void assertEqualsDisregardingExtraSentinels(Set<Long> expectedTimestamps, Set<Long> actualTimestamps) {
+        if (expectedTimestamps.contains(-1L)) {
+            assertEquals(expectedTimestamps, actualTimestamps);
+        } else {
+            assertEquals(expectedTimestamps, Sets.difference(actualTimestamps, ImmutableSet.of(-1L)));
+        }
+    }
+
+    protected void putTwoValuesInEachCell(List<Cell> cells) {
+        createTable(SweepStrategy.CONSERVATIVE);
+
+        int ts = 1;
+        for (Cell cell : cells) {
+            put(cell, "val1", ts);
+            put(cell, "val2", ts + 5);
+            ts += 10;
+        }
+    }
+
+    private void testSweepManyRows(SweepStrategy strategy) {
+        createTable(strategy);
+        putIntoDefaultColumn("foo", "bar1", 5);
+        putIntoDefaultColumn("foo", "bar2", 10);
+        putIntoDefaultColumn("baz", "bar3", 15);
+        putIntoDefaultColumn("baz", "bar4", 20);
+
+        Optional<SweepResults> optResults = completeSweep(175);
+        optResults.ifPresent(results -> {
+            assertEquals(2, results.getStaleValuesDeleted());
+            assertThat(results.getCellTsPairsExamined()).isGreaterThanOrEqualTo(4);
+        });
+    }
+
+    protected Optional<SweepResults> completeSweep(long ts) {
+        return completeSweep(TABLE_NAME, ts);
+    }
+
+    protected abstract Optional<SweepResults> completeSweep(TableReference tableReference, long ts);
+
+    protected String getFromDefaultColumn(String row, long ts) {
+        return get(row, COL, ts);
+    }
+
+    private String get(String row, String column, long ts) {
+        Cell cell = Cell.create(row.getBytes(StandardCharsets.UTF_8), column.getBytes(StandardCharsets.UTF_8));
+        Value val = kvs.get(TABLE_NAME, ImmutableMap.of(cell, ts)).get(cell);
+        return val == null ? null : new String(val.getContents(), StandardCharsets.UTF_8);
+    }
+
+    protected Set<Long> getAllTsFromDefaultColumn(String row) {
+        return getAllTs(row, COL);
+    }
+
+    private Set<Long> getAllTs(String row, String column) {
+        Cell cell = Cell.create(row.getBytes(StandardCharsets.UTF_8), column.getBytes(StandardCharsets.UTF_8));
+        return ImmutableSet.copyOf(kvs.getAllTimestamps(TABLE_NAME, ImmutableSet.of(cell), Long.MAX_VALUE).get(cell));
+    }
+
+    protected void putIntoDefaultColumn(final String row, final String val, final long ts) {
+        put(row, COL, val, ts);
+    }
+
+    protected void put(final String row, final String column, final String val, final long ts) {
+        put(TABLE_NAME, row, column, val, ts);
+    }
+
+    protected void put(final TableReference tableRef,
+            final String row,
+            final String column,
+            final String val,
+            final long ts) {
+        Cell cell = Cell.create(row.getBytes(StandardCharsets.UTF_8), column.getBytes(StandardCharsets.UTF_8));
+        put(tableRef, cell, val, ts);
+    }
+
+    protected void put(Cell cell, final String val, final long ts) {
+        put(TABLE_NAME, cell, val, ts);
+    }
+
+    protected void put(final TableReference tableRef, Cell cell, final String val, final long ts) {
+        Map<Cell, byte[]> writes = ImmutableMap.of(cell, val.getBytes(StandardCharsets.UTF_8));
+        kvs.put(tableRef, writes, ts);
+        putTimestampIntoTransactionTable(ts);
+        InMemorySweepQueue.writer().enqueue(tableRef, writes, ts);
+    }
+
+    private void putTimestampIntoTransactionTable(long ts) {
+        txService.putUnlessExists(ts, ts);
+    }
+
+    protected void putUncommitted(final String row, final String val, final long ts) {
+        Cell cell = Cell.create(row.getBytes(StandardCharsets.UTF_8), COL.getBytes(StandardCharsets.UTF_8));
+        kvs.put(TABLE_NAME, ImmutableMap.of(cell, val.getBytes(StandardCharsets.UTF_8)), ts);
+    }
+
+    protected void createTable(SweepStrategy sweepStrategy) {
+        createTable(TABLE_NAME, sweepStrategy);
+    }
+
+    protected void createTable(TableReference tableReference, SweepStrategy sweepStrategy) {
+        kvs.createTable(tableReference,
+                new TableDefinition() {
+                    {
+                        rowName();
+                        rowComponent("row", ValueType.BLOB);
+                        columns();
+                        column("col", COL, ValueType.BLOB);
+                        conflictHandler(ConflictHandler.IGNORE_ALL);
+                        sweepStrategy(sweepStrategy);
+                    }
+                }.toTableMetadata().persistToBytes()
+        );
+    }
+
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.persistentlock.KvsBackedPersistentLockService;
 import com.palantir.atlasdb.persistentlock.NoOpPersistentLockService;
 import com.palantir.atlasdb.persistentlock.PersistentLockService;
 import com.palantir.atlasdb.schema.SweepSchema;
+import com.palantir.atlasdb.sweep.queue.test.InMemorySweepQueue;
 import com.palantir.atlasdb.table.description.Schemas;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.LockAwareTransactionManager;
@@ -57,7 +58,7 @@ public final class SweepTestUtils {
                 TransactionServices.createTransactionService(kvs));
     }
 
-    public static LockAwareTransactionManager setupTxManager(KeyValueService kvs,
+    public static SerializableTransactionManager setupTxManager(KeyValueService kvs,
             TimestampService tsService,
             SweepStrategyManager ssm,
             TransactionService txService) {
@@ -68,11 +69,12 @@ public final class SweepTestUtils {
                 AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING;
         ConflictDetectionManager cdm = ConflictDetectionManagers.createWithoutWarmingCache(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        LockAwareTransactionManager txManager = SerializableTransactionManager.createForTest(
+        SerializableTransactionManager txManager = SerializableTransactionManager.createForTest(
                 kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+                InMemorySweepQueue.writer());
         setupTables(kvs);
         return txManager;
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -47,6 +47,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -106,7 +107,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 timestampCache,
                 AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_EXECUTOR,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY) {
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                SweepQueueWriter.NO_OP) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -47,7 +47,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -79,7 +79,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+                MultiTableSweepQueueWriter.NO_OP);
     }
 
     @Override
@@ -108,7 +109,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_EXECUTOR,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                SweepQueueWriter.NO_OP) {
+                MultiTableSweepQueueWriter.NO_OP) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -64,7 +64,7 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
@@ -120,7 +120,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 timestampCache,
                 GET_RANGES_EXECUTOR,
                 DEFAULT_GET_RANGES_CONCURRENCY,
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -64,6 +64,7 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
@@ -118,7 +119,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
                 GET_RANGES_EXECUTOR,
-                DEFAULT_GET_RANGES_CONCURRENCY);
+                DEFAULT_GET_RANGES_CONCURRENCY,
+                SweepQueueWriter.NO_OP);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AssertLockedKeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -48,7 +48,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             TransactionService transactionService,
             ConflictDetectionManager conflictDetectionManager,
             SweepStrategyManager sweepStrategyManager,
-            SweepQueueWriter sweepQueue) {
+            MultiTableSweepQueueWriter sweepQueue) {
         super(
                 createAssertKeyValue(keyValueService, lockService),
                 new LegacyTimelockService(timestampService, lockService, lockClient),
@@ -89,7 +89,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -25,6 +25,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AssertLockedKeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -46,7 +47,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             LockService lockService,
             TransactionService transactionService,
             ConflictDetectionManager conflictDetectionManager,
-            SweepStrategyManager sweepStrategyManager) {
+            SweepStrategyManager sweepStrategyManager,
+            SweepQueueWriter sweepQueue) {
         super(
                 createAssertKeyValue(keyValueService, lockService),
                 new LegacyTimelockService(timestampService, lockService, lockClient),
@@ -61,7 +63,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                sweepQueue);
     }
 
     @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
@@ -85,7 +88,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                SweepQueueWriter.NO_OP);
     }
 
     @Override
@@ -119,7 +123,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampValidationReadCache,
                 getRangesExecutor,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                sweepQueueWriter);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -32,7 +32,7 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -99,7 +99,8 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 conflictDetectionManager, sweepStrategyManager, NoOpCleaner.INSTANCE,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+                MultiTableSweepQueueWriter.NO_OP);
 
         // fetch an immutable timestamp once so it's cached
         when(mockTimestampService.getFreshTimestamp()).thenReturn(1L);
@@ -132,7 +133,7 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
 
         when(timelock.getFreshTimestamp()).thenReturn(1L);
         when(timelock.lockImmutableTimestamp(any())).thenReturn(

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -130,7 +131,8 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 false,
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
-                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY);
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                SweepQueueWriter.NO_OP);
 
         when(timelock.getFreshTimestamp()).thenReturn(1L);
         when(timelock.lockImmutableTimestamp(any())).thenReturn(

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -31,6 +31,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -84,7 +85,7 @@ public abstract class TransactionTestSetup {
 
     protected TransactionManager getManager() {
         return new TestTransactionManagerImpl(keyValueService, timestampService, lockClient, lockService,
-                transactionService, conflictDetectionManager, sweepStrategyManager);
+                transactionService, conflictDetectionManager, sweepStrategyManager, SweepQueueWriter.NO_OP);
     }
 
     protected void put(Transaction txn,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -31,7 +31,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -85,7 +85,7 @@ public abstract class TransactionTestSetup {
 
     protected TransactionManager getManager() {
         return new TestTransactionManagerImpl(keyValueService, timestampService, lockClient, lockService,
-                transactionService, conflictDetectionManager, sweepStrategyManager, SweepQueueWriter.NO_OP);
+                transactionService, conflictDetectionManager, sweepStrategyManager, MultiTableSweepQueueWriter.NO_OP);
     }
 
     protected void put(Transaction txn,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -36,7 +36,7 @@ import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.StatsTrackingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TrackingKeyValueService;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.impl.CachingTestTransactionManager;
@@ -75,9 +75,9 @@ public class AtlasDbTestCase {
     protected TestTransactionManager txManager;
     protected TransactionService transactionService;
     protected Map<TableReference, ConflictHandler> conflictHandlerOverrides = new HashMap<>();
-    protected SweepQueueWriter sweepQueue = mock(SweepQueueWriter.class);
+    protected MultiTableSweepQueueWriter sweepQueue = mock(MultiTableSweepQueueWriter.class);
     // default methods make mockito confusing, so we delegate just the important method to the mock
-    protected SweepQueueWriter wrappingSweepQueue = (table, writes) -> sweepQueue.enqueue(table, writes);
+    protected MultiTableSweepQueueWriter wrappingSweepQueue = (table, writes) -> sweepQueue.enqueue(table, writes);
 
     @BeforeClass
     public static void setupLockClient() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb;
 
+import static org.mockito.Mockito.mock;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
@@ -34,6 +36,7 @@ import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.StatsTrackingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TrackingKeyValueService;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.impl.CachingTestTransactionManager;
@@ -72,6 +75,9 @@ public class AtlasDbTestCase {
     protected TestTransactionManager txManager;
     protected TransactionService transactionService;
     protected Map<TableReference, ConflictHandler> conflictHandlerOverrides = new HashMap<>();
+    protected SweepQueueWriter sweepQueue = mock(SweepQueueWriter.class);
+    // default methods make mockito confusing, so we delegate just the important method to the mock
+    protected SweepQueueWriter wrappingSweepQueue = (table, writes) -> sweepQueue.enqueue(table, writes);
 
     @BeforeClass
     public static void setupLockClient() {
@@ -115,7 +121,8 @@ public class AtlasDbTestCase {
                 lockService,
                 transactionService,
                 conflictDetectionManager,
-                sweepStrategyManager);
+                sweepStrategyManager,
+                wrappingSweepQueue);
         txManager = new CachingTestTransactionManager(txManager);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -38,6 +38,7 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.common.TableTasks;
 import com.palantir.atlasdb.table.common.TableTasks.DiffStats;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -77,7 +78,8 @@ public class TableTasksTest {
                 kvs, tsService, lockClient, lockService, txService, constraints, cdm, ssm, cleaner,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE);
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+                MultiTableSweepQueueWriter.NO_OP);
         txManager = transactionManager;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
@@ -34,6 +34,7 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
+import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
@@ -97,7 +98,8 @@ public class TableMigratorTest extends AtlasDbTestCase {
                 lockService,
                 transactionService,
                 cdm2,
-                ssm2);
+                ssm2,
+                SweepQueueWriter.NO_OP);
         kvs2.createTable(tableRef, definition.toTableMetadata().persistToBytes());
         kvs2.createTable(namespacedTableRef, definition.toTableMetadata().persistToBytes());
 
@@ -131,7 +133,8 @@ public class TableMigratorTest extends AtlasDbTestCase {
                 lockService,
                 transactionService,
                 verifyCdm,
-                verifySsm);
+                verifySsm,
+                SweepQueueWriter.NO_OP);
         final MutableLong count = new MutableLong();
         for (final TableReference name : Lists.newArrayList(tableRef, namespacedTableRef)) {
             verifyTxManager.runTaskReadOnly((TransactionTask<Void, RuntimeException>) txn -> {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
@@ -34,7 +34,7 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TableMappingNotFoundException;
-import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
@@ -99,7 +99,7 @@ public class TableMigratorTest extends AtlasDbTestCase {
                 transactionService,
                 cdm2,
                 ssm2,
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
         kvs2.createTable(tableRef, definition.toTableMetadata().persistToBytes());
         kvs2.createTable(namespacedTableRef, definition.toTableMetadata().persistToBytes());
 
@@ -134,7 +134,7 @@ public class TableMigratorTest extends AtlasDbTestCase {
                 transactionService,
                 verifyCdm,
                 verifySsm,
-                SweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP);
         final MutableLong count = new MutableLong();
         for (final TableReference name : Lists.newArrayList(tableRef, namespacedTableRef)) {
             verifyTxManager.runTaskReadOnly((TransactionTask<Void, RuntimeException>) txn -> {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -87,7 +87,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.ForwardingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TrackingKeyValueService;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.CachePriority;
-import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ExpirationStrategy;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.PartitionStrategy;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
@@ -865,7 +864,6 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 0,
                 false,
                 sweepStrategy,
-                ExpirationStrategy.NEVER,
                 false);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -39,10 +39,8 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
@@ -841,14 +839,6 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         }
 
         verifyZeroInteractions(sweepQueue);
-    }
-
-    private void await(CyclicBarrier barrier) {
-        try {
-            barrier.await();
-        } catch (InterruptedException | BrokenBarrierException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private void writeCells(TableReference table, ImmutableMap<Cell, byte[]> cellsToWrite) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -24,6 +24,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.math.BigInteger;
 import java.util.Collection;
@@ -34,8 +39,10 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
@@ -43,6 +50,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -84,6 +92,7 @@ import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.CachePrior
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.PartitionStrategy;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.sweep.queue.Write;
 import com.palantir.atlasdb.table.description.ColumnMetadataDescription;
 import com.palantir.atlasdb.table.description.NameMetadataDescription;
 import com.palantir.atlasdb.table.description.TableMetadata;
@@ -284,7 +293,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
                 getRangesExecutor,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                sweepQueue);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
             fail();
@@ -341,7 +351,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 timestampCache,
                 getRangesExecutor,
-                defaultGetRangesConcurrency);
+                defaultGetRangesConcurrency,
+                sweepQueue);
         snapshot.put(TABLE, ImmutableMap.of(cell, PtBytes.EMPTY_BYTE_ARRAY));
         snapshot.commit();
 
@@ -365,7 +376,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 lockService,
                 transactionService,
                 conflictDetectionManager,
-                sweepStrategyManager);
+                sweepStrategyManager,
+                sweepQueue);
 
         ScheduledExecutorService service = Tracers.wrap(PTExecutors.newScheduledThreadPool(20));
 
@@ -752,6 +764,90 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             Set<LockRefreshToken> expectedTokens = ImmutableSet.of(expiredLockToken.getLockRefreshToken());
             assertThat(e.getMessage(), containsString(expectedTokens.toString()));
             assertThat(e.getMessage(), containsString("Retry is not possible."));
+        }
+    }
+
+    @Test
+    public void committedWritesAreAddedToSweepQueue() {
+        List<Write> table1Writes = ImmutableList.of(
+                Write.of(Cell.create("a".getBytes(), "b".getBytes()), false, 2L),
+                Write.of(Cell.create("a".getBytes(), "c".getBytes()), false, 2L),
+                Write.of(Cell.create("a".getBytes(), "d".getBytes()), true, 2L),
+                Write.of(Cell.create("b".getBytes(), "d".getBytes()), false, 2L));
+        List<Write> table2Writes = ImmutableList.of(
+                Write.of(Cell.create("w".getBytes(), "x".getBytes()), false, 2L),
+                Write.of(Cell.create("y".getBytes(), "z".getBytes()), false, 2L),
+                Write.of(Cell.create("z".getBytes(), "z".getBytes()), true, 2L));
+
+        AtomicLong startTs = new AtomicLong(0);
+        txManager.runTaskWithRetry(txn -> {
+            table1Writes.forEach(write -> {
+                put(txn, TABLE1, write);
+            });
+            table2Writes.forEach(write -> {
+                put(txn, TABLE2, write);
+            });
+            return null;
+        });
+
+        verify(sweepQueue).enqueue(eq(TABLE1), eq(table1Writes));
+        verify(sweepQueue).enqueue(eq(TABLE2), eq(table2Writes));
+    }
+
+    private void put(Transaction txn, TableReference table, Write write) {
+        if (write.isTombstone()) {
+            txn.delete(table, ImmutableSet.of(write.cell()));
+        } else {
+            txn.put(table, ImmutableMap.of(write.cell(), new byte[1]));
+        }
+    }
+
+    @Test
+    public void noWritesAddedToSweepQueueOnConflict() {
+        Cell cell = Cell.create("foo".getBytes(), "bar".getBytes());
+        byte[] value = new byte[1];
+
+        Transaction t1 = txManager.createNewTransaction();
+        Transaction t2 = txManager.createNewTransaction();
+
+        t1.put(TABLE, ImmutableMap.of(cell, value));
+        t2.put(TABLE, ImmutableMap.of(cell, new byte[1]));
+
+        t1.commit();
+        verify(sweepQueue).enqueue(any(), any());
+
+        try {
+            t2.commit();
+            fail();
+        } catch (TransactionConflictException e) {
+            // expected
+        }
+
+        verifyNoMoreInteractions(sweepQueue);
+    }
+
+    @Test
+    public void noWritesAddedToSweepQueueOnException() {
+        Cell cell = Cell.create("foo".getBytes(), "bar".getBytes());
+        byte[] value = new byte[1];
+
+        try {
+            txManager.runTaskWithRetry(txn -> {
+                txn.put(TABLE, ImmutableMap.of(cell, value));
+                throw new RuntimeException("test");
+            });
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        verifyZeroInteractions(sweepQueue);
+    }
+
+    private void await(CyclicBarrier barrier) {
+        try {
+            barrier.await();
+        } catch (InterruptedException | BrokenBarrierException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Implement logic for processing items written to the sweep queue and issuing deletes.

**Implementation Description (bullets)**:
- Create an InMemorySweepQueue for testing (will be removed once we have a KVS implementation)
- Refactor SweepTaskRunner tests so that can also test targeted sweep
- Implement logic for reading the sweep queue and issuing deletes

**Concerns (what feedback would you like?)**:
Note that a lot of the diff here is the test refactors

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2825)
<!-- Reviewable:end -->
