### PR TITLE
[MMM] Typo in Error Message - "transacton"

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
@@ -30,7 +30,7 @@ public class TransactionSerializableConflictException extends TransactionFailedR
             long timestamp,
             long elapsedMillis) {
         String msg = String.format("There was a read-write conflict on table %s.  This means that this table was "
-                + "marked as Serializable and another transacton wrote a different value than this transaction read.  "
+                + "marked as Serializable and another transaction wrote a different value than this transaction read.  "
                 + "startTs: %d  elapsedMillis: %d", tableRef.getQualifiedName(), timestamp, elapsedMillis);
         return new TransactionSerializableConflictException(msg);
     }


### PR DESCRIPTION
**Goals (and why)**:
- Fix typo in error message. This is a cherry pick of #2806.

**Implementation Description (bullets)**:
- Add a missing `i`

**Concerns (what feedback would you like?)**:
- None really. It's spelled `transaction` right? 😅 

**Where should we start reviewing?**: 1/1

**Priority (whenever / two weeks / yesterday)**: whenever

@roxannemoslehi for SA - AtlasDB isn't too friendly to forks unfortunately :(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2866)
<!-- Reviewable:end -->
