### PR TITLE
Remove old comment from AtlasDbRuntimeConfig

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -75,7 +75,6 @@ public abstract class AtlasDbRuntimeConfig {
     /**
      * Runtime live-reloadable parameters for communicating with TimeLock.
      *
-     * This value is ignored if the install config does not specify usage of TimeLock.
      * We do not currently support live reloading from a leader block or using embedded services to using TimeLock.
      */
     public abstract Optional<TimeLockRuntimeConfig> timelockRuntime();


### PR DESCRIPTION
As of https://github.com/palantir/atlasdb/pull/2850, the runtime timelock block is _not_ ignored when the install config does not specify usage of TimeLock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2952)
<!-- Reviewable:end -->
