### PR TITLE
[0.61.x] Backport "Allow overriding JDBC URL for Oracle"

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/OracleConnectionConfig.java
@@ -46,8 +46,7 @@ public abstract class OracleConnectionConfig extends ConnectionConfig {
     public abstract int getPort();
 
     @Override
-    @Value.Derived
-    @JsonIgnore
+    @Value.Default
     public String getUrl() {
         if (getServerDn().isPresent()) {
             return String.format("jdbc:oracle:thin:@(DESCRIPTION=" +

--- a/commons-db/src/main/java/com/palantir/nexus/db/DBType.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/DBType.java
@@ -29,11 +29,10 @@ import com.palantir.sql.Connections;
  */
 public enum DBType {
     // AJ: the oracle jdbc url is missing a final "paren" - processing in DBMgr will fix this...
-    ORACLE("jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL={PROTOCOL})(HOST={HOST})(PORT={PORT}))(CONNECT_DATA=(SID={SID}))", "oracle.jdbc.driver.OracleDriver", "SELECT 1 FROM dual", true),
-    POSTGRESQL("jdbc:postgresql://{HOST}:{PORT}/{DBNAME}", "org.postgresql.Driver", "SELECT 1", true),
-    H2_MEMORY("jdbc:h2:mem:", "org.h2.Driver", "SELECT 1", true);
+    ORACLE("oracle.jdbc.driver.OracleDriver", "SELECT 1 FROM dual", true),
+    POSTGRESQL("org.postgresql.Driver", "SELECT 1", true),
+    H2_MEMORY("org.h2.Driver", "SELECT 1", true);
 
-    private final String defaultUrl;
     private final String driver;
     private final String testQuery;
     private final boolean hasGIS;
@@ -42,15 +41,10 @@ public enum DBType {
         return hasGIS;
     }
 
-    private DBType(String defaultUrl, String driver, String testQuery, boolean hasGIS) {
-        this.defaultUrl = defaultUrl;
+    private DBType(String driver, String testQuery, boolean hasGIS) {
         this.driver = driver;
         this.testQuery = testQuery;
         this.hasGIS = hasGIS;
-    }
-
-    public String getDefaultUrl() {
-        return defaultUrl;
     }
 
     public String getDriverName() {


### PR DESCRIPTION
* Allow overriding JDBC URL for Oracle

Also remove getDefaultUrl() from DBType

* Fix release note syntax

(cherry picked from commit e5c1e8ca3b6dda5408e9c2c9139ec6c6dca3879f)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2854)
<!-- Reviewable:end -->
