### PR TITLE
Revert "[Oracle Compaction][Part 2] Refactor `kvs.compactInternally` …

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -667,14 +667,6 @@ public interface KeyValueService extends AutoCloseable {
     void compactInternally(TableReference tableRef);
 
     /**
-     * Some compaction operations might make block reads and writes.
-     * These operations will just trigger when inSafeHours is set to true.
-     */
-    default void compactInternally(TableReference tableRef, boolean inSafeHours) {
-        compactInternally(tableRef);
-    }
-
-    /**
      * Provides a {@link ClusterAvailabilityStatus}, indicating the current availability of the key value store.
      * This can be used to infer product health - in the usual, conservative case, products can call
      * {@link ClusterAvailabilityStatus#isHealthy()}, which returns true only if all KVS nodes are up.
@@ -692,10 +684,6 @@ public interface KeyValueService extends AutoCloseable {
     @Consumes(MediaType.APPLICATION_JSON)
     ClusterAvailabilityStatus getClusterAvailabilityStatus();
 
-    ////////////////////////////////////////////////////////////
-    // SPECIAL CASING SOME KVSs
-    ////////////////////////////////////////////////////////////
-
     /**
      * @return true iff the KeyValueService has been initialized and is ready to use
      *         Note that this check ignores the cluster's availability - use {@link #getClusterAvailabilityStatus()} if
@@ -710,14 +698,6 @@ public interface KeyValueService extends AutoCloseable {
      * This is used by sweep to determine if it should wait a while between runs after deleting a large number of cells.
      */
     default boolean performanceIsSensitiveToTombstones() {
-        return false;
-    }
-
-    /**
-     * @return If {@link #compactInternally(TableReference)} should be called to free disk space,
-     * e.g. after a table has been swept.
-     */
-    default boolean shouldTriggerCompactions() {
         return false;
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,6 +51,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
+import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -89,6 +91,8 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServices.StartTsResultsCollector;
+import com.palantir.atlasdb.keyvalue.cassandra.jmx.CassandraJmxCompaction;
+import com.palantir.atlasdb.keyvalue.cassandra.jmx.CassandraJmxCompactionManager;
 import com.palantir.atlasdb.keyvalue.cassandra.paging.CassandraRangePagingIterable;
 import com.palantir.atlasdb.keyvalue.cassandra.paging.ColumnGetter;
 import com.palantir.atlasdb.keyvalue.cassandra.paging.RowGetter;
@@ -109,7 +113,6 @@ import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.qos.FakeQosClient;
 import com.palantir.atlasdb.qos.QosClient;
 import com.palantir.atlasdb.qos.ratelimit.QosAwareThrowables;
-import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.util.AnnotatedCallable;
 import com.palantir.atlasdb.util.AnnotationType;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
@@ -178,6 +181,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private final Logger log;
 
     private final CassandraKeyValueServiceConfig config;
+    private final Optional<CassandraJmxCompactionManager> compactionManager;
     private final CassandraClientPool clientPool;
 
     private SchemaMutationLock schemaMutationLock;
@@ -274,10 +278,13 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             Optional<LeaderConfig> leaderConfig,
             Logger log,
             boolean initializeAsync) {
+        Optional<CassandraJmxCompactionManager> compactionManager =
+                CassandraJmxCompaction.createJmxCompactionManager(config);
         CassandraKeyValueServiceImpl keyValueService = new CassandraKeyValueServiceImpl(
                 log,
                 config,
                 clientPool,
+                compactionManager,
                 leaderConfig);
         keyValueService.wrapper.initialize(initializeAsync);
         return keyValueService.wrapper.isInitialized() ? keyValueService : keyValueService.wrapper;
@@ -286,12 +293,14 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private CassandraKeyValueServiceImpl(Logger log,
             CassandraKeyValueServiceConfig config,
             CassandraClientPool clientPool,
+            Optional<CassandraJmxCompactionManager> compactionManager,
             Optional<LeaderConfig> leaderConfig) {
         super(AbstractKeyValueService.createFixedThreadPool("Atlas Cassandra KVS",
                 config.poolSize() * config.servers().size()));
         this.log = log;
         this.config = config;
         this.clientPool = clientPool;
+        this.compactionManager = compactionManager;
         this.leaderConfig = leaderConfig;
 
         SchemaMutationLockTables lockTables = new SchemaMutationLockTables(clientPool, config);
@@ -306,6 +315,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 writeConsistency);
         this.cassandraTableDropper = new CassandraTableDropper(config, clientPool, cellLoader, cellValuePutter,
                 wrappingQueryRunner, deleteConsistency);
+
+        if (!compactionManager.isPresent()) {
+            logLackOfCompactionManager(config.getKeyspaceOrThrow());
+        }
     }
 
     @Override
@@ -1533,8 +1546,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                 for (Entry<Cell, Value> entry : cells) {
                     Value value = entry.getValue();
-                    TableReference tableRef = CassandraKeyValueServices.tableReferenceFromBytes(
-                            entry.getKey().getRowName());
+                    TableReference tableRef = CassandraKeyValueServices.tableReferenceFromBytes(entry.getKey().getRowName());
                     byte[] contents;
                     if (value == null) {
                         contents = AtlasDbConstants.EMPTY_TABLE_METADATA;
@@ -1742,6 +1754,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     @Override
     public void close() {
         clientPool.shutdown();
+        if (compactionManager.isPresent()) {
+            compactionManager.get().close();
+        }
         super.close();
     }
 
@@ -1899,11 +1914,47 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         return newColumn;
     }
 
+    /**
+     * Does whatever can be done to compact or cleanup a table. Intended to be called after many
+     * deletions are performed.
+     *
+     * @param tableRef the name of the table to compact.
+     */
     @Override
     public void compactInternally(TableReference tableRef) {
-        log.info("Called compactInternally on {}, but this is a no-op for Cassandra KVS."
-                + "Cassandra should eventually decide to compact this table for itself.",
-                LoggingArgs.tableRef(tableRef));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()),
+                "tableRef:[%s] should not be null or empty.", tableRef);
+        if (!compactionManager.isPresent()) {
+            return;
+        }
+        long timeoutInSeconds = config.jmx().get().compactionTimeoutSeconds();
+        String keyspace = config.getKeyspaceOrThrow();
+        try {
+            alterGcAndTombstone(keyspace, tableRef, 0, 0.0f);
+            compactionManager.get().performTombstoneCompaction(timeoutInSeconds, keyspace, tableRef);
+        } catch (TimeoutException e) {
+            log.error("Compaction for {}.{} could not finish in {} seconds.", UnsafeArg.of("keyspace", keyspace),
+                    LoggingArgs.tableRef(tableRef), SafeArg.of("timeout", timeoutInSeconds), e);
+            log.error("Compaction status: {}",
+                    UnsafeArg.of("compactionStatus", compactionManager.get().getCompactionStatus()));
+        } catch (InterruptedException e) {
+            log.error("Compaction for {}.{} was interrupted.", UnsafeArg.of("keyspace", keyspace),
+                    LoggingArgs.tableRef(tableRef));
+        } finally {
+            alterGcAndTombstone(
+                    keyspace,
+                    tableRef,
+                    config.gcGraceSeconds(),
+                    CassandraConstants.TOMBSTONE_THRESHOLD_RATIO);
+        }
+    }
+
+    private void logLackOfCompactionManager(String keyspace) {
+        log.info("No compaction client was configured. Sweep and other operations may delete data from an Atlas "
+                + "perspective, but if you actually want to clear deleted data from Cassandra, "
+                + "you will need to run `nodetool compact {} <table_name>`. "
+                + "This will clear data that was deleted more than gc_grace_seconds ago.",
+                UnsafeArg.of("keyspace", keyspace));
     }
 
     @Override
