### PR TITLE
Upgrade postgres jdbc driver to 42.2.1 (was 9.4.1209)

### DIFF
--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -1107,7 +1107,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -1105,7 +1105,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/atlasdb-dbkvs-hikari/versions.lock
+++ b/atlasdb-dbkvs-hikari/versions.lock
@@ -249,7 +249,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -516,7 +516,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -800,7 +800,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -1640,7 +1640,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -713,7 +713,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -1466,7 +1466,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -3132,7 +3132,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -1147,7 +1147,7 @@
             "requested": "1.13"
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -2359,7 +2359,7 @@
             "requested": "1.13"
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/commons-db/versions.lock
+++ b/commons-db/versions.lock
@@ -221,8 +221,8 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
-            "requested": "9.4.1209"
+            "locked": "42.2.1",
+            "requested": "42.2.1"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -457,8 +457,8 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
-            "requested": "9.4.1209"
+            "locked": "42.2.1",
+            "requested": "42.2.1"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |changed|
+         - Upgraded Postgres jdbc driver to 42.2.1 (from 9.4.1209).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2985>`__)
+
     *    - |improved| |new|
          - Added a new parameter ``conservativeRequestExceptionHandler`` to ``CassandraKeyValueServiceRuntimeConfig``.
            Setting this parameter to true will enable more conservative retrying logic for requests, including longer backoffs and not retrying on the same host when encoutering an exception that is indicative of high Cassandra load, e.g., TimeoutExceptions.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -36,14 +36,6 @@ ext.libVersions =
     checkstyle: '6.18',
     findbugsAnnotations: '2.0.3',
     ant: '1.9.4',
-
-    // Danger, Will Robinson!
-    //
-    // This driver has historically low code quality and should be considered a high-risk update.
-    // Severe performance regressions in 1202,3,4.
-    // Severe correctness issues in 1204,5,6.
-    // Update with care and caution.
-    postgresql: '9.4.1209',
-
+    postgresql: '42.2.1',
     c3p0: '0.9.5.1'
 ]

--- a/timelock-server-benchmark-client/versions.lock
+++ b/timelock-server-benchmark-client/versions.lock
@@ -1577,7 +1577,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -3228,7 +3228,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/timelock-server-benchmark-cluster/versions.lock
+++ b/timelock-server-benchmark-cluster/versions.lock
@@ -1565,7 +1565,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]
@@ -3202,7 +3202,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/timelock-server-distribution/versions.lock
+++ b/timelock-server-distribution/versions.lock
@@ -1576,7 +1576,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]

--- a/timelock-server/versions.lock
+++ b/timelock-server/versions.lock
@@ -2881,7 +2881,7 @@
             ]
         },
         "org.postgresql:postgresql": {
-            "locked": "9.4.1209",
+            "locked": "42.2.1",
             "transitive": [
                 "com.palantir.atlasdb:commons-db"
             ]


### PR DESCRIPTION
We're stuck on a postgres jdbc driver build from nearly two years ago. If we discover bugs we can file and fix upstream as opposed to sitting on deprecated builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2985)
<!-- Reviewable:end -->
