### PR TITLE
Fix/generify metrics service

### DIFF
--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/com/palantir/atlasdb/qos/agent/QosAgent.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/com/palantir/atlasdb/qos/agent/QosAgent.java
@@ -22,7 +22,6 @@ import java.util.function.Supplier;
 import com.palantir.atlasdb.qos.QosResource;
 import com.palantir.atlasdb.qos.config.QosServiceInstallConfig;
 import com.palantir.atlasdb.qos.config.QosServiceRuntimeConfig;
-import com.palantir.atlasdb.qos.ratelimit.CassandraMetricsClientLimitMultiplier;
 import com.palantir.atlasdb.qos.ratelimit.ClientLimitMultiplier;
 import com.palantir.atlasdb.qos.ratelimit.OneReturningClientLimitMultiplier;
 
@@ -32,7 +31,8 @@ public class QosAgent {
     private ScheduledExecutorService managedMetricsLoaderExecutor;
     private final Consumer<Object> registrar;
 
-    public QosAgent(Supplier<QosServiceRuntimeConfig> runtimeConfigSupplier, QosServiceInstallConfig installConfig,
+    public QosAgent(Supplier<QosServiceRuntimeConfig> runtimeConfigSupplier,
+            QosServiceInstallConfig installConfig,
             ScheduledExecutorService managedMetricsLoaderExecutor,
             Consumer<Object> registrar) {
         this.runtimeConfigSupplier = runtimeConfigSupplier;
@@ -49,10 +49,7 @@ public class QosAgent {
     }
 
     private ClientLimitMultiplier createClientLimitMultiplier() {
-        return installConfig.qosCassandraMetricsConfig().map(
-                config -> CassandraMetricsClientLimitMultiplier.create(
-                        () -> runtimeConfigSupplier.get().qosCassandraMetricsConfig(),
-                        config, managedMetricsLoaderExecutor))
-                .orElseGet(OneReturningClientLimitMultiplier::create);
+        // "Temporary", until we have a stub implementation for MetricsService
+        return OneReturningClientLimitMultiplier.create();
     }
 }

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/HealthMetric.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/HealthMetric.java
@@ -25,9 +25,9 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 
 @Value.Immutable
-@JsonDeserialize(as = ImmutableCassandraHealthMetric.class)
-@JsonSerialize(as = ImmutableCassandraHealthMetric.class)
-public abstract class CassandraHealthMetric {
+@JsonDeserialize(as = ImmutableHealthMetric.class)
+@JsonSerialize(as = ImmutableHealthMetric.class)
+public abstract class HealthMetric {
     public abstract String type();
     public abstract String name();
     public abstract String attribute();

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/QosCassandraMetricsRuntimeConfig.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/config/QosCassandraMetricsRuntimeConfig.java
@@ -32,7 +32,7 @@ public abstract class QosCassandraMetricsRuntimeConfig {
 
     @JsonProperty("cassandra-health-metrics")
     @Value.Default
-    public List<CassandraHealthMetric> cassandraHealthMetrics() {
+    public List<HealthMetric> cassandraHealthMetrics() {
         return ImmutableList.of();
     }
 }

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/metrics/MetricsService.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/metrics/MetricsService.java
@@ -27,20 +27,15 @@ import javax.ws.rs.core.MediaType;
 
 import com.palantir.logsafe.Safe;
 
-/**
- * Copied from internal sls Cassandra project.
- */
-
 @Path("/metrics")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface MetricsService {
     /**
-     * Get the value for a particular Cassandra metric. The possible metric combinations can be found in
-     * http://cassandra.apache.org/doc/latest/operating/metrics.html.
+     * Get the value for a particular metric.
      *
-     * @param type The type of the Cassandra metric, mostly a sub-type of the metric name eg: CommitLog
-     * @param name The name of the Cassandra metric eg: PendingTasks
+     * @param type The type of the metric, mostly a sub-type of the metric name eg: CommitLog
+     * @param name The name of the metric eg: PendingTasks
      * @param attr The attribute you require for the metric eg: Value, p99 etc.
      * @param additionalParams Any other parameters to make the metric more specific eg: scope:keyspace
      * @return the metric object for the queried metric

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/metrics/MetricsService.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/metrics/MetricsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.cassandra.sidecar.metrics;
+package com.palantir.atlasdb.qos.metrics;
 
 import java.util.Map;
 
@@ -34,7 +34,7 @@ import com.palantir.logsafe.Safe;
 @Path("/metrics")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public interface CassandraMetricsService {
+public interface MetricsService {
     /**
      * Get the value for a particular Cassandra metric. The possible metric combinations can be found in
      * http://cassandra.apache.org/doc/latest/operating/metrics.html.

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoader.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoader.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.palantir.atlasdb.qos.config.CassandraHealthMetric;
+import com.palantir.atlasdb.qos.config.HealthMetric;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.metrics.MetricsService;
@@ -34,11 +34,11 @@ import com.palantir.atlasdb.qos.metrics.MetricsService;
 public class CassandraMetricMeasurementsLoader {
     private static final Logger log = LoggerFactory.getLogger(CassandraMetricMeasurementsLoader.class);
 
-    private final Supplier<List<CassandraHealthMetric>> cassandraHealthMetrics;
+    private final Supplier<List<HealthMetric>> cassandraHealthMetrics;
     private final MetricsService cassandraMetricClient;
     private List<CassandraHealthMetricMeasurement> cassandraHealthMetricMeasurements;
 
-    public CassandraMetricMeasurementsLoader(Supplier<List<CassandraHealthMetric>> cassandraHealthMetrics,
+    public CassandraMetricMeasurementsLoader(Supplier<List<HealthMetric>> cassandraHealthMetrics,
             MetricsService cassandraMetricClient, ScheduledExecutorService scheduledExecutorService) {
         this.cassandraHealthMetrics = cassandraHealthMetrics;
         this.cassandraMetricClient = cassandraMetricClient;

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoader.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoader.java
@@ -26,8 +26,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.palantir.atlasdb.qos.config.HealthMetric;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
+import com.palantir.atlasdb.qos.config.HealthMetric;
 import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.metrics.MetricsService;
 

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoader.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoader.java
@@ -29,17 +29,17 @@ import org.slf4j.LoggerFactory;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetric;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetricMeasurement;
-import com.palantir.cassandra.sidecar.metrics.CassandraMetricsService;
+import com.palantir.atlasdb.qos.metrics.MetricsService;
 
 public class CassandraMetricMeasurementsLoader {
     private static final Logger log = LoggerFactory.getLogger(CassandraMetricMeasurementsLoader.class);
 
     private final Supplier<List<CassandraHealthMetric>> cassandraHealthMetrics;
-    private final CassandraMetricsService cassandraMetricClient;
+    private final MetricsService cassandraMetricClient;
     private List<CassandraHealthMetricMeasurement> cassandraHealthMetricMeasurements;
 
     public CassandraMetricMeasurementsLoader(Supplier<List<CassandraHealthMetric>> cassandraHealthMetrics,
-            CassandraMetricsService cassandraMetricClient, ScheduledExecutorService scheduledExecutorService) {
+            MetricsService cassandraMetricClient, ScheduledExecutorService scheduledExecutorService) {
         this.cassandraHealthMetrics = cassandraHealthMetrics;
         this.cassandraMetricClient = cassandraMetricClient;
         this.cassandraHealthMetricMeasurements = new ArrayList<>();

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
@@ -25,8 +25,6 @@ import com.palantir.atlasdb.qos.config.QosCassandraMetricsInstallConfig;
 import com.palantir.atlasdb.qos.config.QosCassandraMetricsRuntimeConfig;
 import com.palantir.atlasdb.qos.config.ThrottlingStrategy;
 import com.palantir.atlasdb.qos.metrics.MetricsService;
-import com.palantir.remoting3.clients.ClientConfigurations;
-import com.palantir.remoting3.jaxrs.JaxRsClient;
 
 @SuppressWarnings("checkstyle:FinalClass") // Required for testing
 public class CassandraMetricsClientLimitMultiplier implements ClientLimitMultiplier {
@@ -41,11 +39,9 @@ public class CassandraMetricsClientLimitMultiplier implements ClientLimitMultipl
     }
 
     public static ClientLimitMultiplier create(Supplier<QosCassandraMetricsRuntimeConfig> runtimeConfig,
-            QosCassandraMetricsInstallConfig installConfig, ScheduledExecutorService metricsLoaderExecutor) {
-        MetricsService metricsService = JaxRsClient.create(
-                MetricsService.class,
-                "qos-service",
-                ClientConfigurations.of(installConfig.cassandraServiceConfig()));
+            QosCassandraMetricsInstallConfig installConfig,
+            MetricsService metricsService,
+            ScheduledExecutorService metricsLoaderExecutor) {
         ThrottlingStrategy throttlingStrategy = ThrottlingStrategies.getThrottlingStrategy(
                 installConfig.throttlingStrategy());
 

--- a/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
+++ b/qos-service-impl/src/main/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricsClientLimitMultiplier.java
@@ -24,7 +24,7 @@ import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.config.QosCassandraMetricsInstallConfig;
 import com.palantir.atlasdb.qos.config.QosCassandraMetricsRuntimeConfig;
 import com.palantir.atlasdb.qos.config.ThrottlingStrategy;
-import com.palantir.cassandra.sidecar.metrics.CassandraMetricsService;
+import com.palantir.atlasdb.qos.metrics.MetricsService;
 import com.palantir.remoting3.clients.ClientConfigurations;
 import com.palantir.remoting3.jaxrs.JaxRsClient;
 
@@ -42,8 +42,8 @@ public class CassandraMetricsClientLimitMultiplier implements ClientLimitMultipl
 
     public static ClientLimitMultiplier create(Supplier<QosCassandraMetricsRuntimeConfig> runtimeConfig,
             QosCassandraMetricsInstallConfig installConfig, ScheduledExecutorService metricsLoaderExecutor) {
-        CassandraMetricsService metricsService = JaxRsClient.create(
-                CassandraMetricsService.class,
+        MetricsService metricsService = JaxRsClient.create(
+                MetricsService.class,
                 "qos-service",
                 ClientConfigurations.of(installConfig.cassandraServiceConfig()));
         ThrottlingStrategy throttlingStrategy = ThrottlingStrategies.getThrottlingStrategy(

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServerRuntimeConfigDeserializationTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServerRuntimeConfigDeserializationTest.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetric;
+import com.palantir.atlasdb.qos.config.ImmutableHealthMetric;
 import com.palantir.atlasdb.qos.config.ImmutableQosCassandraMetricsRuntimeConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosClientLimitsConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosLimitsConfig;
@@ -63,7 +63,7 @@ public class QosServerRuntimeConfigDeserializationTest {
         assertThat(ImmutableQosServiceRuntimeConfig.builder()
                 .clientLimits(getTestClientLimits())
                 .qosCassandraMetricsConfig(ImmutableQosCassandraMetricsRuntimeConfig.builder()
-                        .cassandraHealthMetrics(ImmutableList.of(ImmutableCassandraHealthMetric.builder()
+                        .cassandraHealthMetrics(ImmutableList.of(ImmutableHealthMetric.builder()
                                 .type("CommitLog")
                                 .name("PendingTasks")
                                 .attribute("Value")

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServiceRuntimeConfigTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/QosServiceRuntimeConfigTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetric;
+import com.palantir.atlasdb.qos.config.ImmutableHealthMetric;
 import com.palantir.atlasdb.qos.config.ImmutableQosCassandraMetricsRuntimeConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosClientLimitsConfig;
 import com.palantir.atlasdb.qos.config.ImmutableQosLimitsConfig;
@@ -71,7 +71,7 @@ public class QosServiceRuntimeConfigTest {
 
     private ImmutableQosCassandraMetricsRuntimeConfig getCassandraMetricsConfig() {
         return ImmutableQosCassandraMetricsRuntimeConfig.builder()
-                .cassandraHealthMetrics(ImmutableList.of(ImmutableCassandraHealthMetric.builder()
+                .cassandraHealthMetrics(ImmutableList.of(ImmutableHealthMetric.builder()
                         .type("CommitLog")
                         .name("PendingTasks")
                         .attribute("Value")

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/config/HealthMetricMeasurementTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/config/HealthMetricMeasurementTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-public class CassandraHealthMetricMeasurementTest {
+public class HealthMetricMeasurementTest {
     @Test
     public void canCreateAValidMetricMeasurementWithValueHigherThanUpperLimit() {
         ImmutableCassandraHealthMetricMeasurement measurement = ImmutableCassandraHealthMetricMeasurement.builder()

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/config/HealthMetricsTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/config/HealthMetricsTest.java
@@ -21,14 +21,14 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 
-public class CassandraHealthMetricsTest {
+public class HealthMetricsTest {
     private static final String TEST_NAME = "metricName";
     private static final String TEST_TYPE = "metricType";
     private static final String TEST_ATTRIBUTE = "attribute";
 
     @Test
     public void canCreateMetricMeasurementWithLowerLimitLessThanUpperLimit() {
-        ImmutableCassandraHealthMetric.builder()
+        ImmutableHealthMetric.builder()
                 .lowerLimit(10)
                 .upperLimit(20)
                 .name(TEST_NAME)
@@ -40,7 +40,7 @@ public class CassandraHealthMetricsTest {
 
     @Test
     public void canNotCreateMetricMeasurementWithLowerLimitMoreThanUpperLimit() {
-        assertThatThrownBy(() -> ImmutableCassandraHealthMetric.builder()
+        assertThatThrownBy(() -> ImmutableHealthMetric.builder()
                 .lowerLimit(20)
                 .upperLimit(10)
                 .name(TEST_NAME)

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoaderTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoaderTest.java
@@ -39,7 +39,7 @@ import com.palantir.atlasdb.qos.config.CassandraHealthMetric;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetric;
 import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetricMeasurement;
-import com.palantir.cassandra.sidecar.metrics.CassandraMetricsService;
+import com.palantir.atlasdb.qos.metrics.MetricsService;
 
 public class CassandraMetricMeasurementsLoaderTest {
     private static final double LOWER_LIMIT = 0.0;
@@ -55,13 +55,13 @@ public class CassandraMetricMeasurementsLoaderTest {
 
     private DeterministicScheduler scheduledExecutorService;
     private Supplier<List<CassandraHealthMetric>> healthMetricSupplier;
-    private CassandraMetricsService cassandraMetricClient;
+    private MetricsService cassandraMetricClient;
     private CassandraMetricMeasurementsLoader cassandraMetricMeasurementsLoader;
 
     @Before
     public void setup() {
         healthMetricSupplier = mock(Supplier.class);
-        cassandraMetricClient = mock(CassandraMetricsService.class);
+        cassandraMetricClient = mock(MetricsService.class);
         scheduledExecutorService = new DeterministicScheduler();
 
         cassandraMetricMeasurementsLoader = new CassandraMetricMeasurementsLoader(

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoaderTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoaderTest.java
@@ -35,10 +35,10 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.qos.config.HealthMetric;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
-import com.palantir.atlasdb.qos.config.ImmutableHealthMetric;
+import com.palantir.atlasdb.qos.config.HealthMetric;
 import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetricMeasurement;
+import com.palantir.atlasdb.qos.config.ImmutableHealthMetric;
 import com.palantir.atlasdb.qos.metrics.MetricsService;
 
 public class CassandraMetricMeasurementsLoaderTest {

--- a/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoaderTest.java
+++ b/qos-service-impl/src/test/java/com/palantir/atlasdb/qos/ratelimit/CassandraMetricMeasurementsLoaderTest.java
@@ -35,9 +35,9 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.qos.config.CassandraHealthMetric;
+import com.palantir.atlasdb.qos.config.HealthMetric;
 import com.palantir.atlasdb.qos.config.CassandraHealthMetricMeasurement;
-import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetric;
+import com.palantir.atlasdb.qos.config.ImmutableHealthMetric;
 import com.palantir.atlasdb.qos.config.ImmutableCassandraHealthMetricMeasurement;
 import com.palantir.atlasdb.qos.metrics.MetricsService;
 
@@ -54,7 +54,7 @@ public class CassandraMetricMeasurementsLoaderTest {
     private static final String METRIC_ATTRIBUTE_2 = "metricAttribute2";
 
     private DeterministicScheduler scheduledExecutorService;
-    private Supplier<List<CassandraHealthMetric>> healthMetricSupplier;
+    private Supplier<List<HealthMetric>> healthMetricSupplier;
     private MetricsService cassandraMetricClient;
     private CassandraMetricMeasurementsLoader cassandraMetricMeasurementsLoader;
 
@@ -129,9 +129,9 @@ public class CassandraMetricMeasurementsLoaderTest {
         assertThat(ImmutableList.of()).isEqualTo(cassandraHealthMetricMeasurements);
     }
 
-    private CassandraHealthMetric getCassandraMetric(String metricType, String metricName,
+    private HealthMetric getCassandraMetric(String metricType, String metricName,
             String metricAttribute) {
-        return ImmutableCassandraHealthMetric.builder()
+        return ImmutableHealthMetric.builder()
                 .type(metricType)
                 .name(metricName)
                 .attribute(metricAttribute)


### PR DESCRIPTION
**Goals (and why)**: Give a couple of classes more generic names

**Concerns (what feedback would you like?)**: This PR couldn't take us very far, because some of the implementation rely on JaxRs stuff - if we removed the Jersey annotations from `MetricsService`, we'd need to move the implementation details internal, which would mean adapting `TransactionManagers`. This would satisfy the Dependency Inversion Principle, but could also be high lift.

**Where should we start reviewing?**: MetricsService / HealthMetric

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2923)
<!-- Reviewable:end -->
