### PR TITLE
Add shared secret when getting a C* metric

### DIFF
--- a/qos-service-api/src/main/java/com/palantir/atlasdb/qos/QosService.java
+++ b/qos-service-api/src/main/java/com/palantir/atlasdb/qos/QosService.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.palantir.logsafe.Safe;
 
-@Path("/qos")
+@Path("/")
 public interface QosService {
     /**
      * Get the read limit for a client.

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/QosCassandraMetricsInstallConfig.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/QosCassandraMetricsInstallConfig.java
@@ -31,6 +31,9 @@ public abstract class QosCassandraMetricsInstallConfig {
     @JsonProperty("cassandra-service-config")
     public abstract ServiceConfiguration cassandraServiceConfig();
 
+    @JsonProperty("shared-secret")
+    public abstract String sharedSecret();
+
     @JsonProperty("throttling-strategy")
     public abstract ThrottlingStrategyEnum throttlingStrategy();
 }

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoader.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoader.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetric;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetricMeasurement;
+import com.palantir.cassandra.sidecar.SharedSecretHeader;
 import com.palantir.cassandra.sidecar.metrics.CassandraMetricsService;
 
 public class CassandraMetricMeasurementsLoader {
@@ -37,11 +38,14 @@ public class CassandraMetricMeasurementsLoader {
     private final Supplier<List<CassandraHealthMetric>> cassandraHealthMetrics;
     private final CassandraMetricsService cassandraMetricClient;
     private List<CassandraHealthMetricMeasurement> cassandraHealthMetricMeasurements;
+    private final String header;
 
     public CassandraMetricMeasurementsLoader(Supplier<List<CassandraHealthMetric>> cassandraHealthMetrics,
-            CassandraMetricsService cassandraMetricClient, ScheduledExecutorService scheduledExecutorService) {
+            CassandraMetricsService cassandraMetricClient, ScheduledExecutorService scheduledExecutorService,
+            String header) {
         this.cassandraHealthMetrics = cassandraHealthMetrics;
         this.cassandraMetricClient = cassandraMetricClient;
+        this.header = header;
         this.cassandraHealthMetricMeasurements = new ArrayList<>();
         scheduledExecutorService
                 .scheduleWithFixedDelay(() -> {
@@ -58,6 +62,7 @@ public class CassandraMetricMeasurementsLoader {
         cassandraHealthMetricMeasurements = this.cassandraHealthMetrics.get().stream().map(metric ->
                 ImmutableCassandraHealthMetricMeasurement.builder()
                         .currentValue(this.cassandraMetricClient.getMetric(
+                                SharedSecretHeader.valueOf(header),
                                 metric.type(),
                                 metric.name(),
                                 metric.attribute(),

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
@@ -50,7 +50,8 @@ public class CassandraMetricsClientLimitMultiplier implements ClientLimitMultipl
                 installConfig.throttlingStrategy());
 
         CassandraMetricMeasurementsLoader cassandraMetricMeasurementsLoader = new CassandraMetricMeasurementsLoader(
-                () -> runtimeConfig.get().cassandraHealthMetrics(), metricsService, metricsLoaderExecutor);
+                () -> runtimeConfig.get().cassandraHealthMetrics(), metricsService, metricsLoaderExecutor,
+                installConfig.sharedSecret());
         return new CassandraMetricsClientLimitMultiplier(throttlingStrategy, cassandraMetricMeasurementsLoader);
     }
 

--- a/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/SharedSecret.java
+++ b/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/SharedSecret.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ */
+
+package com.palantir.cassandra.sidecar;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.immutables.value.Value;
+
+/**
+ * Copied from internal sls Cassandra project.
+ */
+@Value.Immutable
+public abstract class SharedSecret {
+
+    @JsonValue
+    public abstract String secret();
+
+    @JsonCreator
+    public static SharedSecret valueOf(String sharedSecret) {
+        return ImmutableSharedSecret.builder().secret(sharedSecret).build();
+    }
+
+    @Override
+    public final String toString() {
+        return secret();
+    }
+
+}

--- a/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/SharedSecret.java
+++ b/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/SharedSecret.java
@@ -1,12 +1,24 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.palantir.cassandra.sidecar;
+
+import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.immutables.value.Value;
 
 /**
  * Copied from internal sls Cassandra project.

--- a/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/SharedSecretHeader.java
+++ b/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/SharedSecretHeader.java
@@ -1,12 +1,24 @@
 /*
- * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.palantir.cassandra.sidecar;
+
+import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.immutables.value.Value;
 
 /**
  * Copied from internal sls Cassandra project.

--- a/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/SharedSecretHeader.java
+++ b/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/SharedSecretHeader.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ */
+
+package com.palantir.cassandra.sidecar;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.immutables.value.Value;
+
+/**
+ * Copied from internal sls Cassandra project.
+ */
+@Value.Immutable
+public abstract class SharedSecretHeader {
+
+    public abstract SharedSecret secretObj();
+
+    @JsonCreator
+    public static SharedSecretHeader valueOf(String header) {
+        SharedSecret sharedSecret = SharedSecret.valueOf(header.replaceFirst("^Bearer ", "").trim());
+        return ImmutableSharedSecretHeader.of(sharedSecret);
+    }
+    public static SharedSecretHeader of(SharedSecret sharedSecret) {
+        return ImmutableSharedSecretHeader.builder().secretObj(sharedSecret).build();
+    }
+
+    /**
+     * Generates the value for an HTTP Authorization header with this shared secret of the form
+     * "Bearer &lt;secret-value&gt;".
+     */
+    @Override
+    @JsonValue
+    public String toString() {
+        return "Bearer " + secretObj();
+    }
+}

--- a/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/metrics/CassandraMetricsService.java
+++ b/qos-service-impl/src/main/java/com/palantir/cassandra/sidecar/metrics/CassandraMetricsService.java
@@ -1,36 +1,24 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
- *
- * Licensed under the BSD-3 License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://opensource.org/licenses/BSD-3-Clause
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
  */
 
 package com.palantir.cassandra.sidecar.metrics;
 
+import com.palantir.cassandra.sidecar.SharedSecretHeader;
+import com.palantir.logsafe.Safe;
 import java.util.Map;
-
 import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-
-import com.palantir.logsafe.Safe;
 
 /**
  * Copied from internal sls Cassandra project.
  */
-
 @Path("/metrics")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -39,6 +27,7 @@ public interface CassandraMetricsService {
      * Get the value for a particular Cassandra metric. The possible metric combinations can be found in
      * http://cassandra.apache.org/doc/latest/operating/metrics.html.
      *
+     * @param authHeader the shared secret
      * @param type The type of the Cassandra metric, mostly a sub-type of the metric name eg: CommitLog
      * @param name The name of the Cassandra metric eg: PendingTasks
      * @param attr The attribute you require for the metric eg: Value, p99 etc.
@@ -48,6 +37,7 @@ public interface CassandraMetricsService {
     @POST
     @Path("/{type}/{name}/{attribute}")
     Object getMetric(
+            @HeaderParam(HttpHeaders.AUTHORIZATION) SharedSecretHeader authHeader,
             @Safe @PathParam(value = "type") String type,
             @Safe @PathParam(value = "name") String name,
             @Safe @PathParam(value = "attribute") String attr,

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServerInstallConfigDeserializationTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServerInstallConfigDeserializationTest.java
@@ -57,6 +57,7 @@ public class QosServerInstallConfigDeserializationTest {
                                 .security(SslConfiguration.of(Paths.get("trustStore.jks")))
                                 .build())
                         .throttlingStrategy(ThrottlingStrategyEnum.SIMPLE)
+                        .sharedSecret("secret")
                         .build())
                 .build())
                 .isEqualTo(configuration);

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServiceInstallConfigTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServiceInstallConfigTest.java
@@ -47,6 +47,7 @@ public class QosServiceInstallConfigTest {
                         .addUris("uri1")
                         .security(SslConfiguration.of(Paths.get("trustStore.jks")))
                         .build())
+                .sharedSecret("shared-secret")
                 .throttlingStrategy(ThrottlingStrategyEnum.SIMPLE)
                 .build();
     }

--- a/qos-service-impl/src/test/resources/qos-server-install.yml
+++ b/qos-service-impl/src/test/resources/qos-server-install.yml
@@ -4,4 +4,5 @@ qos-cassandra-metrics:
       - https://localhost:9161/cassandra-sidecar/api/
     security:
       trustStorePath: trustStore.jks
+  shared-secret: secret
   throttling-strategy: SIMPLE


### PR DESCRIPTION
**Goals (and why)**: The C*MetricService now has a shared secret, we should be compatible with it.
This is for short-term testing of the metrics service internally. Longer term we dont want to copy the classes. @gsheasby is looking at implementing the shim to be replaced internally.

**Implementation Description (bullets)**: copy up the C*metricsService, sharedSecret and other classes. Add the secret to the install config.

**Concerns (what feedback would you like?)**: N/A

**Where should we start reviewing?**: CMS.java

**Priority (whenever / two weeks / yesterday)**: soon.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2920)
<!-- Reviewable:end -->
