### PR TITLE
99-Flake Part 2: Applying the Retry Rule

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     compile 'org.apache.ant:ant:' + libVersions.ant
   }
 
+  testCompile project(':flake-rule')
+
   testCompile ('com.datastax.cassandra:cassandra-driver-core:' + libVersions.cassandra_driver_core) {
       exclude(group: 'com.codahale.metrics', module: 'metrics-core')
   }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
@@ -23,7 +23,7 @@ import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -36,7 +36,6 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.sweep.AbstractSweepTaskRunnerTest;
-import com.palantir.flake.FlakeRetryingRule;
 import com.palantir.flake.ShouldRetry;
 
 @RunWith(Parameterized.class)
@@ -48,7 +47,8 @@ public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends Abst
             .with(new CassandraContainer());
 
     @Rule
-    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
+    public final RuleChain ruleChain = SchemaMutationLockReleasingRule.createChainedReleaseAndRetry(
+            getKeyValueService());
 
     @Parameterized.Parameter
     public boolean useColumnBatchSize;
@@ -57,7 +57,6 @@ public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends Abst
     public static Iterable<?> parameters() {
         return Arrays.asList(true, false);
     }
-
 
     @Override
     protected KeyValueService getKeyValueService() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
@@ -21,7 +21,9 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -34,13 +36,19 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.sweep.AbstractSweepTaskRunnerTest;
+import com.palantir.flake.FlakeRetryingRule;
+import com.palantir.flake.ShouldRetry;
 
 @RunWith(Parameterized.class)
