### PR TITLE
fix log spam from metric re-registration

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeWritesLogger.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeWritesLogger.java
@@ -68,7 +68,9 @@ public final class TokenRangeWritesLogger {
     }
 
     public void markWritesForTable(Set<Cell> entries, TableReference tableRef) {
-        statsPerTable.putIfAbsent(tableRef, new TokenRangeWrites(tableRef, ranges));
+        if (!statsPerTable.containsKey(tableRef)) {
+            statsPerTable.put(tableRef, new TokenRangeWrites(tableRef, ranges));
+        }
         TokenRangeWrites tokenRangeWrites = statsPerTable.get(tableRef);
         entries.forEach(entry -> tokenRangeWrites.markWrite(entry));
         tokenRangeWrites.maybeLog();

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,8 +51,12 @@ develop
          - Change
 
     *    - |fixed| |metrics|
+         - Fixed metric re-registration log spam in TokenRangeWriteLogger.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2913>`__)
+
+    *    - |fixed| |metrics|
          - TokenRangeWriteLogger now registers different metric names per table even if all are unsafe.  We instead tag with an obfuscated version of the name which is safe for logging.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/xxxx>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2889>`__)
 
     *    - |improved| |logs|
          - AtlasDB internal table names are now safe for logging.


### PR DESCRIPTION
putIfAbsent, while a convenient feature, was still always making a new TokenRangeWrites object and causing metric re-registration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2913)
<!-- Reviewable:end -->
