### PR TITLE
Backport/postgres vacuum to 0 56 x

### DIFF
--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -77,10 +77,12 @@
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -98,6 +100,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -204,6 +207,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -469,6 +473,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -519,6 +535,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -809,6 +831,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -77,10 +77,12 @@
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -98,6 +100,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -203,6 +206,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -458,6 +462,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -508,6 +524,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -815,6 +837,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/DbkvsPostgresTestSuite.java
@@ -35,6 +35,7 @@ import com.palantir.docker.compose.logging.LogDirectory;
 import com.palantir.nexus.db.pool.config.ConnectionConfig;
 import com.palantir.nexus.db.pool.config.ImmutableMaskedValue;
 import com.palantir.nexus.db.pool.config.ImmutablePostgresConnectionConfig;
+import com.palantir.remoting.api.config.service.HumanReadableDuration;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -85,7 +86,9 @@ public final class DbkvsPostgresTestSuite {
 
         return ImmutableDbKeyValueServiceConfig.builder()
                 .connection(connectionConfig)
-                .ddl(ImmutablePostgresDdlConfig.builder().build())
+                .ddl(ImmutablePostgresDdlConfig.builder()
+                        .compactInterval(HumanReadableDuration.days(2))
+                        .build())
                 .build();
     }
 

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -41,10 +41,12 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-client",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
@@ -53,7 +55,8 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -125,6 +128,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics"
@@ -314,6 +318,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -359,6 +375,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -553,6 +575,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -616,10 +639,12 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-client",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
@@ -628,7 +653,8 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -700,6 +726,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics"
@@ -889,6 +916,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -934,6 +973,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1128,6 +1173,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -11,6 +11,8 @@ dependencies {
   compile project(':timestamp-impl')
   compile project(':commons-db')
   compile project(':commons-api')
+  compile group: 'com.palantir.remoting-api', name: 'service-config'
+
 
   testCompile project(':atlasdb-config')
   testCompile project(path: ":atlasdb-client", configuration: "testArtifacts")

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresDdlConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.remoting.api.config.service.HumanReadableDuration;
 
 @JsonDeserialize(as = ImmutablePostgresDdlConfig.class)
 @JsonSerialize(as = ImmutablePostgresDdlConfig.class)
@@ -44,5 +45,10 @@ public abstract class PostgresDdlConfig extends DdlConfig {
     @Override
     public <T> T accept(Visitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Value.Default
+    public HumanReadableDuration compactInterval() {
+        return HumanReadableDuration.seconds(0);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -15,12 +15,15 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
+import java.util.concurrent.Semaphore;
 import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.PostgresDdlConfig;
@@ -30,6 +33,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyle;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.PrimaryKeyConstraintNames;
 import com.palantir.exception.PalantirSqlException;
+import com.palantir.nexus.db.sql.AgnosticResultRow;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
 import com.palantir.nexus.db.sql.ExceptionCheck;
 
@@ -47,10 +51,11 @@ public class PostgresDdlTable implements DbDdlTable {
     private final TableReference tableName;
     private final ConnectionSupplier conns;
     private final PostgresDdlConfig config;
+    private final Semaphore compactionSemaphore = new Semaphore(1);
 
     public PostgresDdlTable(TableReference tableName,
-                            ConnectionSupplier conns,
-                            PostgresDdlConfig config) {
+            ConnectionSupplier conns,
+            PostgresDdlConfig config) {
         this.tableName = tableName;
         this.conns = conns;
         this.config = config;
@@ -81,7 +86,7 @@ public class PostgresDdlTable implements DbDdlTable {
             } else if (prefixedTableName.length() > ATLASDB_POSTGRES_TABLE_NAME_LIMIT) {
                 log.error(FAILED_TO_CREATE_TABLE_MESSAGE, prefixedTableName, ATLASDB_POSTGRES_TABLE_NAME_LIMIT,
                         ATLASDB_POSTGRES_TABLE_NAME_LIMIT, e);
-                String exceptionMsg = MessageFormatter.arrayFormat(FAILED_TO_CREATE_TABLE_MESSAGE, new Object[]{
+                String exceptionMsg = MessageFormatter.arrayFormat(FAILED_TO_CREATE_TABLE_MESSAGE, new Object[] {
                         prefixedTableName, ATLASDB_POSTGRES_TABLE_NAME_LIMIT, ATLASDB_POSTGRES_TABLE_NAME_LIMIT})
                         .getMessage();
                 throw new RuntimeException(exceptionMsg, e);
@@ -118,6 +123,48 @@ public class PostgresDdlTable implements DbDdlTable {
 
     @Override
     public void compactInternally() {
+        if (compactionSemaphore.tryAcquire()) {
+            try {
+                if (shouldRunCompaction()) {
+                    runCompactOnTable();
+                }
+            } finally {
+                compactionSemaphore.release();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    boolean shouldRunCompaction() {
+        long compactIntervalMillis = config.compactInterval().toMilliseconds();
+        return compactIntervalMillis <= 0 || getMillisSinceLastCompact() >= compactIntervalMillis;
+    }
+
+    /**
+     * Returns the number of milliseconds since the last compaction, or Long.MAX_VALUE if
+     * compaction has never run.
+     */
+    private long getMillisSinceLastCompact() {
+        AgnosticResultSet rs = conns.get().selectResultSetUnregisteredQuery(
+                "SELECT FLOOR(EXTRACT(EPOCH FROM GREATEST( "
+                        + "  last_vacuum, last_autovacuum, last_analyze, last_autoanalyze"
+                        + "))*1000) AS last, "
+                        + "FLOOR(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)*1000) AS current "
+                        + "FROM pg_stat_user_tables WHERE relname = ?",
+                prefixedTableName());
+
+        AgnosticResultRow row = Iterables.getOnlyElement(rs.rows());
+
+        // last could be null if vacuum has never run
+        long last = row.getLong("last", -1);
+        if (last == -1) {
+            return Long.MAX_VALUE;
+        }
+        long current = row.getLong("current");
+        return current - last;
+    }
+
+    private void runCompactOnTable() {
         // VACUUM FULL is /really/ what we want here, but it takes out a table lock
         conns.get().executeUnregisteredQuery("VACUUM ANALYZE " + prefixedTableName());
     }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.ImmutablePostgresDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
+import com.palantir.nexus.db.DBType;
+import com.palantir.nexus.db.sql.AgnosticResultSetImpl;
+import com.palantir.nexus.db.sql.SqlConnection;
+import com.palantir.remoting.api.config.service.HumanReadableDuration;
+
+public class PostgresDdlTableTest {
+    private PostgresDdlTable postgresDdlTable;
+    private static final ConnectionSupplier connectionSupplier = mock(ConnectionSupplier.class);
+    private static final TableReference TEST_TABLE = TableReference.createFromFullyQualifiedName("ns.test");
+
+    private static final long NOW_MILLIS = 1000;
+    private static final long COMPACT_INTERVAL_MILLIS = 100;
+    private static final long SMALL_POSITIVE_FACTOR = 10;
+
+    @Before
+    public void setUp() {
+        postgresDdlTable = new PostgresDdlTable(TEST_TABLE,
+                connectionSupplier,
+                ImmutablePostgresDdlConfig.builder()
+                        .compactInterval(HumanReadableDuration.milliseconds(COMPACT_INTERVAL_MILLIS))
+                        .build());
+    }
+
+    @Test
+    public void shouldCompactIfVacuumWasNeverPerformedAndTheDbTimeIsLessThanCompactInterval() throws Exception {
+        SqlConnection sqlConnection = setUpSqlConnection(null, COMPACT_INTERVAL_MILLIS / SMALL_POSITIVE_FACTOR);
+
+        assertThatVacuumWasPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfVacuumWasNeverPerformedAndTheDbTimeIsMoreThanCompactInterval() throws Exception {
+        SqlConnection sqlConnection = setUpSqlConnection(null, COMPACT_INTERVAL_MILLIS * SMALL_POSITIVE_FACTOR);
+
+        assertThatVacuumWasPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfVacuumWasPerformedExactlyBeforeCompactInterval() throws Exception {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS - COMPACT_INTERVAL_MILLIS, NOW_MILLIS);
+
+        assertThatVacuumWasPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfVacuumWasPerformedBeforeCompactInterval() throws Exception {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS - COMPACT_INTERVAL_MILLIS * SMALL_POSITIVE_FACTOR,
+                NOW_MILLIS);
+
+        assertThatVacuumWasPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldNotCompactIfVacuumWasPerformedWithinCompactInterval() {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS - COMPACT_INTERVAL_MILLIS / SMALL_POSITIVE_FACTOR,
+                NOW_MILLIS);
+        assertThatVacuumWasNotPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldNotCompactIfVacuumTimestampExceedsNowTimestampByLessThanCompactInterval() {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS + COMPACT_INTERVAL_MILLIS / SMALL_POSITIVE_FACTOR,
+                NOW_MILLIS);
+        assertThatVacuumWasNotPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfVacuumTimestampExceedsNowTimestampByMoreThanCompactInterval() {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS + COMPACT_INTERVAL_MILLIS * SMALL_POSITIVE_FACTOR,
+                NOW_MILLIS);
+        assertThatVacuumWasNotPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfCompactMillisIsSetToZero() throws Exception {
+        postgresDdlTable = new PostgresDdlTable(TEST_TABLE,
+                connectionSupplier,
+                ImmutablePostgresDdlConfig.builder().compactInterval(HumanReadableDuration.valueOf("0 ms")).build());
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS - SMALL_POSITIVE_FACTOR, NOW_MILLIS);
+        assertThatVacuumWasPerformed(sqlConnection, false);
+
+        verify(sqlConnection, never()).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
+    }
+
+    private SqlConnection setUpSqlConnection(Long lastVacuumTimestamp, Long currentTimestamp) {
+        SqlConnection sqlConnection = mock(SqlConnection.class);
+        when(connectionSupplier.get()).thenReturn(sqlConnection);
+
+        List<List<Object>> selectResults = new ArrayList<>();
+        selectResults.add(Arrays.asList(new Object[] {lastVacuumTimestamp, currentTimestamp}));
+
+        Mockito.when(sqlConnection.selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any()))
+                .thenReturn(
+                        new AgnosticResultSetImpl(selectResults,
+                                DBType.POSTGRESQL,
+                                // This is the columnName to position mapping in the results map. Column Names are both
+                                // upper-case and lower-case, as postgres allows the query to have either of them.
+                                new ImmutableMap.Builder<String, Integer>()
+                                        .put("last", 0)
+                                        .put("LAST", 0)
+                                        .put("current", 1)
+                                        .put("CURRENT", 1)
+                                        .build()));
+        return sqlConnection;
+    }
+
+    private void assertThatVacuumWasPerformed(SqlConnection sqlConnection) {
+        assertThatVacuumWasPerformed(sqlConnection, true);
+    }
+
+    private void assertThatVacuumWasPerformed(SqlConnection sqlConnection, boolean assertThatTimestampsWereChecked) {
+        assertTrue(postgresDdlTable.shouldRunCompaction());
+        postgresDdlTable.compactInternally();
+
+        if (assertThatTimestampsWereChecked) {
+            verify(sqlConnection, times(2)).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
+        }
+
+        verify(sqlConnection).executeUnregisteredQuery(eq("VACUUM ANALYZE " + DbKvs.internalTableName(TEST_TABLE)));
+    }
+
+    private void assertThatVacuumWasNotPerformed(SqlConnection sqlConnection) {
+        assertFalse(postgresDdlTable.shouldRunCompaction());
+        postgresDdlTable.compactInternally();
+
+        verify(sqlConnection, times(2)).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
+
+        verify(sqlConnection, never()).executeUnregisteredQuery(
+                eq("VACUUM ANALYZE " + DbKvs.internalTableName(TEST_TABLE)));
+    }
+}

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -35,10 +35,12 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-client",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
@@ -47,7 +49,8 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -117,6 +120,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics"
@@ -273,6 +277,15 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0"
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -317,6 +330,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -456,6 +475,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -513,10 +533,12 @@
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:timestamp-client",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
@@ -525,7 +547,8 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
-                "com.palantir.remoting2:tracing"
+                "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
@@ -595,6 +618,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics"
@@ -751,6 +775,15 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0"
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -795,6 +828,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -934,6 +973,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -1314,10 +1314,12 @@
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -1336,6 +1338,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -1469,6 +1472,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -1755,6 +1759,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -1805,6 +1821,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -2514,6 +2536,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -78,10 +78,12 @@
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -99,6 +101,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -218,6 +221,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -484,6 +488,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -534,6 +550,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -874,6 +896,7 @@
                 "com.palantir.docker.compose:docker-compose-rule-core",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -980,10 +1003,12 @@
                 "com.palantir.atlasdb:timestamp-client",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -1001,6 +1026,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:jackson-support",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -1120,6 +1146,7 @@
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:ssl-config",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -1386,6 +1413,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.4.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting2:error-handling": {
             "locked": "2.3.0",
             "transitive": [
@@ -1436,6 +1475,12 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.atlasdb:lock-impl",
                 "com.palantir.atlasdb:timestamp-impl"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "1.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1776,6 +1821,7 @@
                 "com.palantir.docker.compose:docker-compose-rule-core",
                 "com.palantir.remoting2:error-handling",
                 "com.palantir.remoting2:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -44,6 +44,13 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - AtlasDB now provides a configurable ``compactInterval`` (0 by default) option for Postgres, in the Postgres DDL Config.
+           A vacuum will be kicked off an a table only if there hasn't been one on the same table in the last ``compactInterval``.
+           This will prevent increasing load on Postgres due to queued up vacuums. We would suggest a value of 1-2 days for this config option
+           and would encourage impls to test this out and report the results back. We will modify the defaults once we have this field tested.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2718>`__)
+
     *    - |fixed|
          - The new concurrent version of `Transaction#getRanges` added in 0.56.0 did not correctly guarantee ordering of the results returned in its stream.
            This will make sure the resulting ordering matches that of the input.

--- a/versions.props
+++ b/versions.props
@@ -13,6 +13,7 @@ com.jayway.awaitility:awaitility = 1.6.5
 com.palantir.config.crypto:encrypted-config-value-module = 1.0.0
 com.palantir.docker.compose:docker-compose-rule* = 0.31.0
 com.palantir.docker.proxy:docker-proxy-rule = 0.3.0
+com.palantir.remoting-api:* = 1.4.0
 com.palantir.remoting2:* = 2.3.0
 com.palantir.safe-logging:* = 0.1.3
 com.palantir.tritium:tritium-lib = 0.6.0


### PR DESCRIPTION
**Goals (and why)**: Moving fix from #2767 back to 0.56.x branch, required for PDS-60169

**Implementation Description (bullets)**: Comprises 3 commits for ease of navigation:
1) cherry picked the merge commit (ce9021e) from the PR
2) added dependency on com.palantir.remoting-api:* = 1.4.0
3) regenerated lock files

**Concerns (what feedback would you like?)**: when regenerating the lock files we picked up a dependency on auth-tokens which appears to be version 1.0.0.  Is this ok?
```
"com.palantir.tokens:auth-tokens": {
            "locked": "1.0.0"
```

**Where should we start reviewing?**: PostgresDdlTable.java for functionality

**Priority (whenever / two weeks / yesterday)**: soon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2827)
<!-- Reviewable:end -->
