### PR TITLE
Make SHRINK COMPACT operation configurable

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -65,6 +65,12 @@ public abstract class OracleDdlConfig extends DdlConfig {
     }
 
     @Value.Default
+    // SHRINK COMPACT is an operation that blocks DML, so enable with care.
+    public boolean useShrinkCompactOnOracleStandardEdition() {
+        return false;
+    }
+
+    @Value.Default
     @Override
     public String tablePrefix() {
         return "a_";

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -271,13 +271,15 @@ public final class OracleDdlTable implements DbDdlTable {
                 log.info("Call to SHRINK SPACE COMPACT on table {} took {} ms.",
                         tableRef, shrinkAndCompactTimer.elapsed(TimeUnit.MILLISECONDS));
 
-                Stopwatch shrinkTimer = Stopwatch.createStarted();
-                conns.get().executeUnregisteredQuery(
-                        "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
-                                + " SHRINK SPACE");
-                log.info("Call to SHRINK SPACE on table {} took {} ms."
-                                + " This implies that locks on the entire table were held for this period.",
-                        tableRef, shrinkTimer.elapsed(TimeUnit.MILLISECONDS));
+                if (config.useShrinkCompactOnOracleStandardEdition()) {
+                    Stopwatch shrinkTimer = Stopwatch.createStarted();
+                    conns.get().executeUnregisteredQuery(
+                            "ALTER TABLE " + oracleTableNameGetter.getInternalShortTableName(conns, tableRef)
+                                    + " SHRINK SPACE");
+                    log.info("Call to SHRINK SPACE on table {} took {} ms."
+                                    + " This implies that locks on the entire table were held for this period.",
+                            tableRef, shrinkTimer.elapsed(TimeUnit.MILLISECONDS));
+                }
             } catch (PalantirSqlException e) {
                 log.error(compactionFailureTemplate,
                         tableRef,


### PR DESCRIPTION
**Goals (and why)**: We've seen instances of SHRINK COMPACT operation blocking DML operations on the affected table for hours. This PR makes such operation configurable.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
