### PR TITLE
Switch AtlasDbConstants.DEFAULT_BACKGROUND_SCRUB_AGGRESIVELY to true

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -107,7 +107,7 @@ public final class AtlasDbConstants {
     public static final long DEFAULT_TRANSACTION_READ_TIMEOUT = 60 * 60 * 1000; // one hour
     public static final long DEFAULT_PUNCH_INTERVAL_MILLIS = 60 * 1000; // one minute
 
-    public static final boolean DEFAULT_BACKGROUND_SCRUB_AGGRESSIVELY = false;
+    public static final boolean DEFAULT_BACKGROUND_SCRUB_AGGRESSIVELY = true;
     public static final int DEFAULT_BACKGROUND_SCRUB_THREADS = 8;
     public static final int DEFAULT_BACKGROUND_SCRUB_READ_THREADS = 8;
     public static final long DEFAULT_BACKGROUND_SCRUB_FREQUENCY_MILLIS = 3600000L;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,10 @@ develop
            This fixes an issue that prevented AtlasDB to start after performing a KVS migration.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3006>`__)
 
+    *    - |changed|
+         - Changes the default scrubber behavior to aggressive scrub (synchronous with scrub request).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3009>`__)
+
 =======
 v0.77.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
Cause that's the default we're using internally.

**Priority (whenever / two weeks / yesterday)**:
pretty short, whenever.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3009)
<!-- Reviewable:end -->
