### PR TITLE
Add metric for the throttling applied by the Qos service

### DIFF
--- a/qos-service-impl/src/integTest/resources/server.yml
+++ b/qos-service-impl/src/integTest/resources/server.yml
@@ -9,17 +9,14 @@ runtime:
       limits:
         readBytesPerSecond: 10
         writeBytesPerSecond: 20
-      clientPriority: HIGH
     test2:
       limits:
         readBytesPerSecond: 30
         writeBytesPerSecond: 40
-      clientPriority: MEDIUM
     test3:
       limits:
         readBytesPerSecond: 50
         writeBytesPerSecond: 50
-      clientPriority: LOW
   qos-cassandra-metrics:
     cassandra-health-metrics:
       - type: CommitLog

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/QosResource.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/QosResource.java
@@ -25,19 +25,20 @@ public class QosResource implements QosService {
     private final ClientLimitMultiplier clientLimitMultiplier;
     private static volatile double readLimitMultiplier = 1.0;
     private static volatile double writeLimitMultiplier = 1.0;
+    private static final MetricsManager metricsManager = new MetricsManager();
 
     public QosResource(QosClientConfigLoader qosClientConfigLoader, ClientLimitMultiplier clientLimitMultiplier) {
         this.qosClientConfigLoader = qosClientConfigLoader;
         this.clientLimitMultiplier = clientLimitMultiplier;
-        new MetricsManager().registerMetric(QosResource.class, "readLimitMultiplier", this::getReadLimitMultiplier);
-        new MetricsManager().registerMetric(QosResource.class, "writeLimitMultiplier", this::getWriteLimitMultiplier);
+        metricsManager.registerMetric(QosResource.class, "readLimitMultiplier", this::getReadLimitMultiplier);
+        metricsManager.registerMetric(QosResource.class, "writeLimitMultiplier", this::getWriteLimitMultiplier);
     }
 
     @Override
     public long readLimit(String client) {
         QosClientLimitsConfig qosClientLimitsConfig = qosClientConfigLoader.getConfigForClient(client);
         readLimitMultiplier = this.clientLimitMultiplier.getClientLimitMultiplier(
-                qosClientLimitsConfig.clientPriority());
+        );
         return (long) (readLimitMultiplier * qosClientLimitsConfig.limits().readBytesPerSecond());
     }
 
@@ -45,7 +46,7 @@ public class QosResource implements QosService {
     public long writeLimit(String client) {
         QosClientLimitsConfig qosClientLimitsConfig = qosClientConfigLoader.getConfigForClient(client);
         writeLimitMultiplier = this.clientLimitMultiplier.getClientLimitMultiplier(
-                qosClientLimitsConfig.clientPriority());
+        );
         return (long) (writeLimitMultiplier * qosClientLimitsConfig.limits().writeBytesPerSecond());
     }
 

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/QosResource.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/QosResource.java
@@ -18,27 +18,42 @@ package com.palantir.atlasdb.qos;
 import com.palantir.atlasdb.qos.com.palantir.atlasdb.qos.agent.QosClientConfigLoader;
 import com.palantir.atlasdb.qos.config.QosClientLimitsConfig;
 import com.palantir.atlasdb.qos.ratelimit.ClientLimitMultiplier;
+import com.palantir.atlasdb.util.MetricsManager;
 
 public class QosResource implements QosService {
     private final QosClientConfigLoader qosClientConfigLoader;
     private final ClientLimitMultiplier clientLimitMultiplier;
+    private static volatile double readLimitMultiplier = 1.0;
+    private static volatile double writeLimitMultiplier = 1.0;
 
     public QosResource(QosClientConfigLoader qosClientConfigLoader, ClientLimitMultiplier clientLimitMultiplier) {
         this.qosClientConfigLoader = qosClientConfigLoader;
         this.clientLimitMultiplier = clientLimitMultiplier;
+        new MetricsManager().registerMetric(QosResource.class, "readLimitMultiplier", this::getReadLimitMultiplier);
+        new MetricsManager().registerMetric(QosResource.class, "writeLimitMultiplier", this::getWriteLimitMultiplier);
     }
 
     @Override
     public long readLimit(String client) {
         QosClientLimitsConfig qosClientLimitsConfig = qosClientConfigLoader.getConfigForClient(client);
-        return (long) (clientLimitMultiplier.getClientLimitMultiplier(qosClientLimitsConfig.clientPriority())
-                * qosClientLimitsConfig.limits().readBytesPerSecond());
+        readLimitMultiplier = this.clientLimitMultiplier.getClientLimitMultiplier(
+                qosClientLimitsConfig.clientPriority());
+        return (long) (readLimitMultiplier * qosClientLimitsConfig.limits().readBytesPerSecond());
     }
 
     @Override
     public long writeLimit(String client) {
         QosClientLimitsConfig qosClientLimitsConfig = qosClientConfigLoader.getConfigForClient(client);
-        return (long) (clientLimitMultiplier.getClientLimitMultiplier(qosClientLimitsConfig.clientPriority())
-                * qosClientLimitsConfig.limits().writeBytesPerSecond());
+        writeLimitMultiplier = this.clientLimitMultiplier.getClientLimitMultiplier(
+                qosClientLimitsConfig.clientPriority());
+        return (long) (writeLimitMultiplier * qosClientLimitsConfig.limits().writeBytesPerSecond());
+    }
+
+    private double getReadLimitMultiplier() {
+        return readLimitMultiplier;
+    }
+
+    private double getWriteLimitMultiplier() {
+        return writeLimitMultiplier;
     }
 }

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/QosClientLimitsConfig.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/QosClientLimitsConfig.java
@@ -39,9 +39,4 @@ public abstract class QosClientLimitsConfig implements Serializable {
                 .writeBytesPerSecond(BYTES_WRITTEN_PER_SECOND_PER_CLIENT)
                 .build();
     }
