### PR TITLE
Test NoOpPersistentLockService + PersistentLockManager interaction

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/PersistentLockManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/PersistentLockManagerTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -45,6 +46,7 @@ import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.persistentlock.ImmutableLockEntry;
 import com.palantir.atlasdb.persistentlock.LockEntry;
+import com.palantir.atlasdb.persistentlock.NoOpPersistentLockService;
 import com.palantir.atlasdb.persistentlock.PersistentLockId;
 import com.palantir.atlasdb.persistentlock.PersistentLockService;
 
@@ -247,6 +249,14 @@ public class PersistentLockManagerTest {
         acquireStarted.await();
 
         manager.shutdown();
+    }
+
+    @Test
+    public void testNoOpPersistentLockDoesNotThrow() {
+        PersistentLockManager noOpManager = new PersistentLockManager(new NoOpPersistentLockService(), 0L);
+        assertTrue("NoOpPersistentLockService should return true when acquiring lock",
+                noOpManager.tryAcquirePersistentLock());
+        noOpManager.releasePersistentLock();
     }
 
     private void whenWeGetTheLockFirstTimeAndThenHoldItForever() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/PersistentLockManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/PersistentLockManagerTest.java
@@ -252,11 +252,20 @@ public class PersistentLockManagerTest {
     }
 
     @Test
-    public void testNoOpPersistentLockDoesNotThrow() {
+    public void noOpPersistentLockDoesNotThrow() {
         PersistentLockManager noOpManager = new PersistentLockManager(new NoOpPersistentLockService(), 0L);
         assertTrue("NoOpPersistentLockService should return true when acquiring lock",
                 noOpManager.tryAcquirePersistentLock());
         noOpManager.releasePersistentLock();
+    }
+
+    @Test
+    public void noOpPersistentLockCanLockTwice() {
+        PersistentLockManager noOpManager = new PersistentLockManager(new NoOpPersistentLockService(), 0L);
+        assertTrue("NoOpPersistentLockService should return true when acquiring lock",
+                noOpManager.tryAcquirePersistentLock());
+        assertTrue("NoOpPersistentLockService should return true when acquiring lock for the second time",
+                noOpManager.tryAcquirePersistentLock());
     }
 
     private void whenWeGetTheLockFirstTimeAndThenHoldItForever() {


### PR DESCRIPTION
**Goals (and why)**: The large internal product will use `NoOpPersistentLockService`, since they don't require backup locks to be taken for their backup procedure. Just wanted to future proof this interaction with this unit test.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2969)
<!-- Reviewable:end -->
