### PR TITLE
Make cells written metric a counter

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedCassandraClient.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.InvalidRequestException;
@@ -28,7 +29,7 @@ import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
 
-import com.codahale.metrics.Meter;
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.logging.LoggingArgs;
@@ -68,14 +69,29 @@ public class InstrumentedCassandraClient implements AutoDelegate_CassandraClient
             });
         });
 
-        tablesToCells.forEach((table, numberOfCells) -> getCellsWrittenMeterForTable(table).mark(numberOfCells));
+        tablesToCells.forEach((table, numberOfCells) -> updateCellsWrittenMeterForTable(table));
     }
 
-    private Meter getCellsWrittenMeterForTable(String table) {
-        return taggedMetricRegistry.meter(
+    private void updateCellsWrittenMeterForTable(String table, Long numberOfCells) {
+        IncrementingGauge incrementingGauge = (IncrementingGauge) taggedMetricRegistry.gauge(
                 MetricName.builder()
-                .safeName(MetricRegistry.name(CassandraClient.class, "cellsWritten"))
-                .safeTags(ImmutableMap.of("tableRef", LoggingArgs.safeInternalTableNameOrPlaceholder(table)))
-                .build());
+                        .safeName(MetricRegistry.name(CassandraClient.class, "cellsWritten"))
+                        .safeTags(ImmutableMap.of("tableRef", LoggingArgs.safeInternalTableNameOrPlaceholder(table)))
+                        .build(),
+                new IncrementingGauge());
+        incrementingGauge.addValue(numberOfCells);
+    }
+
+    private static class IncrementingGauge implements Gauge<Long> {
+        private final AtomicLong atomicLong = new AtomicLong(0L);
+
+        @Override
+        public Long getValue() {
+            return atomicLong.get();
+        }
+
+        public void addValue(Long newValue) {
+            atomicLong.addAndGet(newValue);
+        }
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/InstrumentedCassandraClient.java
@@ -67,10 +67,10 @@ public class InstrumentedCassandraClient implements AutoDelegate_CassandraClient
             });
         });
 
-        tablesToCells.forEach((table, numberOfCells) -> updateCellsWrittenMeterForTable(table, numberOfCells));
+        tablesToCells.forEach((table, numberOfCells) -> updateCellsWrittenForTable(table, numberOfCells));
     }
 
-    private void updateCellsWrittenMeterForTable(String table, Long numberOfCells) {
+    private void updateCellsWrittenForTable(String table, Long numberOfCells) {
         taggedMetricRegistry.counter(MetricName.builder()
                 .safeName(MetricRegistry.name(CassandraClient.class, "cellsWritten"))
                 .safeTags(ImmutableMap.of("tableRef", LoggingArgs.safeInternalTableNameOrPlaceholder(table)))

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -96,6 +96,7 @@ develop
          - Atlas now records the number of cells written over time.
            This metric is reported under ``com.palantir.atlasdb.keyvalue.cassandra.CassandraClient.cellsWritten``
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2967>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2974>`__)
 
     *    - |improved|
          - ``ExecutorInheritableThreadLocal`` from ``commons-executors`` has been split out into a ``commons-executors-api`` dependent project with no dependencies.


### PR DESCRIPTION
**Goals (and why)**: Make the number of cells written metric a counter. We can do all the analysis we want in our metric tool with a counter, and this will reduce the number of tagged metrics we use.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2974)
<!-- Reviewable:end -->
