### PR TITLE
Check if thread is interrupted and stop to Sweep

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -121,6 +121,10 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper {
             Thread.sleep(getBackoffTimeWhenSweepHasNotRun());
             log.info("Starting background sweeper.");
             while (true) {
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
+
                 SweepOutcome outcome = checkConfigAndRunSweep(locks);
 
                 log.info("Sweep iteration finished with outcome: {}", SafeArg.of("sweepOutcome", outcome));


### PR DESCRIPTION
**Goals (and why)**: This should fix #2458. Even though it's unclear why we weren't throwing `InterruptedException` it might be the case that the thread was interrupted when on calls that do not throw such an exception (not sure if Thrift calls throw Interrupted Exception, even though they should), or maybe we're wrapping an InterruptedException wrongly — i.e. I think if we're wrapping Thrift's InterruptedException to AtlasDbDependencyException on the KVS layer.

In any case, this should do the trick.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
