### PR TITLE
Feature/parallel sweep

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.remoting.api.config.ssl.SslConfiguration;
@@ -236,9 +237,21 @@ public abstract class CassandraKeyValueServiceConfig implements KeyValueServiceC
         return false;
     }
 
+    /**
+     * Obsolete value, replaced by {@link SweepConfig#readLimit}.
+     *
+     * @deprecated this parameter is unused and should be removed from the configuration
+     */
+    @SuppressWarnings("DeprecatedIsStillUsed") // Used by immutable copy of this file
     @Value.Default
+    @Deprecated
     public Integer timestampsGetterBatchSize() {
         return 1_000;
+    }
+
+    @Value.Default
+    public Integer sweepReadThreads() {
+        return AtlasDbConstants.DEFAULT_SWEEP_CASSANDRA_READ_THREADS;
     }
 
     public abstract Optional<CassandraJmxCompactionConfig> jmx();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -132,6 +133,7 @@ import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.FunctionCheckedException;
+import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.exception.PalantirRuntimeException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
@@ -1499,7 +1501,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private CqlExecutor newInstrumentedCqlExecutor() {
-        return AtlasDbMetrics.instrument(CqlExecutor.class, new CqlExecutorImpl(clientPool, ConsistencyLevel.ALL));
+        ExecutorService executorService = PTExecutors.newFixedThreadPool(16);
+        return AtlasDbMetrics.instrument(CqlExecutor.class,
+                new CqlExecutorImpl(executorService, clientPool, ConsistencyLevel.ALL));
     }
 
     private <T> ClosableIterator<RowResult<T>> getRangeWithPageCreator(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1501,9 +1501,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     private CqlExecutor newInstrumentedCqlExecutor() {
-        ExecutorService executorService = PTExecutors.newFixedThreadPool(16);
+        int numThreads = configManager.getConfig().sweepReadThreads();
+        ExecutorService executorService = PTExecutors.newFixedThreadPool(numThreads);
         return AtlasDbMetrics.instrument(CqlExecutor.class,
-                new CqlExecutorImpl(executorService, clientPool, ConsistencyLevel.ALL));
+                new CqlExecutorImpl(executorService, clientPool, ConsistencyLevel.ALL, numThreads));
     }
 
     private <T> ClosableIterator<RowResult<T>> getRangeWithPageCreator(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutor.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.sweep.CellWithTimestamp;
@@ -37,6 +38,9 @@ public interface CqlExecutor {
      * Returns a list of {@link CellWithTimestamp}s from cells within the given {@code rows}, starting at the given
      * {@code startRowInclusive}, potentially spanning across multiple rows. Will only return {@code limit} values,
      * so may not return cells from all of the rows provided.
+     * @param executor is used for parallelizing the queries to Cassandra. Each row is fetched in a separate thread.
+     * @param executorThreads the number of threads to use when fetching rows from Cassandra.
      */
-    List<CellWithTimestamp> getTimestamps(TableReference tableRef, List<byte[]> rows, int limit);
+    List<CellWithTimestamp> getTimestamps(TableReference tableRef, List<byte[]> rows, int limit,
+            ExecutorService executor, Integer executorThreads);
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
@@ -111,6 +111,7 @@ public class CqlExecutorImpl implements CqlExecutor {
                 result.addAll(CqlExecutorImpl.getCells(CqlExecutorImpl::getCellFromRow, cqlResult));
 
                 if (result.size() > limit) {
+                    cancelFutures(futures.subList(i + 1, futures.size()));
                     break;
                 }
 
@@ -131,6 +132,10 @@ public class CqlExecutorImpl implements CqlExecutor {
         Callable<CqlResult> task = () -> queryExecutor.executePrepared(queryId,
                 ImmutableList.of(ByteBuffer.wrap(row)));
         return executor.submit(task);
+    }
+
+    private void cancelFutures(List<Future<CqlResult>> futures) {
+        futures.forEach(f -> f.cancel(true));
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
@@ -116,6 +116,10 @@ public class CqlExecutorImpl implements CqlExecutor {
                     // TODO map results to row indices? Use a sorted List?
                     CqlResult cqlResult = f.get();
                     result.addAll(CqlExecutorImpl.getCells(CqlExecutorImpl::getCellFromRow, cqlResult));
+
+                    if (result.size() > limit) {
+                        break;
+                    }
                 }
             } catch (InterruptedException e) {
                 throw Throwables.throwUncheckedException(e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/CandidateRowsForSweepingIterator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/sweep/CandidateRowsForSweepingIterator.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweepingRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -37,18 +38,21 @@ public class CandidateRowsForSweepingIterator extends AbstractIterator<List<Cand
     private final CandidateCellForSweepingRequest request;
 
     byte[] nextStartRow;
+    private CassandraKeyValueServiceConfig config;
 
     public CandidateRowsForSweepingIterator(
             ValuesLoader valuesLoader,
             CqlExecutor cqlExecutor,
             RowGetter rowGetter,
             TableReference table,
-            CandidateCellForSweepingRequest request) {
+            CandidateCellForSweepingRequest request,
+            CassandraKeyValueServiceConfig config) {
         this.valuesLoader = valuesLoader;
         this.cqlExecutor = cqlExecutor;
         this.rowGetter = rowGetter;
         this.table = table;
         this.request = request;
+        this.config = config;
 
         nextStartRow = request.startRowInclusive();
     }
@@ -67,7 +71,12 @@ public class CandidateRowsForSweepingIterator extends AbstractIterator<List<Cand
     }
 
     private List<CandidateRowForSweeping> getCandidateCellsForSweepingBatch() {
-        return new GetCandidateRowsForSweeping(valuesLoader, cqlExecutor, rowGetter, table,
-                request.withStartRow(nextStartRow)).execute();
+        return new GetCandidateRowsForSweeping(valuesLoader,
+                cqlExecutor,
+                rowGetter,
+                table,
+                request.withStartRow(nextStartRow),
+                config)
+                .execute();
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -34,9 +34,11 @@ import org.mockito.ArgumentMatcher;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.common.concurrent.PTExecutors;
 
 public class CqlExecutorTest {
 
@@ -73,7 +75,9 @@ public class CqlExecutorTest {
         String expected = "SELECT key, column1, column2 FROM \"foo__bar\""
                 + " WHERE key = ? LIMIT 100;";
 
-        executor.getTimestamps(TABLE_REF, ImmutableList.of(ROW, END_ROW), LIMIT);
+        int executorThreads = AtlasDbConstants.DEFAULT_SWEEP_CASSANDRA_READ_THREADS;
+        executor.getTimestamps(TABLE_REF, ImmutableList.of(ROW, END_ROW), LIMIT,
+                PTExecutors.newFixedThreadPool(executorThreads), executorThreads);
 
         verify(queryExecutor).prepare(argThat(byteBufferMatcher(expected)), eq(ROW), any());
         verify(queryExecutor).executePrepared(eq(1), eq(ImmutableList.of(ByteBuffer.wrap(ROW))));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -77,7 +77,7 @@ public class CqlExecutorTest {
 
         verify(queryExecutor).prepare(argThat(byteBufferMatcher(expected)), eq(ROW), any());
         verify(queryExecutor).executePrepared(eq(1), eq(ImmutableList.of(ByteBuffer.wrap(ROW))));
-
+        verify(queryExecutor).executePrepared(eq(1), eq(ImmutableList.of(ByteBuffer.wrap(END_ROW))));
     }
 
     @Test

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -113,6 +113,7 @@ public final class AtlasDbConstants {
     public static final int DEFAULT_SWEEP_DELETE_BATCH_HINT = 128;
     public static final int DEFAULT_SWEEP_CANDIDATE_BATCH_HINT = 128;
     public static final int DEFAULT_SWEEP_READ_LIMIT = 128;
+    public static final int DEFAULT_SWEEP_CASSANDRA_READ_THREADS = 16;
 
     public static final int DEFAULT_STREAM_IN_MEMORY_THRESHOLD = 4 * 1024 * 1024;
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,24 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - On Cassandra KVS, sweep reads data from Cassandra in parallel, resulting in improved performance.
+           The parallelism can be changed by adjusting ``sweepReadThreads`` in Cassandra KVS config (default 16).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2860>`__)
+
+===========
+v0.73.0-rc1
+===========
+
+11 January 2018
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
     *    - |improved| |logs| |metrics|
          - Allow StreamStore table names to be marked as safe. This will make StreamStore tables appear correctly on our logs and metrics.
            When building a StreamStore, please use `.tableNameLogSafety(TableMetadataPersistence.LogSafety.SAFE)` to mark the table name as safe.
@@ -84,19 +102,19 @@ develop
 
     *    - |improved|
          - Improvements to how sweep prioritises which tables to sweep, should allow better reclaiming of space from stream stores.
-           Stream store value tables are now more likely to be chosen because they contain lots of data per write.  We ensure we sweep index tables before value tables, and allow a gap after sweeping index tables and before sweeping value tables.  Wait 3 days between sweeps of a value table to prevent unnecessary work, allow other tables to be swept and tombstones to be compacted away. 
+           Stream store value tables are now more likely to be chosen because they contain lots of data per write.  We ensure we sweep index tables before value tables, and allow a gap after sweeping index tables and before sweeping value tables.  Wait 3 days between sweeps of a value table to prevent unnecessary work, allow other tables to be swept and tombstones to be compacted away.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2793>`__)
 
     *    - |fixed| |logs|
          - Safe and Unsafe table name logging args are now different, fixed unreleased bug where tables names were logged as Safe
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2838>`__)
-           
+
     *    - |logs|
          - Messages to the `slow-lock-log` now log at `WARN` rather than `INFO`, these messages can indicate a problem so we should be sure they are visible.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2828>`__)
 
     *    - |fixed|
-         - SweepResults.getCellTsPairsExamined now returns the correct result when sweep is run over multiple batches. 
+         - SweepResults.getCellTsPairsExamined now returns the correct result when sweep is run over multiple batches.
            Previously, the result would only count cell-ts pairs examined in the last batch.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2830>`__)
 


### PR DESCRIPTION
Tagging @tpetracca and @schlosna for Cassandra/parallel code feedback.

**Goals (and why)**: Follow-up to #2849, which itself was a follow-up to #2826. 
Speed up sweep by fetching rows from Cassandra in parallel. This improves the speed by 40-80% compared to develop.

Currently, develop exhibits a 24x regression for the `fullTableScanCleanConservative` benchmark compared to the 0.72 release; this PR reduces the regression to 3.4x.
For the `fullTableScanDirtyConservative` benchmark, this PR is 3% faster than 0.72, whereas develop was 68% slower.

When we consider that deployments should be able to run sweep with a batch size of 1024 (compared to the current default of 128), the read stage will be about 3x faster for regular tables, and only 19% slower for clean (i.e. very narrow/sequential) tables.

**Implementation Description (bullets)**:
* Create an ExecutorService when creating a CqlExecutor
* Use 16 threads (currently hard-coded) to send off CQL queries to Cassandra in parallel

**Concerns (what feedback would you like?)**: This means sweep will use 16 clients from Cassandra's client pool instead of 1. Are we concerned by this increase in utilisation?
I believe that, if sweep exhausts the client pool, we will simply wait on the Atlas side for new clients; however, this could lead to regular queries becoming slower.

**Where should we start reviewing?**: CqlExecutorImpl

**Priority (whenever / two weeks / yesterday)**: ASAP - this is blocking a "proper" AtlasDB release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2860)
<!-- Reviewable:end -->