+@ShouldRetry // Some tests can fail with "could not stop heartbeat" - see also HeartbeatServiceIntegrationTest.
 public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends AbstractSweepTaskRunnerTest {
     @ClassRule
     public static final Containers CONTAINERS = new Containers(
                 CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.class)
             .with(new CassandraContainer());
+
+    @Rule
+    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
 
     @Parameterized.Parameter
     public boolean useColumnBatchSize;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTransactionIntegrationTest.java
@@ -16,17 +16,25 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
 
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.containers.CassandraContainer;
 import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
+import com.palantir.flake.FlakeRetryingRule;
+import com.palantir.flake.ShouldRetry;
 
+@ShouldRetry // The first test can fail with a TException: No host tried was able to create the keyspace requested.
 public class CassandraKeyValueServiceTransactionIntegrationTest extends AbstractTransactionTest {
     @ClassRule
     public static final Containers CONTAINERS = new Containers(CassandraKeyValueServiceTransactionIntegrationTest.class)
             .with(new CassandraContainer());
+
+    @Rule
+    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
 
     @Override
     protected KeyValueService getKeyValueService() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBackupIntegrationTest.java
@@ -23,7 +23,9 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -32,8 +34,10 @@ import com.palantir.atlasdb.containers.CassandraContainer;
 import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.flake.ShouldRetry;
 import com.palantir.timestamp.TimestampBoundStore;
 
+@ShouldRetry
 public class CassandraTimestampBackupIntegrationTest {
     private static final long INITIAL_VALUE = CassandraTimestampUtils.INITIAL_VALUE;
     private static final long TIMESTAMP_1 = INITIAL_VALUE + 1000;
@@ -49,6 +53,9 @@ public class CassandraTimestampBackupIntegrationTest {
             CassandraContainer.LEADER_CONFIG);
     private final TimestampBoundStore timestampBoundStore = CassandraTimestampBoundStore.create(kv);
     private final CassandraTimestampBackupRunner backupRunner = new CassandraTimestampBackupRunner(kv);
+
+    @Rule
+    public final RuleChain ruleChain = SchemaMutationLockReleasingRule.createChainedReleaseAndRetry(kv);
 
     @Before
     public void setUp() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -19,15 +19,19 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.containers.CassandraContainer;
 import com.palantir.atlasdb.containers.Containers;
+import com.palantir.flake.ShouldRetry;
 import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 import com.palantir.timestamp.TimestampBoundStore;
 
+@ShouldRetry
 public class CassandraTimestampIntegrationTest {
     @ClassRule
     public static final Containers CONTAINERS = new Containers(CassandraTimestampIntegrationTest.class)
@@ -36,6 +40,9 @@ public class CassandraTimestampIntegrationTest {
     private CassandraKeyValueService kv = CassandraKeyValueServiceImpl.create(
             CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
             CassandraContainer.LEADER_CONFIG);
+
+    @Rule
+    public final RuleChain ruleChain = SchemaMutationLockReleasingRule.createChainedReleaseAndRetry(kv);
 
     @Before
     public void setUp() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorIntegrationTest.java
@@ -27,7 +27,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -35,7 +34,6 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigManager;
 import com.palantir.atlasdb.containers.CassandraContainer;
 import com.palantir.atlasdb.containers.Containers;
-import com.palantir.flake.FlakeRetryingRule;
 import com.palantir.flake.ShouldRetry;
 import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 import com.palantir.timestamp.TimestampBoundStore;
@@ -52,9 +50,6 @@ public class CassandraTimestampStoreInvalidatorIntegrationTest {
             CassandraKeyValueServiceConfigManager.createSimpleManager(CassandraContainer.KVS_CONFIG),
             CassandraContainer.LEADER_CONFIG);
     private final CassandraTimestampStoreInvalidator invalidator = CassandraTimestampStoreInvalidator.create(kv);
-
-    private final TestRule flakeRetryingRule = new FlakeRetryingRule();
-    private final TestRule schemaMutationLockReleasingRule = new SchemaMutationLockReleasingRule(kv);
 
     @Rule
     public final RuleChain ruleChain = SchemaMutationLockReleasingRule.createChainedReleaseAndRetry(kv);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HeartbeatServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HeartbeatServiceIntegrationTest.java
@@ -29,6 +29,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,10 @@ import com.palantir.atlasdb.config.LockLeader;
 import com.palantir.atlasdb.containers.CassandraContainer;
 import com.palantir.atlasdb.containers.Containers;
 import com.palantir.atlasdb.keyvalue.impl.TracingPrefsConfig;
+import com.palantir.flake.FlakeRetryingRule;
+import com.palantir.flake.ShouldRetry;
 
+@ShouldRetry // There are flakes with the heartbeat service throwing because it was unable to stop beating.
 public class HeartbeatServiceIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(HeartbeatServiceIntegrationTest.class);
 
@@ -46,6 +50,9 @@ public class HeartbeatServiceIntegrationTest {
     @ClassRule
     public static final Containers CONTAINERS = new Containers(HeartbeatServiceIntegrationTest.class)
             .with(new CassandraContainer());
+
+    @Rule
+    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
 
     private HeartbeatService heartbeatService;
     private TracingQueryRunner queryRunner;

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockReleasingRule.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockReleasingRule.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import com.palantir.flake.FlakeRetryingRule;
+
+/**
+ * This test rule cleans up the schema mutation lock tables in the event of a test failure.
+ * Note that this cleanup is done regardless of the nature of the failure.
+ */
+public class SchemaMutationLockReleasingRule implements TestRule {
+    private final CassandraKeyValueService kvs;
+
+    public SchemaMutationLockReleasingRule(CassandraKeyValueService kvs) {
+        this.kvs = kvs;
+    }
+
+    public static RuleChain createChainedReleaseAndRetry(CassandraKeyValueService kvs) {
+        // The ordering is important. If an attempt fails, we want to release the schema mutation lock BEFORE retrying.
+        return RuleChain.outerRule(new FlakeRetryingRule())
+                .around(new SchemaMutationLockReleasingRule(kvs));
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } catch (Throwable t) {
+                    kvs.cleanUpSchemaMutationLockTablesState();
+                    throw t;
+                }
+            }
+        };
+    }
+}

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     testCompile project(':atlasdb-container-test-utils')
     testCompile project(':atlasdb-ete-test-utils')
+    testCompile project(':flake-rule')
 
     testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core'
     testCompile group: 'io.dropwizard', name: 'dropwizard-testing'

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraSingleNodeDownEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/MultiCassandraSingleNodeDownEteTest.java
@@ -21,14 +21,22 @@ import java.util.UUID;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
+import com.palantir.flake.FlakeRetryingRule;
+import com.palantir.flake.ShouldRetry;
 
+@ShouldRetry // In some cases we obtain a TTransportException from Cassandra, probably because we don't wait enough?
 public class MultiCassandraSingleNodeDownEteTest {
     private static final String CASSANDRA_NODE_TO_KILL = "cassandra1";
+
+    @Rule
+    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
 
     @BeforeClass
     public static void shutdownCassandraNode() {

--- a/leader-election-impl/src/test/java/com/palantir/paxos/CoalescingSupplierTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/CoalescingSupplierTest.java
@@ -19,6 +19,8 @@ package com.palantir.paxos;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -69,8 +71,10 @@ public class CoalescingSupplierTest {
 
         batch.await();
 
-        // once for initial task; once for batch
-        verify(delegate, times(2)).get();
+        // At least some of these requests should be batched. We can't guarantee it will always be 2 though, if
+        // we get really unlucky with scheduling.
+        verify(delegate, atLeast(2)).get();
+        verify(delegate, atMost(5)).get();
     }
 
     @Test

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
   processor group: 'org.immutables', name: 'value'
 
+  testCompile project(":flake-rule")
   testCompile group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.1.0'
   testCompile group: 'org.assertj', name: 'assertj-core'
   testCompile group: 'org.hamcrest', name: 'hamcrest-core'

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ClientAwareLockTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ClientAwareLockTest.java
@@ -26,12 +26,16 @@ import java.util.concurrent.TimeoutException;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.common.concurrent.InterruptibleFuture;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.flake.FlakeRetryingRule;
+import com.palantir.flake.ShouldRetry;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockMode;
 import com.palantir.lock.StringLockDescriptor;
@@ -42,6 +46,7 @@ import com.palantir.remoting3.tracing.Tracers;
  *
  * @author jtamer
  */
+@ShouldRetry
 public final class ClientAwareLockTest {
 
     private static final ExecutorService executor = Tracers.wrap(PTExecutors.newCachedThreadPool(
@@ -54,6 +59,9 @@ public final class ClientAwareLockTest {
     private KnownClientLock knownClientReadLock;
     private KnownClientLock knownClientWriteLock;
     private CyclicBarrier barrier;
+
+    @Rule
+    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
 
     /** Sets up the tests. */
     @Before public void setUp() {

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -50,6 +50,7 @@ dependencies {
         exclude(module:'log4j-over-slf4j')
         exclude(module:'jcl-over-slf4j')
     }
+    testCompile project(":flake-rule")
     testCompile group: 'org.assertj', name: 'assertj-core'
     testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
         exclude group: 'org.hamcrest'

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceTransactionIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceTransactionIntegrationTest.java
@@ -64,6 +64,7 @@ public class AsyncTimelockServiceTransactionIntegrationTest extends AbstractAsyn
 
     public AsyncTimelockServiceTransactionIntegrationTest(TestableTimelockCluster cluster) {
         super(cluster);
+        cluster.waitUntilLeaderIsElected();
 
         txnManager = TimeLockTestUtils.createTransactionManager(cluster);
         txnManager.getKeyValueService().createTable(TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/MultiNodePaxosTimeLockServerIntegrationTest.java
@@ -150,7 +150,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void leaderLosesLeadersipIfQuorumIsNotAlive() {
+    public void leaderLosesLeadershipIfQuorumIsNotAlive() {
         TestableTimelockServer leader = CLUSTER.currentLeader();
         CLUSTER.nonLeaders().forEach(TestableTimelockServer::kill);
 
@@ -171,6 +171,7 @@ public class MultiNodePaxosTimeLockServerIntegrationTest {
         bringAllNodesOnline();
         for (TestableTimelockServer server : CLUSTER.servers()) {
             server.kill();
+            waitForClusterToStabilize();
             CLUSTER.getFreshTimestamp();
             server.start();
         }

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -29,11 +29,15 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.common.time.Clock;
+import com.palantir.flake.FlakeRetryingRule;
+import com.palantir.flake.ShouldRetry;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.StringLockDescriptor;
@@ -64,6 +68,9 @@ public class AsyncLockServiceEteTest {
             new HeldLocksCollection(),
             new AwaitedLocksCollection(),
             executor);
+
+    @Rule
+    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
 
     @Test
     public void canLockAndUnlock() {
@@ -130,6 +137,7 @@ public class AsyncLockServiceEteTest {
     }
 
     @Test
+    @ShouldRetry
     public void requestsAreIdempotentWithRespectToTimeout() {
         lockSynchronously(REQUEST_1, LOCK_A);
         service.lock(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
@@ -227,6 +235,7 @@ public class AsyncLockServiceEteTest {
     }
 
     @Test
+    @ShouldRetry
     public void lockRequestTimesOutWhenTimeoutPasses() {
         lockSynchronously(REQUEST_1, LOCK_A);
         AsyncResult<LockToken> result = service.lock(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
@@ -238,6 +247,7 @@ public class AsyncLockServiceEteTest {
     }
 
     @Test
+    @ShouldRetry
     public void waitForLocksRequestTimesOutWhenTimeoutPasses() {
         lockSynchronously(REQUEST_1, LOCK_A);
         AsyncResult<Void> result = service.waitForLocks(REQUEST_2, descriptors(LOCK_A), SHORT_TIMEOUT);
@@ -249,6 +259,7 @@ public class AsyncLockServiceEteTest {
     }
 
     @Test
+    @ShouldRetry
     public void timedOutRequestDoesNotHoldLocks() {
         LockToken lockBToken = lockSynchronously(REQUEST_1, LOCK_B);
         service.lock(REQUEST_2, descriptors(LOCK_A, LOCK_B), SHORT_TIMEOUT);


### PR DESCRIPTION
**Goals (and why)**:
- Reduce the frequency of build flakes by actually retrying tests; #2836 only retried _one_ of the tests that was flaky.

**Implementation Description (bullets)**:
- Apply the `@ShouldRetry` annotation and the flake retrying rule where needed.
- Release the schema mutation lock after failed attempts for the Cassandra integration tests.
- We've had a success rate of 14/16 = 87.5% in preliminary testing, with both failures being outside of the tests (one was on `wget` and another was on the errorprone compiler OOMing).

Flakes I did NOT put the rule on:
- For the TimeLock integration test, I made nodes wait for the cluster to be healthy before firing requests / between requests in a rolling bounce. These are time-limited anyway (see `TestableTimelockCluster`) so we should be fine.
- For the Coalescing Supplier test, I made it a bit more permissive to account for scheduling quirks.

**Concerns (what feedback would you like?)**:
- Is releasing the schema mutation lock after an arbitrary failed attempt in the Cassandra integration tests safe?

**Where should we start reviewing?**:
- Might be easier to do commit by commit, as for the most part the flaky tests are handled one test class at a time.

**Priority (whenever / two weeks / yesterday)**: this/early next week to alleviate ~pain au chocolat~ flaky pain, but of course not super high priority.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2843)
<!-- Reviewable:end -->
