### PR TITLE
SSSS Part 3: Index Cleanup Tasks and Deletion Filters

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamDeletionFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamDeletionFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import java.util.Set;
+
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public interface GenericStreamDeletionFilter {
+    /**
+     * Filters down a set of stream identifiers to a subset of said identifiers that are eligible for deletion
+     * from the key-value service.
+     *
+     * @param tx An open Atlas transaction, which may be useful for retrieving information to guide deletion decisions
+     * @param identifiers Stream identifiers that are to be considered for deletion
+     * @return Set of stream identifiers that should be deleted from the database; guaranteed to be a subset
+     *         of the provided identifiers
+     */
+    Set<GenericStreamIdentifier> getStreamIdentifiersToDelete(Transaction tx, Set<GenericStreamIdentifier> identifiers);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreCleanupTask.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreCleanupTask.java
@@ -51,7 +51,7 @@ public class GenericStreamStoreCleanupTask implements OnCleanupTask {
         this.deleter = deleter;
     }
 
-    public static OnCleanupTask createForMetadataTables(
+    public static OnCleanupTask createForMetadataTable(
             TableReference metadataTableRef, StreamStoreCleanupMetadata cleanupMetadata) {
         return new GenericStreamStoreCleanupTask(
                 cleanupMetadata,
@@ -59,6 +59,17 @@ public class GenericStreamStoreCleanupTask implements OnCleanupTask {
                 new SchemalessStreamStoreDeleter(
                         metadataTableRef.getNamespace(),
                         StreamTableType.getShortName(StreamTableType.METADATA, metadataTableRef),
+                        cleanupMetadata));
+    }
+
+    public static OnCleanupTask createForIndexTable(
+            TableReference indexTableRef, StreamStoreCleanupMetadata cleanupMetadata) {
+        return new GenericStreamStoreCleanupTask(
+                cleanupMetadata,
+                new UnindexedStreamDeletionFilter(indexTableRef, new GenericStreamStoreRowDecoder(cleanupMetadata)),
+                new SchemalessStreamStoreDeleter(
+                        indexTableRef.getNamespace(),
+                        StreamTableType.getShortName(StreamTableType.INDEX, indexTableRef),
                         cleanupMetadata));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreIndexCleanupVisitor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreIndexCleanupVisitor.java
@@ -25,12 +25,12 @@ import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
 import com.palantir.logsafe.SafeArg;
 
-public class GenericStreamStoreMetadataCleanupVisitor implements StreamStoreCleanupMetadataVisitor {
-    private static final Logger log = LoggerFactory.getLogger(GenericStreamStoreMetadataCleanupVisitor.class);
+public class GenericStreamStoreIndexCleanupVisitor implements StreamStoreCleanupMetadataVisitor {
+    private static final Logger log = LoggerFactory.getLogger(GenericStreamStoreIndexCleanupVisitor.class);
 
     private final TableReference tableToSweep;
 
-    public GenericStreamStoreMetadataCleanupVisitor(TableReference tableToSweep) {
+    public GenericStreamStoreIndexCleanupVisitor(TableReference tableToSweep) {
         this.tableToSweep = tableToSweep;
     }
 
@@ -39,6 +39,6 @@ public class GenericStreamStoreMetadataCleanupVisitor implements StreamStoreClea
         log.info("Now creating cleanup task for table {}, which has cleanup metadata {}",
                 LoggingArgs.tableRef(tableToSweep),
                 SafeArg.of("cleanupMetadata", cleanupMetadata));
-        return GenericStreamStoreCleanupTask.createForMetadataTable(tableToSweep, cleanupMetadata);
+        return GenericStreamStoreCleanupTask.createForIndexTable(tableToSweep, cleanupMetadata);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupVisitor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupVisitor.java
@@ -39,6 +39,6 @@ public class GenericStreamStoreMetadataCleanupVisitor implements StreamStoreClea
         log.info("Now creating cleanup task for table {}, which has cleanup metadata {}",
                 LoggingArgs.tableRef(tableToSweep),
                 SafeArg.of("cleanupMetadata", cleanupMetadata));
-        return new GenericStreamStoreMetadataCleanupTask(tableToSweep, cleanupMetadata);
+        return GenericStreamStoreCleanupTask.createForMetadataTables(tableToSweep, cleanupMetadata);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnindexedStreamDeletionFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnindexedStreamDeletionFilter.java
@@ -23,10 +23,8 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
-import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.schema.stream.StreamTableType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 
 /**
@@ -36,16 +34,13 @@ import com.palantir.atlasdb.transaction.api.Transaction;
  * It is a generic implementation of the filter step in the generated deletion task for stream index tables.
  */
 public class UnindexedStreamDeletionFilter implements GenericStreamDeletionFilter {
-    private final Namespace namespace;
-    private final String streamStoreShortName;
+    private final TableReference indexTableRef;
     private final GenericStreamStoreRowDecoder rowDecoder;
 
     public UnindexedStreamDeletionFilter(
-            Namespace namespace,
-            String streamStoreShortName,
+            TableReference indexTableRef,
             GenericStreamStoreRowDecoder rowDecoder) {
-        this.namespace = namespace;
-        this.streamStoreShortName = streamStoreShortName;
+        this.indexTableRef = indexTableRef;
         this.rowDecoder = rowDecoder;
     }
 
@@ -63,8 +58,7 @@ public class UnindexedStreamDeletionFilter implements GenericStreamDeletionFilte
 
     private SortedMap<byte[], RowResult<byte[]>> runGetRowsQuery(Transaction tx,
             Set<GenericStreamIdentifier> identifiers) {
-        return tx.getRows(
-                TableReference.create(namespace, StreamTableType.INDEX.getTableName(streamStoreShortName)),
+        return tx.getRows(indexTableRef,
                 identifiers.stream().map(GenericStreamIdentifier::data).collect(Collectors.toSet()),
                 ColumnSelection.all());
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnindexedStreamDeletionFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnindexedStreamDeletionFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.schema.stream.StreamTableType;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+/**
+ * This filter returns the stream IDs of streams which are being completely deleted from a stream's Index table
+ * in a given sweep (e.g. because they were unmarked as used).
+ *
+ * It is a generic implementation of the filter step in the generated deletion task for stream index tables.
+ */
+public class UnindexedStreamDeletionFilter implements GenericStreamDeletionFilter {
+    private final Namespace namespace;
+    private final String streamStoreShortName;
+    private final GenericStreamStoreRowDecoder rowDecoder;
+
+    public UnindexedStreamDeletionFilter(
+            Namespace namespace,
+            String streamStoreShortName,
+            GenericStreamStoreRowDecoder rowDecoder) {
+        this.namespace = namespace;
+        this.streamStoreShortName = streamStoreShortName;
+        this.rowDecoder = rowDecoder;
+    }
+
+    @Override
+    public Set<GenericStreamIdentifier> getStreamIdentifiersToDelete(
+            Transaction tx,
+            Set<GenericStreamIdentifier> identifiers) {
+        Set<GenericStreamIdentifier> vv = runGetRowsQuery(tx, identifiers)
+                .keySet()
+                .stream()
+                .map(rowDecoder::decodeIndexOrMetadataTableRow)
+                .collect(Collectors.toSet());
+        return ImmutableSet.copyOf(Sets.difference(identifiers, vv));
+    }
+
+    private SortedMap<byte[], RowResult<byte[]>> runGetRowsQuery(Transaction tx,
+            Set<GenericStreamIdentifier> identifiers) {
+        return tx.getRows(
+                TableReference.create(namespace, StreamTableType.INDEX.getTableName(streamStoreShortName)),
+                identifiers.stream().map(GenericStreamIdentifier::data).collect(Collectors.toSet()),
+                ColumnSelection.all());
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnindexedStreamDeletionFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnindexedStreamDeletionFilter.java
@@ -48,12 +48,12 @@ public class UnindexedStreamDeletionFilter implements GenericStreamDeletionFilte
     public Set<GenericStreamIdentifier> getStreamIdentifiersToDelete(
             Transaction tx,
             Set<GenericStreamIdentifier> identifiers) {
-        Set<GenericStreamIdentifier> vv = runGetRowsQuery(tx, identifiers)
+        Set<GenericStreamIdentifier> identifiersInDb = runGetRowsQuery(tx, identifiers)
                 .keySet()
                 .stream()
                 .map(rowDecoder::decodeIndexOrMetadataTableRow)
                 .collect(Collectors.toSet());
-        return ImmutableSet.copyOf(Sets.difference(identifiers, vv));
+        return ImmutableSet.copyOf(Sets.difference(identifiers, identifiersInDb));
     }
 
     private SortedMap<byte[], RowResult<byte[]>> runGetRowsQuery(Transaction tx,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnstoredStreamDeletionFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnstoredStreamDeletionFilter.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.protos.generated.StreamPersistence;
 import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
@@ -32,6 +33,11 @@ public class UnstoredStreamDeletionFilter implements GenericStreamDeletionFilter
         this.metadataReader = new StreamStoreMetadataReader(
                 metadataTableRef,
                 new GenericStreamStoreCellCreator(cleanupMetadata));
+    }
+
+    @VisibleForTesting
+    UnstoredStreamDeletionFilter(StreamStoreMetadataReader metadataReader) {
+        this.metadataReader = metadataReader;
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnstoredStreamDeletionFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnstoredStreamDeletionFilter.java
@@ -26,6 +26,12 @@ import com.palantir.atlasdb.protos.generated.StreamPersistence;
 import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
 import com.palantir.atlasdb.transaction.api.Transaction;
 
+/**
+ * This filter returns the stream identifiers that correspond to streams that have not been actually STORED in the
+ * database (i.e. the metadata table claims they are in STORING or FAILED state).
+ *
+ * It is a generic implementation of the filter step in the generated deletion task for stream metadata tables.
+ */
 public class UnstoredStreamDeletionFilter implements GenericStreamDeletionFilter {
     private final StreamStoreMetadataReader metadataReader;
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnstoredStreamDeletionFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/external/UnstoredStreamDeletionFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.protos.generated.StreamPersistence;
+import com.palantir.atlasdb.schema.cleanup.StreamStoreCleanupMetadata;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class UnstoredStreamDeletionFilter implements GenericStreamDeletionFilter {
+    private final StreamStoreMetadataReader metadataReader;
+
+    public UnstoredStreamDeletionFilter(TableReference metadataTableRef, StreamStoreCleanupMetadata cleanupMetadata) {
+        this.metadataReader = new StreamStoreMetadataReader(
+                metadataTableRef,
+                new GenericStreamStoreCellCreator(cleanupMetadata));
+    }
+
+    @Override
+    public Set<GenericStreamIdentifier> getStreamIdentifiersToDelete(
+            Transaction tx, Set<GenericStreamIdentifier> identifiers) {
+        Map<GenericStreamIdentifier, StreamPersistence.StreamMetadata> metadataFromDb =
+                metadataReader.readMetadata(tx, identifiers);
+        return metadataFromDb.entrySet().stream()
+                .filter(entry -> entry.getValue().getStatus() != StreamPersistence.Status.STORED)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreCleanupTaskTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreCleanupTaskTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class GenericStreamStoreCleanupTaskTest {
+    private static final byte[] ROW_1 = { 1 };
+    private static final byte[] ROW_2 = { 12 };
+    private static final byte[] COLUMN = { 2 };
+    private static final Cell CELL_1 = Cell.create(ROW_1, COLUMN);
+    private static final Cell CELL_2 = Cell.create(ROW_2, COLUMN);
+    private static final GenericStreamIdentifier IDENTIFIER_1 =
+            ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG, ROW_1);
+    private static final GenericStreamIdentifier IDENTIFIER_2 =
+            ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG, ROW_2);
+
+    private final Transaction tx = mock(Transaction.class);
+
+    private final GenericStreamStoreRowDecoder rowDecoder = mock(GenericStreamStoreRowDecoder.class);
+    private final GenericStreamDeletionFilter deletionFilter = mock(GenericStreamDeletionFilter.class);
+    private final SchemalessStreamStoreDeleter deleter = mock(SchemalessStreamStoreDeleter.class);
+    private final GenericStreamStoreCleanupTask cleanupTask =
+            new GenericStreamStoreCleanupTask(rowDecoder, deletionFilter, deleter);
+
+    @Before
+    public void setUp() {
+        when(rowDecoder.decodeIndexOrMetadataTableRow(ROW_1)).thenReturn(IDENTIFIER_1);
+        when(rowDecoder.decodeIndexOrMetadataTableRow(ROW_2)).thenReturn(IDENTIFIER_2);
+    }
+
+    @Test
+    public void deletesStreamsThatFilterReturns() {
+        when(deletionFilter.getStreamIdentifiersToDelete(tx, ImmutableSet.of(IDENTIFIER_1)))
+                .thenReturn(ImmutableSet.of(IDENTIFIER_1));
+
+        cleanupTask.cellsCleanedUp(tx, ImmutableSet.of(CELL_1));
+        verify(deleter).deleteStreams(tx, ImmutableSet.of(IDENTIFIER_1));
+    }
+
+    @Test
+    public void doesNotDeleteStreamsThatFilterDoesNotReturn() {
+        when(deletionFilter.getStreamIdentifiersToDelete(tx, ImmutableSet.of(IDENTIFIER_1)))
+                .thenReturn(ImmutableSet.of());
+
+        cleanupTask.cellsCleanedUp(tx, ImmutableSet.of(CELL_1));
+        verify(deleter).deleteStreams(tx, ImmutableSet.of());
+    }
+
+    @Test
+    public void deletesPreciselyStreamsReturnedByFilterWhenDeletingMultiple() {
+        when(deletionFilter.getStreamIdentifiersToDelete(tx, ImmutableSet.of(IDENTIFIER_1, IDENTIFIER_2)))
+                .thenReturn(ImmutableSet.of(IDENTIFIER_2));
+
+        cleanupTask.cellsCleanedUp(tx, ImmutableSet.of(CELL_1, CELL_2));
+        verify(deleter).deleteStreams(tx, ImmutableSet.of(IDENTIFIER_2));
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTaskTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/GenericStreamStoreMetadataCleanupTaskTest.java
@@ -24,9 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.ByteString;
 import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.protos.generated.StreamPersistence;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 
@@ -34,25 +32,12 @@ public class GenericStreamStoreMetadataCleanupTaskTest {
     private static final byte[] ROW_1 = { 1 };
     private static final byte[] ROW_2 = { 12 };
     private static final byte[] COLUMN = { 2 };
-    private static final byte[] HASH = new byte[32];
     private static final Cell CELL_1 = Cell.create(ROW_1, COLUMN);
     private static final Cell CELL_2 = Cell.create(ROW_2, COLUMN);
     private static final GenericStreamIdentifier IDENTIFIER_1 =
             ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG, ROW_1);
     private static final GenericStreamIdentifier IDENTIFIER_2 =
             ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG, ROW_2);
-    private static final StreamPersistence.StreamMetadata STORING_STREAM_METADATA =
-            StreamPersistence.StreamMetadata.newBuilder()
-                    .setLength(5L)
-                    .setHash(ByteString.copyFrom(HASH))
-                    .setStatus(StreamPersistence.Status.STORING)
-                    .build();
-    private static final StreamPersistence.StreamMetadata STORED_STREAM_METADATA =
-            StreamPersistence.StreamMetadata.newBuilder()
-                    .setLength(7L)
-                    .setHash(ByteString.copyFrom(HASH))
-                    .setStatus(StreamPersistence.Status.STORED)
-                    .build();
 
     private final Transaction tx = mock(Transaction.class);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/UnstoredStreamDeletionFilterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/external/UnstoredStreamDeletionFilterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.ByteString;
+import com.palantir.atlasdb.protos.generated.StreamPersistence;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class UnstoredStreamDeletionFilterTest {
+    private static final byte[] ROW_1 = { 1 };
+    private static final byte[] ROW_2 = { 12 };
+    private static final GenericStreamIdentifier IDENTIFIER_1 =
+            ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG, ROW_1);
+    private static final GenericStreamIdentifier IDENTIFIER_2 =
+            ImmutableGenericStreamIdentifier.of(ValueType.FIXED_LONG, ROW_2);
+
+    private static final byte[] HASH = new byte[32];
+    private static final StreamPersistence.StreamMetadata FAILED_STREAM_METADATA =
+            StreamPersistence.StreamMetadata.newBuilder()
+                    .setLength(3L)
+                    .setHash(ByteString.copyFrom(HASH))
+                    .setStatus(StreamPersistence.Status.FAILED)
+                    .build();
+    private static final StreamPersistence.StreamMetadata STORING_STREAM_METADATA =
+            StreamPersistence.StreamMetadata.newBuilder()
+                    .setLength(5L)
+                    .setHash(ByteString.copyFrom(HASH))
+                    .setStatus(StreamPersistence.Status.STORING)
+                    .build();
+    private static final StreamPersistence.StreamMetadata STORED_STREAM_METADATA =
+            StreamPersistence.StreamMetadata.newBuilder()
+                    .setLength(7L)
+                    .setHash(ByteString.copyFrom(HASH))
+                    .setStatus(StreamPersistence.Status.STORED)
+                    .build();
+
+    private final Transaction tx = mock(Transaction.class);
+    private final StreamStoreMetadataReader metadataReader = mock(StreamStoreMetadataReader.class);
+    private final GenericStreamDeletionFilter deletionFilter = new UnstoredStreamDeletionFilter(metadataReader);
+
+    @Test
+    public void filtersOutStreamsThatAreStored() {
+        when(metadataReader.readMetadata(tx, ImmutableSet.of(IDENTIFIER_1))).thenReturn(
+                ImmutableMap.of(IDENTIFIER_1, STORED_STREAM_METADATA));
+
+        assertThat(deletionFilter.getStreamIdentifiersToDelete(tx, ImmutableSet.of(IDENTIFIER_1)))
+                .isEqualTo(ImmutableSet.of());
+    }
+
+    @Test
+    public void retainsStreamsThatAreNotStored() {
+        when(metadataReader.readMetadata(tx, ImmutableSet.of(IDENTIFIER_1, IDENTIFIER_2))).thenReturn(
+                ImmutableMap.of(IDENTIFIER_1, STORING_STREAM_METADATA,
+                        IDENTIFIER_2, FAILED_STREAM_METADATA));
+
+        assertThat(deletionFilter.getStreamIdentifiersToDelete(tx, ImmutableSet.of(IDENTIFIER_1, IDENTIFIER_2)))
+                .isEqualTo(ImmutableSet.of(IDENTIFIER_1, IDENTIFIER_2));
+    }
+
+    @Test
+    public void retainsPreciselyStreamsThatAreNotStored() {
+        when(metadataReader.readMetadata(tx, ImmutableSet.of(IDENTIFIER_1, IDENTIFIER_2))).thenReturn(
+                ImmutableMap.of(IDENTIFIER_1, STORED_STREAM_METADATA,
+                        IDENTIFIER_2, FAILED_STREAM_METADATA));
+
+        assertThat(deletionFilter.getStreamIdentifiersToDelete(tx, ImmutableSet.of(IDENTIFIER_1, IDENTIFIER_2)))
+                .isEqualTo(ImmutableSet.of(IDENTIFIER_2));
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Provide a generic implementation of a stream store's index cleanup task, so that Nimbus can sweep stream stores.

**Implementation Description (bullets)**:
- Refactor the metadata delete task from #2970 to be a generic task taking a deletion filter, since the only part that differs between the index delete and this one is how we screen out stream IDs that we actually still want to keep
- Implement the index delete using a deletion filter (`UnindexedStreamDeletionFilter`)

**Concerns (what feedback would you like?)**:
- I take a defensive copy at the end of `UnindexedStreamDeletionFilter#getStreamIdentifiersToDelete` - is this needed?
- The unindexed stream deletion filter does a dynamic column range scan while grabbing all columns into memory at one shot. This is probably safe, right?

**Where should we start reviewing?**: Probably `GenericStreamStoreCleanupTask`.

**Priority (whenever / two weeks / yesterday)**: next week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2976)
<!-- Reviewable:end -->
