### PR TITLE
Feature/prepared cql queries

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
@@ -98,12 +98,6 @@ public class CqlExecutorImpl implements CqlExecutor {
         return result;
     }
 
-    private Arg<String> keys(List<byte[]> rowsAscending) {
-        return UnsafeArg.of("keys",
-                rowsAscending.stream().map(CqlExecutorImpl::getKey)
-                        .collect(Collectors.joining(",")));
-    }
-
     /**
      * Returns a list of {@link CellWithTimestamp}s within the given {@code row}, starting at the (column, timestamp)
      * pair represented by ({@code startColumnInclusive}, {@code startTimestampExclusive}).

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -23,8 +23,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.cassandra.thrift.CqlPreparedResult;
 import org.apache.cassandra.thrift.CqlResult;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +34,7 @@ import org.mockito.ArgumentMatcher;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
@@ -57,16 +60,23 @@ public class CqlExecutorTest {
             Uninterruptibles.sleepUninterruptibly(queryDelayMillis, TimeUnit.MILLISECONDS);
             return result;
         });
+
+        CqlPreparedResult preparedResult = new CqlPreparedResult();
+        preparedResult.setItemId(1);
+        when(queryExecutor.prepare(any(), any())).thenReturn(preparedResult);
+
+        when(queryExecutor.executePrepared(eq(1), any())).thenReturn(result);
     }
 
     @Test
     public void getTimestampsForGivenRows() {
         String expected = "SELECT key, column1, column2 FROM \"foo__bar\""
-                + " WHERE key IN (0x0102,0x0509) LIMIT 100;";
+                + " WHERE key = ? LIMIT 100;";
 
         executor.getTimestamps(TABLE_REF, ImmutableList.of(ROW, END_ROW), LIMIT);
 
-        verify(queryExecutor).execute(argThat(cqlQueryMatcher(expected)), eq(ROW));
+        verify(queryExecutor).prepare(argThat(byteBufferMatcher(expected)), any());
+        verify(queryExecutor).executePrepared(eq(1), eq(ImmutableList.of(ByteBuffer.wrap(ROW))));
 
     }
 
@@ -80,6 +90,20 @@ public class CqlExecutorTest {
         verify(queryExecutor).execute(argThat(cqlQueryMatcher(expected)), eq(ROW));
     }
 
+    private ArgumentMatcher<ByteBuffer> byteBufferMatcher(String expected) {
+        return new ArgumentMatcher<ByteBuffer>() {
+            @Override
+            public boolean matches(Object argument) {
+                if (!(argument instanceof ByteBuffer)) {
+                    return false;
+                }
+
+                String actualQuery = PtBytes.toString(((ByteBuffer) argument).array());
+                return expected.equals(actualQuery);
+            }
+        };
+    }
+
     private ArgumentMatcher<CqlQuery> cqlQueryMatcher(String expected) {
         return new ArgumentMatcher<CqlQuery>() {
             @Override
@@ -88,7 +112,7 @@ public class CqlExecutorTest {
                     return false;
                 }
 
-                String actualQuery = ((CqlQuery) argument).toString();
+                String actualQuery = argument.toString();
                 return expected.equals(actualQuery);
             }
         };

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -63,7 +63,7 @@ public class CqlExecutorTest {
 
         CqlPreparedResult preparedResult = new CqlPreparedResult();
         preparedResult.setItemId(1);
-        when(queryExecutor.prepare(any(), any())).thenReturn(preparedResult);
+        when(queryExecutor.prepare(any(), any(), any())).thenReturn(preparedResult);
 
         when(queryExecutor.executePrepared(eq(1), any())).thenReturn(result);
     }
@@ -75,7 +75,7 @@ public class CqlExecutorTest {
 
         executor.getTimestamps(TABLE_REF, ImmutableList.of(ROW, END_ROW), LIMIT);
 
-        verify(queryExecutor).prepare(argThat(byteBufferMatcher(expected)), any());
+        verify(queryExecutor).prepare(argThat(byteBufferMatcher(expected)), eq(ROW), any());
         verify(queryExecutor).executePrepared(eq(1), eq(ImmutableList.of(ByteBuffer.wrap(ROW))));
 
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,10 +63,12 @@ develop
     *    - |improved|
          - Tritium was upgraded to 0.9.0 (from 0.8.4), which provides functionality for de-registration of tagged metrics.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2823>`__)
+
     *    - |fixed|
          - Further reduced memory pressure on sweep for Cassandra KVS, by rewriting one of the CQL queries.
            This removes a significant cause of occurrences of Cassandra OOMs that have been seen in the field recently.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2826>`__)
+           However, performance is significantly degraded on tables with few columns and few overwrites.
+           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/2826>`__ and `Pull Request 2 <https://github.com/palantir/atlasdb/pull/2826>`__)
 
     *    - |improved|
          - Sweep stats are updated more often when large writes are being made.


### PR DESCRIPTION
Use a more performant* CQL query in the read stage of sweep

The query that this replaced had a significant perf regression for tables with wide rows, which this query largely addresses. However, the increased number of round trips leads to a significant slowdown for tables with very narrow rows (e.g. sequential tables).

The suggestion is to merge this in and release a beta version that we can push to the places with OOM concerns, and to follow up with more performant queries.

Perf data (seconds per full table scan, batch size 1000):
Clean tables (1 column, 1 overwrite):
0.72: 25s
develop: 99s (298% worse)
prepared: 810s (3170% worse)

"Average" tables (10 columns, 3 overwrites)
0.72: 3s
develop: 30s (886% worse)
prepared: 11s (263% worse)

"Dirty" tables (1 column, 100 overwrites)
0.72: 8.8s
develop: 185s (2000% worse)
prepared: 15.5s (77% worse)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2849)
<!-- Reviewable:end -->
