### PR TITLE
Fix/sweep results cells examined

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BatchOfCellsToSweep.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BatchOfCellsToSweep.java
@@ -29,7 +29,7 @@ public interface BatchOfCellsToSweep {
     /**
      * Returns the total number of (cell, ts) pairs examined so far, for all batches up to and including this one.
      */
-    long numCellTsPairsExaminedSoFar();
+    long numCellTsPairsExamined();
 
     Cell lastCellExamined();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BatchOfCellsToSweep.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BatchOfCellsToSweep.java
@@ -27,7 +27,7 @@ public interface BatchOfCellsToSweep {
     List<CellToSweep> cells();
 
     /**
-     * Returns the total number of (cell, ts) pairs examined so far, for all batches up to and including this one.
+     * Returns the total number of (cell, ts) pairs examined in this batch.
      */
     long numCellTsPairsExamined();
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsToSweepPartitioningIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsToSweepPartitioningIterator.java
@@ -64,7 +64,7 @@ public class CellsToSweepPartitioningIterator extends AbstractIterator<BatchOfCe
         } else {
             List<CellToSweep> batch = Lists.newArrayList();
             int cellTsPairsToDelete = 0;
-            long numCellTsPairsExaminedSoFar = 0;
+            long numCellTsPairsExamined = 0;
             Cell lastCellExamined = null;
             while (cellTsPairsToDelete < deleteBatchSize && cellsToSweep.hasNext()) {
                 BatchOfCellsToSweep sourceBatch = cellsToSweep.next();
@@ -72,9 +72,9 @@ public class CellsToSweepPartitioningIterator extends AbstractIterator<BatchOfCe
                 for (CellToSweep cell : sourceBatch.cells()) {
                     cellTsPairsToDelete += cell.sortedTimestamps().size();
                 }
-                numCellTsPairsExaminedSoFar = sourceBatch.numCellTsPairsExaminedSoFar();
+                numCellTsPairsExamined += sourceBatch.numCellTsPairsExamined();
                 lastCellExamined = sourceBatch.lastCellExamined();
-                if (limit.examinedEnoughCells(numCellTsPairsExaminedSoFar, lastCellExamined)) {
+                if (limit.examinedEnoughCells(numCellTsPairsExamined, lastCellExamined)) {
                     limitReached = true;
                     break;
                 }
@@ -83,7 +83,7 @@ public class CellsToSweepPartitioningIterator extends AbstractIterator<BatchOfCe
                     ? endOfData()
                     : ImmutableBatchOfCellsToSweep.builder()
                             .cells(batch)
-                            .numCellTsPairsExaminedSoFar(numCellTsPairsExaminedSoFar)
+                            .numCellTsPairsExamined(numCellTsPairsExamined)
                             .lastCellExamined(lastCellExamined)
                             .build();
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTaskRunner.java
@@ -192,7 +192,7 @@ public class SweepTaskRunner {
                 totalCellTsPairsDeleted += sweepBatch(tableRef, batch.cells(), runType,
                         2 * batchConfig.deleteBatchSize());
 
-                totalCellTsPairsExamined = batch.numCellTsPairsExaminedSoFar();
+                totalCellTsPairsExamined += batch.numCellTsPairsExamined();
                 lastRow = batch.lastCellExamined().getRowName();
             }
             return SweepResults.builder()

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
@@ -62,7 +62,7 @@ public class SweepableCellFilter {
             numCellTsPairsExamined += candidate.sortedTimestamps().size();
             lastCellExamined = candidate.cell();
         }
-        return builder.numCellTsPairsExaminedSoFar(numCellTsPairsExamined).lastCellExamined(lastCellExamined).build();
+        return builder.numCellTsPairsExamined(numCellTsPairsExamined).lastCellExamined(lastCellExamined).build();
     }
 
     // Decide if the candidate cell needs to be swept, and if so, for which timestamps.

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CellsToSweepPartitioningIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CellsToSweepPartitioningIteratorTest.java
@@ -78,9 +78,9 @@ public class CellsToSweepPartitioningIteratorTest {
     public void examinedCellLimit() {
         List<BatchOfCellsToSweep> batches = partition(
                 ImmutableList.of(
-                        batchWithExaminedCells(0, 20, 30),
-                        batchWithExaminedCells(20, 20, 30),
-                        batchWithExaminedCells(40, 20, 30)),
+                        batchWithThreeTssPerCell(0, 20, 30),
+                        batchWithThreeTssPerCell(20, 20, 30),
+                        batchWithThreeTssPerCell(40, 20, 30)),
                 // A large timestamp batch size. Without the examined cell limit, we would
                 // combine all three input batches in one.
                 100000,
@@ -89,7 +89,7 @@ public class CellsToSweepPartitioningIteratorTest {
         // The first input batch examines 30 cells and is not sufficient to satisfy the limit (50).
         // However, the first two batches combined together examine 60 cells, which covers the limit.
         // Hence we expect one output batch which is the concatenation of the first two input batches.
-        assertThat(batches).containsExactly(batchWithExaminedCells(0, 40, 60));
+        assertThat(batches).containsExactly(batchWithThreeTssPerCell(0, 40, 60));
     }
 
     @Test
@@ -133,7 +133,8 @@ public class CellsToSweepPartitioningIteratorTest {
                 new CellsToSweepPartitioningIterator.ExaminedCellLimit(startRow, maxCellsToExamine)));
     }
 
-    private static BatchOfCellsToSweep batchWithThreeTssPerCell(int firstCell, int numCells, int numCellsExaminedInBatch) {
+    private static BatchOfCellsToSweep batchWithThreeTssPerCell(int firstCell, int numCells,
+            int numCellsExaminedInBatch) {
         List<CellToSweep> cells = Lists.newArrayList();
         for (int i = 0; i < numCells; ++i) {
             cells.add(cellWithThreeTimestamps(firstCell + i, 0));
@@ -143,11 +144,6 @@ public class CellsToSweepPartitioningIteratorTest {
                 .numCellTsPairsExamined(numCellsExaminedInBatch)
                 .lastCellExamined(cell(firstCell + numCells, 0))
                 .build();
-    }
-
-    private static BatchOfCellsToSweep batchWithExaminedCells(int firstCell, int numCells, int numCellsExamined) {
-        return ImmutableBatchOfCellsToSweep.copyOf(batchWithThreeTssPerCell(firstCell, numCells, (firstCell + numCells) * 5))//TODO
-                .withNumCellTsPairsExamined(numCellsExamined);
     }
 
     private static BatchOfCellsToSweep batch(List<CellToSweep> cells, int numCellTsPairsExamined, Cell lastExamined) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CellsToSweepPartitioningIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CellsToSweepPartitioningIteratorTest.java
@@ -35,7 +35,7 @@ public class CellsToSweepPartitioningIteratorTest {
     @Test(expected = IllegalArgumentException.class)
     public void canNotCreateIteratorWithZeroBatchSize() {
         new CellsToSweepPartitioningIterator(
-                ImmutableList.of(batchWithThreeTssPerCell(1, 1)).iterator(),
+                ImmutableList.of(batchWithThreeTssPerCell(1, 1, 10)).iterator(),
                 0,
                 new CellsToSweepPartitioningIterator.ExaminedCellLimit(PtBytes.toBytes("row"), 1L));
     }
@@ -45,9 +45,9 @@ public class CellsToSweepPartitioningIteratorTest {
         List<BatchOfCellsToSweep> batches = partition(
                 // Three input batches with 6 (cell, timestamp) pairs in each
                 ImmutableList.of(
-                        batchWithThreeTssPerCell(0, 2),
-                        batchWithThreeTssPerCell(2, 2),
-                        batchWithThreeTssPerCell(4, 2)),
+                        batchWithThreeTssPerCell(0, 2, 6),
+                        batchWithThreeTssPerCell(2, 2, 6),
+                        batchWithThreeTssPerCell(4, 2, 6)),
                 // Request 12 (cell, ts) pairs per output batch: this should amount to
                 // exactly two input batches per one output batch
                 12,
@@ -55,7 +55,7 @@ public class CellsToSweepPartitioningIteratorTest {
                 // An arbitrarily large examined cell limit to make sure we go through the entire input
                 1000);
         // Expect two output batches: the first one should be the first two input batches combined
-        assertThat(batches).containsExactly(batchWithThreeTssPerCell(0, 4), batchWithThreeTssPerCell(4, 2));
+        assertThat(batches).containsExactly(batchWithThreeTssPerCell(0, 4, 12), batchWithThreeTssPerCell(4, 2, 6));
     }
 
     @Test
@@ -63,15 +63,15 @@ public class CellsToSweepPartitioningIteratorTest {
         List<BatchOfCellsToSweep> batches = partition(
                 // Three input batches with 6 (cell, timestamp) pairs in each
                 ImmutableList.of(
-                        batchWithThreeTssPerCell(0, 2),
-                        batchWithThreeTssPerCell(2, 2),
-                        batchWithThreeTssPerCell(4, 2)),
+                        batchWithThreeTssPerCell(0, 2, 6),
+                        batchWithThreeTssPerCell(2, 2, 6),
+                        batchWithThreeTssPerCell(4, 2, 6)),
                 // Request 8 (cell, ts) pairs per output batch. The first input batch is not sufficient
                 // to fill that, but the first two batches are.
                 8,
                 RangeRequests.getFirstRowName(),
                 1000);
-        assertThat(batches).containsExactly(batchWithThreeTssPerCell(0, 4), batchWithThreeTssPerCell(4, 2));
+        assertThat(batches).containsExactly(batchWithThreeTssPerCell(0, 4, 12), batchWithThreeTssPerCell(4, 2, 6));
     }
 
     @Test
@@ -79,8 +79,8 @@ public class CellsToSweepPartitioningIteratorTest {
         List<BatchOfCellsToSweep> batches = partition(
                 ImmutableList.of(
                         batchWithExaminedCells(0, 20, 30),
-                        batchWithExaminedCells(20, 20, 60),
-                        batchWithExaminedCells(40, 20, 90)),
+                        batchWithExaminedCells(20, 20, 30),
+                        batchWithExaminedCells(40, 20, 30)),
                 // A large timestamp batch size. Without the examined cell limit, we would
                 // combine all three input batches in one.
                 100000,
@@ -133,28 +133,27 @@ public class CellsToSweepPartitioningIteratorTest {
                 new CellsToSweepPartitioningIterator.ExaminedCellLimit(startRow, maxCellsToExamine)));
     }
 
-    private static BatchOfCellsToSweep batchWithThreeTssPerCell(int firstCell, int numCells) {
+    private static BatchOfCellsToSweep batchWithThreeTssPerCell(int firstCell, int numCells, int numCellsExaminedInBatch) {
         List<CellToSweep> cells = Lists.newArrayList();
         for (int i = 0; i < numCells; ++i) {
             cells.add(cellWithThreeTimestamps(firstCell + i, 0));
         }
         return ImmutableBatchOfCellsToSweep.builder()
                 .cells(cells)
-                // We don't really care about this field. 5 is quite arbitrary
-                .numCellTsPairsExaminedSoFar((firstCell + numCells) * 5)
+                .numCellTsPairsExamined(numCellsExaminedInBatch)
                 .lastCellExamined(cell(firstCell + numCells, 0))
                 .build();
     }
 
-    private static BatchOfCellsToSweep batchWithExaminedCells(int firstCell, int numCells, int numCellsExaminedSoFar) {
-        return ImmutableBatchOfCellsToSweep.copyOf(batchWithThreeTssPerCell(firstCell, numCells))
-                .withNumCellTsPairsExaminedSoFar(numCellsExaminedSoFar);
+    private static BatchOfCellsToSweep batchWithExaminedCells(int firstCell, int numCells, int numCellsExamined) {
+        return ImmutableBatchOfCellsToSweep.copyOf(batchWithThreeTssPerCell(firstCell, numCells, (firstCell + numCells) * 5))//TODO
+                .withNumCellTsPairsExamined(numCellsExamined);
     }
 
     private static BatchOfCellsToSweep batch(List<CellToSweep> cells, int numCellTsPairsExamined, Cell lastExamined) {
         return ImmutableBatchOfCellsToSweep.builder()
                     .cells(cells)
-                    .numCellTsPairsExaminedSoFar(numCellTsPairsExamined)
+                    .numCellTsPairsExamined(numCellTsPairsExamined)
                     .lastCellExamined(lastExamined)
                     .build();
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -64,6 +64,7 @@ import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.timestamp.InMemoryTimestampService;
 import com.palantir.timestamp.TimestampService;
+import com.palantir.util.Pair;
 
 public abstract class AbstractSweepTaskRunnerTest {
     private static final String FULL_TABLE_NAME = "test_table.xyz_atlasdb_sweeper_test";
@@ -73,12 +74,15 @@ public abstract class AbstractSweepTaskRunnerTest {
 
     private static final List<Cell> SMALL_LIST_OF_CELLS = Lists.newArrayList();
     private static final List<Cell> BIG_LIST_OF_CELLS = Lists.newArrayList();
+    private static final List<Cell> BIG_LIST_OF_CELLS_IN_DIFFERENT_ROWS = Lists.newArrayList();
 
     static {
         for (int i = 0; i < 10; i++) {
-            String colName = String.format("c%d", i);
+            String zeroPaddedIndex = String.format("%05d", i);
             BIG_LIST_OF_CELLS.add(
-                    Cell.create("row".getBytes(StandardCharsets.UTF_8), colName.getBytes(StandardCharsets.UTF_8)));
+                    Cell.create("row".getBytes(StandardCharsets.UTF_8), (COL + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8)));
+            BIG_LIST_OF_CELLS_IN_DIFFERENT_ROWS.add(
+                    Cell.create(("row" + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8), (COL + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8)));
         }
         SMALL_LIST_OF_CELLS.addAll(BIG_LIST_OF_CELLS.subList(0, 4));
     }
@@ -474,8 +478,9 @@ public abstract class AbstractSweepTaskRunnerTest {
         putTwoValuesInEachCell(SMALL_LIST_OF_CELLS);
 
         int deleteBatchSize = 1;
-        List<List<Cell>> sweptCells = runSweep(cellsSweeper, spiedSweepRunner,
+        Pair<List<List<Cell>>,SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
                 8, 8, deleteBatchSize);
+        List<List<Cell>> sweptCells = sweptCellsAndSweepResults.getLhSide();
         assertThat(sweptCells).allMatch(list -> list.size() <= 2 * deleteBatchSize);
         assertThat(Iterables.concat(sweptCells)).containsExactlyElementsOf(SMALL_LIST_OF_CELLS);
     }
@@ -488,7 +493,8 @@ public abstract class AbstractSweepTaskRunnerTest {
 
         putTwoValuesInEachCell(SMALL_LIST_OF_CELLS);
 
-        List<List<Cell>> sweptCells = runSweep(cellsSweeper, spiedSweepRunner, 8, 1, 4);
+        Pair<List<List<Cell>>,SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner, 8, 1, 4);
+        List<List<Cell>> sweptCells = sweptCellsAndSweepResults.getLhSide();
 
         assertEquals(1, sweptCells.size());
         assertEquals(SMALL_LIST_OF_CELLS, sweptCells.get(0));
@@ -503,8 +509,10 @@ public abstract class AbstractSweepTaskRunnerTest {
         putTwoValuesInEachCell(BIG_LIST_OF_CELLS);
 
         int deleteBatchSize = 2;
-        List<List<Cell>> sweptCells = runSweep(cellsSweeper, spiedSweepRunner,
+        Pair<List<List<Cell>>,SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
                 1000, 1, deleteBatchSize);
+        List<List<Cell>> sweptCells = sweptCellsAndSweepResults.getLhSide();
+        SweepResults sweepResults = sweptCellsAndSweepResults.getRhSide();
         assertThat(Iterables.concat(sweptCells)).containsExactlyElementsOf(BIG_LIST_OF_CELLS);
         for (List<Cell> sweptBatch : sweptCells.subList(0, sweptCells.size() - 1)) {
             // We requested deleteBatchSize = 2, so we expect between 2 and 4 timestamps deleted at a time.
@@ -513,6 +521,35 @@ public abstract class AbstractSweepTaskRunnerTest {
         }
         // The last batch can be smaller than deleteBatchSize
         assertThat(sweptCells.get(sweptCells.size() - 1).size()).isLessThanOrEqualTo(2 * deleteBatchSize);
+
+        assertEquals("Expected Ts Pairs Examined should add up to entire table (2 values in each cell)",
+                2 * BIG_LIST_OF_CELLS.size(), sweepResults.getCellTsPairsExamined());
+    }
+
+    @Test(timeout = 50000)
+    public void testSweepBatchesInDifferentRows() {
+        CellsSweeper cellsSweeper = Mockito.mock(CellsSweeper.class);
+        SweepTaskRunner spiedSweepRunner =
+                new SweepTaskRunner(kvs, tsSupplier, tsSupplier, txService, ssm, cellsSweeper);
+
+        putTwoValuesInEachCell(BIG_LIST_OF_CELLS_IN_DIFFERENT_ROWS);
+
+        int deleteBatchSize = 2;
+        Pair<List<List<Cell>>,SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
+                10, 1, deleteBatchSize);
+        List<List<Cell>> sweptCells = sweptCellsAndSweepResults.getLhSide();
+        SweepResults sweepResults = sweptCellsAndSweepResults.getRhSide();
+        assertThat(Iterables.concat(sweptCells)).containsExactlyElementsOf(BIG_LIST_OF_CELLS_IN_DIFFERENT_ROWS);
+        for (List<Cell> sweptBatch : sweptCells.subList(0, sweptCells.size() - 1)) {
+            // We requested deleteBatchSize = 2, so we expect between 2 and 4 timestamps deleted at a time.
+            // We also expect a single timestamp to be swept per each cell.
+            assertThat(sweptBatch.size()).isBetween(deleteBatchSize, 2 * deleteBatchSize);
+        }
+        // The last batch can be smaller than deleteBatchSize
+        assertThat(sweptCells.get(sweptCells.size() - 1).size()).isLessThanOrEqualTo(2 * deleteBatchSize);
+
+        assertEquals("Expected Ts Pairs Examined should add up to entire table (2 values in each cell)",
+                2 * BIG_LIST_OF_CELLS_IN_DIFFERENT_ROWS.size(), sweepResults.getCellTsPairsExamined());
     }
 
     private void putTwoValuesInEachCell(List<Cell> cells) {
@@ -529,7 +566,7 @@ public abstract class AbstractSweepTaskRunnerTest {
     }
 
     @SuppressWarnings("unchecked")
-    private List<List<Cell>> runSweep(CellsSweeper cellsSweeper, SweepTaskRunner spiedSweepRunner,
+    private Pair<List<List<Cell>>,SweepResults> runSweep(CellsSweeper cellsSweeper, SweepTaskRunner spiedSweepRunner,
             int maxCellTsPairsToExamine, int candidateBatchSize, int deleteBatchSize) {
         List<List<Cell>> sweptCells = Lists.newArrayList();
 
@@ -540,13 +577,13 @@ public abstract class AbstractSweepTaskRunnerTest {
             return null;
         }).when(cellsSweeper).sweepCells(eq(TABLE_NAME), any(), any());
 
-        spiedSweepRunner.run(TABLE_NAME, ImmutableSweepBatchConfig.builder()
+        SweepResults sweepResults = spiedSweepRunner.run(TABLE_NAME, ImmutableSweepBatchConfig.builder()
                 .maxCellTsPairsToExamine(maxCellTsPairsToExamine)
                 .candidateBatchSize(candidateBatchSize)
                 .deleteBatchSize(deleteBatchSize)
                 .build(), PtBytes.EMPTY_BYTE_ARRAY);
 
-        return sweptCells;
+        return new Pair(sweptCells, sweepResults);
     }
 
     private void testSweepManyRows(SweepStrategy strategy) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -80,9 +80,11 @@ public abstract class AbstractSweepTaskRunnerTest {
         for (int i = 0; i < 10; i++) {
             String zeroPaddedIndex = String.format("%05d", i);
             BIG_LIST_OF_CELLS.add(
-                    Cell.create("row".getBytes(StandardCharsets.UTF_8), (COL + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8)));
+                    Cell.create("row".getBytes(StandardCharsets.UTF_8),
+                            (COL + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8)));
             BIG_LIST_OF_CELLS_IN_DIFFERENT_ROWS.add(
-                    Cell.create(("row" + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8), (COL + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8)));
+                    Cell.create(("row" + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8),
+                            (COL + zeroPaddedIndex).getBytes(StandardCharsets.UTF_8)));
         }
         SMALL_LIST_OF_CELLS.addAll(BIG_LIST_OF_CELLS.subList(0, 4));
     }
@@ -478,7 +480,7 @@ public abstract class AbstractSweepTaskRunnerTest {
         putTwoValuesInEachCell(SMALL_LIST_OF_CELLS);
 
         int deleteBatchSize = 1;
-        Pair<List<List<Cell>>,SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
+        Pair<List<List<Cell>>, SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
                 8, 8, deleteBatchSize);
         List<List<Cell>> sweptCells = sweptCellsAndSweepResults.getLhSide();
         assertThat(sweptCells).allMatch(list -> list.size() <= 2 * deleteBatchSize);
@@ -493,7 +495,8 @@ public abstract class AbstractSweepTaskRunnerTest {
 
         putTwoValuesInEachCell(SMALL_LIST_OF_CELLS);
 
-        Pair<List<List<Cell>>,SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner, 8, 1, 4);
+        Pair<List<List<Cell>>, SweepResults> sweptCellsAndSweepResults =
+                runSweep(cellsSweeper, spiedSweepRunner, 8, 1, 4);
         List<List<Cell>> sweptCells = sweptCellsAndSweepResults.getLhSide();
 
         assertEquals(1, sweptCells.size());
@@ -509,7 +512,7 @@ public abstract class AbstractSweepTaskRunnerTest {
         putTwoValuesInEachCell(BIG_LIST_OF_CELLS);
 
         int deleteBatchSize = 2;
-        Pair<List<List<Cell>>,SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
+        Pair<List<List<Cell>>, SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
                 1000, 1, deleteBatchSize);
         List<List<Cell>> sweptCells = sweptCellsAndSweepResults.getLhSide();
         SweepResults sweepResults = sweptCellsAndSweepResults.getRhSide();
@@ -535,7 +538,7 @@ public abstract class AbstractSweepTaskRunnerTest {
         putTwoValuesInEachCell(BIG_LIST_OF_CELLS_IN_DIFFERENT_ROWS);
 
         int deleteBatchSize = 2;
-        Pair<List<List<Cell>>,SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
+        Pair<List<List<Cell>>, SweepResults> sweptCellsAndSweepResults = runSweep(cellsSweeper, spiedSweepRunner,
                 10, 1, deleteBatchSize);
         List<List<Cell>> sweptCells = sweptCellsAndSweepResults.getLhSide();
         SweepResults sweepResults = sweptCellsAndSweepResults.getRhSide();
@@ -566,7 +569,7 @@ public abstract class AbstractSweepTaskRunnerTest {
     }
 
     @SuppressWarnings("unchecked")
-    private Pair<List<List<Cell>>,SweepResults> runSweep(CellsSweeper cellsSweeper, SweepTaskRunner spiedSweepRunner,
+    private Pair<List<List<Cell>>, SweepResults> runSweep(CellsSweeper cellsSweeper, SweepTaskRunner spiedSweepRunner,
             int maxCellTsPairsToExamine, int candidateBatchSize, int deleteBatchSize) {
         List<List<Cell>> sweptCells = Lists.newArrayList();
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -70,7 +70,8 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2828>`__)
 
     *    - |fixed|
-         - SweepResults.getCellTsPairsExamined now returns the correct result when sweep affects multiple batches.
+         - SweepResults.getCellTsPairsExamined now returns the correct result when sweep is run over multiple batches. 
+           Previously, the result would only count cell-ts pairs examined in the last batch.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2830>`__)
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -69,6 +69,10 @@ develop
          - Messages to the `slow-lock-log` now log at `WARN` rather than `INFO`, these messages can indicate a problem so we should be sure they are visible.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2828>`__)
 
+    *    - |fixed|
+         - SweepResults.getCellTsPairsExamined now returns the correct result when sweep affects multiple batches.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2830>`__)
+
 =======
 v0.72.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
Fix SweepResults.getCellTsPairsExamined over multiple batches

**Implementation Description (bullets)**:
BatchOfCellsToSweep.numCellTsPairsExaminedSoFar() -> numCellTsPairsExamined(), as that's what it was returning anyways.

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2830)
<!-- Reviewable:end -->
