### PR TITLE
SnapshotTransaction#extractLocalWritesForRow takes columnSelection

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -376,7 +376,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         SortedMap<Cell, byte[]> writes = writesByTable.get(tableRef);
         if (writes != null) {
             for (byte[] row : rows) {
-                extractLocalWritesForRow(result, writes, row);
+                extractLocalWritesForRow(result, writes, row, columnSelection);
             }
         }
 
@@ -581,7 +581,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
      * If an empty value was written as a delete, this will also be included in the map.
      */
     private void extractLocalWritesForRow(@Output Map<Cell, byte[]> result,
-            SortedMap<Cell, byte[]> writes, byte[] row) {
+            SortedMap<Cell, byte[]> writes, byte[] row, ColumnSelection columnSelection) {
         Cell lowCell = Cells.createSmallestCellForRow(row);
         Iterator<Entry<Cell, byte[]>> it = writes.tailMap(lowCell).entrySet().iterator();
         while (it.hasNext()) {
@@ -590,7 +590,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             if (!Arrays.equals(row, cell.getRowName())) {
                 break;
             }
-            result.put(cell, entry.getValue());
+            if (columnSelection.allColumnsSelected()
+                    || columnSelection.getSelectedColumns().contains(cell.getColumnName())) {
+                result.put(cell, entry.getValue());
+            }
         }
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -16,7 +16,9 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -478,6 +480,34 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 assertEquals(expectedValue, new BigInteger(storedValue));
             }
         }
+    }
+
+    @Test
+    public void testGetRowsLocalWritesWithColumnSelection() {
+        // This test ensures getRows correctly applies columnSelection
+        byte[] row1 = PtBytes.toBytes("row1");
+        Cell row1Column1 = Cell.create(row1, PtBytes.toBytes("column1"));
+        Cell row1Column2 = Cell.create(row1, PtBytes.toBytes("column2"));
+        byte[] row1Column1Value = BigInteger.valueOf(1).toByteArray();
+        byte[] row1Column2Value = BigInteger.valueOf(2).toByteArray();
+
+        Transaction transaction = txManager.createNewTransaction();
+        transaction.put(TABLE, ImmutableMap.of(
+                row1Column1, row1Column1Value,
+                row1Column2, row1Column2Value));
+
+        ColumnSelection column1Selection = ColumnSelection.create(ImmutableList.of(row1Column1.getColumnName()));
+
+        // local writes still apply columnSelection
+        RowResult<byte[]> rowResult1 = transaction.getRows(TABLE, ImmutableList.of(row1Column1.getRowName()),
+                column1Selection).get(row1);
+        assertThat(rowResult1.getColumns(), hasEntry(row1Column1.getColumnName(), row1Column1Value));
+        assertThat(rowResult1.getColumns(), not(hasEntry(row1Column2.getColumnName(), row1Column2Value)));
+
+        RowResult<byte[]> rowResult2 = transaction.getRows(TABLE, ImmutableList.of(row1Column1.getRowName()),
+                ColumnSelection.all()).get(row1);
+        assertThat(rowResult2.getColumns(), hasEntry(row1Column1.getColumnName(), row1Column1Value));
+        assertThat(rowResult2.getColumns(), hasEntry(row1Column2.getColumnName(), row1Column2Value));
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -77,6 +77,11 @@ develop
            Also reduce the defaults to flush write stats on 32MB overall write size and 2k cells.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2998>`__)
 
+    *    - |fixed|
+         - Fix ``SnapshotTransaction#getRows`` to apply ``ColumnSelection`` when there are local writes.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3008>`__)
+
+
 =======
 v0.76.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
Addresses https://github.com/palantir/atlasdb/issues/3007
ColumnSelection should be applied regardless of whether or not it came from a local write.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
Soon-ish? Will work-around around until push is released.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3008)
<!-- Reviewable:end -->
