### PR TITLE
BackgroundSweeperImpl shutdown and fatal metrics

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -36,6 +36,7 @@ import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.Throwables;
 import com.palantir.lock.LockService;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 
 public final class BackgroundSweeperImpl implements BackgroundSweeper {
     private static final Logger log = LoggerFactory.getLogger(BackgroundSweeperImpl.class);
@@ -133,7 +134,8 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
             log.warn("Shutting down background sweeper. Please restart the service to rerun background sweep.");
             sweepOutcomeMetrics.shutdown();
         } catch (Throwable t) {
-            log.error("BackgroundSweeper failed fatally and will not rerun until restarted", t);
+            log.error("BackgroundSweeper failed fatally and will not rerun until restarted: {}",
+                    UnsafeArg.of("message", t.getMessage()), t);
             sweepOutcomeMetrics.fatal();
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -132,11 +132,11 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
             }
         } catch (InterruptedException e) {
             log.warn("Shutting down background sweeper. Please restart the service to rerun background sweep.");
-            sweepOutcomeMetrics.shutdown();
+            sweepOutcomeMetrics.registerOccurrenceOf(SweepOutcome.SHUTDOWN);
         } catch (Throwable t) {
             log.error("BackgroundSweeper failed fatally and will not rerun until restarted: {}",
                     UnsafeArg.of("message", t.getMessage()), t);
-            sweepOutcomeMetrics.fatal();
+            sweepOutcomeMetrics.registerOccurrenceOf(SweepOutcome.FATAL);
         }
     }
 
@@ -277,7 +277,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
 
     @Override
     public synchronized void shutdown() {
-        sweepOutcomeMetrics.shutdown();
+        sweepOutcomeMetrics.registerOccurrenceOf(SweepOutcome.SHUTDOWN);
         if (daemon == null) {
             return;
         }
@@ -329,23 +329,15 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
 
         void registerOccurrenceOf(SweepOutcome outcome) {
             if (outcome == SweepOutcome.SHUTDOWN) {
-                shutdown();
+                shutdown = true;
                 return;
             }
             if (outcome == SweepOutcome.FATAL) {
-                fatal();
+                fatal = true;
                 return;
             }
 
             reservoir.update(outcome.ordinal());
-        }
-
-        public void shutdown() {
-            this.shutdown = true;
-        }
-
-        void fatal() {
-            this.fatal = true;
         }
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |improved| |metrics|
+         - BackgroundSweeperImpl now logs if there's an uncaught exception.  Added 2 new outcomes for normal and abnormal shutdown to allow closer monitoring.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/xxxx>`__)
+
     *    - |fixed|
          - Qos clients will query the service every 2 seconds instead of every client request. This should prevent too many requests to the service.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2872>`__)


### PR DESCRIPTION
Added 2 new sweep outcomes to the BackgroundSweeperImpl for permanent end states.

**Goals (and why)**: We want to be able to detect and immediately alarm if the Background Sweeper fails.

**Implementation Description (bullets)**:  Add 2 new SweepOutcome values to the enum.  These differ to previous values in that they are permanent end states so we record and publish the metric differently: rather than use a reservoir which evicts values we permanently switch modes for these metric types.

This is done in a bit of a brute force manner for now but there are only 2 of these permanent outcomes so don't think it warrants special handling (if we add more then I'd change the enum value to know if it is permanent or not and store non-permanent values in the reservoir and permanent values in a separate Map).

Set the shutdown flag either if the shutdown method is called on the sweeper or the thread is interrupted directly as either could technically happen.

**Concerns (what feedback would you like?)**: Have I introduced a bug?  There's no testing at the top level of the sweeper.

**Where should we start reviewing?**: Single class.

**Priority (whenever / two weeks / yesterday)**: 1 week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2884)
<!-- Reviewable:end -->
