### PR TITLE
[no release notes] Fixed broken test infra, added a test

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Optional;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
@@ -245,7 +246,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 transactionService,
                 cleaner,
                 startTimestampSupplier,
-                conflictDetectionManager,
+                getConflictDetectionManager(),
                 sweepStrategyManager,
                 immutableTimestamp,
                 Optional.of(immutableTsLock),
@@ -259,6 +260,11 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 sweepQueueWriter);
+    }
+
+    @VisibleForTesting
+    ConflictDetectionManager getConflictDetectionManager() {
+        return conflictDetectionManager;
     }
 
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestConflictDetectionManagers.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestConflictDetectionManagers.java
@@ -37,5 +37,4 @@ public final class TestConflictDetectionManagers {
                     }
                 });
     }
-
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -17,7 +17,9 @@ package com.palantir.atlasdb.transaction.impl;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
+import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
@@ -28,12 +30,14 @@ import com.palantir.atlasdb.monitoring.TimestampTrackerImpl;
 import com.palantir.atlasdb.sweep.queue.SweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
 import com.palantir.lock.impl.LegacyTimelockService;
+import com.palantir.lock.v2.LockToken;
 import com.palantir.timestamp.TimestampService;
 
 public class TestTransactionManagerImpl extends SerializableTransactionManager implements TestTransactionManager {
@@ -108,10 +112,37 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
     }
 
     @Override
-    public Transaction createNewTransaction() {
-        Map<TableReference, ConflictHandler> conflictHandlersWithOverrides = new HashMap<>();
-        conflictHandlersWithOverrides.putAll(conflictDetectionManager.getCachedValues());
-        conflictHandlersWithOverrides.putAll(conflictHandlerOverrides);
+    protected SnapshotTransaction createTransaction(
+            long immutableTimestamp,
+            Supplier<Long> startTimestampSupplier,
+            LockToken immutableTsLock,
+            PreCommitCondition condition) {
+        Map<TableReference, ConflictHandler> conflictHandlersWithOverrides = getConflictHandlerWithOverrides();
+        return new SnapshotTransaction(
+                keyValueService,
+                timelockService,
+                transactionService,
+                cleaner,
+                startTimestampSupplier,
+                TestConflictDetectionManagers.createWithStaticConflictDetection(conflictHandlersWithOverrides),
+                sweepStrategyManager,
+                immutableTimestamp,
+                Optional.of(immutableTsLock),
+                condition,
+                constraintModeSupplier.get(),
+                cleaner.getTransactionReadTimeoutMillis(),
+                TransactionReadSentinelBehavior.THROW_EXCEPTION,
+                allowHiddenTableAccess,
+                timestampValidationReadCache,
+                lockAcquireTimeoutMs.get(),
+                getRangesExecutor,
+                defaultGetRangesConcurrency,
+                sweepQueueWriter);
+    }
+
+    @Override
+    public SnapshotTransaction createNewTransaction() {
+        Map<TableReference, ConflictHandler> conflictHandlersWithOverrides = getConflictHandlerWithOverrides();
         return new SnapshotTransaction(
                 keyValueService,
                 timelockService,
@@ -130,5 +161,12 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
     @Override
     public void overrideConflictHandlerForTable(TableReference table, ConflictHandler conflictHandler) {
         conflictHandlerOverrides.put(table, conflictHandler);
+    }
+
+    Map<TableReference, ConflictHandler> getConflictHandlerWithOverrides() {
+        Map<TableReference, ConflictHandler> conflictHandlersWithOverrides = new HashMap<>();
+        conflictHandlersWithOverrides.putAll(conflictDetectionManager.getCachedValues());
+        conflictHandlersWithOverrides.putAll(conflictHandlerOverrides);
+        return conflictHandlersWithOverrides;
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -108,7 +108,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
     }
 
     @Override
-    public SnapshotTransaction createNewTransaction() {
+    public Transaction createNewTransaction() {
         return new SnapshotTransaction(
                 keyValueService,
                 timelockService,
@@ -126,8 +126,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
 
     @Override
     ConflictDetectionManager getConflictDetectionManager() {
-        Map<TableReference, ConflictHandler> conflictHandlersWithOverrides = getConflictHandlerWithOverrides();
-        return TestConflictDetectionManagers.createWithStaticConflictDetection(conflictHandlersWithOverrides);
+        return TestConflictDetectionManagers.createWithStaticConflictDetection(getConflictHandlerWithOverrides());
     }
 
     @Override


### PR DESCRIPTION
**Goals (and why)**:
Overrides for ConflictHandlers were not being propagated to transactions created by `runTaskWithRetry`. Tests were assuming they were being propagated.
 
**Implementation Description (bullets)**:
Overriding `createTransaction` in `TestTransactionManagerImpl.java`

**Concerns (what feedback would you like?)**:
It's not the cleanest since it duplicates `SerializableTransactionManager` code, but didn't seem valuable to spend too much time on this. At least fixes the existing issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2962)
<!-- Reviewable:end -->
