### PR TITLE
Revert "Add traces to AtlasDbMetrics.instrument() (#2986)"

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/AtlasDbMetrics.java
@@ -34,7 +34,6 @@ import com.palantir.tritium.metrics.MetricRegistries;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import com.palantir.tritium.proxy.Instrumentation;
-import com.palantir.tritium.tracing.TracingInvocationEventHandler;
 
 public final class AtlasDbMetrics {
     private static final Logger log = LoggerFactory.getLogger(AtlasDbMetrics.class);
@@ -98,7 +97,6 @@ public final class AtlasDbMetrics {
     public static <T, U extends T> T instrument(Class<T> serviceInterface, U service, String name) {
         return Instrumentation.builder(serviceInterface, service)
                 .withHandler(new MetricsInvocationEventHandler(getMetricRegistry(), name))
-                .withHandler(new TracingInvocationEventHandler(name))
                 .withLogging(
                         LoggerFactory.getLogger("performance." + name),
                         LoggingLevel.TRACE,

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,9 +50,8 @@ develop
     *    - Type
          - Change
 
-    *    - |improved|
-         - Wrap remote calls from AtlasDB with http-remoting tracing.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2986>`__)
+    *    -
+         -
 
 =======
 v0.76.0


### PR DESCRIPTION
This reverts commit f9b5ff02e4e3a678d67e97560dc730c6d478d2ab.

This caused 40%+ regressions on `getFreshTimestamp` and `getFreshTimestamps` benchmarks.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/2990)
<!-- Reviewable:end -->
