### PR TITLE
Be nice to Cassandra client's input buffers

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -102,6 +102,11 @@ develop
            This allows api projects outside of atlasdb to use ``ExecutorInheritableThreadLocal`` without pulling in the dependencies of ``commons-executors``.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2961>`__)
 
+    *    - |fixed|
+         - Fixed a bug where Cassandra client's input buffers were left in an invalid state
+           before returning the client to the pool, manifesting in NPEs in the Thrift layer.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2971>`__)
+
 =======
 v0.75.0
 =======


### PR DESCRIPTION
Calling clear() on TMemoryInputTransport sets its 'buf' field to null
which can later result in a NullPointerException in places like
TBinaryProtocol.readI32().

Instead, we can call reset() with an empty byte array to achieve
a similar effect without using null pointers. For safety, we also do it
only if there are no bytes left in the buffer to avoid effectively
modifying its state. Not sure why there would be extra bytes left in the
buffer after a successful request, but the evidence suggests that it
might happen occasionally.

----

See QA-111187. Basically, there is a test flake in our internal product:

```
Caused by: java.lang.RuntimeException: java.lang.NullPointerException: null
--
at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:320)
at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219)
at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:69)
at org.apache.cassandra.thrift.Cassandra$Client.recv_describe_keyspace(Cassandra.java:1413)
at org.apache.cassandra.thrift.Cassandra$Client.describe_keyspace(Cassandra.java:1400)
at com.palantir.atlasdb.keyvalue.cassandra.SchemaMutationLockTables.getAllLockTablesInternal(SchemaMutationLockTables.java:58)
 
```
Carefully reading the code points to `eagerlyCleanupReadBuffersFromIdleConnection()` being too eager

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2971)
<!-- Reviewable:end -->
