### PR TITLE
Don't reregister metrics with the same name.

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.util;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
**Goals (and why)**: Fix https://github.com/palantir/atlasdb/pull/2786#discussion_r155537977.

**Implementation Description (bullets)**: 
After Tritium 0.9.0 upgrade, we have access to functionality that allows removing registered metrics.
Check if a gauge with the same name is registered before re-registering.

**Concerns (what feedback would you like?)**: NA

**Where should we start reviewing?**: MetricsManager

**Priority (whenever / two weeks / yesterday)**: this week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2831)
<!-- Reviewable:end -->
