### PR TITLE
Make refresh time configurable (branch-version of #2804)

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -37,7 +37,7 @@ import com.palantir.lock.SimpleHeldLocksToken;
 @SuppressWarnings("checkstyle:FinalClass") // Avoid breaking API in case someone extended this
 public class LockRefreshingLockService extends ForwardingLockService {
     private static final Logger log = LoggerFactory.getLogger(LockRefreshingLockService.class);
-    private static final long DEFAULT_FREFRESH_FREQUENCY_MILLIS = 5000;
+    private static final long DEFAULT_REFRESH_FREQUENCY_MILLIS = 5000;
 
     final LockService delegate;
     final Set<LockRefreshToken> toRefresh;
@@ -46,7 +46,7 @@ public class LockRefreshingLockService extends ForwardingLockService {
     volatile boolean isClosed = false;
 
     public static LockRefreshingLockService create(LockService delegate) {
-        return create(delegate, DEFAULT_FREFRESH_FREQUENCY_MILLIS);
+        return create(delegate, DEFAULT_REFRESH_FREQUENCY_MILLIS);
     }
 
     public static LockRefreshingLockService create(LockService delegate, long refreshFrequencyMillis) {


### PR DESCRIPTION
**Goals (and why)**:
- The LockRefreshingLockService currently hard-codes the refresh period. This change makes it configurable while maintaining back-compatibility.

**Implementation Description (bullets)**:
- Make the param configurable (programmatically - not from config)

**Where should we start reviewing?**: 9/3

@abless: I think we need to figure out the use case here too - see https://github.com/palantir/atlasdb/pull/2804#pullrequestreview-82525569

Fairly sure the change looks fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2875)
<!-- Reviewable:end -->
