### PR TITLE
Docs for manual rate limiting

### DIFF
--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -10,6 +10,7 @@ Configuration
 
    key_value_service_configs/index
    external_timelock_service_configs/index
+   qos_configs/index
    cassandra_config
    multinode_cassandra
    enabling_cassandra_tracing

--- a/docs/source/configuration/qos_configs/index.rst
+++ b/docs/source/configuration/qos_configs/index.rst
@@ -1,0 +1,13 @@
+.. _qos_service_configs:
+
+==========================
+QoS Service Configurations
+==========================
+
+Information on how to configure an AtlasDB client to use the QoS rate limiting can be found below.
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   qos_client_config

--- a/docs/source/configuration/qos_configs/qos_client_config.rst
+++ b/docs/source/configuration/qos_configs/qos_client_config.rst
@@ -1,0 +1,53 @@
+.. _qos-client-configuration:
+
+QoS Client Configuration
+========================
+
+.. warning::
+
+    If you are using Cassandra, then you can use the AtlasDB QoS to rate-limit requests to Cassandra. Note that this
+    service is under active development and testing, please contact the AtlasDB team before using this feature.
+
+
+You will need to update your AtlasDB configuration in order to have said clients limit the read and write requests to
+Cassandra.
+
+.. note::
+
+    QoS client configuration is a part of the AtlasDB Runtime configuration.
+
+Install-Time Configuration
+--------------------------
+
+An AtlasDB config can have an optional ``qos`` block if the service wants to rate limit the reads/writes to Cassandra. This is
+live-reloadable and hence the limits can be modified while the service is online. The limits will be loaded when the
+next request hits the server and knowledge of the previous rate-limiting will be lost.
+
+Optional parameters:
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Property
+         - Description
+
+    *    - maxBackoffSleepTime (HumanReadableDuration)
+         - The rate-limiter can cause the request processing thread to sleep for sometime if soft-limiting is being applied.
+           This parameter configures the maximum time a client request can be made to wait by the rate limiter.
+           This should definitely be less than the server idle timeout or jetty will cause the request to timeout and potentially retry.
+           The default value is 10 seconds.
+           This is of type `HumanReadableDuration <https://github.com/palantir/http-remoting-api/blob/develop/service-config/src/main/java/com/palantir/remoting/api/config/service/HumanReadableDuration.java>`__.
+
+    *    - limits::readBytesPerSecond
+         - The maximum number of bytes to read from Cassandra per second (specified as a long).
+           The default value is ``Long.MAX_VALUE`` implying no read limit.
+
+
+    *    - limits::writeBytesPerSecond
+         - The maximum number of bytes to write to Cassandra per second (specified as a long).
+           The default value is ``Long.MAX_VALUE`` implying no write limit.
+
+    *    - qosService
+         - The config for the QoS Service.
+           This is of type `ServiceConfiguration <https://github.com/palantir/http-remoting-api/blob/develop/service-config/src/main/java/com/palantir/remoting/api/config/service/ServiceConfiguration.java>`__.

--- a/docs/source/configuration/qos_configs/qos_client_config.rst
+++ b/docs/source/configuration/qos_configs/qos_client_config.rst
@@ -5,12 +5,13 @@ QoS Client Configuration
 
 .. warning::
 
-    If you are using Cassandra, then you can use the AtlasDB QoS to rate-limit requests to Cassandra. Note that this
-    service is under active development and testing, please contact the AtlasDB team before using this feature.
+    Note that this service is under active development and testing, please contact the AtlasDB team before using this feature.
 
+The Qos service is currently supported only for services deployed against Cassandra. The Qos service can be used by
+clients to rate-limit requests to Cassandra.
 
-You will need to update your AtlasDB configuration in order to have said clients limit the read and write requests to
-Cassandra.
+You will need to update your AtlasDB configuration with pre-determined limits in terms of the number of bytes for the
+reads and writes.
 
 .. note::
 
@@ -32,7 +33,7 @@ Optional parameters:
     *    - Property
          - Description
 
-    *    - maxBackoffSleepTime (HumanReadableDuration)
+    *    - maxBackoffSleepTime
          - The rate-limiter can cause the request processing thread to sleep for sometime if soft-limiting is being applied.
            This parameter configures the maximum time a client request can be made to wait by the rate limiter.
            This should definitely be less than the server idle timeout or jetty will cause the request to timeout and potentially retry.

--- a/docs/source/services/index.rst
+++ b/docs/source/services/index.rst
@@ -17,3 +17,4 @@ external timestamp and lock service. Please consult the relevant section of the 
    lock_service/index
    timestamp_service/index
    timelock_service/index
+   qos_service/index

--- a/docs/source/services/qos_service/enabling-rate-limiting.rst
+++ b/docs/source/services/qos_service/enabling-rate-limiting.rst
@@ -6,20 +6,20 @@ Enabling Rate Limiting
 Currently the QoS service allows a client to configure the read and write limits and enforces these limits.
 Detailed documentation is :ref:`here <qos-client-configuration>`.
 
