### PR TITLE
TimeLock Documentation Improvements - Reverse Migration / Danger Block / Statelessness

### DIFF
--- a/docs/source/services/timelock_service/index.rst
+++ b/docs/source/services/timelock_service/index.rst
@@ -3,12 +3,6 @@
 External Timelock Service
 =========================
 
-.. danger::
-
-   Running external timestamp and lock services is currently an experimental feature.
-   Improperly configuring one's cluster to use external timestamp and lock services can result in **SEVERE DATA
-   CORRUPTION**! Please contact the AtlasDB team if you wish to try this feature.
-
 .. toctree::
     :maxdepth: 1
     :titlesonly:
@@ -35,3 +29,5 @@ services embedded within one's clients) provides several benefits:
   difficult.
 - Timelock Services can be run in clustered mode, allowing for high availability as long as a majority quorum of nodes
   exists.
+- AtlasDB client services running in HA mode may potentially become stateless, possibly simplifying deployability,
+  availability and backup stories. Previously, these services would keep track of Paxos information on the local disk.

--- a/docs/source/services/timelock_service/reverse-migration.rst
+++ b/docs/source/services/timelock_service/reverse-migration.rst
@@ -19,7 +19,6 @@ Throughout this document, we assume the AtlasDB client you are trying to reverse
 #. Shut down your AtlasDB clients for ``client`` .
 #. Take a restore timestamp.
 #. Revert your AtlasDB client configuration.
-#. Remove your client from the list of TimeLock clients.
 #. Restart the TimeLock servers.
 #. Update your key-value service to the restore timestamp.
 #. Start your AtlasDB clients.
@@ -42,7 +41,7 @@ node that was not the leader; please try the other nodes.
 
 .. code-block:: none
 
-   $ curl -XPOST https://<timelock-host>:8421/client/timestamp/fresh-timestamp
+   $ curl -XPOST https://<timelock-host>:8421/timelock/api/client/timestamp/fresh-timestamp
    123456789
 
 Note down the value returned from this call; we'll refer to it as ``TS`` from here on.
@@ -53,29 +52,13 @@ Step 3: Revert AtlasDB Client Configurations
 Remove the ``timelock`` block from your AtlasDB client configurations. For more detail on options
 for using embedded timestamp and lock services, please consult :ref:`Leader Config<leader-config>`.
 
-Step 4: Reconfigure TimeLock
-----------------------------
-
-Remove ``client`` from the ``clients`` block of your TimeLock server configuration.
-
-Step 5: Start your TimeLock Servers
+Step 4: Start your TimeLock Servers
 -----------------------------------
 
 Start your TimeLock servers. Other services that were still dependent on TimeLock (if any) should now
-work normally. To verify that your client no longer uses TimeLock, it may be useful to curl the fresh-timestamp
-endpoint for your node, expecting a ``NotFoundException`` :
+work normally. This step is placed here to minimise downtime for other services that may be running against TimeLock.
 
-.. code-block:: none
-
-   $ curl -XPOST https://<timelock-host>:8421/client/timestamp/fresh-timestamp
-   {
-     "message" : "d37a5956-c492-4a3b-a057-b7b4ea557043",
-     "exceptionClass" : "javax.ws.rs.NotFoundException",
-     "stackTrace" : null
-   }
-
-
-Step 6: Update your Key-Value Service
+Step 5: Update your Key-Value Service
 -------------------------------------
 
 Update the timestamp table in your key value service, such that it is valid and has the bound set to ``TS`` .
@@ -131,7 +114,7 @@ This will vary depending on your choice of key-value service:
 
      ALTER TABLE atlasdb_timestamp RENAME LEGACY_last_allocated TO last_allocated;
 
-Step 7: Start your AtlasDB Clients
+Step 6: Start your AtlasDB Clients
 ----------------------------------
 
 Finally, start your AtlasDB clients. At this point, it may be useful to perform a simple smoke test to verify that your
@@ -140,7 +123,7 @@ timestamp from above.
 
   .. code-block:: none
 
-   $ curl -XPOST https://<client-host>:<application-port>/client/timestamp/fresh-timestamp
+   $ curl -XPOST https://<client-host>:<application-port><application-context-path>/timestamp/fresh-timestamp
    123456790 # greater than restore timestamp
 
 This completes the reverse migration process.


### PR DESCRIPTION
**Goals (and why)**:
- Fix reverse migration docs (which are wrong after #2252)
- Remove the danger block / experimental feature
- Add a mention of statelessness as a benefit of timelock

**Implementation Description (bullets)**:
Pretty much as outlined above. The main change in the Reverse Migration docs was to account for the fact that a client does not actually go away.

**Concerns (what feedback would you like?)**: not much

**Where should we start reviewing?**: this is an 8/29 so a sweep line algorithm should work.

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2851)
<!-- Reviewable:end -->
