### PR TITLE
SSSS Part 2: Metadata Cleanup Task

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableType.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableType.java
@@ -42,11 +42,6 @@ public enum StreamTableType { // WARNING: do not change these without an upgrade
         return Renderers.CamelCase(prefix) + javaSuffix;
     }
 
-    public static String getShortName(StreamTableType type, TableReference tableReference) {
-        Preconditions.checkArgument(isStreamStoreTableOfSpecificType(type, tableReference));
-        return stripStreamTableSuffix(type, tableReference);
-    }
-
     public TableReference getTableReference(Namespace namespace, String streamStoreShortName) {
         return TableReference.create(namespace, getTableName(streamStoreShortName));
     }
@@ -63,11 +58,15 @@ public enum StreamTableType { // WARNING: do not change these without an upgrade
         Preconditions.checkArgument(isStreamStoreValueTable(tableReference),
                 "tableReference should be a StreamStore value table");
 
-        String indexTableName = stripStreamTableSuffix(VALUE, tableReference) + INDEX.tableSuffix;
+        String indexTableName = getShortName(VALUE, tableReference) + INDEX.tableSuffix;
         return TableReference.create(tableReference.getNamespace(), indexTableName);
     }
 
-    private static String stripStreamTableSuffix(StreamTableType type, TableReference tableReference) {
+    public static String getShortName(StreamTableType type, TableReference tableReference) {
+        Preconditions.checkArgument(isStreamStoreTableOfSpecificType(type, tableReference),
+                "Attempted to strip a stream table suffix, but provided an inconsistent type!"
+                        + " Table reference was {}, alleged type was {}", tableReference, type);
+
         String tableName = tableReference.getTablename();
         return tableName.substring(0, tableName.length() - type.tableSuffix.length());
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableType.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableType.java
@@ -42,6 +42,11 @@ public enum StreamTableType { // WARNING: do not change these without an upgrade
         return Renderers.CamelCase(prefix) + javaSuffix;
     }
 
+    public static String getShortName(StreamTableType type, TableReference tableReference) {
+        Preconditions.checkArgument(isStreamStoreTableOfSpecificType(type, tableReference));
+        return stripStreamTableSuffix(type, tableReference);
+    }
+
     public TableReference getTableReference(Namespace namespace, String streamStoreShortName) {
         return TableReference.create(namespace, getTableName(streamStoreShortName));
     }
@@ -58,8 +63,12 @@ public enum StreamTableType { // WARNING: do not change these without an upgrade
         Preconditions.checkArgument(isStreamStoreValueTable(tableReference),
                 "tableReference should be a StreamStore value table");
 
-        int tableNameLastIndex = tableReference.getQualifiedName().lastIndexOf(StreamTableType.VALUE.tableSuffix);
-        String indexTableName = tableReference.getQualifiedName().substring(0, tableNameLastIndex) + INDEX.tableSuffix;
-        return TableReference.createUnsafe(indexTableName);
+        String indexTableName = stripStreamTableSuffix(VALUE, tableReference) + INDEX.tableSuffix;
+        return TableReference.create(tableReference.getNamespace(), indexTableName);
+    }
+
+    private static String stripStreamTableSuffix(StreamTableType type, TableReference tableReference) {
+        String tableName = tableReference.getTablename();
+        return tableName.substring(0, tableName.length() - type.tableSuffix.length());
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableType.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/stream/StreamTableType.java
@@ -64,7 +64,7 @@ public enum StreamTableType { // WARNING: do not change these without an upgrade
 
     public static String getShortName(StreamTableType type, TableReference tableReference) {
         Preconditions.checkArgument(isStreamStoreTableOfSpecificType(type, tableReference),
-                "Attempted to strip a stream table suffix, but provided an inconsistent type!"
+                "Attempted to get a stream table's short name, but provided an inconsistent type!"
                         + " Table reference was {}, alleged type was {}", tableReference, type);
 
         String tableName = tableReference.getTablename();

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/stream/StreamTableTypeTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/schema/stream/StreamTableTypeTest.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.schema.stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -103,5 +104,34 @@ public class StreamTableTypeTest {
         assertThat(StreamTableType.VALUE.getTableReference(Namespace.EMPTY_NAMESPACE, TEST_TABLE))
                 .isEqualTo(TableReference.create(Namespace.EMPTY_NAMESPACE,
                         StreamTableType.VALUE.getTableName(TEST_TABLE)));
+    }
+
+    @Test
+    public void getShortNameWorksWithTableWithoutNamespace() {
+        assertThat(StreamTableType.getShortName(StreamTableType.VALUE,
+                TableReference.create(Namespace.EMPTY_NAMESPACE, StreamTableType.VALUE.getTableName(TEST_TABLE))))
+                .isEqualTo(TEST_TABLE);
+    }
+
+    @Test
+    public void getShortNameWorksWithTableWithNamespace() {
+        assertThat(StreamTableType.getShortName(StreamTableType.HASH,
+                TableReference.create(TEST_NAMESPACE, StreamTableType.HASH.getTableName(TEST_TABLE))))
+                .isEqualTo(TEST_TABLE);
+    }
+
+    @Test
+    public void getShortNameThrowsIfTableReferenceIsNotAStreamTable() {
+        assertThatThrownBy(() -> StreamTableType.getShortName(
+                StreamTableType.INDEX,
+                TableReference.create(TEST_NAMESPACE, "tab"))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void getShortNameThrowsIfTableReferenceIsAStreamTableOfTheWrongType() {
+        assertThatThrownBy(() -> StreamTableType.getShortName(
+                StreamTableType.INDEX,
+                TableReference.create(TEST_NAMESPACE, StreamTableType.METADATA.getTableName("foo"))))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTask.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTask.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.protos.generated.StreamPersistence;
+import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class GenericStreamStoreMetadataCleanupTask implements OnCleanupTask {
+    private final StreamStoreMetadataReader metadataReader;
+    private final SchemalessStreamStoreDeleter deleter;
+
+    public GenericStreamStoreMetadataCleanupTask(
+            TableReference tableToSweep,
+            StreamStoreCleanupMetadata cleanupMetadata) {
+        // TODO (jkong): Standardise the creation interfaces
+        this.metadataReader = new StreamStoreMetadataReader(
+                tableToSweep,
+                new GenericStreamStoreCellCreator(cleanupMetadata));
+        this.deleter = new SchemalessStreamStoreDeleter(
+                tableToSweep.getNamespace(),
+                tableToSweep.getTablename() /* TODO */,
+                cleanupMetadata);
+    }
+
+    @Override
+    public boolean cellsCleanedUp(Transaction transaction, Set<Cell> cells) {
+        // cells -> generic stream IDs
+        Set<GenericStreamIdentifier> cellIds = ImmutableSet.of();
+
+        // generic stream IDs -> metadata reader to filter
+        Map<GenericStreamIdentifier, StreamPersistence.StreamMetadata> metadataFromDb =
+                metadataReader.readMetadata(transaction, cellIds);
+        Set<GenericStreamIdentifier> unstoredStreamIdentifiers = metadataFromDb.entrySet().stream()
+                .filter(entry -> entry.getValue().getStatus() != StreamPersistence.Status.STORED)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+
+        // actually delete
+        deleter.deleteStreams(transaction, unstoredStreamIdentifiers);
+        return false;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTask.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTask.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -36,7 +37,6 @@ public class GenericStreamStoreMetadataCleanupTask implements OnCleanupTask {
     public GenericStreamStoreMetadataCleanupTask(
             TableReference tableToSweep,
             StreamStoreCleanupMetadata cleanupMetadata) {
-        // TODO (jkong): Standardise the creation interfaces
         this.rowDecoder = new GenericStreamStoreRowDecoder(cleanupMetadata);
         this.metadataReader = new StreamStoreMetadataReader(
                 tableToSweep,
@@ -45,6 +45,16 @@ public class GenericStreamStoreMetadataCleanupTask implements OnCleanupTask {
                 tableToSweep.getNamespace(),
                 StreamTableType.getShortName(StreamTableType.METADATA, tableToSweep),
                 cleanupMetadata);
+    }
+
+    @VisibleForTesting
+    GenericStreamStoreMetadataCleanupTask(
+            GenericStreamStoreRowDecoder rowDecoder,
+            StreamStoreMetadataReader metadataReader,
+            SchemalessStreamStoreDeleter deleter) {
+        this.rowDecoder = rowDecoder;
+        this.metadataReader = metadataReader;
+        this.deleter = deleter;
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupVisitor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupVisitor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
+
+public class GenericStreamStoreMetadataCleanupVisitor implements StreamStoreCleanupMetadataVisitor {
+    private static final Logger log = LoggerFactory.getLogger(GenericStreamStoreMetadataCleanupVisitor.class);
+
+    private final TableReference tableToSweep;
+    private SchemalessStreamStoreDeleter schemalessStreamStoreDeleter;
+
+    public GenericStreamStoreMetadataCleanupVisitor(TableReference tableToSweep) {
+        this.tableToSweep = tableToSweep;
+    }
+
+    @Override
+    public OnCleanupTask visit(StreamStoreCleanupMetadata cleanupMetadata) {
+        return new GenericStreamStoreMetadataCleanupTask(tableToSweep, cleanupMetadata);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupVisitor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupVisitor.java
@@ -21,13 +21,14 @@ import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
+import com.palantir.logsafe.SafeArg;
 
 public class GenericStreamStoreMetadataCleanupVisitor implements StreamStoreCleanupMetadataVisitor {
     private static final Logger log = LoggerFactory.getLogger(GenericStreamStoreMetadataCleanupVisitor.class);
 
     private final TableReference tableToSweep;
-    private SchemalessStreamStoreDeleter schemalessStreamStoreDeleter;
 
     public GenericStreamStoreMetadataCleanupVisitor(TableReference tableToSweep) {
         this.tableToSweep = tableToSweep;
@@ -35,6 +36,9 @@ public class GenericStreamStoreMetadataCleanupVisitor implements StreamStoreClea
 
     @Override
     public OnCleanupTask visit(StreamStoreCleanupMetadata cleanupMetadata) {
+        log.info("Now creating cleanup task for table {}, which has cleanup metadata {}",
+                LoggingArgs.tableRef(tableToSweep),
+                SafeArg.of("cleanupMetadata", cleanupMetadata));
         return new GenericStreamStoreMetadataCleanupTask(tableToSweep, cleanupMetadata);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreRowDecoder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreRowDecoder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import java.util.Arrays;
+
+import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
+
+/**
+ * This class decodes row components of a stream store into a {@link GenericStreamIdentifier}, without needing to know
+ * the stream store's schema.
+ *
+ * Note that of the {@link com.palantir.atlasdb.schema.stream.StreamTableType}s, we only currently support
+ * METADATA and INDEX, because we don't currently have a use case for decoding the VALUE or HASH_AIDX tables in a
+ * generic fashion.
+ */
+public class GenericStreamStoreRowDecoder {
+    private final StreamStoreCleanupMetadata cleanupMetadata;
+
+    public GenericStreamStoreRowDecoder(StreamStoreCleanupMetadata cleanupMetadata) {
+        this.cleanupMetadata = cleanupMetadata;
+    }
+
+    public GenericStreamIdentifier decodeIndexOrMetadataTableRow(byte[] rowComponent) {
+        byte[] encodedStreamId = cleanupMetadata.numHashedRowComponents() == 0
+                ? rowComponent
+                : Arrays.copyOfRange(
+                        rowComponent, StreamStoreHashEncodingUtils.getHashComponentBytes(), rowComponent.length);
+        return ImmutableGenericStreamIdentifier.of(cleanupMetadata.streamIdType(), encodedStreamId);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/StreamStoreHashEncodingUtils.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/StreamStoreHashEncodingUtils.java
@@ -16,11 +16,14 @@
 
 package com.palantir.atlasdb.sweep.external;
 
+import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
 
 public final class StreamStoreHashEncodingUtils {
+    private static final HashFunction HASH_FUNCTION = Hashing.murmur3_128();
+
     private StreamStoreHashEncodingUtils() {
         // utility class
     }
@@ -44,6 +47,10 @@ public final class StreamStoreHashEncodingUtils {
         }
     }
 
+    public static int getHashComponentBytes() {
+        return HASH_FUNCTION.bits() / Byte.SIZE;
+    }
+
     private static byte[] computeHashFirstComponent(GenericStreamIdentifier streamId) {
         return applyBitwiseXorWithMinValueAndConvert(computeMurmurHash(streamId.data()));
     }
@@ -60,6 +67,6 @@ public final class StreamStoreHashEncodingUtils {
     }
 
     private static long computeMurmurHash(byte[]... bytes) {
-        return Hashing.murmur3_128().hashBytes(EncodingUtils.add(bytes)).asLong();
+        return HASH_FUNCTION.hashBytes(EncodingUtils.add(bytes)).asLong();
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTaskTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTaskTest.java
@@ -32,7 +32,7 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 
 public class GenericStreamStoreMetadataCleanupTaskTest {
-    private static final byte[] ROW_1 = {1 };
+    private static final byte[] ROW_1 = { 1 };
     private static final byte[] ROW_2 = { 12 };
     private static final byte[] COLUMN = { 2 };
     private static final byte[] HASH = new byte[32];

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTaskTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTaskTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.ByteString;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.protos.generated.StreamPersistence;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class GenericStreamStoreMetadataCleanupTaskTest {
+    private static final byte[] ROW_1 = {1 };
+    private static final byte[] ROW_2 = { 12 };
+    private static final byte[] COLUMN = { 2 };
+    private static final byte[] HASH = new byte[32];
+    private static final Cell CELL_1 = Cell.create(ROW_1, COLUMN);
+    private static final Cell CELL_2 = Cell.create(ROW_2, COLUMN);
+    private static final GenericStreamIdentifier IDENTIFIER_1 =
+            ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG, ROW_1);
+    private static final GenericStreamIdentifier IDENTIFIER_2 =
+            ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG, ROW_2);
+    private static final StreamPersistence.StreamMetadata STORING_STREAM_METADATA =
+            StreamPersistence.StreamMetadata.newBuilder()
+                    .setLength(5L)
+                    .setHash(ByteString.copyFrom(HASH))
+                    .setStatus(StreamPersistence.Status.STORING)
+                    .build();
+    private static final StreamPersistence.StreamMetadata STORED_STREAM_METADATA =
+            StreamPersistence.StreamMetadata.newBuilder()
+                    .setLength(7L)
+                    .setHash(ByteString.copyFrom(HASH))
+                    .setStatus(StreamPersistence.Status.STORED)
+                    .build();
+
+    private final Transaction tx = mock(Transaction.class);
+
+    private final GenericStreamStoreRowDecoder rowDecoder = mock(GenericStreamStoreRowDecoder.class);
+    private final StreamStoreMetadataReader metadataReader = mock(StreamStoreMetadataReader.class);
+    private final SchemalessStreamStoreDeleter deleter = mock(SchemalessStreamStoreDeleter.class);
+    private final GenericStreamStoreMetadataCleanupTask cleanupTask =
+            new GenericStreamStoreMetadataCleanupTask(rowDecoder, metadataReader, deleter);
+
+    @Before
+    public void setUp() {
+        when(rowDecoder.decodeIndexOrMetadataTableRow(ROW_1)).thenReturn(IDENTIFIER_1);
+        when(rowDecoder.decodeIndexOrMetadataTableRow(ROW_2)).thenReturn(IDENTIFIER_2);
+    }
+
+    @Test
+    public void propagatesDeletesForStreamIdentifiers() {
+        when(metadataReader.readMetadata(tx, ImmutableSet.of(IDENTIFIER_1)))
+                .thenReturn(ImmutableMap.of(IDENTIFIER_1, STORING_STREAM_METADATA));
+
+        cleanupTask.cellsCleanedUp(tx, ImmutableSet.of(CELL_1));
+        verify(deleter).deleteStreams(tx, ImmutableSet.of(IDENTIFIER_1));
+    }
+
+    @Test
+    public void doesNotPropagateDeletesForStreamsThatAreStored() {
+        when(metadataReader.readMetadata(tx, ImmutableSet.of(IDENTIFIER_1)))
+                .thenReturn(ImmutableMap.of(IDENTIFIER_1, STORED_STREAM_METADATA));
+
+        cleanupTask.cellsCleanedUp(tx, ImmutableSet.of(CELL_1));
+        verify(deleter).deleteStreams(tx, ImmutableSet.of());
+    }
+
+    @Test
+    public void deletesOnlyStreamsNotStoredWhenDeletingMultiple() {
+        when(metadataReader.readMetadata(tx, ImmutableSet.of(IDENTIFIER_1, IDENTIFIER_2)))
+                .thenReturn(ImmutableMap.of(
+                        IDENTIFIER_1, STORED_STREAM_METADATA,
+                        IDENTIFIER_2, STORING_STREAM_METADATA));
+
+        cleanupTask.cellsCleanedUp(tx, ImmutableSet.of(CELL_1, CELL_2));
+        verify(deleter).deleteStreams(tx, ImmutableSet.of(IDENTIFIER_2));
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreRowDecoderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreRowDecoderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.schema.cleanup.ImmutableStreamStoreCleanupMetadata;
+import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
+
+public class GenericStreamStoreRowDecoderTest {
+    private static final ImmutableStreamStoreCleanupMetadata METADATA_ZERO_HASHED_COMPONENTS =
+            ImmutableStreamStoreCleanupMetadata.builder()
+                    .numHashedRowComponents(0)
+                    .streamIdType(ValueType.VAR_SIGNED_LONG)
+                    .build();
+    private static final StreamStoreCleanupMetadata METADATA_ONE_HASHED_COMPONENT =
+            ImmutableStreamStoreCleanupMetadata.builder()
+                    .numHashedRowComponents(1)
+                    .streamIdType(ValueType.VAR_LONG)
+                    .build();
+    private static final StreamStoreCleanupMetadata METADATA_TWO_HASHED_COMPONENTS =
+            ImmutableStreamStoreCleanupMetadata.builder()
+                    .numHashedRowComponents(2)
+                    .streamIdType(ValueType.FIXED_LONG)
+                    .build();
+    private static final int HASH_LENGTH = StreamStoreHashEncodingUtils.getHashComponentBytes();
+
+    @Test
+    public void decodesRowKeysWithZeroHashedComponents() {
+        assertThat(new GenericStreamStoreRowDecoder(METADATA_ZERO_HASHED_COMPONENTS)
+                .decodeIndexOrMetadataTableRow(generateIncreasingByteArray(0, 40)))
+                .isEqualTo(ImmutableGenericStreamIdentifier.of(
+                        ValueType.VAR_SIGNED_LONG, generateIncreasingByteArray(0, 40)));
+    }
+
+    @Test
+    public void decodesRowKeysWithOneHashedComponent() {
+        assertThat(new GenericStreamStoreRowDecoder(METADATA_ONE_HASHED_COMPONENT)
+                .decodeIndexOrMetadataTableRow(generateIncreasingByteArray(0, 79)))
+                .isEqualTo(ImmutableGenericStreamIdentifier.of(ValueType.VAR_LONG,
+                        generateIncreasingByteArray(HASH_LENGTH, 79)));
+    }
+
+    @Test
+    public void decodesRowKeysWithTwoHashedComponents() {
+        assertThat(new GenericStreamStoreRowDecoder(METADATA_TWO_HASHED_COMPONENTS)
+                .decodeIndexOrMetadataTableRow(generateIncreasingByteArray(0, 111)))
+                .isEqualTo(ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG,
+                        generateIncreasingByteArray(HASH_LENGTH, 111)));
+    }
+
+    @Test
+    public void throwsIfRowComponentIsTooShortToHaveHashedComponentsAndDecoderHasHashedComponents() {
+        assertThatThrownBy(() -> new GenericStreamStoreRowDecoder(METADATA_TWO_HASHED_COMPONENTS)
+                .decodeIndexOrMetadataTableRow(generateIncreasingByteArray(0, 1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void doesNotThrowIfRowComponentIsTooShortToHaveHashedComponentsButDecoderHasNoHashedComponents() {
+        assertThat(new GenericStreamStoreRowDecoder(METADATA_ZERO_HASHED_COMPONENTS)
+                .decodeIndexOrMetadataTableRow(generateIncreasingByteArray(0, HASH_LENGTH - 1)))
+                .isEqualTo(ImmutableGenericStreamIdentifier.of(
+                        ValueType.VAR_SIGNED_LONG, generateIncreasingByteArray(0, HASH_LENGTH - 1)));
+    }
+
+    private static byte[] generateIncreasingByteArray(int lowerLimit, int upperLimit) {
+        Preconditions.checkArgument(Byte.MIN_VALUE < lowerLimit,
+                "lower limit of %s is too low (byte minimmum: %s)",
+                lowerLimit,
+                Byte.MIN_VALUE);
+        Preconditions.checkArgument(lowerLimit < upperLimit,
+                "lower limit of %s is higher than the upper limit of %s",
+                lowerLimit,
+                upperLimit);
+        Preconditions.checkArgument(upperLimit < Byte.MAX_VALUE,
+                "upper limit of %s is too high (byte maximum: %s)",
+                upperLimit,
+                Byte.MAX_VALUE);
+
+        int[] values = IntStream.range(lowerLimit, upperLimit).toArray();
+        byte[] result = new byte[values.length];
+
+        for (int i = 0; i < values.length; i++) {
+            result[i] = (byte) values[i];
+        }
+        return result;
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreRowDecoderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreRowDecoderTest.java
@@ -86,15 +86,15 @@ public class GenericStreamStoreRowDecoderTest {
     }
 
     private static byte[] generateIncreasingByteArray(int lowerLimit, int upperLimit) {
-        Preconditions.checkArgument(Byte.MIN_VALUE < lowerLimit,
+        Preconditions.checkArgument(Byte.MIN_VALUE <= lowerLimit,
                 "lower limit of %s is too low (byte minimmum: %s)",
                 lowerLimit,
                 Byte.MIN_VALUE);
-        Preconditions.checkArgument(lowerLimit < upperLimit,
+        Preconditions.checkArgument(lowerLimit <= upperLimit,
                 "lower limit of %s is higher than the upper limit of %s",
                 lowerLimit,
                 upperLimit);
-        Preconditions.checkArgument(upperLimit < Byte.MAX_VALUE,
+        Preconditions.checkArgument(upperLimit <= Byte.MAX_VALUE,
                 "upper limit of %s is too high (byte maximum: %s)",
                 upperLimit,
                 Byte.MAX_VALUE);


### PR DESCRIPTION
**Goals (and why)**:
- Implement a stream store's `MetadataCleanupTask` in a generic fashion, so that Nimbus can sweep a service with a stream store.

**Implementation Description (bullets)**:
- Implement an `OnCleanupTask` which is a generic form of the task used to clean a stream store's metadata table

**Concerns (what feedback would you like?)**:
- Is this a faithful translation of the generated version?

**Where should we start reviewing?**:`GenericStreamStoreMetadataCleanupTask`

**Priority (whenever / two weeks / yesterday)**: next week?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2970)
<!-- Reviewable:end -->
