### PR TITLE
Log if sweep cell startTs is null

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.logging;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -29,6 +30,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
@@ -141,6 +143,14 @@ public final class LoggingArgs {
         return getArg(argName,
                 columnName,
                 logArbitrator.isColumnNameSafe(tableReference, columnName));
+    }
+
+    public static boolean isSafeForLogging(TableReference tableRef, Cell cell) {
+        String rowName = new String(cell.getRowName(), Charset.defaultCharset());
+        String columnName = new String(cell.getColumnName(), Charset.defaultCharset());
+
+        return logArbitrator.isRowComponentNameSafe(tableRef, rowName)
+                && logArbitrator.isColumnNameSafe(tableRef, columnName);
     }
 
     public static Arg<Long> durationMillis(Stopwatch stopwatch) {


### PR DESCRIPTION
**Goals (and why)**: To investigate #2881.

**Implementation Description (bullets)**: 

**Concerns (what feedback would you like?)**: Should we skip the delete part and just return as we know delete will throw an NPE and make sweep stuck. Danger is we never see this logging and assume sweep is running, but we can have monitors for the log line - its already error?

**Where should we start reviewing?**: CellsSweeper

**Priority (whenever / two weeks / yesterday)**: soon

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2882)
<!-- Reviewable:end -->