-
-    @Value.Default
-    public QosPriority clientPriority() {
-        return QosPriority.HIGH;
-    }
 }

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
@@ -23,7 +23,6 @@ import java.util.function.Supplier;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.config.QosCassandraMetricsInstallConfig;
 import com.palantir.atlasdb.qos.config.QosCassandraMetricsRuntimeConfig;
-import com.palantir.atlasdb.qos.config.QosPriority;
 import com.palantir.atlasdb.qos.config.ThrottlingStrategy;
 import com.palantir.cassandra.sidecar.metrics.CassandraMetricsService;
 import com.palantir.remoting3.clients.ClientConfigurations;
@@ -55,11 +54,7 @@ public class CassandraMetricsClientLimitMultiplier implements ClientLimitMultipl
         return new CassandraMetricsClientLimitMultiplier(throttlingStrategy, cassandraMetricMeasurementsLoader);
     }
 
-    public double getClientLimitMultiplier(QosPriority qosPriority) {
-        if (qosPriority == QosPriority.HIGH) {
-            return 1.0; // don't lower the limit for HIGH priority clients.
-        }
-
+    public double getClientLimitMultiplier() {
         return throttlingStrategy.getClientLimitMultiplier(getCassandraHealthMetricMeasurements());
     }
 

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/ClientLimitMultiplier.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/ClientLimitMultiplier.java
@@ -16,8 +16,6 @@
 
 package com.palantir.atlasdb.qos.ratelimit;
 
-import com.palantir.atlasdb.qos.config.QosPriority;
-
 public interface ClientLimitMultiplier {
-    double getClientLimitMultiplier(QosPriority qosPriority);
+    double getClientLimitMultiplier();
 }

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/OneReturningClientLimitMultiplier.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/OneReturningClientLimitMultiplier.java
@@ -15,13 +15,11 @@
  */
 package com.palantir.atlasdb.qos.ratelimit;
 
-import com.palantir.atlasdb.qos.config.QosPriority;
-
 public enum OneReturningClientLimitMultiplier implements ClientLimitMultiplier {
     INSTANCE;
 
     @Override
-    public double getClientLimitMultiplier(QosPriority qosPriority) {
+    public double getClientLimitMultiplier() {
         return 1.0;
     }
 

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServerRuntimeConfigDeserializationTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServerRuntimeConfigDeserializationTest.java
@@ -34,7 +34,6 @@ import com.palantir.atlasdb.qos.config.ImmutableQosCassandraMetricsRuntimeConfig
 import com.palantir.atlasdb.qos.config.ImmutableQosClientLimitsConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosLimitsConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosServiceRuntimeConfig;
-import com.palantir.atlasdb.qos.config.QosPriority;
 import com.palantir.atlasdb.qos.config.QosServiceRuntimeConfig;
 
 public class QosServerRuntimeConfigDeserializationTest {
@@ -77,20 +76,18 @@ public class QosServerRuntimeConfigDeserializationTest {
     }
 
     private ImmutableMap<String, ImmutableQosClientLimitsConfig> getTestClientLimits() {
-        return ImmutableMap.of("test", getQosClientLimitsConfig(10, 20, QosPriority.HIGH),
-                "test2", getQosClientLimitsConfig(30, 40, QosPriority.MEDIUM),
-                "test3", getQosClientLimitsConfig(50, 50, QosPriority.LOW));
+        return ImmutableMap.of("test", getQosClientLimitsConfig(10, 20),
+                "test2", getQosClientLimitsConfig(30, 40),
+                "test3", getQosClientLimitsConfig(50, 50));
     }
 
     private ImmutableQosClientLimitsConfig getQosClientLimitsConfig(long readLimit,
-            long writeLimit,
-            QosPriority priority) {
+            long writeLimit) {
         return ImmutableQosClientLimitsConfig.builder()
                 .limits(ImmutableQosLimitsConfig.builder()
                         .readBytesPerSecond(readLimit)
                         .writeBytesPerSecond(writeLimit)
                         .build())
-                .clientPriority(priority)
                 .build();
     }
 }

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServiceRuntimeConfigTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServiceRuntimeConfigTest.java
@@ -24,7 +24,6 @@ import com.palantir.atlasdb.qos.config.ImmutableQosCassandraMetricsRuntimeConfig
 import com.palantir.atlasdb.qos.config.ImmutableQosClientLimitsConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosLimitsConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosServiceRuntimeConfig;
-import com.palantir.atlasdb.qos.config.QosPriority;
 
 public class QosServiceRuntimeConfigTest {
     @Test
@@ -42,30 +41,30 @@ public class QosServiceRuntimeConfigTest {
     @Test
     public void canBuildFromSingleClientLimitWithoutCasandraMetricsConfig() {
         ImmutableQosServiceRuntimeConfig.builder()
-                .clientLimits(ImmutableMap.of("test_client", getQosClientLimitsConfig(QosPriority.LOW)))
+                .clientLimits(ImmutableMap.of("test_client", getQosClientLimitsConfig()))
                 .qosCassandraMetricsConfig(getCassandraMetricsConfig());
     }
 
     @Test
     public void canBuildFromSingleClientLimitWithCasandraMetricsConfig() {
         ImmutableQosServiceRuntimeConfig.builder()
-                .clientLimits(ImmutableMap.of("test_client", getQosClientLimitsConfig(QosPriority.LOW)))
+                .clientLimits(ImmutableMap.of("test_client", getQosClientLimitsConfig()))
                 .build();
     }
 
     @Test
     public void canBuildFromMultipleClientLimitsWithoutCassandraMetricsConfig() {
         ImmutableQosServiceRuntimeConfig.builder()
-                .clientLimits(ImmutableMap.of("test_client", getQosClientLimitsConfig(QosPriority.LOW),
-                        "test_client2", getQosClientLimitsConfig(QosPriority.LOW)))
+                .clientLimits(ImmutableMap.of("test_client", getQosClientLimitsConfig(),
+                        "test_client2", getQosClientLimitsConfig()))
                 .build();
     }
 
     @Test
     public void canBuildFromMultipleClientLimitsWithCassandraMetricsConfig() {
         ImmutableQosServiceRuntimeConfig.builder()
-                .clientLimits(ImmutableMap.of("test_client", getQosClientLimitsConfig(QosPriority.LOW),
-                        "test_client2", getQosClientLimitsConfig(QosPriority.LOW)))
+                .clientLimits(ImmutableMap.of("test_client", getQosClientLimitsConfig(),
+                        "test_client2", getQosClientLimitsConfig()))
                 .qosCassandraMetricsConfig(getCassandraMetricsConfig())
                 .build();
     }
@@ -82,13 +81,12 @@ public class QosServiceRuntimeConfigTest {
                 .build();
     }
 
-    private ImmutableQosClientLimitsConfig getQosClientLimitsConfig(QosPriority priority) {
+    private ImmutableQosClientLimitsConfig getQosClientLimitsConfig() {
         return ImmutableQosClientLimitsConfig.builder()
                 .limits(ImmutableQosLimitsConfig.builder()
                         .readBytesPerSecond(10L)
                         .writeBytesPerSecond(10L)
                         .build())
-                .clientPriority(priority)
                 .build();
     }
 }

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServiceTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServiceTest.java
@@ -34,7 +34,6 @@ import com.palantir.atlasdb.qos.com.palantir.atlasdb.qos.agent.QosClientConfigLo
 import com.palantir.atlasdb.qos.config.ImmutableQosClientLimitsConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosLimitsConfig;
 import com.palantir.atlasdb.qos.config.QosClientLimitsConfig;
-import com.palantir.atlasdb.qos.config.QosPriority;
 import com.palantir.atlasdb.qos.ratelimit.CassandraMetricsClientLimitMultiplier;
 import com.palantir.atlasdb.qos.ratelimit.OneReturningClientLimitMultiplier;
 
@@ -77,7 +76,6 @@ public class QosServiceTest {
     public void canScaleDownLimits() {
         QosClientConfigLoader qosClientConfigLoader = QosClientConfigLoader.create(() -> ImmutableMap.of("foo",
                 ImmutableQosClientLimitsConfig.builder()
-                        .clientPriority(QosPriority.MEDIUM)
                         .limits(ImmutableQosLimitsConfig.builder()
                                 .readBytesPerSecond(100)
                                 .writeBytesPerSecond(20)
@@ -85,7 +83,7 @@ public class QosServiceTest {
                         .build()));
         CassandraMetricsClientLimitMultiplier clientLimitMultiplier = mock(CassandraMetricsClientLimitMultiplier.class);
         resource = new QosResource(qosClientConfigLoader, clientLimitMultiplier);
-        when(clientLimitMultiplier.getClientLimitMultiplier(QosPriority.MEDIUM)).thenReturn(1.0, 1.0, 0.5, 0.5, 0.25,
+        when(clientLimitMultiplier.getClientLimitMultiplier()).thenReturn(1.0, 1.0, 0.5, 0.5, 0.25,
                 0.25);
         assertEquals(100L, resource.readLimit("foo"));
         assertEquals(20L, resource.writeLimit("foo"));
@@ -99,7 +97,6 @@ public class QosServiceTest {
     public void canScaleDownAndScaleUpLimits() {
         QosClientConfigLoader qosClientConfigLoader = QosClientConfigLoader.create(() -> ImmutableMap.of("foo",
                 ImmutableQosClientLimitsConfig.builder()
-                        .clientPriority(QosPriority.MEDIUM)
                         .limits(ImmutableQosLimitsConfig.builder()
                                 .readBytesPerSecond(100)
                                 .writeBytesPerSecond(20)
@@ -107,7 +104,7 @@ public class QosServiceTest {
                         .build()));
         CassandraMetricsClientLimitMultiplier clientLimitMultiplier = mock(CassandraMetricsClientLimitMultiplier.class);
         resource = new QosResource(qosClientConfigLoader, clientLimitMultiplier);
-        when(clientLimitMultiplier.getClientLimitMultiplier(QosPriority.MEDIUM)).thenReturn(1.0, 1.0, 0.5, 0.5, 0.55,
+        when(clientLimitMultiplier.getClientLimitMultiplier()).thenReturn(1.0, 1.0, 0.5, 0.5, 0.55,
                 0.55);
         assertEquals(100L, resource.readLimit("foo"));
         assertEquals(20L, resource.writeLimit("foo"));
@@ -125,7 +122,6 @@ public class QosServiceTest {
                                         .writeBytesPerSecond(entry.getValue())
                                         .readBytesPerSecond(entry.getValue())
                                         .build())
-                                .clientPriority(QosPriority.HIGH)
                                 .build()));
     }
 }

--- a/qos-service-impl/src/test/resources/qos-server-with-cassandra-metrics.yml
+++ b/qos-service-impl/src/test/resources/qos-server-with-cassandra-metrics.yml
@@ -3,17 +3,14 @@ client-limits:
     limits:
       readBytesPerSecond: 10
       writeBytesPerSecond: 20
-    clientPriority: HIGH
   test2:
     limits:
       readBytesPerSecond: 30
       writeBytesPerSecond: 40
-    clientPriority: MEDIUM
   test3:
     limits:
       readBytesPerSecond: 50
       writeBytesPerSecond: 50
-    clientPriority: LOW
 qos-cassandra-metrics:
   cassandra-health-metrics:
     - type: CommitLog

--- a/qos-service-impl/src/test/resources/qos-server-without-cassandra-metrics.yml
+++ b/qos-service-impl/src/test/resources/qos-server-without-cassandra-metrics.yml
@@ -3,14 +3,11 @@ client-limits:
     limits:
       readBytesPerSecond: 10
       writeBytesPerSecond: 20
-    clientPriority: HIGH
   test2:
     limits:
       readBytesPerSecond: 30
       writeBytesPerSecond: 40
-    clientPriority: MEDIUM
   test3:
     limits:
       readBytesPerSecond: 50
       writeBytesPerSecond: 50
-    clientPriority: LOW


### PR DESCRIPTION
**Goals (and why)**: Metrics for read and write limit multipliers

**Implementation Description (bullets)**: add gauges.

**Concerns (what feedback would you like?)**: 
I have two separate metrics because I think going forward we might change the read and write multipliers to not be the same.

**Where should we start reviewing?**: one file.

**Priority (whenever / two weeks / yesterday)**: soon

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2857)
<!-- Reviewable:end -->
