### PR TITLE
Add TimeLockStatus.PENDING_ELECTION

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,10 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |improved|
+         - Added a TimeLock healthcheck for signalling that no leader election has been triggered.
+           This will allow TimeLock itself to broadcast a HEALTHY status even without a leader.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2939>`__)
 
 =======
 v0.75.0

--- a/timelock-agent/src/main/java/com/palantir/timelock/TimeLockStatus.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/TimeLockStatus.java
@@ -21,7 +21,8 @@ public enum TimeLockStatus {
     NO_LEADER("There are no leaders in the Paxos cluster"),
     MULTIPLE_LEADERS("Multiple nodes in the Paxos cluster believe themselves to be the leader."),
     NO_QUORUM("Less than a quorum of nodes responded to a ping request."),
-    NO_CLIENTS("No clients have been registered yet. A leader is elected upon the registration of the first client.");
+    PENDING_ELECTION("No leader election has been triggered yet. A leader is elected upon the registration"
+            + " of the first client, so this might indicate that no clients have been registered yet.");
 
     private final String message;
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/TimeLockStatus.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/TimeLockStatus.java
@@ -20,7 +20,8 @@ public enum TimeLockStatus {
     ONE_LEADER("There is exactly one leader in the Paxos cluster."),
     NO_LEADER("There are no leaders in the Paxos cluster"),
     MULTIPLE_LEADERS("Multiple nodes in the Paxos cluster believe themselves to be the leader."),
-    NO_QUORUM("Less than a quorum of nodes responded to a ping request.");
+    NO_QUORUM("Less than a quorum of nodes responded to a ping request."),
+    NO_CLIENTS("No clients have been registered yet. A leader is elected upon the registration of the first client.");
 
     private final String message;
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -121,7 +121,7 @@ public class TimeLockAgent {
     @SuppressWarnings("unused") // used by external health checks
     public TimeLockStatus getStatus() {
         if (resource.numberOfClients() == 0) {
-            return TimeLockStatus.NO_CLIENTS;
+            return TimeLockStatus.PENDING_ELECTION;
         }
 
         return healthCheckSupplier.get().getStatus();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -75,13 +75,17 @@ public class TimeLockResource {
         return servicesByNamespace.computeIfAbsent(namespace, this::createNewClient);
     }
 
+    public int numberOfClients() {
+        return servicesByNamespace.size();
+    }
+
     private TimeLockServices createNewClient(String namespace) {
         Preconditions.checkArgument(!namespace.equals(PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE),
                 "The client name '%s' is reserved for the leader election service, and may not be "
                         + "used.",
                 PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE);
 
-        if (servicesByNamespace.size() >= maxNumberOfClients.get()) {
+        if (numberOfClients() >= maxNumberOfClients.get()) {
             log.error(
                     "Unable to create timelock services for client {}, as it would exceed the maximum number of "
                             + "allowed clients ({}). If this is intentional, the maximum number of clients can be "

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
@@ -82,6 +82,19 @@ public class TimeLockResourceTest {
     }
 
     @Test
+    public void returnsMaxNumberOfClients() {
+        createMaximumNumberOfClients();
+        assertThat(resource.numberOfClients()).isEqualTo(DEFAULT_MAX_NUMBER_OF_CLIENTS);
+    }
+
+    @Test
+    public void onClientCreationIncreaseNumberOfClients() {
+        assertThat(resource.numberOfClients()).isEqualTo(0);
+        resource.getTimeService(uniqueClient());
+        assertThat(resource.numberOfClients()).isEqualTo(1);
+    }
+
+    @Test
     public void canDynamicallyIncreaseMaxAllowedClients() {
         createMaximumNumberOfClients();
 


### PR DESCRIPTION
**Goals (and why)**: Add TimeLockStatus.PENDING_ELECTION when no clients have been created.

**Concerns (what feedback would you like?)**: Is it too hacky to expose number of clients as a public method of the resource?

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2939)
<!-- Reviewable:end -->
