### PR TITLE
PoC for Atlas-as-a-service write and read transactions

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/RawTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/RawTransaction.java
@@ -19,11 +19,11 @@ import com.palantir.lock.v2.LockToken;
 
 public class RawTransaction extends ForwardingTransaction {
     private final SnapshotTransaction delegate;
-    private final LockToken lock;
+    private final LockToken immutableTsLock;
 
-    public RawTransaction(SnapshotTransaction delegate, LockToken lock) {
+    public RawTransaction(SnapshotTransaction delegate, LockToken immutableTsLock) {
         this.delegate = delegate;
-        this.lock = lock;
+        this.immutableTsLock = immutableTsLock;
     }
 
     @Override
@@ -32,6 +32,6 @@ public class RawTransaction extends ForwardingTransaction {
     }
 
     LockToken getImmutableTsLock() {
-        return lock;
+        return immutableTsLock;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ServiceReadOnlyTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ServiceReadOnlyTransaction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.transaction.api.AutoDelegate_Transaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.processors.AutoDelegate;
+
+@AutoDelegate(typeToExtend = Transaction.class)
+class ServiceReadOnlyTransaction implements AutoDelegate_Transaction {
+    private final SnapshotTransaction delegate;
+
+    ServiceReadOnlyTransaction(SnapshotTransaction delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Transaction delegate() {
+        return delegate;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ServiceWriteTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ServiceWriteTransaction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.transaction.api.AutoDelegate_Transaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.atlasdb.transaction.api.TransactionFailedException;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.processors.AutoDelegate;
+
+@AutoDelegate(typeToExtend = Transaction.class)
+abstract class ServiceWriteTransaction implements AutoDelegate_Transaction {
+    private final SnapshotTransaction delegate;
+
+    ServiceWriteTransaction(SnapshotTransaction delegate) {
+        this.delegate = delegate;
+    }
+
+    public SnapshotTransaction delegate() {
+        return delegate;
+    }
+
+    public abstract void commit();
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerImpl.java
@@ -189,7 +189,7 @@ class SnapshotTransactionManagerImpl extends AbstractTransactionManager implemen
 
             SnapshotTransaction transaction = createTransaction(immutableTs, startTimestampSupplier,
                     immutableTsLock, condition);
-            return new RawTransaction(transaction, null);
+            return new RawTransaction(transaction, immutableTsLock);
         } catch (Throwable e) {
             timelockService.unlock(ImmutableSet.of(immutableTsResponse.getLock()));
             throw Throwables.rewrapAndThrowUncheckedException(e);


### PR DESCRIPTION
**Goals (and why)**: Proof of concept for Atlas-as-a-service getTransactions API. This service needs a `WriteTransaction` and a `ReadOnlyTransaction` to be able to perform transactions manually.

**Implementation Description (bullets)**: Hacked the internals of the transactions to get this done. This heavily relies on what is implemented currently, and the relationship between the transaction methods is not clear in the current impl. This could lead to a change in an area of the codebase creating bugs on the current implemented code.

The above could be said about the whole transactions code though... so maybe this is fine?

What needs to be done:

- [x] Extract the Transactions to separate classes
- [x] **Limit the public API** of the new transaction objects (throw `IllegalArgumentException` on methods we don't expect to be used?)
- [ ] Tests

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2982)
<!-- Reviewable:end -->
