### PR TITLE
Fix overly specific test

### DIFF
--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -374,7 +374,8 @@ public class PaxosTimeLockServerIntegrationTest {
 
         long currentTimestamp = timestampService.getFreshTimestamp();
         anotherClientTimestampManagementService.fastForwardTimestamp(currentTimestamp + ONE_MILLION);
-        assertEquals(currentTimestamp + 1, timestampService.getFreshTimestamp());
+        assertThat(timestampService.getFreshTimestamp())
+                .isBetween(currentTimestamp + 1, currentTimestamp + ONE_MILLION - 1);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
Test flaked on circle because fresh timestamp was currentTimestamp + 2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3002)
<!-- Reviewable:end -->
