### PR TITLE
Allow StreamStores table names to be marked as safe

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamStoreDefinitionBuilder.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
 
@@ -33,6 +34,11 @@ public class StreamStoreDefinitionBuilder {
     private int inMemoryThreshold = AtlasDbConstants.DEFAULT_STREAM_IN_MEMORY_THRESHOLD;
     private boolean compressStream;
 
+    /**
+     * @param shortName The prefix of the table names in the DB.
+     * @param longName The prefix of the generated Java class names.
+     * @param valueType The type of the column that will store the stream ID internally. Usually a VAR_LONG.
+     */
     public StreamStoreDefinitionBuilder(String shortName, String longName, ValueType valueType) {
         for (StreamTableType tableType : StreamTableType.values()) {
             streamTables.put(tableType.getTableName(shortName),
@@ -69,6 +75,12 @@ public class StreamStoreDefinitionBuilder {
                         + "StreamStore internal tables use at most two row components.");
         streamTables.forEach((tableName, streamTableBuilder) ->
                 streamTableBuilder.hashFirstNRowComponents(numberOfComponentsHashed));
+        return this;
+    }
+
+    public StreamStoreDefinitionBuilder tableNameLogSafety(TableMetadataPersistence.LogSafety logSafety) {
+        streamTables.forEach((tableName, streamTableBuilder) ->
+                streamTableBuilder.tableNameLogSafety(logSafety));
         return this;
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/StreamTestSchema.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/StreamTestSchema.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.performance.schema;
 import java.io.File;
 
 import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.schema.AtlasSchema;
 import com.palantir.atlasdb.schema.stream.StreamStoreDefinitionBuilder;
 import com.palantir.atlasdb.table.description.OptionalType;
@@ -54,6 +55,7 @@ public final class StreamTestSchema implements AtlasSchema {
 
         schema.addStreamStoreDefinition(new StreamStoreDefinitionBuilder("blob", "Value", ValueType.VAR_LONG)
                 .inMemoryThreshold(1024 * 1024)
+                .tableNameLogSafety(TableMetadataPersistence.LogSafety.SAFE)
                 .build());
 
         return schema;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |improved| |logs| |metrics|
+         - Allow StreamStore table names to be marked as safe. This will make StreamStore tables appear correctly on our logs and metrics.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2835>`__)
+
     *    - |devbreak|
          - For clarity, we renamed `ForwardingLockService` to `SimplifyingLockService`, since this class also overwrote some of its parents methods.
            Also, its `delegate` methods now is public.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,6 +52,7 @@ develop
 
     *    - |improved| |logs| |metrics|
          - Allow StreamStore table names to be marked as safe. This will make StreamStore tables appear correctly on our logs and metrics.
+           When building a StreamStore, please use `.tableNameLogSafety(TableMetadataPersistence.LogSafety.SAFE)` to mark the table name as safe.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2835>`__)
 
     *    - |devbreak|

--- a/docs/source/schemas/streams.rst
+++ b/docs/source/schemas/streams.rst
@@ -54,9 +54,16 @@ Additional options for the builder include:
     *   - ``inMemoryThreshold``
         - Specifies the largest size object (in bytes) which AtlasDB will cache in memory in order to boost retrieval performance.
 
+    *   - ``tableNameLogSafety``
+        - Specifies the if the table name is safe to added to logs and metrics. By default, the table is considered ``UNSAFE``.
+
 .. note::
 
     If using Cassandra KVS, we *strongly* recommend that ``hashRowComponents()`` is set, in order to avoid hotspotting.
+
+.. note::
+
+    We *strongly* recommend using ``tableNameLogSafety(TableMetadataPersistence.LogSafety.SAFE)`` if the table has a safe name.
 
 For an example of streams in use, see the ``user_profile`` table and ``user_photos`` stream store in `ProfileSchema`_, and the ``updateImage`` method in `ProfileStore`_.
 

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/ProfileSchema.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/ProfileSchema.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.persister.JsonNodePersister;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueByteOrder;
 import com.palantir.atlasdb.schema.AtlasSchema;
 import com.palantir.atlasdb.schema.stream.StreamStoreDefinitionBuilder;
@@ -46,6 +47,7 @@ public class ProfileSchema implements AtlasSchema {
                 OptionalType.JAVA8);
 
         schema.addTableDefinition("user_profile", new TableDefinition() {{
+            allSafeForLoggingByDefault();
             rowName();
                 rowComponent("id", ValueType.UUID);
             columns();
@@ -86,7 +88,9 @@ public class ProfileSchema implements AtlasSchema {
         }});
 
         schema.addStreamStoreDefinition(
-                new StreamStoreDefinitionBuilder("user_photos", "user_photos", ValueType.VAR_LONG).build());
+                new StreamStoreDefinitionBuilder("user_photos", "user_photos", ValueType.VAR_LONG)
+                        .tableNameLogSafety(TableMetadataPersistence.LogSafety.SAFE)
+                        .build());
 
         return schema;
     }


### PR DESCRIPTION
**Goals (and why)**: Allow StreamStore table names to marked as safe for logging.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2835)
<!-- Reviewable:end -->
