### PR TITLE
Fix/migration cli

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/GeneralTaskCheckpointer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/GeneralTaskCheckpointer.java
@@ -104,7 +104,7 @@ public class GeneralTaskCheckpointer extends AbstractTaskCheckpointer {
 
     @Override
     public void deleteCheckpoints() {
-        Schemas.deleteTable(kvs, checkpointTable);
+        Schemas.truncateTable(kvs, checkpointTable);
     }
 
     private Cell getCell(String extraId, long rangeId) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schemas.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schemas.java
@@ -135,8 +135,8 @@ public final class Schemas {
         return schemaFullTableNames.stream().filter(allTables::contains).collect(Collectors.toSet());
     }
 
-    public static void deleteTable(KeyValueService kvs, TableReference tableRef) {
-        kvs.dropTable(tableRef);
+    public static void truncateTable(KeyValueService kvs, TableReference tableRef) {
+        kvs.truncateTable(tableRef);
     }
 
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemasTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/SchemasTest.java
@@ -100,11 +100,11 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDeleteTable() {
+    public void testTruncateTable() {
         mockery.checking(new Expectations(){{
-            oneOf(kvs).dropTable(with(equal(TABLE_REF)));
+            oneOf(kvs).truncateTable(with(equal(TABLE_REF)));
         }});
-        Schemas.deleteTable(kvs, TABLE_REF);
+        Schemas.truncateTable(kvs, TABLE_REF);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,7 +53,7 @@ develop
     *    - |changed|
          - AtlasDB migration CLI no longer drops the temporary table used during migration and instead truncates it.
            This avoids an issue where AtlasDB would refuse to start after a migration because it would try to hydrate empty table metadata for the above table.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2999>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3000>`__)
 
     *    - |changed|
          - Upgraded Postgres jdbc driver to 42.2.1 (from 9.4.1209).

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,11 @@ develop
          - Change
 
     *    - |changed|
+         - AtlasDB migration CLI no longer drops the temporary table used during migration and instead truncates it.
+           This avoids an issue where AtlasDB would refuse to start after a migration because it would try to hydrate empty table metadata for the above table.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2999>`__)
+
+    *    - |changed|
          - Upgraded Postgres jdbc driver to 42.2.1 (from 9.4.1209).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2985>`__)
 


### PR DESCRIPTION
**Goals (and why)**:
Avoid dropping the temporary table as it makes LoggingArgs error out on startup due to hydrating empty metadata. This avoids people having to patch their version or do db surgery to be able to start AtlasDB.

**Concerns (what feedback would you like?)**:
We leave an empty table around

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3000)
<!-- Reviewable:end -->
