### PR TITLE
Hsaraogi/query the qos service less frequently

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -72,7 +72,6 @@ import com.palantir.atlasdb.persistentlock.PersistentLockService;
 import com.palantir.atlasdb.qos.QosClient;
 import com.palantir.atlasdb.qos.QosService;
 import com.palantir.atlasdb.qos.client.AtlasDbQosClient;
-import com.palantir.atlasdb.qos.config.ImmutableQosLimitsConfig;
 import com.palantir.atlasdb.qos.config.QosClientConfig;
 import com.palantir.atlasdb.qos.ratelimit.QosRateLimiters;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
@@ -312,18 +311,13 @@ public abstract class TransactionManagers {
                     ClientConfigurations.of(qosServiceConfig.get()));
             rateLimiters = QosRateLimiters.create(
                     JavaSuppliers.compose(conf -> conf.maxBackoffSleepTime().toMilliseconds(), config),
-                    () -> {
-                        long readLimit = qosService.readLimit(config().getNamespaceString());
-                        long writeLimit = qosService.writeLimit(config().getNamespaceString());
-                        return ImmutableQosLimitsConfig.builder()
-                                .readBytesPerSecond(readLimit)
-                                .writeBytesPerSecond(writeLimit)
-                                .build();
-                    });
+                    () -> qosService.readLimit(config().getNamespaceString()),
+                    () -> qosService.writeLimit(config().getNamespaceString()));
         } else {
             rateLimiters = QosRateLimiters.create(
                     JavaSuppliers.compose(conf -> conf.maxBackoffSleepTime().toMilliseconds(), config),
-                    JavaSuppliers.compose(QosClientConfig::limits, config));
+                    JavaSuppliers.compose(conf -> conf.limits().readBytesPerSecond(), config),
+                    JavaSuppliers.compose(conf -> conf.limits().writeBytesPerSecond(), config));
         }
         return AtlasDbQosClient.create(rateLimiters);
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Qos clients will query the service every 2 seconds instead of every client request. This should prevent too many requests to the service.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2872>`__)
+
     *    - |improved|
          - AtlasDB now throws an error during schema code generation stage if index table name length exceeds KVS table name length limits.
            To override this, please specify ``ignoreTableNameLengthChecks()`` on your schema.

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/SimpleThrottlingStrategy.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/SimpleThrottlingStrategy.java
@@ -18,18 +18,18 @@ package com.palantir.atlasdb.qos.config;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import com.palantir.atlasdb.qos.ratelimit.guava.RateLimiter;
+import com.google.common.util.concurrent.RateLimiter;
 
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public class SimpleThrottlingStrategy implements ThrottlingStrategy {
-    private static final double ONCE_EVERY_HUNDRED_SECONDS = 0.01;
+    private static final double ONCE_EVERY_TEN_SECONDS = 0.1;
     private final RateLimiter rateLimiter;
     private double multiplier;
 
     public SimpleThrottlingStrategy() {
-        this.rateLimiter = RateLimiter.create(ONCE_EVERY_HUNDRED_SECONDS);
+        this.rateLimiter = RateLimiter.create(ONCE_EVERY_TEN_SECONDS);
         this.multiplier = 1.0;
     }
 

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiter.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiter.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.qos.ratelimit;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -41,9 +42,14 @@ import com.palantir.logsafe.SafeArg;
 public class QosRateLimiter {
 
     private static final Logger log = LoggerFactory.getLogger(QosRateLimiter.class);
-    private static final double ONCE_EVERY_TWO_SECONDS = 0.5;
 
     private static final long MAX_BURST_SECONDS = 5;
+    private static final String RATE_UPDATE_ERROR_MESSAGE = "Could not refresh the Qos rate."
+            + " This can happen if the Qos Service is unreachable."
+            + " Extended periods of being unable to refresh will hinder QoS of all clients.";
+
+    @VisibleForTesting
+    static final int RATE_UPDATE_INTERVAL_IN_SECONDS = 2;
 
     private final Supplier<Long> maxBackoffTimeMillis;
     private final String rateLimiterName;
@@ -51,25 +57,41 @@ public class QosRateLimiter {
     private final RateLimiter.SleepingStopwatch stopwatch;
 
     private volatile RateLimiter rateLimiter;
-    private final com.google.common.util.concurrent.RateLimiter rateUpdateLimiter;
     private volatile long currentRate;
+    private final long defaultRate;
 
-    public static QosRateLimiter create(Supplier<Long> maxBackoffTimeMillis, Supplier<Long> unitsPerSecond,
-            String rateLimiterType) {
+    public static QosRateLimiter create(
+            Supplier<Long> maxBackoffTimeMillis,
+            Supplier<Long> unitsPerSecond,
+            String rateLimiterType,
+            ScheduledExecutorService executorService,
+            long defaultRate) {
         return new QosRateLimiter(RateLimiter.SleepingStopwatch.createFromSystemTimer(), maxBackoffTimeMillis,
-                unitsPerSecond, rateLimiterType);
+                unitsPerSecond, rateLimiterType, executorService, defaultRate);
     }
 
     @VisibleForTesting
-    QosRateLimiter(RateLimiter.SleepingStopwatch stopwatch, Supplier<Long> maxBackoffTimeMillis,
-            Supplier<Long> unitsPerSecond, String rateLimiterName) {
+    QosRateLimiter(RateLimiter.SleepingStopwatch stopwatch,
+            Supplier<Long> maxBackoffTimeMillis,
+            Supplier<Long> unitsPerSecond,
+            String rateLimiterName,
+            ScheduledExecutorService executorService,
+            long defaultRate) {
         this.stopwatch = stopwatch;
         this.unitsPerSecond = unitsPerSecond;
         this.maxBackoffTimeMillis = maxBackoffTimeMillis;
         this.rateLimiterName = rateLimiterName;
-        this.rateUpdateLimiter = com.google.common.util.concurrent.RateLimiter.create(ONCE_EVERY_TWO_SECONDS);
+        this.defaultRate = defaultRate;
+        createRateLimiterAtomically(getUpdatedRate());
 
-        createRateLimiterAtomically(unitsPerSecond.get());
+        executorService
+                .scheduleWithFixedDelay(() -> {
+                    try {
+                        updateRateIfNeeded();
+                    } catch (Throwable t) {
+                        log.error(RATE_UPDATE_ERROR_MESSAGE, t);
+                    }
+                }, 0, RATE_UPDATE_INTERVAL_IN_SECONDS, TimeUnit.SECONDS);
     }
 
     /**
@@ -79,8 +101,6 @@ public class QosRateLimiter {
      * @return the amount of time slept for, if any
      */
     public Duration consumeWithBackoff(long estimatedNumUnits) {
-        updateRateIfNeeded();
-
         Optional<Duration> waitTime = rateLimiter.tryAcquire(
                 estimatedNumUnits,
                 maxBackoffTimeMillis.get(),
@@ -98,11 +118,9 @@ public class QosRateLimiter {
      * overhead and double comparisons, we maintain the current rate ourselves.
      */
     private void updateRateIfNeeded() {
-        if (rateUpdateLimiter.tryAcquire()) {
-            long updatedRate = getUpdatedRate();
-            if (currentRate != updatedRate) {
-                createRateLimiterAtomically(updatedRate);
-            }
+        long updatedRate = getUpdatedRate();
+        if (currentRate != updatedRate) {
+            createRateLimiterAtomically(updatedRate);
         }
     }
 
@@ -110,9 +128,16 @@ public class QosRateLimiter {
         try {
             return unitsPerSecond.get();
         } catch (Exception e) {
-            log.error("Could not refresh the Qos rate. This can happen if the Qos Service is unreachable."
-                    + " Extended periods of being unable to refresh will hinder QoS of all clients., ", e);
+            log.error(RATE_UPDATE_ERROR_MESSAGE, e);
+            return returnPreviousOrDefaultRate();
+        }
+    }
+
+    private long returnPreviousOrDefaultRate() {
+        if (currentRate > 0) {
             return currentRate;
+        } else {
+            return defaultRate;
         }
     }
 

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiters.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiters.java
@@ -26,7 +26,7 @@ public interface QosRateLimiters {
     static QosRateLimiters create(Supplier<Long> maxBackoffSleepTimeMillis, Supplier<Long> readLimitSupplier,
             Supplier<Long> writeLimitSupplier) {
         QosRateLimiter readLimiter = QosRateLimiter.create(maxBackoffSleepTimeMillis,
-               readLimitSupplier, "read");
+                readLimitSupplier, "read");
 
         QosRateLimiter writeLimiter = QosRateLimiter.create(maxBackoffSleepTimeMillis,
                 writeLimitSupplier, "write");

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiters.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiters.java
@@ -20,16 +20,25 @@ import java.util.function.Supplier;
 
 import org.immutables.value.Value;
 
+import com.palantir.atlasdb.qos.config.QosClientLimitsConfig;
+import com.palantir.common.concurrent.PTExecutors;
+
 @Value.Immutable
 public interface QosRateLimiters {
 
     static QosRateLimiters create(Supplier<Long> maxBackoffSleepTimeMillis, Supplier<Long> readLimitSupplier,
             Supplier<Long> writeLimitSupplier) {
         QosRateLimiter readLimiter = QosRateLimiter.create(maxBackoffSleepTimeMillis,
-                readLimitSupplier, "read");
+                readLimitSupplier,
+                "read",
+                PTExecutors.newSingleThreadScheduledExecutor(),
+                QosClientLimitsConfig.BYTES_READ_PER_SECOND_PER_CLIENT);
 
         QosRateLimiter writeLimiter = QosRateLimiter.create(maxBackoffSleepTimeMillis,
-                writeLimitSupplier, "write");
+                writeLimitSupplier,
+                "write",
+                PTExecutors.newSingleThreadScheduledExecutor(),
+                QosClientLimitsConfig.BYTES_WRITTEN_PER_SECOND_PER_CLIENT);
 
         return ImmutableQosRateLimiters.builder()
                 .read(readLimiter)

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiters.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiters.java
@@ -20,17 +20,16 @@ import java.util.function.Supplier;
 
 import org.immutables.value.Value;
 
-import com.palantir.atlasdb.qos.config.QosLimitsConfig;
-
 @Value.Immutable
 public interface QosRateLimiters {
 
-    static QosRateLimiters create(Supplier<Long> maxBackoffSleepTimeMillis, Supplier<QosLimitsConfig> config) {
+    static QosRateLimiters create(Supplier<Long> maxBackoffSleepTimeMillis, Supplier<Long> readLimitSupplier,
+            Supplier<Long> writeLimitSupplier) {
         QosRateLimiter readLimiter = QosRateLimiter.create(maxBackoffSleepTimeMillis,
-                () -> config.get().readBytesPerSecond(), "read");
+               readLimitSupplier, "read");
 
         QosRateLimiter writeLimiter = QosRateLimiter.create(maxBackoffSleepTimeMillis,
-                () -> config.get().writeBytesPerSecond(), "write");
+                writeLimitSupplier, "write");
 
         return ImmutableQosRateLimiters.builder()
                 .read(readLimiter)

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/config/SimpleThrottlingStrategyTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/config/SimpleThrottlingStrategyTest.java
@@ -76,7 +76,7 @@ public class SimpleThrottlingStrategyTest {
                 ImmutableList.of(getMetricMeasurement(5, 10, 8), getMetricMeasurement(4, 8, 6));
 
         assertThat(simpleThrottlingStrategy.getClientLimitMultiplier(unhealthyMetricMeasurements)).isEqualTo(0.5);
-        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.SECONDS);
+        Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
         assertThat(simpleThrottlingStrategy.getClientLimitMultiplier(healthyMetricMeasurements)).isEqualTo(0.55);
     }
 

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiterTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/ratelimit/QosRateLimiterTest.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.atlasdb.qos.ratelimit.guava.RateLimiter;
 
 public class QosRateLimiterTest {
@@ -35,9 +36,9 @@ public class QosRateLimiterTest {
     private static final long START_TIME_NANOS = 0L;
     private static final Supplier<Long> MAX_BACKOFF_TIME_MILLIS = () -> 10_000L;
 
-    RateLimiter.SleepingStopwatch stopwatch = mock(RateLimiter.SleepingStopwatch.class);
-    Supplier<Long> currentRate = mock(Supplier.class);
-    QosRateLimiter limiter;
+    private RateLimiter.SleepingStopwatch stopwatch = mock(RateLimiter.SleepingStopwatch.class);
+    private Supplier<Long> currentRate = mock(Supplier.class);
+    private QosRateLimiter limiter;
 
     @Before
     public void before() {
@@ -223,6 +224,7 @@ public class QosRateLimiterTest {
 
         // increase to a large rate
         when(currentRate.get()).thenReturn(1000000L);
+        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
         limiter.consumeWithBackoff(1);
         tickMillis(1);
 
@@ -231,6 +233,7 @@ public class QosRateLimiterTest {
 
         // decrease to small rate
         when(currentRate.get()).thenReturn(10L);
+        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
         tickMillis(1000);
 
         limiter.consumeWithBackoff(1);


### PR DESCRIPTION
**Goals (and why)**:
1. Query the qos service for the rate every 2 seconds, instead of every read/write request to Cassandra.

**Implementation Description (bullets)**: rate limit the limit updating, handle exceptions

**Concerns (what feedback would you like?)**: Is 2 seconds okay? Is preserving the limit if we cannot contact QoS a good idea?
Should we add more metrics here to get a client side view of the limits? Concern is that we have two metrics tracking the same thing then.

**Where should we start reviewing?**: QosRateLimiters.

**Priority (whenever / two weeks / yesterday)**: soon

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2872)
<!-- Reviewable:end -->
