### PR TITLE
Don't run errorprone in parallel

### DIFF
--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -51,11 +51,11 @@ JAVA_GC_LOGGING_OPTIONS="${JAVA_GC_LOGGING_OPTIONS} -Xloggc:build-%t-%p.gc.log"
 
 # External builds have a 4GB limit so we have to tune everything so it fits in memory (only just!)
 if [[ $INTERNAL_BUILD == true ]]; then
-    BASE_GRADLE_ARGS+=" --parallel"
     if [ "$CIRCLE_NODE_INDEX" -eq "7" ]; then
         export _JAVA_OPTIONS="-Xmx2048m ${JAVA_GC_LOGGING_OPTIONS}"
     else
         export _JAVA_OPTIONS="-Xmx1024m ${JAVA_GC_LOGGING_OPTIONS}"
+        BASE_GRADLE_ARGS+=" --parallel"
     fi
     export CASSANDRA_MAX_HEAP_SIZE=512m
     export CASSANDRA_HEAP_NEWSIZE=64m


### PR DESCRIPTION
This seems to lead to increased memory usage and GC sadness on circle.
[no release notes]

**Goals (and why)**: have non-flaky builds

**Implementation Description (bullets)**: don't run errorprone in parallel

**Concerns (what feedback would you like?)**: N/A. Might want to rebuild this branch and see if the GC overhead issues have really gone away?

**Where should we start reviewing?**: one file

**Priority (whenever / two weeks / yesterday)**: ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2916)
<!-- Reviewable:end -->