-QoS also publishes client level metrics for the following:
+QoS also publishes client level metrics (meters) for the following:
 
-        - Meter readRequestCount
-        - Meter bytesRead
-        - Meter readTime
-        - Meter rowsRead
-        - Meter estimatedBytesRead
-        - Meter estimatedRowsRead
-        - Meter writeRequestCount
-        - Meter bytesWritten
-        - Meter writeTime
-        - Meter rowsWritten
-        - Meter backoffTime
-        - Meter rateLimitedExceptions
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.readRequestCount`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.bytesRead`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.readTime`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.rowsRead`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.estimatedBytesRead`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.estimatedRowsRead`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.writeRequestCount`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.bytesWritten`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.writeTime`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.rowsWritten`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.backoffTime`
+        `com.palantir.atlasdb.qos.metrics.QosMetrics.rateLimitedExceptions`
 
 A client should ideally look at the historical values of the ``bytesRead`` and ``bytesWritten`` metrics to determine the limits.
 

--- a/docs/source/services/qos_service/enabling-rate-limiting.rst
+++ b/docs/source/services/qos_service/enabling-rate-limiting.rst
@@ -1,0 +1,42 @@
+.. _enabling-rate-limiting:
+
+Enabling Rate Limiting
+======================
+
+Currently the QoS service allows a client to configure the read and write limits and enforces these limits.
+Detailed documentation is :ref:`here <qos-client-configuration>`.
+
+QoS also publishes client level metrics for the following:
+
+        - Meter readRequestCount
+        - Meter bytesRead
+        - Meter readTime
+        - Meter rowsRead
+        - Meter estimatedBytesRead
+        - Meter estimatedRowsRead
+        - Meter writeRequestCount
+        - Meter bytesWritten
+        - Meter writeTime
+        - Meter rowsWritten
+        - Meter backoffTime
+        - Meter rateLimitedExceptions
+
+A client should ideally look at the historical values of the ``bytesRead`` and ``bytesWritten`` metrics to determine the limits.
+
+How does QoS rate limit?
+------------------------
+
+We are using the standard Java Rate limiter to enforce the rate limiting with some modifications to support adjustment.
+It is not possible to estimate the number of bytes a read request is going to consume beforehand, so we request a
+default number of permits from the ratelimiter (currently 100) and subsequently return some permits (if the request
+returned less than a 100 bytes) or steal more permits (if the request returned more than a 100 bytes).
+
+When the client has consumed the permits per second and continues making data requests to Cassandra, soft-limiting can kick in
+causing the requesting thread to wait. This wait time depends on the historical requests and how much extra permits have been
+consumed by the previous requests. However, to prevent client threads from waiting indefinitely, the client can configure the
+``maxBackoffTime`` and the rate-limiter will not cause a request to wait for more than this time.
+
+If the requested number of permits cannot be made available within the ``maxBackoffTime`` then the rate-limiter will throw a
+``RateLimitExceededException`` causing the client request to fail. AtlasDB recommends that clients should map this exception
+to the status code 429 (too many requests) and provides the ``RateLimitExceededExceptionMapper`` that can be registered
+by the application server.

--- a/docs/source/services/qos_service/index.rst
+++ b/docs/source/services/qos_service/index.rst
@@ -13,5 +13,5 @@ Qos Service
 
     enabling-rate-limiting
 
-The AtlasDB QoS Service is an attempt to prevent misbehaving or rogue clients from making Cassandra slow for everyone
+The AtlasDB QoS Service aims to prevent misbehaving or rogue clients from making Cassandra slow for everyone
 when Cassandra multi-tenancy is achieved by creating a separate keyspace per client in the same Cassandra cluster.

--- a/docs/source/services/qos_service/index.rst
+++ b/docs/source/services/qos_service/index.rst
@@ -1,0 +1,17 @@
+.. _qos-service:
+
+Qos Service
+===========
+
+.. warning::
+
+   Rate limiting using the QoS service is currently an experimental feature.
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+
+    enabling-rate-limiting
+
+The AtlasDB QoS Service is an attempt to prevent misbehaving or rogue clients from making Cassandra slow for everyone
+when Cassandra multi-tenancy is achieved by creating a separate keyspace per client in the same Cassandra cluster.


### PR DESCRIPTION
**Goals (and why)**: Docs for client level configuration of limits in the qos service.

**Implementation Description (bullets)**: Docs.

**Concerns (what feedback would you like?)**: 
1. Should we include the future plans in the docs? (eg: we have a QoS service config but no QoS service which is awkward)
2. Should we skip the config option for ``qosService`` in the config?
3. Do we want to make all config param names kabab-case to prevent breaks in the future. (This will be a break at the moment but we can be pretty confident that no-one is using this yet.)

**Where should we start reviewing?**: any file.
 
**Priority (whenever / two weeks / yesterday)**: two weeks (as this is the break week).

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2834)
<!-- Reviewable:end -->
