### PR TITLE
ThrottlingStrategyFactory -> ThrottlingStrategies

### DIFF
--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
@@ -47,7 +47,7 @@ public class CassandraMetricsClientLimitMultiplier implements ClientLimitMultipl
                 CassandraMetricsService.class,
                 "qos-service",
                 ClientConfigurations.of(installConfig.cassandraServiceConfig()));
-        ThrottlingStrategy throttlingStrategy = ThrottlingStrategyFactory.getThrottlingStrategy(
+        ThrottlingStrategy throttlingStrategy = ThrottlingStrategies.getThrottlingStrategy(
                 installConfig.throttlingStrategy());
 
         CassandraMetricMeasurementsLoader cassandraMetricMeasurementsLoader = new CassandraMetricMeasurementsLoader(

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/ThrottlingStrategies.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/ThrottlingStrategies.java
@@ -19,9 +19,9 @@ package com.palantir.atlasdb.qos.ratelimit;
 import com.palantir.atlasdb.qos.config.SimpleThrottlingStrategy;
 import com.palantir.atlasdb.qos.config.ThrottlingStrategy;
 
-public final class ThrottlingStrategyFactory {
+public final class ThrottlingStrategies {
 
-    private ThrottlingStrategyFactory() {
+    private ThrottlingStrategies() {
         //utility class
     }
 


### PR DESCRIPTION
**Goals (and why)**:
- This name breaks large internal product, which has very strict rules on naming conventions.
- Generally _factory_ is used to refer to a concrete object that produces other concrete objects too, so it doesn't really apply here.

**Implementation Description (bullets)**:
- Rename `ThrottlingStrategyFactory` to `ThrottlingStrategies`

**Concerns (what feedback would you like?)**:
- Technically this is a dev break but I didn't feel a need to call it out as this is part of our internal API. Is this reasonable?

**Where should we start reviewing?**: 3/3

**Priority (whenever / two weeks / yesterday)**: yesterday!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2870)
<!-- Reviewable:end -->