@@ -1969,6 +2020,64 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private boolean isQuorumAvailable(int countUnreachableNodes) {
         int replicationFactor = config.replicationFactor();
         return countUnreachableNodes < (replicationFactor + 1) / 2;
+    }
+
+    private void alterGcAndTombstone(
+            String keyspace,
+            TableReference tableRef,
+            int gcGraceSeconds,
+            float tombstoneThresholdRatio) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(keyspace),
+                "keyspace:[%s] should not be null or empty.", keyspace);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()),
+                "tableRef:[%s] should not be null or empty.", tableRef);
+        Preconditions.checkArgument(gcGraceSeconds >= 0,
+                "gc_grace_seconds:[%s] should not be negative.", gcGraceSeconds);
+        Preconditions.checkArgument(tombstoneThresholdRatio >= 0.0f && tombstoneThresholdRatio <= 1.0f,
+                "tombstone_threshold_ratio:[%s] should be between [0.0, 1.0]", tombstoneThresholdRatio);
+
+        schemaMutationLock.runWithLock(() ->
+                alterGcAndTombstoneInternal(keyspace, tableRef, gcGraceSeconds, tombstoneThresholdRatio));
+    }
+
+    private void alterGcAndTombstoneInternal(
+            String keyspace,
+            TableReference tableRef,
+            int gcGraceSeconds,
+            float tombstoneThresholdRatio) {
+        try {
+            clientPool.runWithRetry((FunctionCheckedException<CassandraClient, Void, Exception>) client -> {
+                KsDef ks = client.rawClient().describe_keyspace(keyspace);
+                List<CfDef> cfs = ks.getCf_defs();
+                for (CfDef cf : cfs) {
+                    if (cf.getName().equalsIgnoreCase(internalTableName(tableRef))) {
+                        cf.setGc_grace_seconds(gcGraceSeconds);
+                        cf.setCompaction_strategy_options(ImmutableMap.of(
+                                "tombstone_threshold",
+                                String.valueOf(tombstoneThresholdRatio)));
+                        client.rawClient().system_update_column_family(cf);
+                        CassandraKeyValueServices.waitForSchemaVersions(
+                                config,
+                                client.rawClient(),
+                                tableRef.getQualifiedName());
+                        log.trace("gc_grace_seconds is set to {} for {}.{}",
+                                SafeArg.of("gcGraceSeconds", gcGraceSeconds), UnsafeArg.of("keyspace", keyspace),
+                                LoggingArgs.tableRef(tableRef));
+                        log.trace("tombstone_threshold_ratio is set to {} for {}.{}",
+                                SafeArg.of("tombstoneThresholdRatio", tombstoneThresholdRatio),
+                                UnsafeArg.of("keyspace", keyspace), LoggingArgs.tableRef(tableRef));
+                    }
+                }
+                return null;
+            });
+        } catch (Exception e) {
+            log.error("Exception encountered while setting gc_grace_seconds:{} and tombstone_threshold:{} for {}.{}",
+                    SafeArg.of("gcGraceSeconds", gcGraceSeconds),
+                    SafeArg.of("tombstoneThresholdRatio", tombstoneThresholdRatio),
+                    UnsafeArg.of("keyspace", keyspace),
+                    LoggingArgs.tableRef(tableRef),
+                    e);
+        }
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxBeanFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxBeanFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * <p>
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://opensource.org/licenses/BSD-3-Clause
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra.jmx;
+
+import java.io.IOException;
+
+import javax.management.JMX;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+public class CassandraJmxBeanFactory {
+    private final JMXConnector jmxConnector;
+
+    public CassandraJmxBeanFactory(JMXConnector jmxConnector) {
+        this.jmxConnector = Preconditions.checkNotNull(jmxConnector, "jmxConnector cannot be null");
+    }
+
+    public <T> T create(String name, Class<T> interfaceClass) {
+        MBeanServerConnection jmxBeanServerConnection = null;
+        ObjectName objectName = null;
+        try {
+            jmxBeanServerConnection = jmxConnector.getMBeanServerConnection();
+            objectName = new ObjectName(name);
+        } catch (MalformedObjectNameException | IOException e) {
+            Throwables.propagate(e);
+        }
+        return JMX.newMBeanProxy(jmxBeanServerConnection, objectName, interfaceClass);
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompaction.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompaction.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * <p>
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://opensource.org/licenses/BSD-3-Clause
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra.jmx;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import javax.management.remote.JMXConnector;
+
+import org.apache.cassandra.db.HintedHandOffManagerMBean;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
+import org.apache.cassandra.service.StorageServiceMBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.atlasdb.cassandra.CassandraJmxCompactionConfig;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
+import com.palantir.common.concurrent.PTExecutors;
+
+public final class CassandraJmxCompaction {
+    private static final Logger log = LoggerFactory.getLogger(CassandraJmxCompaction.class);
+    private final CassandraKeyValueServiceConfig config;
+
+    private CassandraJmxCompaction(CassandraKeyValueServiceConfig config) {
+        this.config = Preconditions.checkNotNull(config, "config cannot be null");
+    }
+
+    public static Optional<CassandraJmxCompactionManager> createJmxCompactionManager(
+            CassandraKeyValueServiceConfig config) {
+        Preconditions.checkNotNull(config, "config cannot be null");
+        CassandraJmxCompaction jmxCompaction = new CassandraJmxCompaction(config);
+
+        Optional<CassandraJmxCompactionConfig> jmxConfig = config.jmx();
+        // need to set the property before creating the JMX compaction client
+        if (!jmxConfig.isPresent()) {
+            log.info("Jmx compaction is not enabled.");
+            return Optional.empty();
+        }
+
+        jmxCompaction.setJmxSslProperty(jmxConfig.get());
+        ImmutableSet<CassandraJmxCompactionClient> clients = jmxCompaction.createCompactionClients(jmxConfig.get());
+        ExecutorService exec = PTExecutors.newFixedThreadPool(clients.size(),
+                new ThreadFactoryBuilder().setNameFormat("Cassandra-Jmx-Compaction-ThreadPool-%d").build());
+
+        return Optional.of(CassandraJmxCompactionManager.create(clients, exec));
+    }
+
+    /**
+     * Running compaction against C* without SSL enabled experiences some hanging tcp connection
+     * during compaction processes. "sun.rmi.transport.tcp.responseTimeout" will enforce the tcp
+     * connection timeout in case it happens.
+     */
+    private void setJmxSslProperty(CassandraJmxCompactionConfig jmxConfig) {
+        long rmiTimeoutMillis = jmxConfig.rmiTimeoutMillis();
+        // NOTE: RMI timeout to avoid hanging tcp connection
+        System.setProperty("sun.rmi.transport.tcp.responseTimeout", String.valueOf(rmiTimeoutMillis));
+
+        if (!jmxConfig.ssl()) {
+            return;
+        }
+
+        String keyStoreFile = jmxConfig.keystore();
+        String keyStorePassword = jmxConfig.keystorePassword();
+        String trustStoreFile = jmxConfig.truststore();
+        String trustStorePassword = jmxConfig.truststorePassword();
+        Preconditions.checkState((new File(keyStoreFile)).exists(), "file: '%s' does not exist!", keyStoreFile);
+        Preconditions.checkState((new File(trustStoreFile)).exists(), "file: '%s' does not exist!", trustStoreFile);
+        System.setProperty("javax.net.ssl.keyStore", keyStoreFile);
+        System.setProperty("javax.net.ssl.keyStorePassword", keyStorePassword);
+        System.setProperty("javax.net.ssl.trustStore", trustStoreFile);
+        System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword);
+    }
+
+    /**
+     * Return an empty set if no client can be created.
+     */
+    private ImmutableSet<CassandraJmxCompactionClient> createCompactionClients(CassandraJmxCompactionConfig jmxConfig) {
+        Set<CassandraJmxCompactionClient> clients = Sets.newHashSet();
+        Set<InetSocketAddress> servers = config.servers();
+        int jmxPort = jmxConfig.port();
+        for (InetSocketAddress addr : servers) {
+            CassandraJmxCompactionClient client =
+                    createCompactionClient(addr.getHostString(), jmxPort, jmxConfig.username(), jmxConfig.password());
+            clients.add(client);
+        }
+
+        return ImmutableSet.copyOf(clients);
+    }
+
+    private CassandraJmxCompactionClient createCompactionClient(
+            String host,
+            int port,
+            String username,
+            String password) {
+        CassandraJmxConnectorFactory jmxConnectorFactory =
+                new CassandraJmxConnectorFactory(host, port, username, password);
+        JMXConnector jmxConnector = jmxConnectorFactory.create();
+
+        CassandraJmxBeanFactory jmxBeanFactory = new CassandraJmxBeanFactory(jmxConnector);
+        StorageServiceMBean storageServiceProxy = jmxBeanFactory.create(
+                CassandraConstants.STORAGE_SERVICE_OBJECT_NAME,
+                StorageServiceMBean.class);
+        HintedHandOffManagerMBean hintedHandoffProxy = jmxBeanFactory.create(
+                CassandraConstants.HINTED_HANDOFF_MANAGER_OBJECT_NAME,
+                HintedHandOffManagerMBean.class);
+        CompactionManagerMBean compactionManagerProxy = jmxBeanFactory.create(
+                CassandraConstants.COMPACTION_MANAGER_OBJECT_NAME,
+                CompactionManagerMBean.class);
+
+        return CassandraJmxCompactionClient.create(
+                host,
+                port,
+                jmxConnector,
+                storageServiceProxy,
+                hintedHandoffProxy,
+                compactionManagerProxy);
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompactionClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompactionClient.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * <p>
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://opensource.org/licenses/BSD-3-Clause
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra.jmx;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import javax.management.remote.JMXConnector;
+
+import org.apache.cassandra.db.HintedHandOffManagerMBean;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
+import org.apache.cassandra.service.StorageServiceMBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+/**
+ * Maintains a JMX client for each node in C* cluster.
+ */
+public class CassandraJmxCompactionClient {
+    private static final Logger log = LoggerFactory.getLogger(CassandraJmxCompactionClient.class);
+    private final String host;
+    private final int port;
+    private final JMXConnector jmxConnector;
+    private final StorageServiceMBean storageServiceProxy;
+    private final HintedHandOffManagerMBean hintedHandoffProxy;
+    private final CompactionManagerMBean compactionManagerProxy;
+
+    protected CassandraJmxCompactionClient(
+            String host,
+            int port,
+            JMXConnector jmxConnector,
+            StorageServiceMBean storageServiceProxy,
+            HintedHandOffManagerMBean hintedHandoffProxy,
+            CompactionManagerMBean compactionManagerProxy) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(host));
+        Preconditions.checkArgument(port > 0);
+        this.host = host;
+        this.port = port;
+        this.jmxConnector = Preconditions.checkNotNull(jmxConnector, "jmxConnector cannot be null");
+        this.storageServiceProxy = Preconditions.checkNotNull(storageServiceProxy,
+                "storageServiceProxy cannot be null");
+        this.hintedHandoffProxy = Preconditions.checkNotNull(hintedHandoffProxy, "hintedHandoffProxy cannot be null");
+        this.compactionManagerProxy = Preconditions.checkNotNull(compactionManagerProxy,
+                "compactionManagerProxy cannot be null");
+    }
+
+    public static CassandraJmxCompactionClient create(String host,
+                                                      int port,
+                                                      JMXConnector jmxConnector,
+                                                      StorageServiceMBean storageServiceProxy,
+                                                      HintedHandOffManagerMBean hintedHandoffProxy,
+                                                      CompactionManagerMBean compactionManagerProxy) {
+        return new CassandraJmxCompactionClient(
+                host,
+                port,
+                jmxConnector,
+                storageServiceProxy,
+                hintedHandoffProxy,
+                compactionManagerProxy);
+    }
+
+    public void deleteLocalHints() {
+        // hintedHandoff needs to be deleted to make sure data will not resurrect.
+        hintedHandoffProxy.deleteHintsForEndpoint(host);
+    }
+
+    public void forceTableFlush(String keyspace, TableReference tableRef) {
+        log.trace("flushing {}.{} for tombstone compaction!", keyspace, tableRef.getQualifiedName());
+        try {
+            storageServiceProxy.forceKeyspaceFlush(keyspace, tableRef.getQualifiedName());
+        } catch (Exception e) {
+            log.error("Failed to flush table {}.{}.", keyspace, tableRef.getQualifiedName(), e);
+            Throwables.propagateIfPossible(e);
+        }
+    }
+
+    private static final int RETRY_TIMES = 3;
+    private static final long RETRY_INTERVAL_IN_SECONDS = 5;
+
+    /**
+     * retry for a number of times. The reason why we need to retry compaction is:
+     * during a node's coming back process, the keyspace is not ready to be compacted
+     * even the JMX connection can be established.
+     */
+    public boolean forceTableCompaction(String keyspace, TableReference tableRef) {
+        boolean status = tryTableCompactionInternal(keyspace, tableRef);
+        int retries = 0;
+        while (!status && retries < RETRY_TIMES) {
+            retries++;
+            log.info("Failed to compact, retrying in {} seconds for {} time(s)", RETRY_INTERVAL_IN_SECONDS, retries);
+            try {
+                TimeUnit.SECONDS.sleep(RETRY_INTERVAL_IN_SECONDS);
+            } catch (InterruptedException e) {
+                log.error("Sleep interrupted while trying to compact", e);
+            }
+            status = tryTableCompactionInternal(keyspace, tableRef);
+        }
+        if (!status) {
+            log.error("Failed to compact after {} retries.", RETRY_INTERVAL_IN_SECONDS);
+        }
+        return status;
+    }
+
+    private boolean tryTableCompactionInternal(String keyspace, TableReference tableRef) {
+        try {
+            Stopwatch stopWatch = Stopwatch.createStarted();
+            storageServiceProxy.forceKeyspaceCompaction(true, keyspace, tableRef.getQualifiedName());
+            log.info("Compaction for {}.{} completed in {}", keyspace, tableRef, stopWatch.stop());
+        } catch (Exception e) {
+            log.error("Failed to compact {}.{}.", keyspace, tableRef, e);
+            Throwables.propagateIfPossible(e);
+            return false;
+        }
+        return true;
+    }
+
+    public List<String> getCompactionStatus() {
+        return compactionManagerProxy.getCompactionSummary();
+    }
+
+    public void close() {
+        if (jmxConnector != null) {
+            try {
+                jmxConnector.close();
+            } catch (IOException e) {
+                log.error("Error in closing Cassandra JMX compaction connection.", e);
+            }
+        }
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        CassandraJmxCompactionClient that = (CassandraJmxCompactionClient) obj;
+        return port == that.port
+                && Objects.equals(host, that.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(host, port);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("host", host)
+                .add("port", port)
+                .toString();
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompactionManager.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxCompactionManager.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * <p>
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://opensource.org/licenses/BSD-3-Clause
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra.jmx;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+/**
+ * CassandraJmxCompactionManager manages all JMX compaction clients for C* cluster.
+ * Each node in C* cluster will have one CassandraJmxCompactionClient connection.
+ */
+public final class CassandraJmxCompactionManager {
+    private static final Logger log = LoggerFactory.getLogger(CassandraJmxCompactionManager.class);
+    private final ImmutableSet<CassandraJmxCompactionClient> clients;
+    private final ExecutorService exec;
+
+    private CassandraJmxCompactionManager(ImmutableSet<CassandraJmxCompactionClient> clients, ExecutorService exec) {
+        this.clients = Preconditions.checkNotNull(clients, "clients cannot be null");
+        this.exec = Preconditions.checkNotNull(exec, "exec cannot be null");
+    }
+
+    public static CassandraJmxCompactionManager create(
+            ImmutableSet<CassandraJmxCompactionClient> clients,
+            ExecutorService exec) {
+        return new CassandraJmxCompactionManager(clients, exec);
+    }
+
+    public void performTombstoneCompaction(long timeoutInSeconds,
+                                           String keyspace,
+                                           TableReference tableRef) throws InterruptedException, TimeoutException {
+        Stopwatch stopWatch = Stopwatch.createStarted();
+        if (!removeHintedHandoff(timeoutInSeconds)) {
+            return;
+        }
+        log.info("All hinted handoff deletion tasks are completed.");
+
+        long elapsedSeconds = stopWatch.elapsed(TimeUnit.SECONDS);
+        long remainingTimeoutSeconds = timeoutInSeconds - elapsedSeconds;
+        if (remainingTimeoutSeconds <= 0) {
+            throw new TimeoutException(String.format("Task execution timeout in %d seconds. Timeout seconds:%d.",
+                    elapsedSeconds, timeoutInSeconds));
+        }
+
+        // ALL HINTED HANDOFFS NEED TO BE DELETED BEFORE MOVING TO TOMBSTONE COMPACTION TASK
+        if (!deleteTombstone(keyspace, tableRef, remainingTimeoutSeconds)) {
+            return;
+        }
+        log.info("All compaction tasks are completed.");
+    }
+
+    private boolean removeHintedHandoff(long timeoutInSeconds) throws InterruptedException, TimeoutException {
+        List<HintedHandOffDeletionTask> hintedHandoffDeletionTasks = Lists.newArrayListWithExpectedSize(clients.size());
+        for (CassandraJmxCompactionClient client : clients) {
+            hintedHandoffDeletionTasks.add(new HintedHandOffDeletionTask(client));
+        }
+
+        return executeInParallel(hintedHandoffDeletionTasks, timeoutInSeconds);
+    }
+
+    private boolean deleteTombstone(String keyspace, TableReference tableRef, long timeoutInSeconds)
+            throws InterruptedException, TimeoutException {
+        List<TombstoneCompactionTask> compactionTasks = Lists.newArrayListWithExpectedSize(clients.size());
+        for (CassandraJmxCompactionClient client : clients) {
+            compactionTasks.add(new TombstoneCompactionTask(client, keyspace, tableRef));
+        }
+
+        return executeInParallel(compactionTasks, timeoutInSeconds);
+    }
+
+    private boolean executeInParallel(List<? extends Callable<Void>> tasks, long timeoutInSeconds)
+            throws InterruptedException, TimeoutException {
+        Stopwatch stopWatch = Stopwatch.createStarted();
+        List<Future<Void>> futures = exec.invokeAll(tasks, timeoutInSeconds, TimeUnit.SECONDS);
+
+        for (Future<Void> f : futures) {
+            if (f.isCancelled()) {
+                log.error("Task execution timeouts in {} seconds. Timeout seconds: {}.",
+                        stopWatch.stop().elapsed(TimeUnit.SECONDS), timeoutInSeconds);
+                throw new TimeoutException(String.format("Task execution timeouts in %d seconds. Timeout seconds: %d.",
+                        stopWatch.elapsed(TimeUnit.SECONDS), timeoutInSeconds));
+            }
+
+            try {
+                f.get();
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof UndeclaredThrowableException) {
+                    log.error("Major LCS compactions are only supported against C* 2.2+; "
+                            + "you will need to manually re-arrange SSTables into L0 "
+                            + "if you want all deleted data immediately removed from the cluster.");
+                }
+                log.error("Failed to complete tasks.", e);
+                return false;
+            }
+        }
+
+        log.info("All tasks completed in {}.", stopWatch.stop());
+        return true;
+    }
+
+    public String getCompactionStatus() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("Jmx compaction information. Total number of Jmx clients: %d.%n", clients.size()));
+        for (CassandraJmxCompactionClient client : clients) {
+            sb.append(String.format("%s compaction summary: %s%n", client, client.getCompactionStatus()));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Close all the JMX compaction connections.
+     */
+    public void close() {
+        log.info("shutting down...");
+        exec.shutdown();
+        log.info("closing {} JMX clients.", clients.size());
+        for (CassandraJmxCompactionClient client : clients) {
+            client.close();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("clients", clients).toString();
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxConnectorFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/CassandraJmxConnectorFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * <p>
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://opensource.org/licenses/BSD-3-Clause
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra.jmx;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraConstants;
+
+public class CassandraJmxConnectorFactory {
+    private final String host;
+    private final int port;
+    private final String username;
+    private final String password;
+
+    public CassandraJmxConnectorFactory(String host, int port, String username, String password) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(host));
+        Preconditions.checkArgument(port > 0);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(username));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(password));
+
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+    }
+
+    public JMXConnector create() {
+        Map<String, Object> env = new HashMap<>();
+        String[] creds = {username, password};
+        env.put(JMXConnector.CREDENTIALS, creds);
+
+        JMXServiceURL jmxServiceUrl;
+        JMXConnector jmxConnector = null;
+        try {
+            jmxServiceUrl = new JMXServiceURL(String.format(CassandraConstants.JMX_RMI, host, port));
+            jmxConnector = JMXConnectorFactory.connect(jmxServiceUrl, env);
+        } catch (MalformedURLException e) {
+            Throwables.propagate(e);
+        } catch (IOException e) {
+            Throwables.propagate(e);
+        }
+
+        return jmxConnector;
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/HintedHandOffDeletionTask.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/HintedHandOffDeletionTask.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * <p>
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://opensource.org/licenses/BSD-3-Clause
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra.jmx;
+
+import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HintedHandOffDeletionTask implements Callable<Void> {
+    private static final Logger log = LoggerFactory.getLogger(HintedHandOffDeletionTask.class);
+    private final CassandraJmxCompactionClient client;
+
+    HintedHandOffDeletionTask(CassandraJmxCompactionClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Void call() throws Exception {
+        client.deleteLocalHints();
+        log.info("Deleted local hints.");
+        return null;
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/TombstoneCompactionTask.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/jmx/TombstoneCompactionTask.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * <p>
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://opensource.org/licenses/BSD-3-Clause
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra.jmx;
+
+import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+public class TombstoneCompactionTask implements Callable<Void> {
+    private static final Logger log = LoggerFactory.getLogger(TombstoneCompactionTask.class);
+    private final CassandraJmxCompactionClient client;
+    private final String keyspace;
+    private final TableReference tableRef;
+
+    TombstoneCompactionTask(CassandraJmxCompactionClient client, String keyspace, TableReference tableRef) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(keyspace));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(tableRef.getQualifiedName()));
+
+        this.client = Preconditions.checkNotNull(client, "client cannot be null");
+        this.keyspace = keyspace;
+        this.tableRef = tableRef;
+    }
+
+    @Override
+    public Void call() throws Exception {
+        // table flush will make sure tombstone is persisted on disk for tombstone compaction
+        client.forceTableFlush(keyspace, tableRef);
+        log.info("Completed table flush.");
+
+        client.forceTableCompaction(keyspace, tableRef);
+        log.info("Completed table compaction.");
+        return null;
+    }
+}

--- a/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/HintedHandOffManagerMBean.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/HintedHandOffManagerMBean.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db;
+
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public interface HintedHandOffManagerMBean {
+    /**
+     * Nuke all hints from this node to `ep`.
+     *
+     * @param host String rep. of endpoint address to delete hints for, either ip address ("127.0.0.1") or hostname
+     */
+    void deleteHintsForEndpoint(String host);
+
+    /**
+     *  Truncate all the hints.
+     */
+    void truncateAllHints() throws ExecutionException, InterruptedException;
+
+    /**
+     * List all the endpoints that this node has hints for.
+     *
+     * @return set of endpoints; as Strings
+     */
+    List<String> listEndpointsPendingHints();
+
+    /**
+     * Force hint delivery to an endpoint.
+     */
+    void scheduleHintDelivery(String host) throws UnknownHostException;
+
+    /**
+     * Pause hints delivery process.
+     */
+    void pauseHintsDelivery(boolean pauseHintsDelivery);
+}

--- a/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/compaction/CompactionManagerMBean.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/cassandra/db/compaction/CompactionManagerMBean.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.compaction;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.management.openmbean.TabularData;
+
+public interface CompactionManagerMBean {
+    /**
+     * List of running compaction objects.
+     */
+    List<Map<String, String>> getCompactions();
+
+    /**
+     * List of running compaction summary strings.
+     */
+    List<String> getCompactionSummary();
+
+    /**
+     * Get the compaction history.
+     */
+    TabularData getCompactionHistory();
+
+    /**
+     * Triggers the compaction of user specified sstables.
+     * You can specify files from various keyspaces and columnfamilies.
+     * If you do so, user defined compaction is performed several times to the groups of files
+     * in the same keyspace/columnfamily.
+     *
+     * @param dataFiles a comma separated list of sstable file to compact.
+     *                  must contain keyspace and columnfamily name in path(for 2.1+) or file name itself.
+     */
+    void forceUserDefinedCompaction(String dataFiles);
+
+    /**
+     * Stop all running compaction-like tasks having the provided {@code type}.
+     * @param type the type of compaction to stop. Can be one of:
+     *   - COMPACTION
+     *   - VALIDATION
+     *   - CLEANUP
+     *   - SCRUB
+     *   - INDEX_BUILD
+     */
+    void stopCompaction(String type);
+
+    /**
+     * Stop an individual running compaction using the compactionId.
+     *
+     * @param compactionId Compaction ID of compaction to stop. Such IDs can be found in
+     *                     the compactions_in_progress table of the system keyspace.
+     */
+    void stopCompactionById(String compactionId);
+
+    /**
+     * Returns core size of compaction thread pool.
+     */
+    int getCoreCompactorThreads();
+
+    /**
+     * Allows user to resize maximum size of the compaction thread pool.
+     * @param number New maximum of compaction threads
+     */
+    void setCoreCompactorThreads(int number);
+
+    /**
+     * Returns maximum size of compaction thread pool.
+     */
+    int getMaximumCompactorThreads();
+
+    /**
+     * Allows user to resize maximum size of the compaction thread pool.
+     *
+     * @param number New maximum of compaction threads
+     */
+    void setMaximumCompactorThreads(int number);
+
+    /**
+     * Returns core size of validation thread pool.
+     */
+    int getCoreValidationThreads();
+
+    /**
+     * Allows user to resize maximum size of the compaction thread pool.
+     *
+     * @param number New maximum of compaction threads
+     */
+    void setCoreValidationThreads(int number);
+
+    /**
+     * Returns size of validator thread pool.
+     */
+    int getMaximumValidatorThreads();
+
+    /**
+     * Allows user to resize maximum size of the validator thread pool.
+     * @param number New maximum of validator threads
+     */
+    void setMaximumValidatorThreads(int number);
+}

--- a/atlasdb-cassandra/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/atlasdb-cassandra/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -1,0 +1,690 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.service;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import javax.management.NotificationEmitter;
+import javax.management.openmbean.TabularData;
+
+@SuppressWarnings("AbbreviationAsWordInName")
+public interface StorageServiceMBean extends NotificationEmitter {
+    /**
+     * Retrieve the list of live nodes in the cluster, where "liveness" is
+     * determined by the failure detector of the node being queried.
+     *
+     * @return set of IP addresses, as Strings
+     */
+    List<String> getLiveNodes();
+
+    /**
+     * Retrieve the list of unreachable nodes in the cluster, as determined
+     * by this node's failure detector.
+     *
+     * @return set of IP addresses, as Strings
+     */
+    List<String> getUnreachableNodes();
+
+    /**
+     * Retrieve the list of nodes currently bootstrapping into the ring.
+     *
+     * @return set of IP addresses, as Strings
+     */
+    List<String> getJoiningNodes();
+
+    /**
+     * Retrieve the list of nodes currently leaving the ring.
+     *
+     * @return set of IP addresses, as Strings
+     */
+    List<String> getLeavingNodes();
+
+    /**
+     * Retrieve the list of nodes currently moving in the ring.
+     *
+     * @return set of IP addresses, as Strings
+     */
+    List<String> getMovingNodes();
+
+    /**
+     * Fetch string representations of the tokens for this node.
+     *
+     * @return a collection of tokens formatted as strings
+     */
+    List<String> getTokens();
+
+    /**
+     * Fetch string representations of the tokens for a specified node.
+     *
+     * @param endpoint string representation of an node
+     * @return a collection of tokens formatted as strings
+     */
+    List<String> getTokens(String endpoint) throws UnknownHostException;
+
+    /**
+     * Fetch a string representation of the Cassandra version.
+     *
+     * @return A string representation of the Cassandra version
+     */
+    String getReleaseVersion();
+
+    /**
+     * Fetch a string representation of the current Schema version.
+     *
+     * @return A string representation of the Schema version
+     */
+    String getSchemaVersion();
+
+    /**
+     * Get the list of all data file locations from conf.
+     *
+     * @return String array of all locations
+     */
+    String[] getAllDataFileLocations();
+
+    /**
+     * Get location of the commit log.
+     *
+     * @return a string path
+     */
+    String getCommitLogLocation();
+
+    /**
+     * Get location of the saved caches dir.
+     *
+     * @return a string path
+     */
+    String getSavedCachesLocation();
+
+    /**
+     * Retrieve a map of range to end points that describe the ring topology
+     * of a Cassandra cluster.
+     *
+     * @return mapping of ranges to end points
+     */
+    Map<List<String>, List<String>> getRangeToEndpointMap(String keyspace);
+
+    /**
+     * Retrieve a map of range to rpc addresses that describe the ring topology
+     * of a Cassandra cluster.
+     *
+     * @return mapping of ranges to rpc addresses
+     */
+    Map<List<String>, List<String>> getRangeToRpcaddressMap(String keyspace);
+
+    /**
+     * The same as {@code describeRing(String)} but converts TokenRange to the String for JMX compatibility.
+     *
+     * @param keyspace The keyspace to fetch information about
+     *
+     * @return a List of TokenRange(s) converted to String for the given keyspace
+     */
+    List<String> describeRingJMX(String keyspace) throws IOException;
+
+    /**
+     * Retrieve a map of pending ranges to endpoints that describe the ring topology.
+     *
+     * @param keyspace the keyspace to get the pending range map for.
+     * @return a map of pending ranges to endpoints
+     */
+    Map<List<String>, List<String>> getPendingRangeToEndpointMap(String keyspace);
+
+    /**
+     * Retrieve a map of tokens to endpoints, including the bootstrapping
+     * ones.
+     *
+     * @return a map of tokens to endpoints in ascending order
+     */
+    Map<String, String> getTokenToEndpointMap();
+
+    /**
+     *  Retrieve this hosts unique ID.
+     */
+    String getLocalHostId();
+
+    /**
+     * Retrieve the mapping of endpoint to host ID.
+     */
+    Map<String, String> getHostIdMap();
+
+    /**
+     * Human-readable load value.
+     */
+    String getLoadString();
+
+    /**
+     * Human-readable load value.  Keys are IP addresses.
+     */
+    Map<String, String> getLoadMap();
+
+    /**
+     * Returns the generation value for this node.
+     *
+     * @return generation number
+     */
+    int getCurrentGenerationNumber();
+
+    /**
+     * Returns the N endpoints that are responsible for storing the specified key i.e for replication.
+     *
+     * @param keyspaceName keyspace name
+     * @param cf Column family name
+     * @param key - key for which we need to find the endpoint return value -
+     * the endpoint responsible for this key
+     */
+    List<InetAddress> getNaturalEndpoints(String keyspaceName, String cf, String key);
+    List<InetAddress> getNaturalEndpoints(String keyspaceName, ByteBuffer key);
+
+    /**
+     * Takes the snapshot for the given keyspaces. A snapshot name must be specified.
+     *
+     * @param tag the tag given to the snapshot; may not be null or empty
+     * @param keyspaceNames the name of the keyspaces to snapshot; empty means "all."
+     */
+    void takeSnapshot(String tag, String... keyspaceNames) throws IOException;
+
+    /**
+     * Takes the snapshot of a specific column family. A snapshot name must be specified.
+     *
+     * @param keyspaceName the keyspace which holds the specified column family
+     * @param columnFamilyName the column family to snapshot
+     * @param tag the tag given to the snapshot; may not be null or empty
+     */
+    void takeColumnFamilySnapshot(String keyspaceName, String columnFamilyName, String tag) throws IOException;
+
+    /**
+     * Takes the snapshot of a multiple column family from different keyspaces. A snapshot name must be specified.
+     *
+     * @param tag
+     *            the tag given to the snapshot; may not be null or empty
+     * @param columnFamilyList
+     *            list of columnfamily from different keyspace in the form of ks1.cf1 ks2.cf2
+     */
+    void takeMultipleColumnFamilySnapshot(String tag, String... columnFamilyList) throws IOException;
+
+    /**
+     * Remove the snapshot with the given name from the given keyspaces.
+     * If no tag is specified we will remove all snapshots.
+     */
+    void clearSnapshot(String tag, String... keyspaceNames) throws IOException;
+
+    /**
+     * Get the details of all the snapshot.
+     *
+     * @return A map of snapshotName to all its details in Tabular form
+     */
+    Map<String, TabularData> getSnapshotDetails();
+
+    /**
+     * Get the true size taken by all snapshots across all keyspaces.
+     *
+     * @return True size taken by all the snapshots
+     */
+    long trueSnapshotsSize();
+
+    /**
+     * Forces major compaction of a single keyspace.
+     */
+    void forceKeyspaceCompaction(boolean splitOutput, String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
+     * Trigger a cleanup of keys on a single keyspace.
+     */
+    int forceKeyspaceCleanup(String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
+     * See {@link #scrub(boolean, boolean, boolean, String, String...)}.
+     *
+     * @deprecated Use {@link #scrub(boolean, boolean, boolean, String, String...)} instead.
+     */
+    @Deprecated
+    int scrub(boolean disableSnapshot, boolean skipCorrupted, String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
+     * Scrub (deserialize + reserialize at the latest version, skipping bad rows if any) the given keyspace.
+     * If columnFamilies array is empty, all CFs are scrubbed.
+     *
+     * Scrubbed CFs will be snapshotted first, if disableSnapshot is false.
+     */
+    int scrub(
+            boolean disableSnapshot,
+            boolean skipCorrupted,
+            boolean checkData,
+            String keyspaceName,
+            String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
+     * Verify (checksums of) the given keyspace.
+     * If columnFamilies array is empty, all CFs are verified.
+     *
+     * The entire sstable will be read to ensure each cell validates if extendedVerify is true.
+     */
+    int verify(boolean extendedVerify, String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
+     * Rewrite all sstables to the latest version.
+     * Unlike scrub, it doesn't skip bad rows and do not snapshot sstables first.
+     */
+    int upgradeSSTables(String keyspaceName, boolean excludeCurrentVersion, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
+     * Flush all memtables for the given column families, or all columnfamilies for the given keyspace
+     * if none are explicitly listed.
+     */
+    void forceKeyspaceFlush(String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
+     * Invoke repair asynchronously.
+     * You can track repair progress by subscribing JMX notification sent from this StorageServiceMBean.
+     * Notification format is:
+     *   type: "repair"
+     *   userObject: int array of length 2, [0]=command number, [1]=ordinal of ActiveRepairService.Status
+     *
+     * @param keyspace Keyspace name to repair. Should not be null.
+     * @param options repair option.
+     * @return Repair command number, or 0 if nothing to repair
+     */
+    int repairAsync(String keyspace, Map<String, String> options);
+
+    /**
+     * Invoke repair asynchronously.
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
+    @Deprecated
+    int forceRepairAsync(
+            String keyspace,
+            boolean isSequential,
+            Collection<String> dataCenters,
+            Collection<String> hosts,
+            boolean primaryRange,
+            boolean repairedAt,
+            String... columnFamilies) throws IOException;
+
+    /**
+     * Invoke repair asynchronously.
+     * You can track repair progress by subscribing JMX notification sent from this StorageServiceMBean.
+     * Notification format is:
+     *   type: "repair"
+     *   userObject: int array of length 2, [0]=command number, [1]=ordinal of ActiveRepairService.Status
+     *
+     * @param parallelismDegree 0: sequential, 1: parallel, 2: DC parallel
+     * @return Repair command number, or 0 if nothing to repair
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
+    @Deprecated
+    int forceRepairAsync(
+            String keyspace,
+            int parallelismDegree,
+            Collection<String> dataCenters,
+            Collection<String> hosts,
+            boolean primaryRange,
+            boolean fullRepair,
+            String... columnFamilies);
+
+    /**
+     * Invoke repair asynchronously.
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
+    @Deprecated
+    int forceRepairAsync(
+            String keyspace,
+            boolean isSequential,
+            boolean isLocal,
+            boolean primaryRange,
+            boolean fullRepair,
+            String... columnFamilies);
+
+    /**
+     * Same as {@link #forceRepairAsync}, but handles a specified range.
+     *
+     * @param parallelismDegree 0: sequential, 1: parallel, 2: DC parallel
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
+    @Deprecated
+    int forceRepairRangeAsync(
+            String beginToken,
+            String endToken,
+            String keyspaceName,
+            int parallelismDegree,
+            Collection<String> dataCenters,
+            Collection<String> hosts,
+            boolean fullRepair,
+            String... columnFamilies);
+
+    /**
+     * Invoke repair asynchronously.
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
+    @Deprecated
+    int forceRepairRangeAsync(
+            String beginToken,
+            String endToken,
+            String keyspaceName,
+            boolean isSequential,
+            Collection<String> dataCenters,
+            Collection<String> hosts,
+            boolean repairedAt,
+            String... columnFamilies) throws IOException;
+
+    /**
+     * Invoke repair asynchronously.
+     *
+     * @deprecated Use {@link #repairAsync} instead.
+     */
+    @Deprecated
+    int forceRepairRangeAsync(
+            String beginToken,
+            String endToken,
+            String keyspaceName,
+            boolean isSequential,
+            boolean isLocal,
+            boolean repairedAt,
+            String... columnFamilies);
+
+    void forceTerminateAllRepairSessions();
+
+    /**
+     * transfer this node's data to other machines and remove it from service.
+     */
+    void decommission() throws InterruptedException;
+
+    /**
+     * This node will unload its data onto its neighbors, and bootstrap to the new token.
+     *
+     * @param newToken token to move this node to.
+     */
+    void move(String newToken) throws IOException;
+
+    /**
+     * removeNode removes the token (and all data associated with the endpoint that had it) from the ring.
+     */
+    void removeNode(String token);
+
+    /**
+     * Get the status of a token removal.
+     */
+    String getRemovalStatus();
+
+    /**
+     * Force a remove operation to finish.
+     */
+    void forceRemoveCompletion();
+
+    /**
+     * set the logging level at runtime<br>
+     * <br>
+     * If both classQualifer and level are empty/null, it will reload the configuration to reset.<br>
+     * If classQualifier is not empty but level is empty/null, it will set the level to null for
+     * the defined classQualifier<br>
+     * If level cannot be parsed, then the level will be defaulted to DEBUG<br>
+     * <br>
+     * The logback configuration should have < jmxConfigurator /> set
+     *
+     * @param classQualifier The logger's classQualifer
+     * @param level The log level
+     *
+     * @see ch.qos.logback.classic.Level#toLevel(String)
+     */
+    void setLoggingLevel(String classQualifier, String level) throws Exception;
+
+    /**
+     *  Get the runtime logging levels.
+     */
+    Map<String, String> getLoggingLevels();
+
+    /**
+     * Get the operational mode (leaving, joining, normal, decommissioned, client).
+     */
+    String getOperationMode();
+
+    /**
+     * Returns whether the storage service is starting or not.
+     */
+    boolean isStarting();
+
+    /**
+     * Get the progress of a drain operation.
+     */
+    String getDrainProgress();
+
+    /**
+     * makes node unavailable for writes, flushes memtables and replays commitlog.
+     */
+    void drain() throws IOException, InterruptedException, ExecutionException;
+
+    /**
+     * Truncates (deletes) the given columnFamily from the provided keyspace.
+     * Calling truncate results in actual deletion of all data in the cluster
+     * under the given columnFamily and it will fail unless all hosts are up.
+     * All data in the given column family will be deleted, but its definition
+     * will not be affected.
+     *
+     * @param keyspace The keyspace to delete from
+     * @param columnFamily The column family to delete data from.
+     */
+    void truncate(String keyspace, String columnFamily) throws TimeoutException, IOException;
+
+    /**
+     * Gets the percentage of the cluster owned per token.
+     *
+     * @return A mapping from "token -> %age of cluster owned by that token"
+     */
+    Map<InetAddress, Float> getOwnership();
+
+    /**
+     * Effective ownership is % of the data each node owns given the keyspace
+     * we calculate the percentage using replication factor.
+     * If Keyspace == null, this method will try to verify if all the keyspaces
+     * in the cluster have the same replication strategies and if yes then we will
+     * use the first else a empty Map is returned.
+     */
+    Map<InetAddress, Float> effectiveOwnership(String keyspace) throws IllegalStateException;
+
+    List<String> getKeyspaces();
+
+    List<String> getNonSystemKeyspaces();
+
+    /**
+     * Change endpointsnitch class and dynamic-ness (and dynamic attributes) at runtime.
+     *
+     * @param epSnitchClassName        the canonical path name for a class implementing IEndpointSnitch
+     * @param dynamic                  boolean that decides whether dynamicsnitch is used or not
+     * @param dynamicUpdateInterval    integer, in ms (default 100)
+     * @param dynamicResetInterval     integer, in ms (default 600,000)
+     * @param dynamicBadnessThreshold  double, (default 0.0)
+     */
+    void updateSnitch(
+            String epSnitchClassName,
+            Boolean dynamic,
+            Integer dynamicUpdateInterval,
+            Integer dynamicResetInterval,
+            Double dynamicBadnessThreshold) throws ClassNotFoundException;
+
+    // allows a user to forcibly 'kill' a sick node
+    void stopGossiping();
+
+    // allows a user to recover a forcibly 'killed' node
+    void startGossiping();
+
+    // allows a user to see whether gossip is running or not
+    boolean isGossipRunning();
+
+    // allows a user to forcibly completely stop cassandra
+    void stopDaemon();
+
+    // to determine if gossip is disabled
+    boolean isInitialized();
+
+    // allows a user to disable thrift
+    void stopRPCServer();
+
+    // allows a user to reenable thrift
+    void startRPCServer();
+
+    // to determine if thrift is running
+    boolean isRPCServerRunning();
+
+    void stopNativeTransport();
+    void startNativeTransport();
+    boolean isNativeTransportRunning();
+
+    // allows a node that have been started without joining the ring to join it
+    void joinRing() throws IOException;
+    boolean isJoined();
+
+    void setStreamThroughputMbPerSec(int value);
+    int getStreamThroughputMbPerSec();
+
+    int getCompactionThroughputMbPerSec();
+    void setCompactionThroughputMbPerSec(int value);
+
+    boolean isIncrementalBackupsEnabled();
+    void setIncrementalBackupsEnabled(boolean value);
+
+    /**
+     * Initiate a process of streaming data for which we are responsible from other nodes. It is similar to bootstrap
+     * except meant to be used on a node which is already in the cluster (typically containing no data) as an
+     * alternative to running repair.
+     *
+     * @param sourceDc Name of DC from which to select sources for streaming or null to pick any node
+     */
+    void rebuild(String sourceDc);
+
+    /** Starts a bulk load and blocks until it completes. */
+    void bulkLoad(String directory);
+
+    /**
+     * Starts a bulk load asynchronously and returns the String representation of the planID for the new
+     * streaming session.
+     */
+    String bulkLoadAsync(String directory);
+
+    void rescheduleFailedDeletions();
+
+    /**
+     * Load new SSTables to the given keyspace/columnFamily.
+     *
+     * @param ksName The parent keyspace name
+     * @param cfName The ColumnFamily name where SSTables belong
+     */
+    void loadNewSSTables(String ksName, String cfName);
+
+    /**
+     * Return a List of Tokens representing a sample of keys across all ColumnFamilyStores.
+     *
+     * Note: this should be left as an operation, not an attribute (methods starting with "get")
+     * to avoid sending potentially multiple MB of data when accessing this mbean by default.  See CASSANDRA-4452.
+     *
+     * @return set of Tokens as Strings
+     */
+    List<String> sampleKeyRange();
+
+    /**
+     * Rebuild the specified indexes.
+     */
+    void rebuildSecondaryIndex(String ksName, String cfName, String... idxNames);
+
+    void resetLocalSchema() throws IOException;
+
+    /**
+     * Enables/Disables tracing for the whole system. Only thrift requests can start tracing currently.
+     *
+     * @param probability
+     *            ]0,1[ will enable tracing on a partial number of requests with the provided probability. 0 will
+     *            disable tracing and 1 will enable tracing for all requests (which mich severely cripple the system)
+     */
+    void setTraceProbability(double probability);
+
+    /**
+     * Returns the configured tracing probability.
+     */
+    double getTraceProbability();
+
+    void disableAutoCompaction(String ks, String ... columnFamilies) throws IOException;
+    void enableAutoCompaction(String ks, String ... columnFamilies) throws IOException;
+
+    void deliverHints(String host) throws UnknownHostException;
+
+    /**
+     * Returns the name of the cluster.
+     */
+    String getClusterName();
+    /**
+     * Returns the cluster partitioner.
+     */
+    String getPartitionerName();
+
+    /**
+     * Returns the threshold for warning of queries with many tombstones.
+     */
+    int getTombstoneWarnThreshold();
+    /**
+     * Sets the threshold for warning queries with many tombstones.
+     */
+    void setTombstoneWarnThreshold(int tombstoneDebugThreshold);
+
+    /**
+     * Returns the threshold for abandoning queries with many tombstones.
+     */
+    int getTombstoneFailureThreshold();
+
+    /**
+     * Sets the threshold for abandoning queries with many tombstones.
+     */
+    void setTombstoneFailureThreshold(int tombstoneDebugThreshold);
+
+    /**
+     * Returns the threshold for rejecting queries due to a large batch size.
+     */
+    int getBatchSizeFailureThreshold();
+
+    /**
+     * Sets the threshold for rejecting queries due to a large batch size.
+     */
+    void setBatchSizeFailureThreshold(int batchSizeDebugThreshold);
+
+    /**
+     * Sets the hinted handoff throttle in kb per second, per delivery thread.
+     */
+    void setHintedHandoffThrottleInKB(int throttleInKB);
+
+    /**
+     * Resume bootstrap streaming when there is failed data streaming.
+     *
+     * @return true if the node successfully starts resuming. (this does not mean bootstrap streaming was success.)
+     */
+    boolean resumeBootstrap();
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraJmxCompactionClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraJmxCompactionClientTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import javax.management.remote.JMXConnector;
+
+import org.apache.cassandra.db.HintedHandOffManagerMBean;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
+import org.apache.cassandra.service.StorageServiceMBean;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.jmx.CassandraJmxCompactionClient;
+
+public class CassandraJmxCompactionClientTest {
+    private JMXConnector jmxConnector;
+    private StorageServiceMBean storageServiceProxy;
+    private HintedHandOffManagerMBean hintedHandoffProxy;
+    private CompactionManagerMBean compactionManagerProxy;
+    private CassandraJmxCompactionClient jmxClient;
+
+    private static final String FAKE_HOST = "localhost";
+    private static final int FAKE_JMX_PORT = 7199;
+    private static final String TEST_KEY_SPACE = "testKeySpace";
+    private static final TableReference TEST_TABLE_NAME = TableReference.createWithEmptyNamespace("testTableName");
+
+    @Before
+    public void before() {
+        jmxConnector = mock(JMXConnector.class);
+        storageServiceProxy = mock(StorageServiceMBean.class);
+        hintedHandoffProxy = mock(HintedHandOffManagerMBean.class);
+        compactionManagerProxy = mock(CompactionManagerMBean.class);
+        jmxClient = CassandraJmxCompactionClient.create(FAKE_HOST, FAKE_JMX_PORT,
+                jmxConnector, storageServiceProxy, hintedHandoffProxy, compactionManagerProxy);
+    }
+
+    @Test
+    public void verifyDeleteLocalHints() {
+        jmxClient.deleteLocalHints();
+        verify(hintedHandoffProxy).deleteHintsForEndpoint(FAKE_HOST);
+    }
+
+    @Test
+    public void verifyForceTableFlush() throws InterruptedException, ExecutionException, IOException {
+        jmxClient.forceTableFlush(TEST_KEY_SPACE, TEST_TABLE_NAME);
+        verify(storageServiceProxy).forceKeyspaceFlush(TEST_KEY_SPACE, TEST_TABLE_NAME.getQualifiedName());
+    }
+
+    @Test
+    public void verifyForceTableCompaction() throws InterruptedException, ExecutionException, IOException {
+        jmxClient.forceTableCompaction(TEST_KEY_SPACE, TEST_TABLE_NAME);
+        verify(storageServiceProxy).forceKeyspaceCompaction(true, TEST_KEY_SPACE, TEST_TABLE_NAME.getQualifiedName());
+    }
+
+    @Test
+    public void verifyGetCompactionStatus() {
+        jmxClient.getCompactionStatus();
+        verify(compactionManagerProxy).getCompactionSummary();
+    }
+
+    @Test
+    public void verifyClose() throws IOException {
+        jmxClient.close();
+        verify(jmxConnector).close();
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraJmxCompactionManagerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraJmxCompactionManagerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.jmx.CassandraJmxCompactionClient;
+import com.palantir.atlasdb.keyvalue.cassandra.jmx.CassandraJmxCompactionManager;
+
+/**
+ * All tests are Jmx disabled.
+ */
+public class CassandraJmxCompactionManagerTest {
+    private ExecutorService exec;
+    ImmutableSet<CassandraJmxCompactionClient> mockedClients;
+
+    private static final String TEST_KEY_SPACE = "testKeySpace";
+    private static final TableReference TEST_TABLE_NAME = TableReference.createWithEmptyNamespace("testTableName");
+
+    @Before
+    public void before() {
+        CassandraJmxCompactionClient jmxCompactionClient = mock(CassandraJmxCompactionClient.class);
+        mockedClients = ImmutableSet.of(jmxCompactionClient);
+        exec = Executors.newFixedThreadPool(
+                1, new ThreadFactoryBuilder().setNameFormat("test-Cassandra-Compaction-ThreadPool-%d").build());
+    }
+
+    @After
+    public void tearDown() {
+        if (exec != null) {
+            exec.shutdownNow();
+        }
+    }
+
+    @Test
+    public void createShouldWorkWithEmptyClients() {
+        CassandraJmxCompactionManager.create(ImmutableSet.<CassandraJmxCompactionClient>of(), exec);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createShouldFailWithNullParameter() {
+        CassandraJmxCompactionManager.create(null, exec);
+    }
+
+    @Test
+    public void verifyTombstoneCompactionTask() throws InterruptedException, TimeoutException, ExecutionException {
+        CassandraJmxCompactionManager clientManager = CassandraJmxCompactionManager.create(mockedClients, exec);
+        clientManager.performTombstoneCompaction(10, TEST_KEY_SPACE, TEST_TABLE_NAME);
+        CassandraJmxCompactionClient client = Iterables.get(mockedClients, 0);
+
+        verify(client).deleteLocalHints();
+        verify(client).forceTableFlush(TEST_KEY_SPACE, TEST_TABLE_NAME);
+        verify(client).forceTableCompaction(TEST_KEY_SPACE, TEST_TABLE_NAME);
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -23,7 +23,6 @@ import org.immutables.value.Value;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.compact.CompactorConfig;
 import com.palantir.atlasdb.qos.config.QosClientConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 
@@ -35,11 +34,6 @@ public abstract class AtlasDbRuntimeConfig {
     @Value.Default
     public SweepConfig sweep() {
         return SweepConfig.defaultSweepConfig();
-    }
-
-    @Value.Default
-    public CompactorConfig compact() {
-        return CompactorConfig.defaultCompactorConfig();
     }
 
     /**

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -45,7 +45,6 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
-import com.palantir.atlasdb.compact.BackgroundCompactor;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
@@ -356,32 +355,8 @@ public abstract class TransactionManagers {
                         transactionManager,
                         persistentLockManager),
                 closeables);
-        initializeCloseable(
-                initializeCompactBackgroundProcess(
-                        lockAndTimestampServices,
-                        keyValueService,
-                        transactionManager,
-                        JavaSuppliers.compose(o -> o.compact().inSafeHours(), runtimeConfigSupplier)),
-                closeables);
 
         return transactionManager;
-    }
-
-    private Optional<BackgroundCompactor> initializeCompactBackgroundProcess(
-            LockAndTimestampServices lockAndTimestampServices,
-            KeyValueService keyValueService,
-            SerializableTransactionManager transactionManager,
-            Supplier<Boolean> inSafeHours) {
-        Optional<BackgroundCompactor> backgroundCompactorOptional = BackgroundCompactor.createAndRun(
-                transactionManager,
-                keyValueService,
-                lockAndTimestampServices.lock(),
-                inSafeHours);
-
-        backgroundCompactorOptional.ifPresent(backgroundCompactor ->
-                transactionManager.registerClosingCallback(backgroundCompactor::close));
-
-        return backgroundCompactorOptional;
     }
 
     private <T extends AutoCloseable> T initializeCloseable(
@@ -389,13 +364,6 @@ public abstract class TransactionManagers {
         T ret = closeableSupplier.get();
         closeables.add(ret);
         return ret;
-    }
-
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private <T extends AutoCloseable> Optional<T> initializeCloseable(
-            Optional<T> closeableOptional, @Output List<AutoCloseable> closeables) {
-        closeableOptional.ifPresent(closeables::add);
-        return closeableOptional;
     }
 
     private QosClient getQosClient(Supplier<QosClientConfig> config) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbDdlTable.java
@@ -20,5 +20,5 @@ public interface DbDdlTable {
     void drop();
     void truncate();
     void checkDatabaseVersion();
-    void compactInternally(boolean inSafeHours);
+    void compactInternally();
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -1168,19 +1168,9 @@ public final class DbKvs extends AbstractKeyValueService {
     }
 
     @Override
-    public boolean shouldTriggerCompactions() {
-        return true;
-    }
-
-    @Override
     public void compactInternally(TableReference tableRef) {
-        compactInternally(tableRef, false);
-    }
-
-    @Override
-    public void compactInternally(TableReference tableRef, boolean inSafeHours) {
         runDdl(tableRef, (Function<DbDdlTable, Void>) table -> {
-            table.compactInternally(inSafeHours);
+            table.compactInternally();
             return null;
         });
     }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -122,7 +122,7 @@ public class PostgresDdlTable implements DbDdlTable {
     }
 
     @Override
-    public void compactInternally(boolean unused) {
+    public void compactInternally() {
         if (compactionSemaphore.tryAcquire()) {
             try {
                 if (shouldRunCompaction()) {

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
@@ -151,7 +151,7 @@ public class PostgresDdlTableTest {
 
     private void assertThatVacuumWasPerformed(SqlConnection sqlConnection, boolean assertThatTimestampsWereChecked) {
         assertTrue(postgresDdlTable.shouldRunCompaction());
-        postgresDdlTable.compactInternally(false);
+        postgresDdlTable.compactInternally();
 
         if (assertThatTimestampsWereChecked) {
             verify(sqlConnection, times(2)).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
@@ -162,7 +162,7 @@ public class PostgresDdlTableTest {
 
     private void assertThatVacuumWasNotPerformed(SqlConnection sqlConnection) {
         assertFalse(postgresDdlTable.shouldRunCompaction());
-        postgresDdlTable.compactInternally(false);
+        postgresDdlTable.compactInternally();
 
         verify(sqlConnection, times(2)).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
@@ -19,10 +19,9 @@ package com.palantir.atlasdb.compact;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface CompactorConfig {
-    boolean inSafeHours();
+interface CompactorConfig {
+    // Enables OracleDB SHRINK COMPACT, which can be blocking
+    boolean shrinkCompactEnabled();
 
-    static CompactorConfig defaultCompactorConfig() {
-        return ImmutableCompactorConfig.builder().inSafeHours(true).build();
-    }
+
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -302,7 +302,6 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
             daemon.join();
             daemon = null;
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             throw Throwables.rewrapAndThrowUncheckedException(e);
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.sweep;
 
+import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
@@ -22,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.SweepResults;
@@ -219,6 +222,7 @@ public class SpecificTableSweeper {
 
     private void processFinishedSweep(TableToSweep tableToSweep, SweepResults cumulativeResults) {
         saveFinalSweepResults(tableToSweep, cumulativeResults);
+        performInternalCompactionIfNecessary(tableToSweep.getTableRef(), cumulativeResults);
         log.info("Finished sweeping table {}. Examined {} cell+timestamp pairs, deleted {} stale values. Time taken "
                         + "sweeping: {} ms, time elapsed since sweep first started on this table: {} ms.",
                 LoggingArgs.tableRef("tableRef", tableToSweep.getTableRef()),
@@ -228,6 +232,24 @@ public class SpecificTableSweeper {
                 SafeArg.of("time elapsed", cumulativeResults.getTimeElapsedSinceStartedSweeping()));
         updateMetricsFullTable(cumulativeResults, tableToSweep.getTableRef());
         sweepProgressStore.clearProgress();
+    }
+
+    private void performInternalCompactionIfNecessary(TableReference tableRef, SweepResults results) {
+        if (results.getStaleValuesDeleted() > 0) {
+            Stopwatch watch = Stopwatch.createStarted();
+            kvs.compactInternally(tableRef);
+            long elapsedMillis = watch.elapsed(TimeUnit.MILLISECONDS);
+            log.debug("Finished performing compactInternally on {} in {} ms.",
+                    LoggingArgs.tableRef("tableRef", tableRef),
+                    SafeArg.of("elapsedMillis", elapsedMillis));
+            sweepPerfLogger.logInternalCompaction(
+                    SweepCompactionPerformanceResults.builder()
+                            .tableName(tableRef.getQualifiedName())
+                            .cellsDeleted(results.getStaleValuesDeleted())
+                            .cellsExamined(results.getCellTsPairsExamined())
+                            .elapsedMillis(elapsedMillis)
+                            .build());
+        }
     }
 
     private void saveFinalSweepResults(TableToSweep tableToSweep, SweepResults finalSweepResults) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
@@ -240,4 +240,34 @@ public class BackgroundSweeperFastTest extends SweeperTestSetup {
                 .updateMetrics(intermediateResults, TABLE_REF, UpdateEventType.ONE_ITERATION);
         Mockito.verify(sweepMetricsManager).updateMetrics(fullResults, TABLE_REF, UpdateEventType.FULL_TABLE);
     }
+
+    @Test
+    public void testCompactInternallyAfterCompleteRunIfNonZeroDeletes() {
+        setNoProgress();
+        setNextTableToSweep(TABLE_REF);
+        setupTaskRunner(ImmutableSweepResults.builder()
+                .staleValuesDeleted(1)
+                .cellTsPairsExamined(10)
+                .minSweptTimestamp(12345L)
+                .timeInMillis(0L)
+                .timeSweepStarted(0L)
+                .build());
+        backgroundSweeper.runOnce();
+        Mockito.verify(kvs).compactInternally(TABLE_REF);
+    }
+
+    @Test
+    public void testDontCompactInternallyAfterCompleteRunIfZeroDeletes() {
+        setNoProgress();
+        setNextTableToSweep(TABLE_REF);
+        setupTaskRunner(ImmutableSweepResults.builder()
+                .staleValuesDeleted(0)
+                .cellTsPairsExamined(10)
+                .minSweptTimestamp(12345L)
+                .timeInMillis(0L)
+                .timeSweepStarted(0L)
+                .build());
+        backgroundSweeper.runOnce();
+        Mockito.verify(kvs, Mockito.never()).compactInternally(TABLE_REF);
+    }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,12 +50,6 @@ develop
     *    - Type
          - Change
 
-    *    - |new|
-         - DbKvs: introduced a Background compactor thread that carries out post-sweep compaction operations.
-           For non-enterprise Oracle deployments, this will only run the blocking ``SHRINK SPACE`` command during safe hours.
-           (`Pull Request 1 <https://github.com/palantir/atlasdb/pull/2984>`__ and
-           `Pull Request 2 <https://github.com/palantir/atlasdb/pull/2991>`__)
-
     *    - |fixed|
          - LoggingArgs no longer throws when it tries to hydrate invalid table metadata.
            This fixes an issue that prevented AtlasDB to start after performing a KVS migration.


### PR DESCRIPTION
…(#2991)"

This reverts commit 5234e7ec1ddd8f35412a40ab79a6096331502c73.

**Goals (and why)**: Revert Oracle Compaction part 2, as we want to smoke test this before it gets deployed anywhere.

**Priority (whenever / two weeks / yesterday)**: today

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3012)
<!-- Reviewable:end -->
