### PR TITLE
CellsSweeper inter-delete-batch logging

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsSweeper.java
@@ -82,11 +82,12 @@ public class CellsSweeper {
             Multimap<Cell, Long> cellTsPairsToSweep,
             Collection<Cell> sentinelsToAdd) {
         if (cellTsPairsToSweep.isEmpty()) {
-            log.info("Attempted to sweep a batch of 0 cell+timestamp pairs.");
+            log.info("Attempted to delete 0 cell+timestamp pairs from table {}.",
+                    LoggingArgs.tableRef(tableRef));
             return;
         }
 
-        log.info("Attempting to delete {} stale cell+timestamp pairs from table {}, and add {} sentinels.",
+        log.info("Attempted to delete {} stale cell+timestamp pairs from table {}, and add {} sentinels.",
                 SafeArg.of("numCellTsPairsToDelete", cellTsPairsToSweep.size()),
                 LoggingArgs.tableRef(tableRef),
                 SafeArg.of("numGarbageCollectionSentinelsToAdd", sentinelsToAdd.size()));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CellsSweeper.java
@@ -82,8 +82,14 @@ public class CellsSweeper {
             Multimap<Cell, Long> cellTsPairsToSweep,
             Collection<Cell> sentinelsToAdd) {
         if (cellTsPairsToSweep.isEmpty()) {
+            log.info("Attempted to sweep a batch of 0 cell+timestamp pairs.");
             return;
         }
+
+        log.info("Attempting to delete {} stale cell+timestamp pairs from table {}, and add {} sentinels.",
+                SafeArg.of("numCellTsPairsToDelete", cellTsPairsToSweep.size()),
+                LoggingArgs.tableRef(tableRef),
+                SafeArg.of("numGarbageCollectionSentinelsToAdd", sentinelsToAdd.size()));
 
         for (Follower follower : followers) {
             follower.run(txManager, tableRef, cellTsPairsToSweep.keySet(), Transaction.TransactionType.HARD_DELETE);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -64,6 +64,11 @@ develop
            Docs about this config can be found :ref:`here <atlas-config>` and :ref:`here <cassandra-configuration>`.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2896>`__)
 
+    *    - |improved| |logs|
+         - Sweep now logs the number of cells it is deleting when performing a single batch of deletes.
+           This is useful for visibility of Sweep progress; previously, Sweep would only log when a top-level batch was complete, meaning that for highly versioned rows Sweep would only log after deleting all stale versions of said row.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2958>`__)
+
 =======
 v0.75.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
- Improve visibility into Sweep when deleting wide / highly versioned rows. See #2944 

**Implementation Description (bullets)**:
- Add logging into `CellsSweeper` so we log after deleting every individual batch of cells, as opposed to after the entire row for very wide rows

**Concerns (what feedback would you like?)**:
- Does this cause too much noise in the logs?
- Is this the right place?

**Where should we start reviewing?**: CellsSweeper

**Priority (whenever / two weeks / yesterday)**: two weeks; not that high, but useful for debugging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2958)
<!-- Reviewable:end -->
