### PR TITLE
[WIP] Retry on RateLimitedException

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -34,6 +34,7 @@ import org.slf4j.helpers.MessageFormatter;
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientFactory.ClientCreationFailedException;
+import com.palantir.atlasdb.qos.ratelimit.RateLimitExceededException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.remoting.api.config.service.HumanReadableDuration;
@@ -155,7 +156,8 @@ class CassandraRequestExceptionHandler {
         return isConnectionException(ex)
                 || isTransientException(ex)
                 || isIndicativeOfCassandraLoad(ex)
-                || isFastFailoverException(ex);
+                || isFastFailoverException(ex)
+                || isQosException(ex);
     }
 
     @VisibleForTesting
@@ -167,6 +169,9 @@ class CassandraRequestExceptionHandler {
     Backoff shouldBackoff(Exception ex) {
         if (isConnectionException(ex) || isIndicativeOfCassandraLoad(ex)) {
             return Backoff.SHORT;
+        }
+        if (isQosException(ex)) {
+            return Backoff.LONG;
         }
 
         return Backoff.NO;
@@ -216,6 +221,12 @@ class CassandraRequestExceptionHandler {
                 || isFastFailoverException(ex.getCause()));
     }
 
+    private boolean isQosException(Throwable ex) {
+        return ex != null
+                && (ex instanceof RateLimitExceededException
+                || isQosException(ex.getCause()));
+    }
+
     private static final String CONNECTION_FAILURE_MSG = "Tried to connect to cassandra {} times."
             + " Error writing to Cassandra socket."
             + " Likely cause: Exceeded maximum thrift frame size;"
@@ -224,7 +235,8 @@ class CassandraRequestExceptionHandler {
     @VisibleForTesting
     enum Backoff {
         NO(HumanReadableDuration.minutes(0L)),
-        SHORT(HumanReadableDuration.seconds(1L));
+        SHORT(HumanReadableDuration.seconds(1L)),
+        LONG(HumanReadableDuration.seconds(10L));
 
         private HumanReadableDuration duration;
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
+import com.palantir.atlasdb.qos.ratelimit.RateLimitExceededException;
 
 public class CassandraRequestExceptionHandlerTest {
 
@@ -52,6 +53,7 @@ public class CassandraRequestExceptionHandlerTest {
     private Set<Exception> indicativeOfCassandraLoadException = Sets.newHashSet(new NoSuchElementException(),
             new UnavailableException());
     private Set<Exception> fastFailoverExceptions = Sets.newHashSet(new InvalidRequestException());
+    private Set<Exception> qosExceptions = Sets.newHashSet(new RateLimitExceededException(MESSAGE));
 
     private CassandraRequestExceptionHandler exceptionHandler = new CassandraRequestExceptionHandler(
             () -> MAX_RETRIES_PER_HOST,
@@ -65,6 +67,7 @@ public class CassandraRequestExceptionHandlerTest {
         allExceptions = Sets.union(allExceptions, transientExceptions);
         allExceptions = Sets.union(allExceptions, indicativeOfCassandraLoadException);
         allExceptions = Sets.union(allExceptions, fastFailoverExceptions);
+        allExceptions = Sets.union(allExceptions, qosExceptions);
 
         for (Exception ex : allExceptions) {
             assertTrue(String.format("Exception %s should be retryable", ex), exceptionHandler.isRetryable(ex));
@@ -100,6 +103,12 @@ public class CassandraRequestExceptionHandlerTest {
             assertEquals(String.format("Exception %s should have short backoff", ex),
                     exceptionHandler.shouldBackoff(ex),
                     CassandraRequestExceptionHandler.Backoff.SHORT);
+        }
+
+        for (Exception ex : qosExceptions) {
+            assertEquals(String.format("QoS exception %s should have long backoff", ex),
+                    exceptionHandler.shouldBackoff(ex),
+                    CassandraRequestExceptionHandler.Backoff.LONG);
         }
 
         for (Exception ex : fastFailoverExceptions) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -91,6 +91,11 @@ develop
            Previously, the result would only count cell-ts pairs examined in the last batch.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2830>`__)
 
+    *    - |fixed|
+         - Make RateLimitedException retriable.
+           If configuring the QosClientConfig to rate limit, please watch the metric `QosMetrics.rateLimitedExceptions` and tune your config.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2848>`__)
+
 =======
 v0.72.0
 =======


### PR DESCRIPTION
**Goals (and why)**: When doing StreamStore writes, we break the stream in 1MB blocks and call `kvs.multiPut`. MultiPut groups up blocks in groups of 10MBs and spawns a thread to write such group to CKVS.

If the stream is big, as the internal search product case, we will use all CKVS threads to attempt such write. This causes problems to the underlying DB. We want to throttle the write at the QoS level.

If one of the threads that attempt the write fails at the QoS layer (e.g. it takes more time than `maxBackoffSleepTime` to write), it's likely the stream write will fail, and further retries to write the stream completely will also fail.

We want to add a retry layer in AtlasDB per thread, to avoid the write from failing completely.

**Implementation Description (bullets)**: Special case RLE in `CassandraRequestExceptionHandler`.

**Concerns (what feedback would you like?)**: Is this the right approach for this problem?

**Priority (whenever / two weeks / yesterday)**: EOW.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2844)
<!-- Reviewable:end -->
