### PR TITLE
Cleanup Requirements Part 1.5: Stream Store Cleanup Metadata

### DIFF
--- a/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
+++ b/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
@@ -4910,35 +4910,37 @@ public final class SchemaMetadataPersistence {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\037SchemaMetadataPersistence.proto\022%com.p" +
-      "alantir.atlasdb.protos.generated\032\036TableM" +
-      "etadataPersistence.proto\"q\n\016SchemaMetada" +
-      "ta\022_\n\rtableMetadata\030\001 \003(\0132H.com.palantir" +
-      ".atlasdb.protos.generated.SchemaDependen" +
-      "tTableMetadataEntry\"\335\001\n!SchemaDependentT" +
-      "ableMetadataEntry\022M\n\016tableReference\030\001 \001(" +
-      "\01325.com.palantir.atlasdb.protos.generate" +
-      "d.TableReference\022i\n\034schemaDependentTable" +
-      "Metadata\030\002 \001(\0132C.com.palantir.atlasdb.pr",
-      "otos.generated.SchemaDependentTableMetad" +
-      "ata\"6\n\016TableReference\022\021\n\tnamespace\030\001 \001(\t" +
-      "\022\021\n\ttableName\030\002 \001(\t\"\305\002\n\034SchemaDependentT" +
-      "ableMetadata\022R\n\014nullMetadata\030\001 \001(\0132:.com" +
-      ".palantir.atlasdb.protos.generated.NullC" +
-      "leanupMetadataH\000\022`\n\023streamStoreMetadata\030" +
-      "\002 \001(\0132A.com.palantir.atlasdb.protos.gene" +
-      "rated.StreamStoreCleanupMetadataH\000\022\\\n\021ar" +
-      "bitraryMetadata\030\003 \001(\0132?.com.palantir.atl" +
-      "asdb.protos.generated.ArbitraryCleanupMe",
-      "tadataH\000B\021\n\017cleanupMetadata\"\025\n\023NullClean" +
-      "upMetadata\"u\n\032StreamStoreCleanupMetadata" +
-      "\022W\n\nv1Metadata\030\001 \001(\0132C.com.palantir.atla" +
-      "sdb.protos.generated.StreamStoreCleanupV" +
-      "1Metadata\"\211\001\n\034StreamStoreCleanupV1Metada" +
-      "ta\022!\n\026numHashedRowComponents\030\001 \001(\005:\0010\022F\n" +
-      "\014streamIdType\030\002 \001(\01620.com.palantir.atlas" +
-      "db.protos.generated.ValueType\"\032\n\030Arbitra" +
-      "ryCleanupMetadata"
+      "\nFmain/proto/com/palantir/atlasdb/protos" +
+      "/SchemaMetadataPersistence.proto\022%com.pa" +
+      "lantir.atlasdb.protos.generated\032Emain/pr" +
+      "oto/com/palantir/atlasdb/protos/TableMet" +
+      "adataPersistence.proto\"q\n\016SchemaMetadata" +
+      "\022_\n\rtableMetadata\030\001 \003(\0132H.com.palantir.a" +
+      "tlasdb.protos.generated.SchemaDependentT" +
+      "ableMetadataEntry\"\335\001\n!SchemaDependentTab" +
+      "leMetadataEntry\022M\n\016tableReference\030\001 \001(\0132" +
+      "5.com.palantir.atlasdb.protos.generated.",
+      "TableReference\022i\n\034schemaDependentTableMe" +
+      "tadata\030\002 \001(\0132C.com.palantir.atlasdb.prot" +
+      "os.generated.SchemaDependentTableMetadat" +
+      "a\"6\n\016TableReference\022\021\n\tnamespace\030\001 \001(\t\022\021" +
+      "\n\ttableName\030\002 \001(\t\"\305\002\n\034SchemaDependentTab" +
+      "leMetadata\022R\n\014nullMetadata\030\001 \001(\0132:.com.p" +
+      "alantir.atlasdb.protos.generated.NullCle" +
+      "anupMetadataH\000\022`\n\023streamStoreMetadata\030\002 " +
+      "\001(\0132A.com.palantir.atlasdb.protos.genera" +
+      "ted.StreamStoreCleanupMetadataH\000\022\\\n\021arbi",
+      "traryMetadata\030\003 \001(\0132?.com.palantir.atlas" +
+      "db.protos.generated.ArbitraryCleanupMeta" +
+      "dataH\000B\021\n\017cleanupMetadata\"\025\n\023NullCleanup" +
+      "Metadata\"u\n\032StreamStoreCleanupMetadata\022W" +
+      "\n\nv1Metadata\030\001 \001(\0132C.com.palantir.atlasd" +
+      "b.protos.generated.StreamStoreCleanupV1M" +
+      "etadata\"\211\001\n\034StreamStoreCleanupV1Metadata" +
+      "\022!\n\026numHashedRowComponents\030\001 \001(\005:\0010\022F\n\014s" +
+      "treamIdType\030\002 \001(\01620.com.palantir.atlasdb" +
+      ".protos.generated.ValueType\"\032\n\030Arbitrary",
+      "CleanupMetadata"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
+++ b/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
@@ -2159,41 +2159,56 @@ public final class SchemaMetadataPersistence {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+     *
+     * <pre>
+     * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+     * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+     * </pre>
      */
     boolean hasNullCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+     *
+     * <pre>
+     * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+     * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+     * </pre>
      */
     com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+     *
+     * <pre>
+     * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+     * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+     * </pre>
      */
     com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullCleanupMetadataOrBuilder();
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
      */
     boolean hasStreamStoreCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
      */
     com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
      */
     com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreCleanupMetadataOrBuilder();
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
      */
     boolean hasArbitraryCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
      */
     com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
      */
     com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryCleanupMetadataOrBuilder();
   }
@@ -2332,9 +2347,9 @@ public final class SchemaMetadataPersistence {
     private java.lang.Object cleanupMetadata_;
     public enum CleanupMetadataCase
         implements com.google.protobuf.Internal.EnumLite {
-      NULLCLEANUPMETADATA(1),
-      STREAMSTORECLEANUPMETADATA(2),
-      ARBITRARYCLEANUPMETADATA(3),
+      NULL_CLEANUP_METADATA(1),
+      STREAM_STORE_CLEANUP_METADATA(2),
+      ARBITRARY_CLEANUP_METADATA(3),
       CLEANUPMETADATA_NOT_SET(0);
       private int value = 0;
       private CleanupMetadataCase(int value) {
@@ -2342,9 +2357,9 @@ public final class SchemaMetadataPersistence {
       }
       public static CleanupMetadataCase valueOf(int value) {
         switch (value) {
-          case 1: return NULLCLEANUPMETADATA;
-          case 2: return STREAMSTORECLEANUPMETADATA;
-          case 3: return ARBITRARYCLEANUPMETADATA;
+          case 1: return NULL_CLEANUP_METADATA;
+          case 2: return STREAM_STORE_CLEANUP_METADATA;
+          case 3: return ARBITRARY_CLEANUP_METADATA;
           case 0: return CLEANUPMETADATA_NOT_SET;
           default: throw new java.lang.IllegalArgumentException(
             "Value is undefined for this oneof enum.");
@@ -2361,15 +2376,25 @@ public final class SchemaMetadataPersistence {
           cleanupMetadataCase_);
     }
 
-    public static final int NULLCLEANUPMETADATA_FIELD_NUMBER = 1;
+    public static final int NULL_CLEANUP_METADATA_FIELD_NUMBER = 1;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+     *
+     * <pre>
+     * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+     * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+     * </pre>
      */
     public boolean hasNullCleanupMetadata() {
       return cleanupMetadataCase_ == 1;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+     *
+     * <pre>
+     * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+     * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+     * </pre>
      */
     public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullCleanupMetadata() {
       if (cleanupMetadataCase_ == 1) {
@@ -2378,7 +2403,12 @@ public final class SchemaMetadataPersistence {
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+     *
+     * <pre>
+     * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+     * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+     * </pre>
      */
     public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullCleanupMetadataOrBuilder() {
       if (cleanupMetadataCase_ == 1) {
@@ -2387,15 +2417,15 @@ public final class SchemaMetadataPersistence {
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
     }
 
-    public static final int STREAMSTORECLEANUPMETADATA_FIELD_NUMBER = 2;
+    public static final int STREAM_STORE_CLEANUP_METADATA_FIELD_NUMBER = 2;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
      */
     public boolean hasStreamStoreCleanupMetadata() {
       return cleanupMetadataCase_ == 2;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
      */
     public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreCleanupMetadata() {
       if (cleanupMetadataCase_ == 2) {
@@ -2404,7 +2434,7 @@ public final class SchemaMetadataPersistence {
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
      */
     public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreCleanupMetadataOrBuilder() {
       if (cleanupMetadataCase_ == 2) {
@@ -2413,15 +2443,15 @@ public final class SchemaMetadataPersistence {
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
     }
 
-    public static final int ARBITRARYCLEANUPMETADATA_FIELD_NUMBER = 3;
+    public static final int ARBITRARY_CLEANUP_METADATA_FIELD_NUMBER = 3;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
      */
     public boolean hasArbitraryCleanupMetadata() {
       return cleanupMetadataCase_ == 3;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
      */
     public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryCleanupMetadata() {
       if (cleanupMetadataCase_ == 3) {
@@ -2430,7 +2460,7 @@ public final class SchemaMetadataPersistence {
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
      */
     public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryCleanupMetadataOrBuilder() {
       if (cleanupMetadataCase_ == 3) {
@@ -2670,15 +2700,15 @@ public final class SchemaMetadataPersistence {
       public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata other) {
         if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.getDefaultInstance()) return this;
         switch (other.getCleanupMetadataCase()) {
-          case NULLCLEANUPMETADATA: {
+          case NULL_CLEANUP_METADATA: {
             mergeNullCleanupMetadata(other.getNullCleanupMetadata());
             break;
           }
-          case STREAMSTORECLEANUPMETADATA: {
+          case STREAM_STORE_CLEANUP_METADATA: {
             mergeStreamStoreCleanupMetadata(other.getStreamStoreCleanupMetadata());
             break;
           }
-          case ARBITRARYCLEANUPMETADATA: {
+          case ARBITRARY_CLEANUP_METADATA: {
             mergeArbitraryCleanupMetadata(other.getArbitraryCleanupMetadata());
             break;
           }
@@ -2731,13 +2761,23 @@ public final class SchemaMetadataPersistence {
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> nullCleanupMetadataBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       public boolean hasNullCleanupMetadata() {
         return cleanupMetadataCase_ == 1;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullCleanupMetadata() {
         if (nullCleanupMetadataBuilder_ == null) {
@@ -2753,7 +2793,12 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       public Builder setNullCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
         if (nullCleanupMetadataBuilder_ == null) {
@@ -2769,7 +2814,12 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       public Builder setNullCleanupMetadata(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder builderForValue) {
@@ -2783,7 +2833,12 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       public Builder mergeNullCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
         if (nullCleanupMetadataBuilder_ == null) {
@@ -2805,7 +2860,12 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       public Builder clearNullCleanupMetadata() {
         if (nullCleanupMetadataBuilder_ == null) {
@@ -2824,13 +2884,23 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder getNullCleanupMetadataBuilder() {
         return getNullCleanupMetadataFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullCleanupMetadataOrBuilder() {
         if ((cleanupMetadataCase_ == 1) && (nullCleanupMetadataBuilder_ != null)) {
@@ -2843,7 +2913,12 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null_cleanup_metadata = 1;</code>
+       *
+       * <pre>
+       * These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+       * SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+       * </pre>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> 
@@ -2866,13 +2941,13 @@ public final class SchemaMetadataPersistence {
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> streamStoreCleanupMetadataBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       public boolean hasStreamStoreCleanupMetadata() {
         return cleanupMetadataCase_ == 2;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreCleanupMetadata() {
         if (streamStoreCleanupMetadataBuilder_ == null) {
@@ -2888,7 +2963,7 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       public Builder setStreamStoreCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
         if (streamStoreCleanupMetadataBuilder_ == null) {
@@ -2904,7 +2979,7 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       public Builder setStreamStoreCleanupMetadata(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder builderForValue) {
@@ -2918,7 +2993,7 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       public Builder mergeStreamStoreCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
         if (streamStoreCleanupMetadataBuilder_ == null) {
@@ -2940,7 +3015,7 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       public Builder clearStreamStoreCleanupMetadata() {
         if (streamStoreCleanupMetadataBuilder_ == null) {
@@ -2959,13 +3034,13 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder getStreamStoreCleanupMetadataBuilder() {
         return getStreamStoreCleanupMetadataFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreCleanupMetadataOrBuilder() {
         if ((cleanupMetadataCase_ == 2) && (streamStoreCleanupMetadataBuilder_ != null)) {
@@ -2978,7 +3053,7 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> 
@@ -3001,13 +3076,13 @@ public final class SchemaMetadataPersistence {
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> arbitraryCleanupMetadataBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       public boolean hasArbitraryCleanupMetadata() {
         return cleanupMetadataCase_ == 3;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryCleanupMetadata() {
         if (arbitraryCleanupMetadataBuilder_ == null) {
@@ -3023,7 +3098,7 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       public Builder setArbitraryCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
         if (arbitraryCleanupMetadataBuilder_ == null) {
@@ -3039,7 +3114,7 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       public Builder setArbitraryCleanupMetadata(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder builderForValue) {
@@ -3053,7 +3128,7 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       public Builder mergeArbitraryCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
         if (arbitraryCleanupMetadataBuilder_ == null) {
@@ -3075,7 +3150,7 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       public Builder clearArbitraryCleanupMetadata() {
         if (arbitraryCleanupMetadataBuilder_ == null) {
@@ -3094,13 +3169,13 @@ public final class SchemaMetadataPersistence {
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder getArbitraryCleanupMetadataBuilder() {
         return getArbitraryCleanupMetadataFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryCleanupMetadataOrBuilder() {
         if ((cleanupMetadataCase_ == 3) && (arbitraryCleanupMetadataBuilder_ != null)) {
@@ -3113,7 +3188,7 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> 
@@ -4924,23 +4999,24 @@ public final class SchemaMetadataPersistence {
       "tadata\030\002 \001(\0132C.com.palantir.atlasdb.prot" +
       "os.generated.SchemaDependentTableMetadat" +
       "a\"6\n\016TableReference\022\021\n\tnamespace\030\001 \001(\t\022\021" +
-      "\n\ttableName\030\002 \001(\t\"\332\002\n\034SchemaDependentTab" +
-      "leMetadata\022Y\n\023nullCleanupMetadata\030\001 \001(\0132" +
-      ":.com.palantir.atlasdb.protos.generated." +
-      "NullCleanupMetadataH\000\022g\n\032streamStoreClea" +
-      "nupMetadata\030\002 \001(\0132A.com.palantir.atlasdb" +
-      ".protos.generated.StreamStoreCleanupMeta",
-      "dataH\000\022c\n\030arbitraryCleanupMetadata\030\003 \001(\013" +
-      "2?.com.palantir.atlasdb.protos.generated" +
-      ".ArbitraryCleanupMetadataH\000B\021\n\017cleanupMe" +
-      "tadata\"\025\n\023NullCleanupMetadata\"u\n\032StreamS" +
-      "toreCleanupMetadata\022W\n\nv1Metadata\030\001 \001(\0132" +
-      "C.com.palantir.atlasdb.protos.generated." +
-      "StreamStoreCleanupV1Metadata\"\211\001\n\034StreamS" +
-      "toreCleanupV1Metadata\022!\n\026numHashedRowCom" +
-      "ponents\030\001 \001(\005:\0010\022F\n\014streamIdType\030\002 \001(\01620" +
-      ".com.palantir.atlasdb.protos.generated.V",
-      "alueType\"\032\n\030ArbitraryCleanupMetadata"
+      "\n\ttableName\030\002 \001(\t\"\341\002\n\034SchemaDependentTab" +
+      "leMetadata\022[\n\025null_cleanup_metadata\030\001 \001(" +
+      "\0132:.com.palantir.atlasdb.protos.generate" +
+      "d.NullCleanupMetadataH\000\022j\n\035stream_store_" +
+      "cleanup_metadata\030\002 \001(\0132A.com.palantir.at" +
+      "lasdb.protos.generated.StreamStoreCleanu",
+      "pMetadataH\000\022e\n\032arbitrary_cleanup_metadat" +
+      "a\030\003 \001(\0132?.com.palantir.atlasdb.protos.ge" +
+      "nerated.ArbitraryCleanupMetadataH\000B\021\n\017cl" +
+      "eanupMetadata\"\025\n\023NullCleanupMetadata\"u\n\032" +
+      "StreamStoreCleanupMetadata\022W\n\nv1Metadata" +
+      "\030\001 \001(\0132C.com.palantir.atlasdb.protos.gen" +
+      "erated.StreamStoreCleanupV1Metadata\"\211\001\n\034" +
+      "StreamStoreCleanupV1Metadata\022!\n\026numHashe" +
+      "dRowComponents\030\001 \001(\005:\0010\022F\n\014streamIdType\030" +
+      "\002 \001(\01620.com.palantir.atlasdb.protos.gene",
+      "rated.ValueType\"\032\n\030ArbitraryCleanupMetad" +
+      "ata"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
+++ b/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
@@ -2159,43 +2159,43 @@ public final class SchemaMetadataPersistence {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
      */
-    boolean hasNull();
+    boolean hasNullCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNull();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullOrBuilder();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullCleanupMetadataOrBuilder();
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
      */
-    boolean hasStreamStore();
+    boolean hasStreamStoreCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStore();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreOrBuilder();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreCleanupMetadataOrBuilder();
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
      */
-    boolean hasArbitrary();
+    boolean hasArbitraryCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitrary();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryCleanupMetadata();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryOrBuilder();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryCleanupMetadataOrBuilder();
   }
   /**
    * Protobuf type {@code com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata}
@@ -2332,9 +2332,9 @@ public final class SchemaMetadataPersistence {
     private java.lang.Object cleanupMetadata_;
     public enum CleanupMetadataCase
         implements com.google.protobuf.Internal.EnumLite {
-      NULL(1),
-      STREAMSTORE(2),
-      ARBITRARY(3),
+      NULLCLEANUPMETADATA(1),
+      STREAMSTORECLEANUPMETADATA(2),
+      ARBITRARYCLEANUPMETADATA(3),
       CLEANUPMETADATA_NOT_SET(0);
       private int value = 0;
       private CleanupMetadataCase(int value) {
@@ -2342,9 +2342,9 @@ public final class SchemaMetadataPersistence {
       }
       public static CleanupMetadataCase valueOf(int value) {
         switch (value) {
-          case 1: return NULL;
-          case 2: return STREAMSTORE;
-          case 3: return ARBITRARY;
+          case 1: return NULLCLEANUPMETADATA;
+          case 2: return STREAMSTORECLEANUPMETADATA;
+          case 3: return ARBITRARYCLEANUPMETADATA;
           case 0: return CLEANUPMETADATA_NOT_SET;
           default: throw new java.lang.IllegalArgumentException(
             "Value is undefined for this oneof enum.");
@@ -2361,78 +2361,78 @@ public final class SchemaMetadataPersistence {
           cleanupMetadataCase_);
     }
 
-    public static final int NULL_FIELD_NUMBER = 1;
+    public static final int NULLCLEANUPMETADATA_FIELD_NUMBER = 1;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
      */
-    public boolean hasNull() {
+    public boolean hasNullCleanupMetadata() {
       return cleanupMetadataCase_ == 1;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNull() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullCleanupMetadata() {
       if (cleanupMetadataCase_ == 1) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullOrBuilder() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullCleanupMetadataOrBuilder() {
       if (cleanupMetadataCase_ == 1) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
     }
 
-    public static final int STREAMSTORE_FIELD_NUMBER = 2;
+    public static final int STREAMSTORECLEANUPMETADATA_FIELD_NUMBER = 2;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
      */
-    public boolean hasStreamStore() {
+    public boolean hasStreamStoreCleanupMetadata() {
       return cleanupMetadataCase_ == 2;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStore() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreCleanupMetadata() {
       if (cleanupMetadataCase_ == 2) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreOrBuilder() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreCleanupMetadataOrBuilder() {
       if (cleanupMetadataCase_ == 2) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
     }
 
-    public static final int ARBITRARY_FIELD_NUMBER = 3;
+    public static final int ARBITRARYCLEANUPMETADATA_FIELD_NUMBER = 3;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
      */
-    public boolean hasArbitrary() {
+    public boolean hasArbitraryCleanupMetadata() {
       return cleanupMetadataCase_ == 3;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitrary() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryCleanupMetadata() {
       if (cleanupMetadataCase_ == 3) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryOrBuilder() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryCleanupMetadataOrBuilder() {
       if (cleanupMetadataCase_ == 3) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
       }
@@ -2632,24 +2632,24 @@ public final class SchemaMetadataPersistence {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (cleanupMetadataCase_ == 1) {
-          if (nullBuilder_ == null) {
+          if (nullCleanupMetadataBuilder_ == null) {
             result.cleanupMetadata_ = cleanupMetadata_;
           } else {
-            result.cleanupMetadata_ = nullBuilder_.build();
+            result.cleanupMetadata_ = nullCleanupMetadataBuilder_.build();
           }
         }
         if (cleanupMetadataCase_ == 2) {
-          if (streamStoreBuilder_ == null) {
+          if (streamStoreCleanupMetadataBuilder_ == null) {
             result.cleanupMetadata_ = cleanupMetadata_;
           } else {
-            result.cleanupMetadata_ = streamStoreBuilder_.build();
+            result.cleanupMetadata_ = streamStoreCleanupMetadataBuilder_.build();
           }
         }
         if (cleanupMetadataCase_ == 3) {
-          if (arbitraryBuilder_ == null) {
+          if (arbitraryCleanupMetadataBuilder_ == null) {
             result.cleanupMetadata_ = cleanupMetadata_;
           } else {
-            result.cleanupMetadata_ = arbitraryBuilder_.build();
+            result.cleanupMetadata_ = arbitraryCleanupMetadataBuilder_.build();
           }
         }
         result.bitField0_ = to_bitField0_;
@@ -2670,16 +2670,16 @@ public final class SchemaMetadataPersistence {
       public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata other) {
         if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.getDefaultInstance()) return this;
         switch (other.getCleanupMetadataCase()) {
-          case NULL: {
-            mergeNull(other.getNull());
+          case NULLCLEANUPMETADATA: {
+            mergeNullCleanupMetadata(other.getNullCleanupMetadata());
             break;
           }
-          case STREAMSTORE: {
-            mergeStreamStore(other.getStreamStore());
+          case STREAMSTORECLEANUPMETADATA: {
+            mergeStreamStoreCleanupMetadata(other.getStreamStoreCleanupMetadata());
             break;
           }
-          case ARBITRARY: {
-            mergeArbitrary(other.getArbitrary());
+          case ARBITRARYCLEANUPMETADATA: {
+            mergeArbitraryCleanupMetadata(other.getArbitraryCleanupMetadata());
             break;
           }
           case CLEANUPMETADATA_NOT_SET: {
@@ -2729,64 +2729,64 @@ public final class SchemaMetadataPersistence {
       private int bitField0_;
 
       private com.google.protobuf.SingleFieldBuilder<
-          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> nullBuilder_;
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> nullCleanupMetadataBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
-      public boolean hasNull() {
+      public boolean hasNullCleanupMetadata() {
         return cleanupMetadataCase_ == 1;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNull() {
-        if (nullBuilder_ == null) {
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullCleanupMetadata() {
+        if (nullCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 1) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
         } else {
           if (cleanupMetadataCase_ == 1) {
-            return nullBuilder_.getMessage();
+            return nullCleanupMetadataBuilder_.getMessage();
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
-      public Builder setNull(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
-        if (nullBuilder_ == null) {
+      public Builder setNullCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
+        if (nullCleanupMetadataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
           cleanupMetadata_ = value;
           onChanged();
         } else {
-          nullBuilder_.setMessage(value);
+          nullCleanupMetadataBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 1;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
-      public Builder setNull(
+      public Builder setNullCleanupMetadata(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder builderForValue) {
-        if (nullBuilder_ == null) {
+        if (nullCleanupMetadataBuilder_ == null) {
           cleanupMetadata_ = builderForValue.build();
           onChanged();
         } else {
-          nullBuilder_.setMessage(builderForValue.build());
+          nullCleanupMetadataBuilder_.setMessage(builderForValue.build());
         }
         cleanupMetadataCase_ = 1;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
-      public Builder mergeNull(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
-        if (nullBuilder_ == null) {
+      public Builder mergeNullCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
+        if (nullCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 1 &&
               cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance()) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_)
@@ -2797,18 +2797,18 @@ public final class SchemaMetadataPersistence {
           onChanged();
         } else {
           if (cleanupMetadataCase_ == 1) {
-            nullBuilder_.mergeFrom(value);
+            nullCleanupMetadataBuilder_.mergeFrom(value);
           }
-          nullBuilder_.setMessage(value);
+          nullCleanupMetadataBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 1;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
-      public Builder clearNull() {
-        if (nullBuilder_ == null) {
+      public Builder clearNullCleanupMetadata() {
+        if (nullCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 1) {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
@@ -2819,22 +2819,22 @@ public final class SchemaMetadataPersistence {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
           }
-          nullBuilder_.clear();
+          nullCleanupMetadataBuilder_.clear();
         }
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder getNullBuilder() {
-        return getNullFieldBuilder().getBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder getNullCleanupMetadataBuilder() {
+        return getNullCleanupMetadataFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullOrBuilder() {
-        if ((cleanupMetadataCase_ == 1) && (nullBuilder_ != null)) {
-          return nullBuilder_.getMessageOrBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullCleanupMetadataOrBuilder() {
+        if ((cleanupMetadataCase_ == 1) && (nullCleanupMetadataBuilder_ != null)) {
+          return nullCleanupMetadataBuilder_.getMessageOrBuilder();
         } else {
           if (cleanupMetadataCase_ == 1) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
@@ -2843,16 +2843,16 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullCleanupMetadata = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> 
-          getNullFieldBuilder() {
-        if (nullBuilder_ == null) {
+          getNullCleanupMetadataFieldBuilder() {
+        if (nullCleanupMetadataBuilder_ == null) {
           if (!(cleanupMetadataCase_ == 1)) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
           }
-          nullBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          nullCleanupMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder>(
                   (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_,
                   getParentForChildren(),
@@ -2860,68 +2860,68 @@ public final class SchemaMetadataPersistence {
           cleanupMetadata_ = null;
         }
         cleanupMetadataCase_ = 1;
-        return nullBuilder_;
+        return nullCleanupMetadataBuilder_;
       }
 
       private com.google.protobuf.SingleFieldBuilder<
-          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> streamStoreBuilder_;
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> streamStoreCleanupMetadataBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
-      public boolean hasStreamStore() {
+      public boolean hasStreamStoreCleanupMetadata() {
         return cleanupMetadataCase_ == 2;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStore() {
-        if (streamStoreBuilder_ == null) {
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreCleanupMetadata() {
+        if (streamStoreCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 2) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
         } else {
           if (cleanupMetadataCase_ == 2) {
-            return streamStoreBuilder_.getMessage();
+            return streamStoreCleanupMetadataBuilder_.getMessage();
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
-      public Builder setStreamStore(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
-        if (streamStoreBuilder_ == null) {
+      public Builder setStreamStoreCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
+        if (streamStoreCleanupMetadataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
           cleanupMetadata_ = value;
           onChanged();
         } else {
-          streamStoreBuilder_.setMessage(value);
+          streamStoreCleanupMetadataBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 2;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
-      public Builder setStreamStore(
+      public Builder setStreamStoreCleanupMetadata(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder builderForValue) {
-        if (streamStoreBuilder_ == null) {
+        if (streamStoreCleanupMetadataBuilder_ == null) {
           cleanupMetadata_ = builderForValue.build();
           onChanged();
         } else {
-          streamStoreBuilder_.setMessage(builderForValue.build());
+          streamStoreCleanupMetadataBuilder_.setMessage(builderForValue.build());
         }
         cleanupMetadataCase_ = 2;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
-      public Builder mergeStreamStore(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
-        if (streamStoreBuilder_ == null) {
+      public Builder mergeStreamStoreCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
+        if (streamStoreCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 2 &&
               cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance()) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_)
@@ -2932,18 +2932,18 @@ public final class SchemaMetadataPersistence {
           onChanged();
         } else {
           if (cleanupMetadataCase_ == 2) {
-            streamStoreBuilder_.mergeFrom(value);
+            streamStoreCleanupMetadataBuilder_.mergeFrom(value);
           }
-          streamStoreBuilder_.setMessage(value);
+          streamStoreCleanupMetadataBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 2;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
-      public Builder clearStreamStore() {
-        if (streamStoreBuilder_ == null) {
+      public Builder clearStreamStoreCleanupMetadata() {
+        if (streamStoreCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 2) {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
@@ -2954,22 +2954,22 @@ public final class SchemaMetadataPersistence {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
           }
-          streamStoreBuilder_.clear();
+          streamStoreCleanupMetadataBuilder_.clear();
         }
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder getStreamStoreBuilder() {
-        return getStreamStoreFieldBuilder().getBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder getStreamStoreCleanupMetadataBuilder() {
+        return getStreamStoreCleanupMetadataFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreOrBuilder() {
-        if ((cleanupMetadataCase_ == 2) && (streamStoreBuilder_ != null)) {
-          return streamStoreBuilder_.getMessageOrBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreCleanupMetadataOrBuilder() {
+        if ((cleanupMetadataCase_ == 2) && (streamStoreCleanupMetadataBuilder_ != null)) {
+          return streamStoreCleanupMetadataBuilder_.getMessageOrBuilder();
         } else {
           if (cleanupMetadataCase_ == 2) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
@@ -2978,16 +2978,16 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> 
-          getStreamStoreFieldBuilder() {
-        if (streamStoreBuilder_ == null) {
+          getStreamStoreCleanupMetadataFieldBuilder() {
+        if (streamStoreCleanupMetadataBuilder_ == null) {
           if (!(cleanupMetadataCase_ == 2)) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
           }
-          streamStoreBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          streamStoreCleanupMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder>(
                   (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_,
                   getParentForChildren(),
@@ -2995,68 +2995,68 @@ public final class SchemaMetadataPersistence {
           cleanupMetadata_ = null;
         }
         cleanupMetadataCase_ = 2;
-        return streamStoreBuilder_;
+        return streamStoreCleanupMetadataBuilder_;
       }
 
       private com.google.protobuf.SingleFieldBuilder<
-          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> arbitraryBuilder_;
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> arbitraryCleanupMetadataBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
-      public boolean hasArbitrary() {
+      public boolean hasArbitraryCleanupMetadata() {
         return cleanupMetadataCase_ == 3;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitrary() {
-        if (arbitraryBuilder_ == null) {
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryCleanupMetadata() {
+        if (arbitraryCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 3) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
         } else {
           if (cleanupMetadataCase_ == 3) {
-            return arbitraryBuilder_.getMessage();
+            return arbitraryCleanupMetadataBuilder_.getMessage();
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
-      public Builder setArbitrary(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
-        if (arbitraryBuilder_ == null) {
+      public Builder setArbitraryCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
+        if (arbitraryCleanupMetadataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
           cleanupMetadata_ = value;
           onChanged();
         } else {
-          arbitraryBuilder_.setMessage(value);
+          arbitraryCleanupMetadataBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 3;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
-      public Builder setArbitrary(
+      public Builder setArbitraryCleanupMetadata(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder builderForValue) {
-        if (arbitraryBuilder_ == null) {
+        if (arbitraryCleanupMetadataBuilder_ == null) {
           cleanupMetadata_ = builderForValue.build();
           onChanged();
         } else {
-          arbitraryBuilder_.setMessage(builderForValue.build());
+          arbitraryCleanupMetadataBuilder_.setMessage(builderForValue.build());
         }
         cleanupMetadataCase_ = 3;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
-      public Builder mergeArbitrary(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
-        if (arbitraryBuilder_ == null) {
+      public Builder mergeArbitraryCleanupMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
+        if (arbitraryCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 3 &&
               cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance()) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_)
@@ -3067,18 +3067,18 @@ public final class SchemaMetadataPersistence {
           onChanged();
         } else {
           if (cleanupMetadataCase_ == 3) {
-            arbitraryBuilder_.mergeFrom(value);
+            arbitraryCleanupMetadataBuilder_.mergeFrom(value);
           }
-          arbitraryBuilder_.setMessage(value);
+          arbitraryCleanupMetadataBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 3;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
-      public Builder clearArbitrary() {
-        if (arbitraryBuilder_ == null) {
+      public Builder clearArbitraryCleanupMetadata() {
+        if (arbitraryCleanupMetadataBuilder_ == null) {
           if (cleanupMetadataCase_ == 3) {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
@@ -3089,22 +3089,22 @@ public final class SchemaMetadataPersistence {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
           }
-          arbitraryBuilder_.clear();
+          arbitraryCleanupMetadataBuilder_.clear();
         }
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder getArbitraryBuilder() {
-        return getArbitraryFieldBuilder().getBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder getArbitraryCleanupMetadataBuilder() {
+        return getArbitraryCleanupMetadataFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryOrBuilder() {
-        if ((cleanupMetadataCase_ == 3) && (arbitraryBuilder_ != null)) {
-          return arbitraryBuilder_.getMessageOrBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryCleanupMetadataOrBuilder() {
+        if ((cleanupMetadataCase_ == 3) && (arbitraryCleanupMetadataBuilder_ != null)) {
+          return arbitraryCleanupMetadataBuilder_.getMessageOrBuilder();
         } else {
           if (cleanupMetadataCase_ == 3) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
@@ -3113,16 +3113,16 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> 
-          getArbitraryFieldBuilder() {
-        if (arbitraryBuilder_ == null) {
+          getArbitraryCleanupMetadataFieldBuilder() {
+        if (arbitraryCleanupMetadataBuilder_ == null) {
           if (!(cleanupMetadataCase_ == 3)) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
           }
-          arbitraryBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          arbitraryCleanupMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder>(
                   (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_,
                   getParentForChildren(),
@@ -3130,7 +3130,7 @@ public final class SchemaMetadataPersistence {
           cleanupMetadata_ = null;
         }
         cleanupMetadataCase_ = 3;
-        return arbitraryBuilder_;
+        return arbitraryCleanupMetadataBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
@@ -4924,22 +4924,23 @@ public final class SchemaMetadataPersistence {
       "tadata\030\002 \001(\0132C.com.palantir.atlasdb.prot" +
       "os.generated.SchemaDependentTableMetadat" +
       "a\"6\n\016TableReference\022\021\n\tnamespace\030\001 \001(\t\022\021" +
-      "\n\ttableName\030\002 \001(\t\"\255\002\n\034SchemaDependentTab" +
-      "leMetadata\022J\n\004null\030\001 \001(\0132:.com.palantir." +
-      "atlasdb.protos.generated.NullCleanupMeta" +
-      "dataH\000\022X\n\013streamStore\030\002 \001(\0132A.com.palant" +
-      "ir.atlasdb.protos.generated.StreamStoreC" +
-      "leanupMetadataH\000\022T\n\tarbitrary\030\003 \001(\0132?.co",
-      "m.palantir.atlasdb.protos.generated.Arbi" +
-      "traryCleanupMetadataH\000B\021\n\017cleanupMetadat" +
-      "a\"\025\n\023NullCleanupMetadata\"u\n\032StreamStoreC" +
-      "leanupMetadata\022W\n\nv1Metadata\030\001 \001(\0132C.com" +
-      ".palantir.atlasdb.protos.generated.Strea" +
-      "mStoreCleanupV1Metadata\"\211\001\n\034StreamStoreC" +
-      "leanupV1Metadata\022!\n\026numHashedRowComponen" +
-      "ts\030\001 \001(\005:\0010\022F\n\014streamIdType\030\002 \001(\01620.com." +
-      "palantir.atlasdb.protos.generated.ValueT" +
-      "ype\"\032\n\030ArbitraryCleanupMetadata"
+      "\n\ttableName\030\002 \001(\t\"\332\002\n\034SchemaDependentTab" +
+      "leMetadata\022Y\n\023nullCleanupMetadata\030\001 \001(\0132" +
+      ":.com.palantir.atlasdb.protos.generated." +
+      "NullCleanupMetadataH\000\022g\n\032streamStoreClea" +
+      "nupMetadata\030\002 \001(\0132A.com.palantir.atlasdb" +
+      ".protos.generated.StreamStoreCleanupMeta",
+      "dataH\000\022c\n\030arbitraryCleanupMetadata\030\003 \001(\013" +
+      "2?.com.palantir.atlasdb.protos.generated" +
+      ".ArbitraryCleanupMetadataH\000B\021\n\017cleanupMe" +
+      "tadata\"\025\n\023NullCleanupMetadata\"u\n\032StreamS" +
+      "toreCleanupMetadata\022W\n\nv1Metadata\030\001 \001(\0132" +
+      "C.com.palantir.atlasdb.protos.generated." +
+      "StreamStoreCleanupV1Metadata\"\211\001\n\034StreamS" +
+      "toreCleanupV1Metadata\022!\n\026numHashedRowCom" +
+      "ponents\030\001 \001(\005:\0010\022F\n\014streamIdType\030\002 \001(\01620" +
+      ".com.palantir.atlasdb.protos.generated.V",
+      "alueType\"\032\n\030ArbitraryCleanupMetadata"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4977,7 +4978,7 @@ public final class SchemaMetadataPersistence {
     internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor,
-        new java.lang.String[] { "Null", "StreamStore", "Arbitrary", "CleanupMetadata", });
+        new java.lang.String[] { "NullCleanupMetadata", "StreamStoreCleanupMetadata", "ArbitraryCleanupMetadata", "CleanupMetadata", });
     internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_fieldAccessorTable = new

--- a/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
+++ b/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
@@ -2159,43 +2159,43 @@ public final class SchemaMetadataPersistence {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
      */
-    boolean hasNullMetadata();
+    boolean hasNull();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullMetadata();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNull();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullMetadataOrBuilder();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullOrBuilder();
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
      */
-    boolean hasStreamStoreMetadata();
+    boolean hasStreamStore();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreMetadata();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStore();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreMetadataOrBuilder();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreOrBuilder();
 
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
      */
-    boolean hasArbitraryMetadata();
+    boolean hasArbitrary();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryMetadata();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitrary();
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
      */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryMetadataOrBuilder();
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryOrBuilder();
   }
   /**
    * Protobuf type {@code com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata}
@@ -2332,9 +2332,9 @@ public final class SchemaMetadataPersistence {
     private java.lang.Object cleanupMetadata_;
     public enum CleanupMetadataCase
         implements com.google.protobuf.Internal.EnumLite {
-      NULLMETADATA(1),
-      STREAMSTOREMETADATA(2),
-      ARBITRARYMETADATA(3),
+      NULL(1),
+      STREAMSTORE(2),
+      ARBITRARY(3),
       CLEANUPMETADATA_NOT_SET(0);
       private int value = 0;
       private CleanupMetadataCase(int value) {
@@ -2342,9 +2342,9 @@ public final class SchemaMetadataPersistence {
       }
       public static CleanupMetadataCase valueOf(int value) {
         switch (value) {
-          case 1: return NULLMETADATA;
-          case 2: return STREAMSTOREMETADATA;
-          case 3: return ARBITRARYMETADATA;
+          case 1: return NULL;
+          case 2: return STREAMSTORE;
+          case 3: return ARBITRARY;
           case 0: return CLEANUPMETADATA_NOT_SET;
           default: throw new java.lang.IllegalArgumentException(
             "Value is undefined for this oneof enum.");
@@ -2361,78 +2361,78 @@ public final class SchemaMetadataPersistence {
           cleanupMetadataCase_);
     }
 
-    public static final int NULLMETADATA_FIELD_NUMBER = 1;
+    public static final int NULL_FIELD_NUMBER = 1;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
      */
-    public boolean hasNullMetadata() {
+    public boolean hasNull() {
       return cleanupMetadataCase_ == 1;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullMetadata() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNull() {
       if (cleanupMetadataCase_ == 1) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullMetadataOrBuilder() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullOrBuilder() {
       if (cleanupMetadataCase_ == 1) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
     }
 
-    public static final int STREAMSTOREMETADATA_FIELD_NUMBER = 2;
+    public static final int STREAMSTORE_FIELD_NUMBER = 2;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
      */
-    public boolean hasStreamStoreMetadata() {
+    public boolean hasStreamStore() {
       return cleanupMetadataCase_ == 2;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreMetadata() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStore() {
       if (cleanupMetadataCase_ == 2) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreMetadataOrBuilder() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreOrBuilder() {
       if (cleanupMetadataCase_ == 2) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
     }
 
-    public static final int ARBITRARYMETADATA_FIELD_NUMBER = 3;
+    public static final int ARBITRARY_FIELD_NUMBER = 3;
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
      */
-    public boolean hasArbitraryMetadata() {
+    public boolean hasArbitrary() {
       return cleanupMetadataCase_ == 3;
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryMetadata() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitrary() {
       if (cleanupMetadataCase_ == 3) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
       }
       return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
     }
     /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
      */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryMetadataOrBuilder() {
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryOrBuilder() {
       if (cleanupMetadataCase_ == 3) {
          return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
       }
@@ -2632,24 +2632,24 @@ public final class SchemaMetadataPersistence {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (cleanupMetadataCase_ == 1) {
-          if (nullMetadataBuilder_ == null) {
+          if (nullBuilder_ == null) {
             result.cleanupMetadata_ = cleanupMetadata_;
           } else {
-            result.cleanupMetadata_ = nullMetadataBuilder_.build();
+            result.cleanupMetadata_ = nullBuilder_.build();
           }
         }
         if (cleanupMetadataCase_ == 2) {
-          if (streamStoreMetadataBuilder_ == null) {
+          if (streamStoreBuilder_ == null) {
             result.cleanupMetadata_ = cleanupMetadata_;
           } else {
-            result.cleanupMetadata_ = streamStoreMetadataBuilder_.build();
+            result.cleanupMetadata_ = streamStoreBuilder_.build();
           }
         }
         if (cleanupMetadataCase_ == 3) {
-          if (arbitraryMetadataBuilder_ == null) {
+          if (arbitraryBuilder_ == null) {
             result.cleanupMetadata_ = cleanupMetadata_;
           } else {
-            result.cleanupMetadata_ = arbitraryMetadataBuilder_.build();
+            result.cleanupMetadata_ = arbitraryBuilder_.build();
           }
         }
         result.bitField0_ = to_bitField0_;
@@ -2670,16 +2670,16 @@ public final class SchemaMetadataPersistence {
       public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata other) {
         if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.getDefaultInstance()) return this;
         switch (other.getCleanupMetadataCase()) {
-          case NULLMETADATA: {
-            mergeNullMetadata(other.getNullMetadata());
+          case NULL: {
+            mergeNull(other.getNull());
             break;
           }
-          case STREAMSTOREMETADATA: {
-            mergeStreamStoreMetadata(other.getStreamStoreMetadata());
+          case STREAMSTORE: {
+            mergeStreamStore(other.getStreamStore());
             break;
           }
-          case ARBITRARYMETADATA: {
-            mergeArbitraryMetadata(other.getArbitraryMetadata());
+          case ARBITRARY: {
+            mergeArbitrary(other.getArbitrary());
             break;
           }
           case CLEANUPMETADATA_NOT_SET: {
@@ -2729,64 +2729,64 @@ public final class SchemaMetadataPersistence {
       private int bitField0_;
 
       private com.google.protobuf.SingleFieldBuilder<
-          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> nullMetadataBuilder_;
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> nullBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
-      public boolean hasNullMetadata() {
+      public boolean hasNull() {
         return cleanupMetadataCase_ == 1;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullMetadata() {
-        if (nullMetadataBuilder_ == null) {
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNull() {
+        if (nullBuilder_ == null) {
           if (cleanupMetadataCase_ == 1) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
         } else {
           if (cleanupMetadataCase_ == 1) {
-            return nullMetadataBuilder_.getMessage();
+            return nullBuilder_.getMessage();
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
-      public Builder setNullMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
-        if (nullMetadataBuilder_ == null) {
+      public Builder setNull(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
+        if (nullBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
           cleanupMetadata_ = value;
           onChanged();
         } else {
-          nullMetadataBuilder_.setMessage(value);
+          nullBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 1;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
-      public Builder setNullMetadata(
+      public Builder setNull(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder builderForValue) {
-        if (nullMetadataBuilder_ == null) {
+        if (nullBuilder_ == null) {
           cleanupMetadata_ = builderForValue.build();
           onChanged();
         } else {
-          nullMetadataBuilder_.setMessage(builderForValue.build());
+          nullBuilder_.setMessage(builderForValue.build());
         }
         cleanupMetadataCase_ = 1;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
-      public Builder mergeNullMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
-        if (nullMetadataBuilder_ == null) {
+      public Builder mergeNull(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
+        if (nullBuilder_ == null) {
           if (cleanupMetadataCase_ == 1 &&
               cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance()) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_)
@@ -2797,18 +2797,18 @@ public final class SchemaMetadataPersistence {
           onChanged();
         } else {
           if (cleanupMetadataCase_ == 1) {
-            nullMetadataBuilder_.mergeFrom(value);
+            nullBuilder_.mergeFrom(value);
           }
-          nullMetadataBuilder_.setMessage(value);
+          nullBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 1;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
-      public Builder clearNullMetadata() {
-        if (nullMetadataBuilder_ == null) {
+      public Builder clearNull() {
+        if (nullBuilder_ == null) {
           if (cleanupMetadataCase_ == 1) {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
@@ -2819,22 +2819,22 @@ public final class SchemaMetadataPersistence {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
           }
-          nullMetadataBuilder_.clear();
+          nullBuilder_.clear();
         }
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder getNullMetadataBuilder() {
-        return getNullMetadataFieldBuilder().getBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder getNullBuilder() {
+        return getNullFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullMetadataOrBuilder() {
-        if ((cleanupMetadataCase_ == 1) && (nullMetadataBuilder_ != null)) {
-          return nullMetadataBuilder_.getMessageOrBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullOrBuilder() {
+        if ((cleanupMetadataCase_ == 1) && (nullBuilder_ != null)) {
+          return nullBuilder_.getMessageOrBuilder();
         } else {
           if (cleanupMetadataCase_ == 1) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
@@ -2843,16 +2843,16 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata null = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> 
-          getNullMetadataFieldBuilder() {
-        if (nullMetadataBuilder_ == null) {
+          getNullFieldBuilder() {
+        if (nullBuilder_ == null) {
           if (!(cleanupMetadataCase_ == 1)) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
           }
-          nullMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          nullBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder>(
                   (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_,
                   getParentForChildren(),
@@ -2860,68 +2860,68 @@ public final class SchemaMetadataPersistence {
           cleanupMetadata_ = null;
         }
         cleanupMetadataCase_ = 1;
-        return nullMetadataBuilder_;
+        return nullBuilder_;
       }
 
       private com.google.protobuf.SingleFieldBuilder<
-          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> streamStoreMetadataBuilder_;
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> streamStoreBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
-      public boolean hasStreamStoreMetadata() {
+      public boolean hasStreamStore() {
         return cleanupMetadataCase_ == 2;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreMetadata() {
-        if (streamStoreMetadataBuilder_ == null) {
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStore() {
+        if (streamStoreBuilder_ == null) {
           if (cleanupMetadataCase_ == 2) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
         } else {
           if (cleanupMetadataCase_ == 2) {
-            return streamStoreMetadataBuilder_.getMessage();
+            return streamStoreBuilder_.getMessage();
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
-      public Builder setStreamStoreMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
-        if (streamStoreMetadataBuilder_ == null) {
+      public Builder setStreamStore(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
+        if (streamStoreBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
           cleanupMetadata_ = value;
           onChanged();
         } else {
-          streamStoreMetadataBuilder_.setMessage(value);
+          streamStoreBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 2;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
-      public Builder setStreamStoreMetadata(
+      public Builder setStreamStore(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder builderForValue) {
-        if (streamStoreMetadataBuilder_ == null) {
+        if (streamStoreBuilder_ == null) {
           cleanupMetadata_ = builderForValue.build();
           onChanged();
         } else {
-          streamStoreMetadataBuilder_.setMessage(builderForValue.build());
+          streamStoreBuilder_.setMessage(builderForValue.build());
         }
         cleanupMetadataCase_ = 2;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
-      public Builder mergeStreamStoreMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
-        if (streamStoreMetadataBuilder_ == null) {
+      public Builder mergeStreamStore(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
+        if (streamStoreBuilder_ == null) {
           if (cleanupMetadataCase_ == 2 &&
               cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance()) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_)
@@ -2932,18 +2932,18 @@ public final class SchemaMetadataPersistence {
           onChanged();
         } else {
           if (cleanupMetadataCase_ == 2) {
-            streamStoreMetadataBuilder_.mergeFrom(value);
+            streamStoreBuilder_.mergeFrom(value);
           }
-          streamStoreMetadataBuilder_.setMessage(value);
+          streamStoreBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 2;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
-      public Builder clearStreamStoreMetadata() {
-        if (streamStoreMetadataBuilder_ == null) {
+      public Builder clearStreamStore() {
+        if (streamStoreBuilder_ == null) {
           if (cleanupMetadataCase_ == 2) {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
@@ -2954,22 +2954,22 @@ public final class SchemaMetadataPersistence {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
           }
-          streamStoreMetadataBuilder_.clear();
+          streamStoreBuilder_.clear();
         }
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder getStreamStoreMetadataBuilder() {
-        return getStreamStoreMetadataFieldBuilder().getBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder getStreamStoreBuilder() {
+        return getStreamStoreFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreMetadataOrBuilder() {
-        if ((cleanupMetadataCase_ == 2) && (streamStoreMetadataBuilder_ != null)) {
-          return streamStoreMetadataBuilder_.getMessageOrBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreOrBuilder() {
+        if ((cleanupMetadataCase_ == 2) && (streamStoreBuilder_ != null)) {
+          return streamStoreBuilder_.getMessageOrBuilder();
         } else {
           if (cleanupMetadataCase_ == 2) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
@@ -2978,16 +2978,16 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStore = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> 
-          getStreamStoreMetadataFieldBuilder() {
-        if (streamStoreMetadataBuilder_ == null) {
+          getStreamStoreFieldBuilder() {
+        if (streamStoreBuilder_ == null) {
           if (!(cleanupMetadataCase_ == 2)) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
           }
-          streamStoreMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          streamStoreBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder>(
                   (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_,
                   getParentForChildren(),
@@ -2995,68 +2995,68 @@ public final class SchemaMetadataPersistence {
           cleanupMetadata_ = null;
         }
         cleanupMetadataCase_ = 2;
-        return streamStoreMetadataBuilder_;
+        return streamStoreBuilder_;
       }
 
       private com.google.protobuf.SingleFieldBuilder<
-          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> arbitraryMetadataBuilder_;
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> arbitraryBuilder_;
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
-      public boolean hasArbitraryMetadata() {
+      public boolean hasArbitrary() {
         return cleanupMetadataCase_ == 3;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryMetadata() {
-        if (arbitraryMetadataBuilder_ == null) {
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitrary() {
+        if (arbitraryBuilder_ == null) {
           if (cleanupMetadataCase_ == 3) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
         } else {
           if (cleanupMetadataCase_ == 3) {
-            return arbitraryMetadataBuilder_.getMessage();
+            return arbitraryBuilder_.getMessage();
           }
           return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
-      public Builder setArbitraryMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
-        if (arbitraryMetadataBuilder_ == null) {
+      public Builder setArbitrary(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
+        if (arbitraryBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
           cleanupMetadata_ = value;
           onChanged();
         } else {
-          arbitraryMetadataBuilder_.setMessage(value);
+          arbitraryBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 3;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
-      public Builder setArbitraryMetadata(
+      public Builder setArbitrary(
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder builderForValue) {
-        if (arbitraryMetadataBuilder_ == null) {
+        if (arbitraryBuilder_ == null) {
           cleanupMetadata_ = builderForValue.build();
           onChanged();
         } else {
-          arbitraryMetadataBuilder_.setMessage(builderForValue.build());
+          arbitraryBuilder_.setMessage(builderForValue.build());
         }
         cleanupMetadataCase_ = 3;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
-      public Builder mergeArbitraryMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
-        if (arbitraryMetadataBuilder_ == null) {
+      public Builder mergeArbitrary(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
+        if (arbitraryBuilder_ == null) {
           if (cleanupMetadataCase_ == 3 &&
               cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance()) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_)
@@ -3067,18 +3067,18 @@ public final class SchemaMetadataPersistence {
           onChanged();
         } else {
           if (cleanupMetadataCase_ == 3) {
-            arbitraryMetadataBuilder_.mergeFrom(value);
+            arbitraryBuilder_.mergeFrom(value);
           }
-          arbitraryMetadataBuilder_.setMessage(value);
+          arbitraryBuilder_.setMessage(value);
         }
         cleanupMetadataCase_ = 3;
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
-      public Builder clearArbitraryMetadata() {
-        if (arbitraryMetadataBuilder_ == null) {
+      public Builder clearArbitrary() {
+        if (arbitraryBuilder_ == null) {
           if (cleanupMetadataCase_ == 3) {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
@@ -3089,22 +3089,22 @@ public final class SchemaMetadataPersistence {
             cleanupMetadataCase_ = 0;
             cleanupMetadata_ = null;
           }
-          arbitraryMetadataBuilder_.clear();
+          arbitraryBuilder_.clear();
         }
         return this;
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder getArbitraryMetadataBuilder() {
-        return getArbitraryMetadataFieldBuilder().getBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder getArbitraryBuilder() {
+        return getArbitraryFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryMetadataOrBuilder() {
-        if ((cleanupMetadataCase_ == 3) && (arbitraryMetadataBuilder_ != null)) {
-          return arbitraryMetadataBuilder_.getMessageOrBuilder();
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryOrBuilder() {
+        if ((cleanupMetadataCase_ == 3) && (arbitraryBuilder_ != null)) {
+          return arbitraryBuilder_.getMessageOrBuilder();
         } else {
           if (cleanupMetadataCase_ == 3) {
             return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
@@ -3113,16 +3113,16 @@ public final class SchemaMetadataPersistence {
         }
       }
       /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitrary = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> 
-          getArbitraryMetadataFieldBuilder() {
-        if (arbitraryMetadataBuilder_ == null) {
+          getArbitraryFieldBuilder() {
+        if (arbitraryBuilder_ == null) {
           if (!(cleanupMetadataCase_ == 3)) {
             cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
           }
-          arbitraryMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          arbitraryBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder>(
                   (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_,
                   getParentForChildren(),
@@ -3130,7 +3130,7 @@ public final class SchemaMetadataPersistence {
           cleanupMetadata_ = null;
         }
         cleanupMetadataCase_ = 3;
-        return arbitraryMetadataBuilder_;
+        return arbitraryBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
@@ -4924,23 +4924,22 @@ public final class SchemaMetadataPersistence {
       "tadata\030\002 \001(\0132C.com.palantir.atlasdb.prot" +
       "os.generated.SchemaDependentTableMetadat" +
       "a\"6\n\016TableReference\022\021\n\tnamespace\030\001 \001(\t\022\021" +
-      "\n\ttableName\030\002 \001(\t\"\305\002\n\034SchemaDependentTab" +
-      "leMetadata\022R\n\014nullMetadata\030\001 \001(\0132:.com.p" +
-      "alantir.atlasdb.protos.generated.NullCle" +
-      "anupMetadataH\000\022`\n\023streamStoreMetadata\030\002 " +
-      "\001(\0132A.com.palantir.atlasdb.protos.genera" +
-      "ted.StreamStoreCleanupMetadataH\000\022\\\n\021arbi",
-      "traryMetadata\030\003 \001(\0132?.com.palantir.atlas" +
-      "db.protos.generated.ArbitraryCleanupMeta" +
-      "dataH\000B\021\n\017cleanupMetadata\"\025\n\023NullCleanup" +
-      "Metadata\"u\n\032StreamStoreCleanupMetadata\022W" +
-      "\n\nv1Metadata\030\001 \001(\0132C.com.palantir.atlasd" +
-      "b.protos.generated.StreamStoreCleanupV1M" +
-      "etadata\"\211\001\n\034StreamStoreCleanupV1Metadata" +
-      "\022!\n\026numHashedRowComponents\030\001 \001(\005:\0010\022F\n\014s" +
-      "treamIdType\030\002 \001(\01620.com.palantir.atlasdb" +
-      ".protos.generated.ValueType\"\032\n\030Arbitrary",
-      "CleanupMetadata"
+      "\n\ttableName\030\002 \001(\t\"\255\002\n\034SchemaDependentTab" +
+      "leMetadata\022J\n\004null\030\001 \001(\0132:.com.palantir." +
+      "atlasdb.protos.generated.NullCleanupMeta" +
+      "dataH\000\022X\n\013streamStore\030\002 \001(\0132A.com.palant" +
+      "ir.atlasdb.protos.generated.StreamStoreC" +
+      "leanupMetadataH\000\022T\n\tarbitrary\030\003 \001(\0132?.co",
+      "m.palantir.atlasdb.protos.generated.Arbi" +
+      "traryCleanupMetadataH\000B\021\n\017cleanupMetadat" +
+      "a\"\025\n\023NullCleanupMetadata\"u\n\032StreamStoreC" +
+      "leanupMetadata\022W\n\nv1Metadata\030\001 \001(\0132C.com" +
+      ".palantir.atlasdb.protos.generated.Strea" +
+      "mStoreCleanupV1Metadata\"\211\001\n\034StreamStoreC" +
+      "leanupV1Metadata\022!\n\026numHashedRowComponen" +
+      "ts\030\001 \001(\005:\0010\022F\n\014streamIdType\030\002 \001(\01620.com." +
+      "palantir.atlasdb.protos.generated.ValueT" +
+      "ype\"\032\n\030ArbitraryCleanupMetadata"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4978,7 +4977,7 @@ public final class SchemaMetadataPersistence {
     internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor,
-        new java.lang.String[] { "NullMetadata", "StreamStoreMetadata", "ArbitraryMetadata", "CleanupMetadata", });
+        new java.lang.String[] { "Null", "StreamStore", "Arbitrary", "CleanupMetadata", });
     internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_fieldAccessorTable = new

--- a/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
+++ b/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
@@ -4068,6 +4068,15 @@ public final class SchemaMetadataPersistence {
      * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
      */
     int getNumHashedRowComponents();
+
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ValueType streamIdType = 2;</code>
+     */
+    boolean hasStreamIdType();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ValueType streamIdType = 2;</code>
+     */
+    com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType getStreamIdType();
   }
   /**
    * Protobuf type {@code com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata}
@@ -4126,6 +4135,17 @@ public final class SchemaMetadataPersistence {
               numHashedRowComponents_ = input.readInt32();
               break;
             }
+            case 16: {
+              int rawValue = input.readEnum();
+              com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType value = com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(2, rawValue);
+              } else {
+                bitField0_ |= 0x00000002;
+                streamIdType_ = value;
+              }
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -4181,8 +4201,24 @@ public final class SchemaMetadataPersistence {
       return numHashedRowComponents_;
     }
 
+    public static final int STREAMIDTYPE_FIELD_NUMBER = 2;
+    private com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType streamIdType_;
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ValueType streamIdType = 2;</code>
+     */
+    public boolean hasStreamIdType() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ValueType streamIdType = 2;</code>
+     */
+    public com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType getStreamIdType() {
+      return streamIdType_;
+    }
+
     private void initFields() {
       numHashedRowComponents_ = 0;
+      streamIdType_ = com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType.VAR_LONG;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4200,6 +4236,9 @@ public final class SchemaMetadataPersistence {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         output.writeInt32(1, numHashedRowComponents_);
       }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeEnum(2, streamIdType_.getNumber());
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -4212,6 +4251,10 @@ public final class SchemaMetadataPersistence {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(1, numHashedRowComponents_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(2, streamIdType_.getNumber());
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -4332,6 +4375,8 @@ public final class SchemaMetadataPersistence {
         super.clear();
         numHashedRowComponents_ = 0;
         bitField0_ = (bitField0_ & ~0x00000001);
+        streamIdType_ = com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType.VAR_LONG;
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -4364,6 +4409,10 @@ public final class SchemaMetadataPersistence {
           to_bitField0_ |= 0x00000001;
         }
         result.numHashedRowComponents_ = numHashedRowComponents_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.streamIdType_ = streamIdType_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4382,6 +4431,9 @@ public final class SchemaMetadataPersistence {
         if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.getDefaultInstance()) return this;
         if (other.hasNumHashedRowComponents()) {
           setNumHashedRowComponents(other.getNumHashedRowComponents());
+        }
+        if (other.hasStreamIdType()) {
+          setStreamIdType(other.getStreamIdType());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4438,6 +4490,41 @@ public final class SchemaMetadataPersistence {
       public Builder clearNumHashedRowComponents() {
         bitField0_ = (bitField0_ & ~0x00000001);
         numHashedRowComponents_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType streamIdType_ = com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType.VAR_LONG;
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ValueType streamIdType = 2;</code>
+       */
+      public boolean hasStreamIdType() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ValueType streamIdType = 2;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType getStreamIdType() {
+        return streamIdType_;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ValueType streamIdType = 2;</code>
+       */
+      public Builder setStreamIdType(com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000002;
+        streamIdType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ValueType streamIdType = 2;</code>
+       */
+      public Builder clearStreamIdType() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        streamIdType_ = com.palantir.atlasdb.protos.generated.TableMetadataPersistence.ValueType.VAR_LONG;
         onChanged();
         return this;
       }
@@ -4824,31 +4911,34 @@ public final class SchemaMetadataPersistence {
   static {
     java.lang.String[] descriptorData = {
       "\n\037SchemaMetadataPersistence.proto\022%com.p" +
-      "alantir.atlasdb.protos.generated\"q\n\016Sche" +
-      "maMetadata\022_\n\rtableMetadata\030\001 \003(\0132H.com." +
-      "palantir.atlasdb.protos.generated.Schema" +
-      "DependentTableMetadataEntry\"\335\001\n!SchemaDe" +
-      "pendentTableMetadataEntry\022M\n\016tableRefere" +
-      "nce\030\001 \001(\01325.com.palantir.atlasdb.protos." +
-      "generated.TableReference\022i\n\034schemaDepend" +
-      "entTableMetadata\030\002 \001(\0132C.com.palantir.at" +
-      "lasdb.protos.generated.SchemaDependentTa",
-      "bleMetadata\"6\n\016TableReference\022\021\n\tnamespa" +
-      "ce\030\001 \001(\t\022\021\n\ttableName\030\002 \001(\t\"\305\002\n\034SchemaDe" +
-      "pendentTableMetadata\022R\n\014nullMetadata\030\001 \001" +
-      "(\0132:.com.palantir.atlasdb.protos.generat" +
-      "ed.NullCleanupMetadataH\000\022`\n\023streamStoreM" +
-      "etadata\030\002 \001(\0132A.com.palantir.atlasdb.pro" +
-      "tos.generated.StreamStoreCleanupMetadata" +
-      "H\000\022\\\n\021arbitraryMetadata\030\003 \001(\0132?.com.pala" +
-      "ntir.atlasdb.protos.generated.ArbitraryC" +
-      "leanupMetadataH\000B\021\n\017cleanupMetadata\"\025\n\023N",
-      "ullCleanupMetadata\"u\n\032StreamStoreCleanup" +
-      "Metadata\022W\n\nv1Metadata\030\001 \001(\0132C.com.palan" +
-      "tir.atlasdb.protos.generated.StreamStore" +
-      "CleanupV1Metadata\"A\n\034StreamStoreCleanupV" +
-      "1Metadata\022!\n\026numHashedRowComponents\030\001 \001(" +
-      "\005:\0010\"\032\n\030ArbitraryCleanupMetadata"
+      "alantir.atlasdb.protos.generated\032\036TableM" +
+      "etadataPersistence.proto\"q\n\016SchemaMetada" +
+      "ta\022_\n\rtableMetadata\030\001 \003(\0132H.com.palantir" +
+      ".atlasdb.protos.generated.SchemaDependen" +
+      "tTableMetadataEntry\"\335\001\n!SchemaDependentT" +
+      "ableMetadataEntry\022M\n\016tableReference\030\001 \001(" +
+      "\01325.com.palantir.atlasdb.protos.generate" +
+      "d.TableReference\022i\n\034schemaDependentTable" +
+      "Metadata\030\002 \001(\0132C.com.palantir.atlasdb.pr",
+      "otos.generated.SchemaDependentTableMetad" +
+      "ata\"6\n\016TableReference\022\021\n\tnamespace\030\001 \001(\t" +
+      "\022\021\n\ttableName\030\002 \001(\t\"\305\002\n\034SchemaDependentT" +
+      "ableMetadata\022R\n\014nullMetadata\030\001 \001(\0132:.com" +
+      ".palantir.atlasdb.protos.generated.NullC" +
+      "leanupMetadataH\000\022`\n\023streamStoreMetadata\030" +
+      "\002 \001(\0132A.com.palantir.atlasdb.protos.gene" +
+      "rated.StreamStoreCleanupMetadataH\000\022\\\n\021ar" +
+      "bitraryMetadata\030\003 \001(\0132?.com.palantir.atl" +
+      "asdb.protos.generated.ArbitraryCleanupMe",
+      "tadataH\000B\021\n\017cleanupMetadata\"\025\n\023NullClean" +
+      "upMetadata\"u\n\032StreamStoreCleanupMetadata" +
+      "\022W\n\nv1Metadata\030\001 \001(\0132C.com.palantir.atla" +
+      "sdb.protos.generated.StreamStoreCleanupV" +
+      "1Metadata\"\211\001\n\034StreamStoreCleanupV1Metada" +
+      "ta\022!\n\026numHashedRowComponents\030\001 \001(\005:\0010\022F\n" +
+      "\014streamIdType\030\002 \001(\01620.com.palantir.atlas" +
+      "db.protos.generated.ValueType\"\032\n\030Arbitra" +
+      "ryCleanupMetadata"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4861,6 +4951,7 @@ public final class SchemaMetadataPersistence {
     com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
+          com.palantir.atlasdb.protos.generated.TableMetadataPersistence.getDescriptor(),
         }, assigner);
     internal_static_com_palantir_atlasdb_protos_generated_SchemaMetadata_descriptor =
       getDescriptor().getMessageTypes().get(0);
@@ -4903,13 +4994,14 @@ public final class SchemaMetadataPersistence {
     internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_descriptor,
-        new java.lang.String[] { "NumHashedRowComponents", });
+        new java.lang.String[] { "NumHashedRowComponents", "StreamIdType", });
     internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_descriptor,
         new java.lang.String[] { });
+    com.palantir.atlasdb.protos.generated.TableMetadataPersistence.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
+++ b/atlasdb-client-protobufs/src/main/java/com/palantir/atlasdb/protos/generated/SchemaMetadataPersistence.java
@@ -8,108 +8,6 @@ public final class SchemaMetadataPersistence {
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
   }
-  /**
-   * Protobuf enum {@code com.palantir.atlasdb.protos.generated.CleanupRequirement}
-   */
-  public enum CleanupRequirement
-      implements com.google.protobuf.ProtocolMessageEnum {
-    /**
-     * <code>NOT_NEEDED = 0;</code>
-     *
-     * <pre>
-     * Used for tables without cleanup tasks.
-     * </pre>
-     */
-    NOT_NEEDED(0, 0),
-    /**
-     * <code>ARBITRARY_ASYNC = 64;</code>
-     *
-     * <pre>
-     * Used for tables (possibly inclusive of stream-store meta-tables) that have user-defined cleanup tasks
-     * which can safely be processed asynchronously (e.g. via a queue).
-     * Examples include cascading deletes and reads from append-only Atlas tables.
-     * </pre>
-     */
-    ARBITRARY_ASYNC(1, 64),
-    ;
-
-    /**
-     * <code>NOT_NEEDED = 0;</code>
-     *
-     * <pre>
-     * Used for tables without cleanup tasks.
-     * </pre>
-     */
-    public static final int NOT_NEEDED_VALUE = 0;
-    /**
-     * <code>ARBITRARY_ASYNC = 64;</code>
-     *
-     * <pre>
-     * Used for tables (possibly inclusive of stream-store meta-tables) that have user-defined cleanup tasks
-     * which can safely be processed asynchronously (e.g. via a queue).
-     * Examples include cascading deletes and reads from append-only Atlas tables.
-     * </pre>
-     */
-    public static final int ARBITRARY_ASYNC_VALUE = 64;
-
-
-    public final int getNumber() { return value; }
-
-    public static CleanupRequirement valueOf(int value) {
-      switch (value) {
-        case 0: return NOT_NEEDED;
-        case 64: return ARBITRARY_ASYNC;
-        default: return null;
-      }
-    }
-
-    public static com.google.protobuf.Internal.EnumLiteMap<CleanupRequirement>
-        internalGetValueMap() {
-      return internalValueMap;
-    }
-    private static com.google.protobuf.Internal.EnumLiteMap<CleanupRequirement>
-        internalValueMap =
-          new com.google.protobuf.Internal.EnumLiteMap<CleanupRequirement>() {
-            public CleanupRequirement findValueByNumber(int number) {
-              return CleanupRequirement.valueOf(number);
-            }
-          };
-
-    public final com.google.protobuf.Descriptors.EnumValueDescriptor
-        getValueDescriptor() {
-      return getDescriptor().getValues().get(index);
-    }
-    public final com.google.protobuf.Descriptors.EnumDescriptor
-        getDescriptorForType() {
-      return getDescriptor();
-    }
-    public static final com.google.protobuf.Descriptors.EnumDescriptor
-        getDescriptor() {
-      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.getDescriptor().getEnumTypes().get(0);
-    }
-
-    private static final CleanupRequirement[] VALUES = values();
-
-    public static CleanupRequirement valueOf(
-        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-      if (desc.getType() != getDescriptor()) {
-        throw new java.lang.IllegalArgumentException(
-          "EnumValueDescriptor is not for this type.");
-      }
-      return VALUES[desc.getIndex()];
-    }
-
-    private final int index;
-    private final int value;
-
-    private CleanupRequirement(int index, int value) {
-      this.index = index;
-      this.value = value;
-    }
-
-    // @@protoc_insertion_point(enum_scope:com.palantir.atlasdb.protos.generated.CleanupRequirement)
-  }
-
   public interface SchemaMetadataOrBuilder extends
       // @@protoc_insertion_point(interface_extends:com.palantir.atlasdb.protos.generated.SchemaMetadata)
       com.google.protobuf.MessageOrBuilder {
@@ -1623,412 +1521,6 @@ public final class SchemaMetadataPersistence {
     // @@protoc_insertion_point(class_scope:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadataEntry)
   }
 
-  public interface SchemaDependentTableMetadataOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
-      com.google.protobuf.MessageOrBuilder {
-
-    /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.CleanupRequirement cleanupRequirement = 1;</code>
-     */
-    boolean hasCleanupRequirement();
-    /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.CleanupRequirement cleanupRequirement = 1;</code>
-     */
-    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement getCleanupRequirement();
-  }
-  /**
-   * Protobuf type {@code com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata}
-   */
-  public static final class SchemaDependentTableMetadata extends
-      com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
-      SchemaDependentTableMetadataOrBuilder {
-    // Use SchemaDependentTableMetadata.newBuilder() to construct.
-    private SchemaDependentTableMetadata(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
-      super(builder);
-      this.unknownFields = builder.getUnknownFields();
-    }
-    private SchemaDependentTableMetadata(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
-
-    private static final SchemaDependentTableMetadata defaultInstance;
-    public static SchemaDependentTableMetadata getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public SchemaDependentTableMetadata getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final com.google.protobuf.UnknownFieldSet unknownFields;
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-        getUnknownFields() {
-      return this.unknownFields;
-    }
-    private SchemaDependentTableMetadata(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      initFields();
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownField(input, unknownFields,
-                                     extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-            case 8: {
-              int rawValue = input.readEnum();
-              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement value = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement.valueOf(rawValue);
-              if (value == null) {
-                unknownFields.mergeVarintField(1, rawValue);
-              } else {
-                bitField0_ |= 0x00000001;
-                cleanupRequirement_ = value;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e.getMessage()).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor;
-    }
-
-    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.Builder.class);
-    }
-
-    public static com.google.protobuf.Parser<SchemaDependentTableMetadata> PARSER =
-        new com.google.protobuf.AbstractParser<SchemaDependentTableMetadata>() {
-      public SchemaDependentTableMetadata parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SchemaDependentTableMetadata(input, extensionRegistry);
-      }
-    };
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<SchemaDependentTableMetadata> getParserForType() {
-      return PARSER;
-    }
-
-    private int bitField0_;
-    public static final int CLEANUPREQUIREMENT_FIELD_NUMBER = 1;
-    private com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement cleanupRequirement_;
-    /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.CleanupRequirement cleanupRequirement = 1;</code>
-     */
-    public boolean hasCleanupRequirement() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
-    }
-    /**
-     * <code>optional .com.palantir.atlasdb.protos.generated.CleanupRequirement cleanupRequirement = 1;</code>
-     */
-    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement getCleanupRequirement() {
-      return cleanupRequirement_;
-    }
-
-    private void initFields() {
-      cleanupRequirement_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement.NOT_NEEDED;
-    }
-    private byte memoizedIsInitialized = -1;
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeEnum(1, cleanupRequirement_.getNumber());
-      }
-      getUnknownFields().writeTo(output);
-    }
-
-    private int memoizedSerializedSize = -1;
-    public int getSerializedSize() {
-      int size = memoizedSerializedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, cleanupRequirement_.getNumber());
-      }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
-      return size;
-    }
-
-    private static final long serialVersionUID = 0L;
-    @java.lang.Override
-    protected java.lang.Object writeReplace()
-        throws java.io.ObjectStreamException {
-      return super.writeReplace();
-    }
-
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static Builder newBuilder() { return Builder.create(); }
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-    public Builder toBuilder() { return newBuilder(this); }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * Protobuf type {@code com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata}
-     */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
-        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadataOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor;
-      }
-
-      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.Builder.class);
-      }
-
-      // Construct using com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-        }
-      }
-      private static Builder create() {
-        return new Builder();
-      }
-
-      public Builder clear() {
-        super.clear();
-        cleanupRequirement_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement.NOT_NEEDED;
-        bitField0_ = (bitField0_ & ~0x00000001);
-        return this;
-      }
-
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor;
-      }
-
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata getDefaultInstanceForType() {
-        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.getDefaultInstance();
-      }
-
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata build() {
-        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata buildPartial() {
-        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata result = new com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.cleanupRequirement_ = cleanupRequirement_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata) {
-          return mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata other) {
-        if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.getDefaultInstance()) return this;
-        if (other.hasCleanupRequirement()) {
-          setCleanupRequirement(other.getCleanupRequirement());
-        }
-        this.mergeUnknownFields(other.getUnknownFields());
-        return this;
-      }
-
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata) e.getUnfinishedMessage();
-          throw e;
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement cleanupRequirement_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement.NOT_NEEDED;
-      /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.CleanupRequirement cleanupRequirement = 1;</code>
-       */
-      public boolean hasCleanupRequirement() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
-      }
-      /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.CleanupRequirement cleanupRequirement = 1;</code>
-       */
-      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement getCleanupRequirement() {
-        return cleanupRequirement_;
-      }
-      /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.CleanupRequirement cleanupRequirement = 1;</code>
-       */
-      public Builder setCleanupRequirement(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        bitField0_ |= 0x00000001;
-        cleanupRequirement_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional .com.palantir.atlasdb.protos.generated.CleanupRequirement cleanupRequirement = 1;</code>
-       */
-      public Builder clearCleanupRequirement() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        cleanupRequirement_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement.NOT_NEEDED;
-        onChanged();
-        return this;
-      }
-
-      // @@protoc_insertion_point(builder_scope:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
-    }
-
-    static {
-      defaultInstance = new SchemaDependentTableMetadata(true);
-      defaultInstance.initFields();
-    }
-
-    // @@protoc_insertion_point(class_scope:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
-  }
-
   public interface TableReferenceOrBuilder extends
       // @@protoc_insertion_point(interface_extends:com.palantir.atlasdb.protos.generated.TableReference)
       com.google.protobuf.MessageOrBuilder {
@@ -2662,6 +2154,2626 @@ public final class SchemaMetadataPersistence {
     // @@protoc_insertion_point(class_scope:com.palantir.atlasdb.protos.generated.TableReference)
   }
 
+  public interface SchemaDependentTableMetadataOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     */
+    boolean hasNullMetadata();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     */
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullMetadata();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     */
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullMetadataOrBuilder();
+
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     */
+    boolean hasStreamStoreMetadata();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     */
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreMetadata();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     */
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreMetadataOrBuilder();
+
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     */
+    boolean hasArbitraryMetadata();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     */
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryMetadata();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     */
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryMetadataOrBuilder();
+  }
+  /**
+   * Protobuf type {@code com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata}
+   */
+  public static final class SchemaDependentTableMetadata extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
+      SchemaDependentTableMetadataOrBuilder {
+    // Use SchemaDependentTableMetadata.newBuilder() to construct.
+    private SchemaDependentTableMetadata(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private SchemaDependentTableMetadata(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final SchemaDependentTableMetadata defaultInstance;
+    public static SchemaDependentTableMetadata getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public SchemaDependentTableMetadata getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private SchemaDependentTableMetadata(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder subBuilder = null;
+              if (cleanupMetadataCase_ == 1) {
+                subBuilder = ((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_).toBuilder();
+              }
+              cleanupMetadata_ = input.readMessage(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_);
+                cleanupMetadata_ = subBuilder.buildPartial();
+              }
+              cleanupMetadataCase_ = 1;
+              break;
+            }
+            case 18: {
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder subBuilder = null;
+              if (cleanupMetadataCase_ == 2) {
+                subBuilder = ((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_).toBuilder();
+              }
+              cleanupMetadata_ = input.readMessage(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_);
+                cleanupMetadata_ = subBuilder.buildPartial();
+              }
+              cleanupMetadataCase_ = 2;
+              break;
+            }
+            case 26: {
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder subBuilder = null;
+              if (cleanupMetadataCase_ == 3) {
+                subBuilder = ((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_).toBuilder();
+              }
+              cleanupMetadata_ = input.readMessage(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_);
+                cleanupMetadata_ = subBuilder.buildPartial();
+              }
+              cleanupMetadataCase_ = 3;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<SchemaDependentTableMetadata> PARSER =
+        new com.google.protobuf.AbstractParser<SchemaDependentTableMetadata>() {
+      public SchemaDependentTableMetadata parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new SchemaDependentTableMetadata(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SchemaDependentTableMetadata> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    private int cleanupMetadataCase_ = 0;
+    private java.lang.Object cleanupMetadata_;
+    public enum CleanupMetadataCase
+        implements com.google.protobuf.Internal.EnumLite {
+      NULLMETADATA(1),
+      STREAMSTOREMETADATA(2),
+      ARBITRARYMETADATA(3),
+      CLEANUPMETADATA_NOT_SET(0);
+      private int value = 0;
+      private CleanupMetadataCase(int value) {
+        this.value = value;
+      }
+      public static CleanupMetadataCase valueOf(int value) {
+        switch (value) {
+          case 1: return NULLMETADATA;
+          case 2: return STREAMSTOREMETADATA;
+          case 3: return ARBITRARYMETADATA;
+          case 0: return CLEANUPMETADATA_NOT_SET;
+          default: throw new java.lang.IllegalArgumentException(
+            "Value is undefined for this oneof enum.");
+        }
+      }
+      public int getNumber() {
+        return this.value;
+      }
+    };
+
+    public CleanupMetadataCase
+    getCleanupMetadataCase() {
+      return CleanupMetadataCase.valueOf(
+          cleanupMetadataCase_);
+    }
+
+    public static final int NULLMETADATA_FIELD_NUMBER = 1;
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     */
+    public boolean hasNullMetadata() {
+      return cleanupMetadataCase_ == 1;
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     */
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullMetadata() {
+      if (cleanupMetadataCase_ == 1) {
+         return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
+      }
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+     */
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullMetadataOrBuilder() {
+      if (cleanupMetadataCase_ == 1) {
+         return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
+      }
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
+    }
+
+    public static final int STREAMSTOREMETADATA_FIELD_NUMBER = 2;
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     */
+    public boolean hasStreamStoreMetadata() {
+      return cleanupMetadataCase_ == 2;
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     */
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreMetadata() {
+      if (cleanupMetadataCase_ == 2) {
+         return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
+      }
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+     */
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreMetadataOrBuilder() {
+      if (cleanupMetadataCase_ == 2) {
+         return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
+      }
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
+    }
+
+    public static final int ARBITRARYMETADATA_FIELD_NUMBER = 3;
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     */
+    public boolean hasArbitraryMetadata() {
+      return cleanupMetadataCase_ == 3;
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     */
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryMetadata() {
+      if (cleanupMetadataCase_ == 3) {
+         return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
+      }
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+     */
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryMetadataOrBuilder() {
+      if (cleanupMetadataCase_ == 3) {
+         return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
+      }
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
+    }
+
+    private void initFields() {
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (cleanupMetadataCase_ == 1) {
+        output.writeMessage(1, (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_);
+      }
+      if (cleanupMetadataCase_ == 2) {
+        output.writeMessage(2, (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_);
+      }
+      if (cleanupMetadataCase_ == 3) {
+        output.writeMessage(3, (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (cleanupMetadataCase_ == 1) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_);
+      }
+      if (cleanupMetadataCase_ == 2) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_);
+      }
+      if (cleanupMetadataCase_ == 3) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadataOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.Builder.class);
+      }
+
+      // Construct using com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        cleanupMetadataCase_ = 0;
+        cleanupMetadata_ = null;
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata getDefaultInstanceForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.getDefaultInstance();
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata build() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata buildPartial() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata result = new com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (cleanupMetadataCase_ == 1) {
+          if (nullMetadataBuilder_ == null) {
+            result.cleanupMetadata_ = cleanupMetadata_;
+          } else {
+            result.cleanupMetadata_ = nullMetadataBuilder_.build();
+          }
+        }
+        if (cleanupMetadataCase_ == 2) {
+          if (streamStoreMetadataBuilder_ == null) {
+            result.cleanupMetadata_ = cleanupMetadata_;
+          } else {
+            result.cleanupMetadata_ = streamStoreMetadataBuilder_.build();
+          }
+        }
+        if (cleanupMetadataCase_ == 3) {
+          if (arbitraryMetadataBuilder_ == null) {
+            result.cleanupMetadata_ = cleanupMetadata_;
+          } else {
+            result.cleanupMetadata_ = arbitraryMetadataBuilder_.build();
+          }
+        }
+        result.bitField0_ = to_bitField0_;
+        result.cleanupMetadataCase_ = cleanupMetadataCase_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata) {
+          return mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata other) {
+        if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata.getDefaultInstance()) return this;
+        switch (other.getCleanupMetadataCase()) {
+          case NULLMETADATA: {
+            mergeNullMetadata(other.getNullMetadata());
+            break;
+          }
+          case STREAMSTOREMETADATA: {
+            mergeStreamStoreMetadata(other.getStreamStoreMetadata());
+            break;
+          }
+          case ARBITRARYMETADATA: {
+            mergeArbitraryMetadata(other.getArbitraryMetadata());
+            break;
+          }
+          case CLEANUPMETADATA_NOT_SET: {
+            break;
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.SchemaDependentTableMetadata) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int cleanupMetadataCase_ = 0;
+      private java.lang.Object cleanupMetadata_;
+      public CleanupMetadataCase
+          getCleanupMetadataCase() {
+        return CleanupMetadataCase.valueOf(
+            cleanupMetadataCase_);
+      }
+
+      public Builder clearCleanupMetadata() {
+        cleanupMetadataCase_ = 0;
+        cleanupMetadata_ = null;
+        onChanged();
+        return this;
+      }
+
+      private int bitField0_;
+
+      private com.google.protobuf.SingleFieldBuilder<
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> nullMetadataBuilder_;
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      public boolean hasNullMetadata() {
+        return cleanupMetadataCase_ == 1;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getNullMetadata() {
+        if (nullMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 1) {
+            return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
+        } else {
+          if (cleanupMetadataCase_ == 1) {
+            return nullMetadataBuilder_.getMessage();
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      public Builder setNullMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
+        if (nullMetadataBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          cleanupMetadata_ = value;
+          onChanged();
+        } else {
+          nullMetadataBuilder_.setMessage(value);
+        }
+        cleanupMetadataCase_ = 1;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      public Builder setNullMetadata(
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder builderForValue) {
+        if (nullMetadataBuilder_ == null) {
+          cleanupMetadata_ = builderForValue.build();
+          onChanged();
+        } else {
+          nullMetadataBuilder_.setMessage(builderForValue.build());
+        }
+        cleanupMetadataCase_ = 1;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      public Builder mergeNullMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata value) {
+        if (nullMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 1 &&
+              cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance()) {
+            cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            cleanupMetadata_ = value;
+          }
+          onChanged();
+        } else {
+          if (cleanupMetadataCase_ == 1) {
+            nullMetadataBuilder_.mergeFrom(value);
+          }
+          nullMetadataBuilder_.setMessage(value);
+        }
+        cleanupMetadataCase_ = 1;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      public Builder clearNullMetadata() {
+        if (nullMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 1) {
+            cleanupMetadataCase_ = 0;
+            cleanupMetadata_ = null;
+            onChanged();
+          }
+        } else {
+          if (cleanupMetadataCase_ == 1) {
+            cleanupMetadataCase_ = 0;
+            cleanupMetadata_ = null;
+          }
+          nullMetadataBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder getNullMetadataBuilder() {
+        return getNullMetadataFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder getNullMetadataOrBuilder() {
+        if ((cleanupMetadataCase_ == 1) && (nullMetadataBuilder_ != null)) {
+          return nullMetadataBuilder_.getMessageOrBuilder();
+        } else {
+          if (cleanupMetadataCase_ == 1) {
+            return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_;
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.NullCleanupMetadata nullMetadata = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder> 
+          getNullMetadataFieldBuilder() {
+        if (nullMetadataBuilder_ == null) {
+          if (!(cleanupMetadataCase_ == 1)) {
+            cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
+          }
+          nullMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder>(
+                  (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) cleanupMetadata_,
+                  getParentForChildren(),
+                  isClean());
+          cleanupMetadata_ = null;
+        }
+        cleanupMetadataCase_ = 1;
+        return nullMetadataBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilder<
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> streamStoreMetadataBuilder_;
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      public boolean hasStreamStoreMetadata() {
+        return cleanupMetadataCase_ == 2;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getStreamStoreMetadata() {
+        if (streamStoreMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 2) {
+            return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
+        } else {
+          if (cleanupMetadataCase_ == 2) {
+            return streamStoreMetadataBuilder_.getMessage();
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      public Builder setStreamStoreMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
+        if (streamStoreMetadataBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          cleanupMetadata_ = value;
+          onChanged();
+        } else {
+          streamStoreMetadataBuilder_.setMessage(value);
+        }
+        cleanupMetadataCase_ = 2;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      public Builder setStreamStoreMetadata(
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder builderForValue) {
+        if (streamStoreMetadataBuilder_ == null) {
+          cleanupMetadata_ = builderForValue.build();
+          onChanged();
+        } else {
+          streamStoreMetadataBuilder_.setMessage(builderForValue.build());
+        }
+        cleanupMetadataCase_ = 2;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      public Builder mergeStreamStoreMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata value) {
+        if (streamStoreMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 2 &&
+              cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance()) {
+            cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            cleanupMetadata_ = value;
+          }
+          onChanged();
+        } else {
+          if (cleanupMetadataCase_ == 2) {
+            streamStoreMetadataBuilder_.mergeFrom(value);
+          }
+          streamStoreMetadataBuilder_.setMessage(value);
+        }
+        cleanupMetadataCase_ = 2;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      public Builder clearStreamStoreMetadata() {
+        if (streamStoreMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 2) {
+            cleanupMetadataCase_ = 0;
+            cleanupMetadata_ = null;
+            onChanged();
+          }
+        } else {
+          if (cleanupMetadataCase_ == 2) {
+            cleanupMetadataCase_ = 0;
+            cleanupMetadata_ = null;
+          }
+          streamStoreMetadataBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder getStreamStoreMetadataBuilder() {
+        return getStreamStoreMetadataFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder getStreamStoreMetadataOrBuilder() {
+        if ((cleanupMetadataCase_ == 2) && (streamStoreMetadataBuilder_ != null)) {
+          return streamStoreMetadataBuilder_.getMessageOrBuilder();
+        } else {
+          if (cleanupMetadataCase_ == 2) {
+            return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_;
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata streamStoreMetadata = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder> 
+          getStreamStoreMetadataFieldBuilder() {
+        if (streamStoreMetadataBuilder_ == null) {
+          if (!(cleanupMetadataCase_ == 2)) {
+            cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
+          }
+          streamStoreMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder>(
+                  (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) cleanupMetadata_,
+                  getParentForChildren(),
+                  isClean());
+          cleanupMetadata_ = null;
+        }
+        cleanupMetadataCase_ = 2;
+        return streamStoreMetadataBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilder<
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> arbitraryMetadataBuilder_;
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      public boolean hasArbitraryMetadata() {
+        return cleanupMetadataCase_ == 3;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getArbitraryMetadata() {
+        if (arbitraryMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 3) {
+            return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
+        } else {
+          if (cleanupMetadataCase_ == 3) {
+            return arbitraryMetadataBuilder_.getMessage();
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      public Builder setArbitraryMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
+        if (arbitraryMetadataBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          cleanupMetadata_ = value;
+          onChanged();
+        } else {
+          arbitraryMetadataBuilder_.setMessage(value);
+        }
+        cleanupMetadataCase_ = 3;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      public Builder setArbitraryMetadata(
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder builderForValue) {
+        if (arbitraryMetadataBuilder_ == null) {
+          cleanupMetadata_ = builderForValue.build();
+          onChanged();
+        } else {
+          arbitraryMetadataBuilder_.setMessage(builderForValue.build());
+        }
+        cleanupMetadataCase_ = 3;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      public Builder mergeArbitraryMetadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata value) {
+        if (arbitraryMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 3 &&
+              cleanupMetadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance()) {
+            cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.newBuilder((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            cleanupMetadata_ = value;
+          }
+          onChanged();
+        } else {
+          if (cleanupMetadataCase_ == 3) {
+            arbitraryMetadataBuilder_.mergeFrom(value);
+          }
+          arbitraryMetadataBuilder_.setMessage(value);
+        }
+        cleanupMetadataCase_ = 3;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      public Builder clearArbitraryMetadata() {
+        if (arbitraryMetadataBuilder_ == null) {
+          if (cleanupMetadataCase_ == 3) {
+            cleanupMetadataCase_ = 0;
+            cleanupMetadata_ = null;
+            onChanged();
+          }
+        } else {
+          if (cleanupMetadataCase_ == 3) {
+            cleanupMetadataCase_ = 0;
+            cleanupMetadata_ = null;
+          }
+          arbitraryMetadataBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder getArbitraryMetadataBuilder() {
+        return getArbitraryMetadataFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder getArbitraryMetadataOrBuilder() {
+        if ((cleanupMetadataCase_ == 3) && (arbitraryMetadataBuilder_ != null)) {
+          return arbitraryMetadataBuilder_.getMessageOrBuilder();
+        } else {
+          if (cleanupMetadataCase_ == 3) {
+            return (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_;
+          }
+          return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata arbitraryMetadata = 3;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder> 
+          getArbitraryMetadataFieldBuilder() {
+        if (arbitraryMetadataBuilder_ == null) {
+          if (!(cleanupMetadataCase_ == 3)) {
+            cleanupMetadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
+          }
+          arbitraryMetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder>(
+                  (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) cleanupMetadata_,
+                  getParentForChildren(),
+                  isClean());
+          cleanupMetadata_ = null;
+        }
+        cleanupMetadataCase_ = 3;
+        return arbitraryMetadataBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
+    }
+
+    static {
+      defaultInstance = new SchemaDependentTableMetadata(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:com.palantir.atlasdb.protos.generated.SchemaDependentTableMetadata)
+  }
+
+  public interface NullCleanupMetadataOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.palantir.atlasdb.protos.generated.NullCleanupMetadata)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code com.palantir.atlasdb.protos.generated.NullCleanupMetadata}
+   *
+   * <pre>
+   * Used for tables without cleanup tasks.
+   * </pre>
+   */
+  public static final class NullCleanupMetadata extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.palantir.atlasdb.protos.generated.NullCleanupMetadata)
+      NullCleanupMetadataOrBuilder {
+    // Use NullCleanupMetadata.newBuilder() to construct.
+    private NullCleanupMetadata(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private NullCleanupMetadata(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final NullCleanupMetadata defaultInstance;
+    public static NullCleanupMetadata getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public NullCleanupMetadata getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private NullCleanupMetadata(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<NullCleanupMetadata> PARSER =
+        new com.google.protobuf.AbstractParser<NullCleanupMetadata>() {
+      public NullCleanupMetadata parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new NullCleanupMetadata(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<NullCleanupMetadata> getParserForType() {
+      return PARSER;
+    }
+
+    private void initFields() {
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code com.palantir.atlasdb.protos.generated.NullCleanupMetadata}
+     *
+     * <pre>
+     * Used for tables without cleanup tasks.
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.palantir.atlasdb.protos.generated.NullCleanupMetadata)
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadataOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.Builder.class);
+      }
+
+      // Construct using com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_descriptor;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata getDefaultInstanceForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance();
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata build() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata buildPartial() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata result = new com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata(this);
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) {
+          return mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata other) {
+        if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.NullCleanupMetadata) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.palantir.atlasdb.protos.generated.NullCleanupMetadata)
+    }
+
+    static {
+      defaultInstance = new NullCleanupMetadata(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:com.palantir.atlasdb.protos.generated.NullCleanupMetadata)
+  }
+
+  public interface StreamStoreCleanupMetadataOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+     *
+     * <pre>
+     * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+     * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+     * </pre>
+     */
+    boolean hasV1Metadata();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+     *
+     * <pre>
+     * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+     * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+     * </pre>
+     */
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata getV1Metadata();
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+     *
+     * <pre>
+     * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+     * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+     * </pre>
+     */
+    com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1MetadataOrBuilder getV1MetadataOrBuilder();
+  }
+  /**
+   * Protobuf type {@code com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata}
+   *
+   * <pre>
+   * Used for stream store tables which have cleanup tasks.
+   * </pre>
+   */
+  public static final class StreamStoreCleanupMetadata extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata)
+      StreamStoreCleanupMetadataOrBuilder {
+    // Use StreamStoreCleanupMetadata.newBuilder() to construct.
+    private StreamStoreCleanupMetadata(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private StreamStoreCleanupMetadata(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final StreamStoreCleanupMetadata defaultInstance;
+    public static StreamStoreCleanupMetadata getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public StreamStoreCleanupMetadata getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private StreamStoreCleanupMetadata(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                subBuilder = v1Metadata_.toBuilder();
+              }
+              v1Metadata_ = input.readMessage(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(v1Metadata_);
+                v1Metadata_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<StreamStoreCleanupMetadata> PARSER =
+        new com.google.protobuf.AbstractParser<StreamStoreCleanupMetadata>() {
+      public StreamStoreCleanupMetadata parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new StreamStoreCleanupMetadata(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<StreamStoreCleanupMetadata> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int V1METADATA_FIELD_NUMBER = 1;
+    private com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata v1Metadata_;
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+     *
+     * <pre>
+     * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+     * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+     * </pre>
+     */
+    public boolean hasV1Metadata() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+     *
+     * <pre>
+     * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+     * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+     * </pre>
+     */
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata getV1Metadata() {
+      return v1Metadata_;
+    }
+    /**
+     * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+     *
+     * <pre>
+     * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+     * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+     * </pre>
+     */
+    public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1MetadataOrBuilder getV1MetadataOrBuilder() {
+      return v1Metadata_;
+    }
+
+    private void initFields() {
+      v1Metadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.getDefaultInstance();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeMessage(1, v1Metadata_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, v1Metadata_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata}
+     *
+     * <pre>
+     * Used for stream store tables which have cleanup tasks.
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata)
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadataOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.Builder.class);
+      }
+
+      // Construct using com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getV1MetadataFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        if (v1MetadataBuilder_ == null) {
+          v1Metadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.getDefaultInstance();
+        } else {
+          v1MetadataBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_descriptor;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata getDefaultInstanceForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance();
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata build() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata buildPartial() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata result = new com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        if (v1MetadataBuilder_ == null) {
+          result.v1Metadata_ = v1Metadata_;
+        } else {
+          result.v1Metadata_ = v1MetadataBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) {
+          return mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata other) {
+        if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata.getDefaultInstance()) return this;
+        if (other.hasV1Metadata()) {
+          mergeV1Metadata(other.getV1Metadata());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupMetadata) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata v1Metadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1MetadataOrBuilder> v1MetadataBuilder_;
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      public boolean hasV1Metadata() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata getV1Metadata() {
+        if (v1MetadataBuilder_ == null) {
+          return v1Metadata_;
+        } else {
+          return v1MetadataBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      public Builder setV1Metadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata value) {
+        if (v1MetadataBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          v1Metadata_ = value;
+          onChanged();
+        } else {
+          v1MetadataBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      public Builder setV1Metadata(
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.Builder builderForValue) {
+        if (v1MetadataBuilder_ == null) {
+          v1Metadata_ = builderForValue.build();
+          onChanged();
+        } else {
+          v1MetadataBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      public Builder mergeV1Metadata(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata value) {
+        if (v1MetadataBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+              v1Metadata_ != com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.getDefaultInstance()) {
+            v1Metadata_ =
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.newBuilder(v1Metadata_).mergeFrom(value).buildPartial();
+          } else {
+            v1Metadata_ = value;
+          }
+          onChanged();
+        } else {
+          v1MetadataBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      public Builder clearV1Metadata() {
+        if (v1MetadataBuilder_ == null) {
+          v1Metadata_ = com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.getDefaultInstance();
+          onChanged();
+        } else {
+          v1MetadataBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.Builder getV1MetadataBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getV1MetadataFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1MetadataOrBuilder getV1MetadataOrBuilder() {
+        if (v1MetadataBuilder_ != null) {
+          return v1MetadataBuilder_.getMessageOrBuilder();
+        } else {
+          return v1Metadata_;
+        }
+      }
+      /**
+       * <code>optional .com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata v1Metadata = 1;</code>
+       *
+       * <pre>
+       * Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+       * AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+       * </pre>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1MetadataOrBuilder> 
+          getV1MetadataFieldBuilder() {
+        if (v1MetadataBuilder_ == null) {
+          v1MetadataBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.Builder, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1MetadataOrBuilder>(
+                  getV1Metadata(),
+                  getParentForChildren(),
+                  isClean());
+          v1Metadata_ = null;
+        }
+        return v1MetadataBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata)
+    }
+
+    static {
+      defaultInstance = new StreamStoreCleanupMetadata(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:com.palantir.atlasdb.protos.generated.StreamStoreCleanupMetadata)
+  }
+
+  public interface StreamStoreCleanupV1MetadataOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
+     */
+    boolean hasNumHashedRowComponents();
+    /**
+     * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
+     */
+    int getNumHashedRowComponents();
+  }
+  /**
+   * Protobuf type {@code com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata}
+   */
+  public static final class StreamStoreCleanupV1Metadata extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata)
+      StreamStoreCleanupV1MetadataOrBuilder {
+    // Use StreamStoreCleanupV1Metadata.newBuilder() to construct.
+    private StreamStoreCleanupV1Metadata(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private StreamStoreCleanupV1Metadata(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final StreamStoreCleanupV1Metadata defaultInstance;
+    public static StreamStoreCleanupV1Metadata getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public StreamStoreCleanupV1Metadata getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private StreamStoreCleanupV1Metadata(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              numHashedRowComponents_ = input.readInt32();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<StreamStoreCleanupV1Metadata> PARSER =
+        new com.google.protobuf.AbstractParser<StreamStoreCleanupV1Metadata>() {
+      public StreamStoreCleanupV1Metadata parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new StreamStoreCleanupV1Metadata(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<StreamStoreCleanupV1Metadata> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int NUMHASHEDROWCOMPONENTS_FIELD_NUMBER = 1;
+    private int numHashedRowComponents_;
+    /**
+     * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
+     */
+    public boolean hasNumHashedRowComponents() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
+     */
+    public int getNumHashedRowComponents() {
+      return numHashedRowComponents_;
+    }
+
+    private void initFields() {
+      numHashedRowComponents_ = 0;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt32(1, numHashedRowComponents_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, numHashedRowComponents_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata)
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1MetadataOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.Builder.class);
+      }
+
+      // Construct using com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        numHashedRowComponents_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_descriptor;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata getDefaultInstanceForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.getDefaultInstance();
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata build() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata buildPartial() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata result = new com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.numHashedRowComponents_ = numHashedRowComponents_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata) {
+          return mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata other) {
+        if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.getDefaultInstance()) return this;
+        if (other.hasNumHashedRowComponents()) {
+          setNumHashedRowComponents(other.getNumHashedRowComponents());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private int numHashedRowComponents_ ;
+      /**
+       * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
+       */
+      public boolean hasNumHashedRowComponents() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
+       */
+      public int getNumHashedRowComponents() {
+        return numHashedRowComponents_;
+      }
+      /**
+       * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
+       */
+      public Builder setNumHashedRowComponents(int value) {
+        bitField0_ |= 0x00000001;
+        numHashedRowComponents_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 numHashedRowComponents = 1 [default = 0];</code>
+       */
+      public Builder clearNumHashedRowComponents() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        numHashedRowComponents_ = 0;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata)
+    }
+
+    static {
+      defaultInstance = new StreamStoreCleanupV1Metadata(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:com.palantir.atlasdb.protos.generated.StreamStoreCleanupV1Metadata)
+  }
+
+  public interface ArbitraryCleanupMetadataOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata}
+   *
+   * <pre>
+   * Used for tables with arbitrary cleanup tasks.
+   * </pre>
+   */
+  public static final class ArbitraryCleanupMetadata extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata)
+      ArbitraryCleanupMetadataOrBuilder {
+    // Use ArbitraryCleanupMetadata.newBuilder() to construct.
+    private ArbitraryCleanupMetadata(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private ArbitraryCleanupMetadata(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final ArbitraryCleanupMetadata defaultInstance;
+    public static ArbitraryCleanupMetadata getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public ArbitraryCleanupMetadata getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ArbitraryCleanupMetadata(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<ArbitraryCleanupMetadata> PARSER =
+        new com.google.protobuf.AbstractParser<ArbitraryCleanupMetadata>() {
+      public ArbitraryCleanupMetadata parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ArbitraryCleanupMetadata(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ArbitraryCleanupMetadata> getParserForType() {
+      return PARSER;
+    }
+
+    private void initFields() {
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata}
+     *
+     * <pre>
+     * Used for tables with arbitrary cleanup tasks.
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata)
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadataOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.class, com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.Builder.class);
+      }
+
+      // Construct using com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_descriptor;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata getDefaultInstanceForType() {
+        return com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance();
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata build() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata buildPartial() {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata result = new com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata(this);
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) {
+          return mergeFrom((com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata other) {
+        if (other == com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.ArbitraryCleanupMetadata) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata)
+    }
+
+    static {
+      defaultInstance = new ArbitraryCleanupMetadata(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:com.palantir.atlasdb.protos.generated.ArbitraryCleanupMetadata)
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_com_palantir_atlasdb_protos_generated_SchemaMetadata_descriptor;
   private static
@@ -2673,15 +4785,35 @@ public final class SchemaMetadataPersistence {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadataEntry_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_palantir_atlasdb_protos_generated_TableReference_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_palantir_atlasdb_protos_generated_TableReference_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_com_palantir_atlasdb_protos_generated_TableReference_descriptor;
+    internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_com_palantir_atlasdb_protos_generated_TableReference_fieldAccessorTable;
+      internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -2691,24 +4823,32 @@ public final class SchemaMetadataPersistence {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\nFmain/proto/com/palantir/atlasdb/protos" +
-      "/SchemaMetadataPersistence.proto\022%com.pa" +
-      "lantir.atlasdb.protos.generated\"q\n\016Schem" +
-      "aMetadata\022_\n\rtableMetadata\030\001 \003(\0132H.com.p" +
-      "alantir.atlasdb.protos.generated.SchemaD" +
-      "ependentTableMetadataEntry\"\335\001\n!SchemaDep" +
-      "endentTableMetadataEntry\022M\n\016tableReferen" +
-      "ce\030\001 \001(\01325.com.palantir.atlasdb.protos.g" +
-      "enerated.TableReference\022i\n\034schemaDepende" +
-      "ntTableMetadata\030\002 \001(\0132C.com.palantir.atl",
-      "asdb.protos.generated.SchemaDependentTab" +
-      "leMetadata\"u\n\034SchemaDependentTableMetada" +
-      "ta\022U\n\022cleanupRequirement\030\001 \001(\01629.com.pal" +
-      "antir.atlasdb.protos.generated.CleanupRe" +
-      "quirement\"6\n\016TableReference\022\021\n\tnamespace" +
-      "\030\001 \001(\t\022\021\n\ttableName\030\002 \001(\t*9\n\022CleanupRequ" +
-      "irement\022\016\n\nNOT_NEEDED\020\000\022\023\n\017ARBITRARY_ASY" +
-      "NC\020@"
+      "\n\037SchemaMetadataPersistence.proto\022%com.p" +
+      "alantir.atlasdb.protos.generated\"q\n\016Sche" +
+      "maMetadata\022_\n\rtableMetadata\030\001 \003(\0132H.com." +
+      "palantir.atlasdb.protos.generated.Schema" +
+      "DependentTableMetadataEntry\"\335\001\n!SchemaDe" +
+      "pendentTableMetadataEntry\022M\n\016tableRefere" +
+      "nce\030\001 \001(\01325.com.palantir.atlasdb.protos." +
+      "generated.TableReference\022i\n\034schemaDepend" +
+      "entTableMetadata\030\002 \001(\0132C.com.palantir.at" +
+      "lasdb.protos.generated.SchemaDependentTa",
+      "bleMetadata\"6\n\016TableReference\022\021\n\tnamespa" +
+      "ce\030\001 \001(\t\022\021\n\ttableName\030\002 \001(\t\"\305\002\n\034SchemaDe" +
+      "pendentTableMetadata\022R\n\014nullMetadata\030\001 \001" +
+      "(\0132:.com.palantir.atlasdb.protos.generat" +
+      "ed.NullCleanupMetadataH\000\022`\n\023streamStoreM" +
+      "etadata\030\002 \001(\0132A.com.palantir.atlasdb.pro" +
+      "tos.generated.StreamStoreCleanupMetadata" +
+      "H\000\022\\\n\021arbitraryMetadata\030\003 \001(\0132?.com.pala" +
+      "ntir.atlasdb.protos.generated.ArbitraryC" +
+      "leanupMetadataH\000B\021\n\017cleanupMetadata\"\025\n\023N",
+      "ullCleanupMetadata\"u\n\032StreamStoreCleanup" +
+      "Metadata\022W\n\nv1Metadata\030\001 \001(\0132C.com.palan" +
+      "tir.atlasdb.protos.generated.StreamStore" +
+      "CleanupV1Metadata\"A\n\034StreamStoreCleanupV" +
+      "1Metadata\022!\n\026numHashedRowComponents\030\001 \001(" +
+      "\005:\0010\"\032\n\030ArbitraryCleanupMetadata"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -2734,18 +4874,42 @@ public final class SchemaMetadataPersistence {
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadataEntry_descriptor,
         new java.lang.String[] { "TableReference", "SchemaDependentTableMetadata", });
-    internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor,
-        new java.lang.String[] { "CleanupRequirement", });
     internal_static_com_palantir_atlasdb_protos_generated_TableReference_descriptor =
-      getDescriptor().getMessageTypes().get(3);
+      getDescriptor().getMessageTypes().get(2);
     internal_static_com_palantir_atlasdb_protos_generated_TableReference_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_com_palantir_atlasdb_protos_generated_TableReference_descriptor,
         new java.lang.String[] { "Namespace", "TableName", });
+    internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_palantir_atlasdb_protos_generated_SchemaDependentTableMetadata_descriptor,
+        new java.lang.String[] { "NullMetadata", "StreamStoreMetadata", "ArbitraryMetadata", "CleanupMetadata", });
+    internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_descriptor =
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_palantir_atlasdb_protos_generated_NullCleanupMetadata_descriptor,
+        new java.lang.String[] { });
+    internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupMetadata_descriptor,
+        new java.lang.String[] { "V1Metadata", });
+    internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_descriptor =
+      getDescriptor().getMessageTypes().get(6);
+    internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_palantir_atlasdb_protos_generated_StreamStoreCleanupV1Metadata_descriptor,
+        new java.lang.String[] { "NumHashedRowComponents", });
+    internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_descriptor =
+      getDescriptor().getMessageTypes().get(7);
+    internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_palantir_atlasdb_protos_generated_ArbitraryCleanupMetadata_descriptor,
+        new java.lang.String[] { });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SchemaDependentTableMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SchemaDependentTableMetadata.java
@@ -63,11 +63,11 @@ public abstract class SchemaDependentTableMetadata implements Persistable {
     private static CleanupMetadata parseCleanupMetadata(
             SchemaMetadataPersistence.SchemaDependentTableMetadata message) {
         switch (message.getCleanupMetadataCase()) {
-            case ARBITRARYCLEANUPMETADATA:
+            case ARBITRARY_CLEANUP_METADATA:
                 return ArbitraryCleanupMetadata.hydrateFromProto(message.getArbitraryCleanupMetadata());
-            case NULLCLEANUPMETADATA:
+            case NULL_CLEANUP_METADATA:
                 return NullCleanupMetadata.hydrateFromProto(message.getNullCleanupMetadata());
-            case STREAMSTORECLEANUPMETADATA:
+            case STREAM_STORE_CLEANUP_METADATA:
                 return StreamStoreCleanupMetadata.hydrateFromProto(message.getStreamStoreCleanupMetadata());
             default:
                 throw new IllegalStateException("Unexpected type of cleanup metadata found: "

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SchemaDependentTableMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/SchemaDependentTableMetadata.java
@@ -20,13 +20,16 @@ import org.immutables.value.Value;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
-import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.CleanupRequirement;
+import com.palantir.atlasdb.schema.cleanup.ArbitraryCleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.CleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.NullCleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.persist.Persistable;
 
 @Value.Immutable
 public abstract class SchemaDependentTableMetadata implements Persistable {
-    public static final Hydrator<SchemaDependentTableMetadata> HYDRATOR = input -> {
+    public static final Hydrator<SchemaDependentTableMetadata> BYTES_HYDRATOR = input -> {
         try {
             SchemaMetadataPersistence.SchemaDependentTableMetadata message =
                     SchemaMetadataPersistence.SchemaDependentTableMetadata.parseFrom(input);
@@ -36,7 +39,7 @@ public abstract class SchemaDependentTableMetadata implements Persistable {
         }
     };
 
-    public abstract CleanupRequirement cleanupRequirement();
+    public abstract CleanupMetadata cleanupMetadata();
 
     @Override
     public byte[] persistToBytes() {
@@ -46,18 +49,56 @@ public abstract class SchemaDependentTableMetadata implements Persistable {
     public SchemaMetadataPersistence.SchemaDependentTableMetadata persistToProto() {
         SchemaMetadataPersistence.SchemaDependentTableMetadata.Builder builder =
                 SchemaMetadataPersistence.SchemaDependentTableMetadata.newBuilder();
-        builder.setCleanupRequirement(cleanupRequirement());
+        cleanupMetadata().accept(new CleanupMetadataPersisterVisitor(builder));
         return builder.build();
     }
 
     public static SchemaDependentTableMetadata hydrateFromProto(
             SchemaMetadataPersistence.SchemaDependentTableMetadata message) {
-        CleanupRequirement cleanupRequirement = CleanupRequirement.ARBITRARY_ASYNC; // strictest default
-        if (message.hasCleanupRequirement()) {
-            cleanupRequirement = message.getCleanupRequirement();
+        ImmutableSchemaDependentTableMetadata.Builder builder = ImmutableSchemaDependentTableMetadata.builder();
+        builder.cleanupMetadata(parseCleanupMetadata(message));
+        return builder.build();
+    }
+
+    private static CleanupMetadata parseCleanupMetadata(
+            SchemaMetadataPersistence.SchemaDependentTableMetadata message) {
+        switch (message.getCleanupMetadataCase()) {
+            case ARBITRARYCLEANUPMETADATA:
+                return ArbitraryCleanupMetadata.hydrateFromProto(message.getArbitraryCleanupMetadata());
+            case NULLCLEANUPMETADATA:
+                return NullCleanupMetadata.hydrateFromProto(message.getNullCleanupMetadata());
+            case STREAMSTORECLEANUPMETADATA:
+                return StreamStoreCleanupMetadata.hydrateFromProto(message.getStreamStoreCleanupMetadata());
+            default:
+                throw new IllegalStateException("Unexpected type of cleanup metadata found: "
+                        + message.getCleanupMetadataCase());
         }
-        return ImmutableSchemaDependentTableMetadata.builder()
-                .cleanupRequirement(cleanupRequirement)
-                .build();
+    }
+
+    private static class CleanupMetadataPersisterVisitor implements CleanupMetadata.Visitor<Void> {
+        private final SchemaMetadataPersistence.SchemaDependentTableMetadata.Builder builder;
+
+        private CleanupMetadataPersisterVisitor(
+                SchemaMetadataPersistence.SchemaDependentTableMetadata.Builder builder) {
+            this.builder = builder;
+        }
+
+        @Override
+        public Void visit(ArbitraryCleanupMetadata metadata) {
+            builder.setArbitraryCleanupMetadata(metadata.persistToProto());
+            return null;
+        }
+
+        @Override
+        public Void visit(NullCleanupMetadata metadata) {
+            builder.setNullCleanupMetadata(metadata.persistToProto());
+            return null;
+        }
+
+        @Override
+        public Void visit(StreamStoreCleanupMetadata metadata) {
+            builder.setStreamStoreCleanupMetadata(metadata.persistToProto());
+            return null;
+        }
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadata.java
@@ -31,7 +31,7 @@ public class ArbitraryCleanupMetadata implements CleanupMetadata {
 
     public static ArbitraryCleanupMetadata hydrateFromProto(
             SchemaMetadataPersistence.ArbitraryCleanupMetadata unused) {
-        // For now, this is correct!
+        // This is correct while the ArbitraryCleanupMetadata message has no fields.
         return new ArbitraryCleanupMetadata();
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadata.java
@@ -16,14 +16,32 @@
 
 package com.palantir.atlasdb.schema.cleanup;
 
+import com.google.common.base.Throwables;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
 
 public class ArbitraryCleanupMetadata implements CleanupMetadata {
+    public static Hydrator<ArbitraryCleanupMetadata> BYTES_HYDRATOR = message -> {
+        try {
+            return hydrateFromProto(SchemaMetadataPersistence.ArbitraryCleanupMetadata.parseFrom(message));
+        } catch (InvalidProtocolBufferException e) {
+            throw Throwables.propagate(e);
+        }
+    };
+
+    public static ArbitraryCleanupMetadata hydrateFromProto(
+            SchemaMetadataPersistence.ArbitraryCleanupMetadata unused) {
+        // For now, this is correct!
+        return new ArbitraryCleanupMetadata();
+    }
+
     @Override
     public byte[] persistToBytes() {
-        return SchemaMetadataPersistence.ArbitraryCleanupMetadata.newBuilder()
-                .build()
-                .toByteArray();
+        return persistToProto().toByteArray();
+    }
+
+    public SchemaMetadataPersistence.ArbitraryCleanupMetadata persistToProto() {
+        return SchemaMetadataPersistence.ArbitraryCleanupMetadata.newBuilder().build();
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadata.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.cleanup;
+
+import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
+
+public class ArbitraryCleanupMetadata implements CleanupMetadata {
+    @Override
+    public byte[] persistToBytes() {
+        return SchemaMetadataPersistence.ArbitraryCleanupMetadata.newBuilder()
+                .build()
+                .toByteArray();
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadata.java
@@ -48,4 +48,14 @@ public class ArbitraryCleanupMetadata implements CleanupMetadata {
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other != null && this.getClass() == other.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return ArbitraryCleanupMetadata.class.hashCode();
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/CleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/CleanupMetadata.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.cleanup;
+
+import com.palantir.common.persist.Persistable;
+
+public interface CleanupMetadata extends Persistable {
+    void accept(CleanupMetadata.Visitor visitor);
+
+    interface Visitor<T> {
+        default T visit(NullCleanupMetadata cleanupMetadata) {
+            throw new UnsupportedOperationException("This visitor doesn't support null cleanup metadata");
+        }
+
+        default T visit(StreamStoreCleanupMetadata cleanupMetadata) {
+            throw new UnsupportedOperationException("This visitor doesn't support streamstore cleanup metadata");
+        }
+
+        default T visit(ArbitraryCleanupMetadata cleanupMetadata) {
+            throw new UnsupportedOperationException("This visitor doesn't support arbitrary cleanup metadata");
+        }
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadata.java
@@ -30,7 +30,7 @@ public class NullCleanupMetadata implements CleanupMetadata {
     };
 
     public static NullCleanupMetadata hydrateFromProto(SchemaMetadataPersistence.NullCleanupMetadata unused) {
-        // For now, this is correct!
+        // This is correct while the NullCleanupMetadata message has no fields.
         return new NullCleanupMetadata();
     }
 
@@ -55,6 +55,6 @@ public class NullCleanupMetadata implements CleanupMetadata {
 
     @Override
     public int hashCode() {
-        return ArbitraryCleanupMetadata.class.hashCode();
+        return NullCleanupMetadata.class.hashCode();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadata.java
@@ -16,14 +16,31 @@
 
 package com.palantir.atlasdb.schema.cleanup;
 
+import com.google.common.base.Throwables;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
 
 public class NullCleanupMetadata implements CleanupMetadata {
+    public static Hydrator<NullCleanupMetadata> BYTES_HYDRATOR = message -> {
+        try {
+            return hydrateFromProto(SchemaMetadataPersistence.NullCleanupMetadata.parseFrom(message));
+        } catch (InvalidProtocolBufferException e) {
+            throw Throwables.propagate(e);
+        }
+    };
+
+    public static NullCleanupMetadata hydrateFromProto(SchemaMetadataPersistence.NullCleanupMetadata unused) {
+        // For now, this is correct!
+        return new NullCleanupMetadata();
+    }
+
     @Override
     public byte[] persistToBytes() {
-        return SchemaMetadataPersistence.NullCleanupMetadata.newBuilder()
-                .build()
-                .toByteArray();
+        return persistToProto().toByteArray();
+    }
+
+    public SchemaMetadataPersistence.NullCleanupMetadata persistToProto() {
+        return SchemaMetadataPersistence.NullCleanupMetadata.newBuilder().build();
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadata.java
@@ -47,4 +47,14 @@ public class NullCleanupMetadata implements CleanupMetadata {
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || (other != null && this.getClass() == other.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return ArbitraryCleanupMetadata.class.hashCode();
+    }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadata.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.cleanup;
+
+import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
+
+public class NullCleanupMetadata implements CleanupMetadata {
+    @Override
+    public byte[] persistToBytes() {
+        return SchemaMetadataPersistence.NullCleanupMetadata.newBuilder()
+                .build()
+                .toByteArray();
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/StreamStoreCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/StreamStoreCleanupMetadata.java
@@ -50,7 +50,10 @@ public abstract class StreamStoreCleanupMetadata implements CleanupMetadata {
                 builder.streamIdType(ValueType.hydrateFromProto(v1Metadata.getStreamIdType()));
             }
         } else {
-            log.warn("Encountered stream store cleanup metadata without v1 metadata, which is unexpected.");
+            final String v1MetadataNotFound = "Encountered stream store cleanup metadata without v1 metadata,"
+                    + " which is unexpected.";
+            log.warn(v1MetadataNotFound);
+            throw new IllegalStateException(v1MetadataNotFound);
         }
         return builder.build();
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/StreamStoreCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/StreamStoreCleanupMetadata.java
@@ -17,12 +17,44 @@
 package com.palantir.atlasdb.schema.cleanup;
 
 import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Throwables;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
+import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence.StreamStoreCleanupV1Metadata;
 import com.palantir.atlasdb.table.description.ValueType;
 
 @Value.Immutable
 public abstract class StreamStoreCleanupMetadata implements CleanupMetadata {
+    private static final Logger log = LoggerFactory.getLogger(StreamStoreCleanupMetadata.class);
+
+    public static final Hydrator<StreamStoreCleanupMetadata> BYTES_HYDRATOR = message -> {
+        try {
+            return hydrateFromProto(SchemaMetadataPersistence.StreamStoreCleanupMetadata.parseFrom(message));
+        } catch (InvalidProtocolBufferException e) {
+            throw Throwables.propagate(e);
+        }
+    };
+
+    public static StreamStoreCleanupMetadata hydrateFromProto(
+            SchemaMetadataPersistence.StreamStoreCleanupMetadata streamStoreCleanupMetadata) {
+        ImmutableStreamStoreCleanupMetadata.Builder builder = ImmutableStreamStoreCleanupMetadata.builder();
+        if (streamStoreCleanupMetadata.hasV1Metadata()) {
+            StreamStoreCleanupV1Metadata v1Metadata = streamStoreCleanupMetadata.getV1Metadata();
+            if (v1Metadata.hasNumHashedRowComponents()) {
+                builder.numHashedRowComponents(v1Metadata.getNumHashedRowComponents());
+            }
+            if (v1Metadata.hasStreamIdType()) {
+                builder.streamIdType(ValueType.hydrateFromProto(v1Metadata.getStreamIdType()));
+            }
+        } else {
+            log.warn("Encountered stream store cleanup metadata without v1 metadata, which is unexpected.");
+        }
+        return builder.build();
+    }
+
     public abstract int numHashedRowComponents();
 
     public abstract ValueType streamIdType();
@@ -37,7 +69,7 @@ public abstract class StreamStoreCleanupMetadata implements CleanupMetadata {
         return persistToProto().toByteArray();
     }
 
-    private SchemaMetadataPersistence.StreamStoreCleanupMetadata persistToProto() {
+    public SchemaMetadataPersistence.StreamStoreCleanupMetadata persistToProto() {
         SchemaMetadataPersistence.StreamStoreCleanupV1Metadata v1Metadata = persistV1Metadata();
 
         return SchemaMetadataPersistence.StreamStoreCleanupMetadata.newBuilder()

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/StreamStoreCleanupMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/cleanup/StreamStoreCleanupMetadata.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.cleanup;
+
+import org.immutables.value.Value;
+
+import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
+import com.palantir.atlasdb.table.description.ValueType;
+
+@Value.Immutable
+public abstract class StreamStoreCleanupMetadata implements CleanupMetadata {
+    public abstract int numHashedRowComponents();
+
+    public abstract ValueType streamIdType();
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public byte[] persistToBytes() {
+        return persistToProto().toByteArray();
+    }
+
+    private SchemaMetadataPersistence.StreamStoreCleanupMetadata persistToProto() {
+        SchemaMetadataPersistence.StreamStoreCleanupV1Metadata v1Metadata = persistV1Metadata();
+
+        return SchemaMetadataPersistence.StreamStoreCleanupMetadata.newBuilder()
+                .setV1Metadata(v1Metadata)
+                .build();
+    }
+
+    private SchemaMetadataPersistence.StreamStoreCleanupV1Metadata persistV1Metadata() {
+        return SchemaMetadataPersistence.StreamStoreCleanupV1Metadata.newBuilder()
+                .setNumHashedRowComponents(numHashedRowComponents())
+                .setStreamIdType(streamIdType().persistToProto())
+                .build();
+    }
+}

--- a/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
+++ b/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
@@ -11,21 +11,35 @@ message SchemaDependentTableMetadataEntry {
     optional SchemaDependentTableMetadata schemaDependentTableMetadata = 2;
 }
 
-message SchemaDependentTableMetadata {
-    optional CleanupRequirement cleanupRequirement = 1;
-}
-
 message TableReference {
     optional string namespace = 1;
     optional string tableName = 2;
 }
 
-enum CleanupRequirement {
-    // Used for tables without cleanup tasks.
-    NOT_NEEDED = 0;
+message SchemaDependentTableMetadata {
+    oneof cleanupMetadata {
+        NullCleanupMetadata nullMetadata = 1;
+        StreamStoreCleanupMetadata streamStoreMetadata = 2;
+        ArbitraryCleanupMetadata arbitraryMetadata = 3;
+    }
+}
 
-    // Used for tables (possibly inclusive of stream-store meta-tables) that have user-defined cleanup tasks
-    // which can safely be processed asynchronously (e.g. via a queue).
-    // Examples include cascading deletes and reads from append-only Atlas tables.
-    ARBITRARY_ASYNC = 64;
+message NullCleanupMetadata {
+    // Used for tables without cleanup tasks.
+}
+
+message StreamStoreCleanupMetadata {
+    // Used for stream store tables which have cleanup tasks.
+
+    // Note that we expect to have multiple versions of the metadata as a sweeper service with a single version of
+    // AtlasDB should still be able to operate (to the best of its ability) even if AtlasDB users upgrade past it.
+    optional StreamStoreCleanupV1Metadata v1Metadata = 1;
+}
+
+message StreamStoreCleanupV1Metadata {
+    optional int32 numHashedRowComponents = 1 [default = 0];
+}
+
+message ArbitraryCleanupMetadata {
+    // Used for tables with arbitrary cleanup tasks.
 }

--- a/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
+++ b/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
@@ -1,7 +1,7 @@
 package com.palantir.atlasdb.protos.generated;
 
 // Don't want to duplicate ValueType, but moving things whilst not doing a dev break seems nontrivial.
-import "TableMetadataPersistence.proto";
+import "main/proto/com/palantir/atlasdb/protos/TableMetadataPersistence.proto";
 
 message SchemaMetadata {
     // Using this rather than map, to avoid introducing a dependency on proto3

--- a/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
+++ b/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
@@ -21,9 +21,11 @@ message TableReference {
 
 message SchemaDependentTableMetadata {
     oneof cleanupMetadata {
-        NullCleanupMetadata nullCleanupMetadata = 1;
-        StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;
-        ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;
+        // These parameters use snake case for the parameter names, so that the code gen generates enum cases using
+        // SCREAMING_SNAKE_CASE as opposed to ALLUPPERCASE.
+        NullCleanupMetadata null_cleanup_metadata = 1;
+        StreamStoreCleanupMetadata stream_store_cleanup_metadata = 2;
+        ArbitraryCleanupMetadata arbitrary_cleanup_metadata = 3;
     }
 }
 

--- a/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
+++ b/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
@@ -21,9 +21,9 @@ message TableReference {
 
 message SchemaDependentTableMetadata {
     oneof cleanupMetadata {
-        NullCleanupMetadata nullMetadata = 1;
-        StreamStoreCleanupMetadata streamStoreMetadata = 2;
-        ArbitraryCleanupMetadata arbitraryMetadata = 3;
+        NullCleanupMetadata null = 1;
+        StreamStoreCleanupMetadata streamStore = 2;
+        ArbitraryCleanupMetadata arbitrary = 3;
     }
 }
 

--- a/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
+++ b/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
@@ -1,5 +1,8 @@
 package com.palantir.atlasdb.protos.generated;
 
+// Don't want to duplicate ValueType, but moving things whilst not doing a dev break seems nontrivial.
+import "TableMetadataPersistence.proto";
+
 message SchemaMetadata {
     // Using this rather than map, to avoid introducing a dependency on proto3
     // TODO (jkong): Eventually coordinate a shift to proto3
@@ -38,6 +41,7 @@ message StreamStoreCleanupMetadata {
 
 message StreamStoreCleanupV1Metadata {
     optional int32 numHashedRowComponents = 1 [default = 0];
+    optional ValueType streamIdType = 2;
 }
 
 message ArbitraryCleanupMetadata {

--- a/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
+++ b/atlasdb-client/src/main/proto/com/palantir/atlasdb/protos/SchemaMetadataPersistence.proto
@@ -21,9 +21,9 @@ message TableReference {
 
 message SchemaDependentTableMetadata {
     oneof cleanupMetadata {
-        NullCleanupMetadata null = 1;
-        StreamStoreCleanupMetadata streamStore = 2;
-        ArbitraryCleanupMetadata arbitrary = 3;
+        NullCleanupMetadata nullCleanupMetadata = 1;
+        StreamStoreCleanupMetadata streamStoreCleanupMetadata = 2;
+        ArbitraryCleanupMetadata arbitraryCleanupMetadata = 3;
     }
 }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/SchemaDependentTableMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/SchemaDependentTableMetadataTest.java
@@ -18,22 +18,21 @@ package com.palantir.atlasdb.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-
 import org.junit.Test;
 
-import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
+import com.palantir.atlasdb.schema.cleanup.ImmutableStreamStoreCleanupMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
 
 public class SchemaDependentTableMetadataTest {
     @Test
-    public void canSerializeAndDeserializeMetadataWithVariousCleanupRequirements() {
-        Arrays.stream(SchemaMetadataPersistence.CleanupRequirement.values())
-                .forEach(cleanupRequirement -> {
-                    SchemaDependentTableMetadata tableMetadata = ImmutableSchemaDependentTableMetadata.builder()
-                            .cleanupRequirement(cleanupRequirement)
-                            .build();
-                    assertThat(SchemaDependentTableMetadata.HYDRATOR.hydrateFromBytes(tableMetadata.persistToBytes()))
-                            .isEqualTo(tableMetadata);
-                });
+    public void canSerializeAndDeserialize() {
+        SchemaDependentTableMetadata metadata = ImmutableSchemaDependentTableMetadata.builder()
+                .cleanupMetadata(ImmutableStreamStoreCleanupMetadata.builder()
+                        .numHashedRowComponents(1)
+                        .streamIdType(ValueType.FIXED_LONG)
+                        .build())
+                .build();
+        assertThat(SchemaDependentTableMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadata.persistToBytes()))
+                .isEqualTo(metadata);
     }
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/SchemaMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/SchemaMetadataTest.java
@@ -22,14 +22,15 @@ import org.junit.Test;
 
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
+import com.palantir.atlasdb.schema.cleanup.ArbitraryCleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.NullCleanupMetadata;
 
 public class SchemaMetadataTest {
     private final SchemaDependentTableMetadata TABLE_METADATA_1 = ImmutableSchemaDependentTableMetadata.builder()
-            .cleanupRequirement(SchemaMetadataPersistence.CleanupRequirement.NOT_NEEDED)
+            .cleanupMetadata(new ArbitraryCleanupMetadata())
             .build();
     private final SchemaDependentTableMetadata TABLE_METADATA_2 = ImmutableSchemaDependentTableMetadata.builder()
-            .cleanupRequirement(SchemaMetadataPersistence.CleanupRequirement.ARBITRARY_ASYNC)
+            .cleanupMetadata(new NullCleanupMetadata())
             .build();
 
     @Test

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/ArbitraryCleanupMetadataTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+public class ArbitraryCleanupMetadataTest {
+    @Test
+    public void distinctArbitraryCleanupMetadatasAreConsideredEqual() {
+        ArbitraryCleanupMetadata metadata1 = new ArbitraryCleanupMetadata();
+        ArbitraryCleanupMetadata metadata2 = new ArbitraryCleanupMetadata();
+
+        assertThat(metadata1).isNotSameAs(metadata2)
+                .isEqualTo(metadata2);
+    }
+
+    @Test
+    public void canSerializeAndDeserialize() {
+        ArbitraryCleanupMetadata metadata = new ArbitraryCleanupMetadata();
+        assertThat(ArbitraryCleanupMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadata.persistToBytes()))
+                .isEqualTo(metadata);
+    }
+
+    @Test
+    public void cannotDeserializeMalformedByteArray() {
+        byte[] badBytes = {1};
+        assertThatThrownBy(() -> ArbitraryCleanupMetadata.BYTES_HYDRATOR.hydrateFromBytes(badBytes))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(InvalidProtocolBufferException.class);
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/CleanupMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/CleanupMetadataTest.java
@@ -42,7 +42,7 @@ public class CleanupMetadataTest {
                                 ImmutableStreamStoreCleanupMetadata.builder()
                                         .numHashedRowComponents(num)
                                         .streamIdType(ValueType.UUID)
-                                        .build())).isEqualTo(7));
+                                        .build())).isEqualTo(num));
     }
 
     private static class HashComponentsVisitor implements CleanupMetadata.Visitor<Integer> {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/CleanupMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/CleanupMetadataTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.table.description.ValueType;
+
+public class CleanupMetadataTest {
+    @Test
+    public void visitorThrowsIfMethodUnimplemented() {
+        assertThatThrownBy(() -> new HashComponentsVisitor().visit(new ArbitraryCleanupMetadata()))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> new HashComponentsVisitor().visit(new NullCleanupMetadata()))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void canInvokeMethodsOnVisitor() {
+        IntStream.range(0, 2)
+                .forEach(num ->
+                        assertThat(new HashComponentsVisitor().visit(
+                                ImmutableStreamStoreCleanupMetadata.builder()
+                                        .numHashedRowComponents(num)
+                                        .streamIdType(ValueType.UUID)
+                                        .build())).isEqualTo(num));
+    }
+
+    private static class HashComponentsVisitor implements CleanupMetadata.Visitor<Integer> {
+        @Override
+        public Integer visit(StreamStoreCleanupMetadata metadata) {
+            return metadata.numHashedRowComponents();
+        }
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/CleanupMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/CleanupMetadataTest.java
@@ -42,7 +42,7 @@ public class CleanupMetadataTest {
                                 ImmutableStreamStoreCleanupMetadata.builder()
                                         .numHashedRowComponents(num)
                                         .streamIdType(ValueType.UUID)
-                                        .build())).isEqualTo(num));
+                                        .build())).isEqualTo(7));
     }
 
     private static class HashComponentsVisitor implements CleanupMetadata.Visitor<Integer> {

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/NullCleanupMetadataTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+public class NullCleanupMetadataTest {
+    @Test
+    public void distinctNullCleanupMetadatasAreConsideredEqual() {
+        NullCleanupMetadata metadata1 = new NullCleanupMetadata();
+        NullCleanupMetadata metadata2 = new NullCleanupMetadata();
+
+        assertThat(metadata1).isNotSameAs(metadata2)
+                .isEqualTo(metadata2);
+    }
+
+    @Test
+    public void canSerializeAndDeserialize() {
+        NullCleanupMetadata metadata = new NullCleanupMetadata();
+        assertThat(NullCleanupMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadata.persistToBytes()))
+                .isEqualTo(metadata);
+    }
+
+    @Test
+    public void cannotDeserializeMalformedByteArray() {
+        byte[] badBytes = {1};
+        assertThatThrownBy(() -> NullCleanupMetadata.BYTES_HYDRATOR.hydrateFromBytes(badBytes))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(InvalidProtocolBufferException.class);
+    }
+}

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/StreamStoreCleanupMetadataTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/cleanup/StreamStoreCleanupMetadataTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.schema.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.protos.generated.SchemaMetadataPersistence;
+import com.palantir.atlasdb.table.description.ValueType;
+
+public class StreamStoreCleanupMetadataTest {
+    @Test
+    public void canSerializeAndDeserializePreservingHashedComponentsAndValueTypes() {
+        IntStream.range(0, 2).forEach(numHashedComponents ->
+                Arrays.stream(ValueType.values()).forEach(valueType -> {
+                    StreamStoreCleanupMetadata metadata = ImmutableStreamStoreCleanupMetadata.builder()
+                            .numHashedRowComponents(numHashedComponents)
+                            .streamIdType(valueType)
+                            .build();
+                    assertThat(StreamStoreCleanupMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadata.persistToBytes()))
+                            .isEqualTo(metadata);
+                 }));
+    }
+
+    @Test
+    public void throwsIfDeserializingEmptyStreamStoreCleanupMetadata() {
+        SchemaMetadataPersistence.StreamStoreCleanupMetadata metadataProto =
+                SchemaMetadataPersistence.StreamStoreCleanupMetadata.newBuilder().build();
+
+        assertThatThrownBy(() -> StreamStoreCleanupMetadata.hydrateFromProto(metadataProto))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Be able to provide enough information for an external sweeper service to sweep stream stores.
- Yet, in doing the above, ensure that there is a smooth way to add more information to sweep if needed.

**Implementation Description (bullets)**:
- Add a tagged-union-type of metadata options, which allows us to tell which type is present.
- Provide a mechanism for specifying multiple versions of the stream store cleanup metadata, in case we need to pass more parameters to it (one possibility is if we want to make block size configurable and want sweep prioritisation to incorporate block size as an input).

**Concerns (what feedback would you like?)**:
- Is the `import` of `ValueType` from `TableMetadataPersistence` a good idea?
- Is the v1 metadata actually enough to allow us to sweep things?
- Have we designed ourselves into a corner? I don't think so as we can always destroy the `StreamStoreCleanupMetadata` protobuf and make a new one.
- The code for parsing is a bit nasty, though it is consistent with what we have e.g. for table metadata.
- I used a Visitor so that the classes eventually making decisions in Nimbus (along the lines of `shouldExternalSweeperSweepThisTable` and `createCleanupTaskForTable`) don't have to do this side by side with the data. Is this unnecessarily complex?

**Where should we start reviewing?**: `SchemaMetadataPersistence.proto` first. The `SchemaDependentTableMetadata` class and the `cleanup` package probably next.

**Priority (whenever / two weeks / yesterday)**: soon - next steps for sweeper are to re-work #2747 and #2748 for this schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2847)
<!-- Reviewable:end -->
