### PR TITLE
speed up certain types of read-only txn

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -213,6 +213,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     protected final long lockAcquireTimeoutMs;
     protected final ExecutorService getRangesExecutor;
     protected final int defaultGetRangesConcurrency;
+    private final Set<TableReference> involvedTables = Sets.newConcurrentHashSet();
 
     protected volatile boolean hasReads;
 
@@ -352,6 +353,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     }
 
     protected void checkGetPreconditions(TableReference tableRef) {
+        markTableAsInvolvedInThisTransaction(tableRef);
         if (transactionReadTimeoutMillis != null
                 && System.currentTimeMillis() - timeCreated > transactionReadTimeoutMillis) {
             throw new TransactionFailedRetriableException("Transaction timed out.");
@@ -1205,6 +1207,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     public void putInternal(TableReference tableRef, Map<Cell, byte[]> values) {
         Preconditions.checkArgument(!AtlasDbConstants.hiddenTables.contains(tableRef));
+        markTableAsInvolvedInThisTransaction(tableRef);
 
         if (values.isEmpty()) {
             return;
@@ -1359,9 +1362,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
                 // if there are no writes, we must still make sure the immutable timestamp lock is still valid,
                 // to ensure that sweep hasn't thoroughly deleted cells we tried to read
-                // TODO(nziebart): we actually only need to do this if we've read from tables with THOROUGH
-                // sweep strategy
-                throwIfImmutableTsOrCommitLocksExpired(null);
+                if (validationNecessaryForInvolvedTables()) {
+                    throwIfImmutableTsOrCommitLocksExpired(null);
+                }
                 return;
             }
             return;
@@ -1974,6 +1977,18 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     @Override
     public void useTable(TableReference tableRef, ConstraintCheckable table) {
         constraintsByTableName.put(tableRef, table);
+    }
+
+    /** the similarly-named-and-intentioned useTable method is only called on writes,
+     *  this one is more comprehensive and covers read paths as well
+     * (necessary because we wish to get the sweep strategies of tables in read-only transactions)
+     */
+    private void markTableAsInvolvedInThisTransaction(TableReference tableRef) {
+        involvedTables.add(tableRef);
+    }
+
+    private boolean validationNecessaryForInvolvedTables() {
+        return involvedTables.stream().anyMatch(this::isValidationNecessary);
     }
 
     private long getStartTimestamp() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -114,7 +114,7 @@ public class TransactionManagerTest extends TransactionTestSetup {
     }
 
     @Test
-    public void shouldConflictIfImmutableTimestampLockExpiresEvenIfNoWrites() {
+    public void shouldConflictIfImmutableTimestampLockExpiresEvenIfNoWritesOnThoroughSweptTable() {
         TimelockService timelock = mock(TimelockService.class);
         LockService mockLockService = mock(LockService.class);
         TransactionManager txnManagerWithMocks = new SerializableTransactionManager(keyValueService,
@@ -138,10 +138,40 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 LockImmutableTimestampResponse.of(2L, LockToken.of(UUID.randomUUID())));
 
         assertThatThrownBy(() -> txnManagerWithMocks.runTaskThrowOnConflict(txn -> {
-            get(txn, "row1", "col1");
+            get(txn, TEST_TABLE_THOROUGH, "row1", "col1");
             return null;
         }))
                 .isInstanceOf(TransactionFailedRetriableException.class);
+    }
+
+    @Test
+    public void shouldNotConflictIfImmutableTimestampLockExpiresEvenIfNoWritesOnNonThoroughSweptTable() {
+        TimelockService timelock = mock(TimelockService.class);
+        LockService mockLockService = mock(LockService.class);
+        TransactionManager txnManagerWithMocks = new SerializableTransactionManager(keyValueService,
+                timelock,
+                mockLockService,
+                transactionService,
+                () -> AtlasDbConstraintCheckingMode.FULL_CONSTRAINT_CHECKING_THROWS_EXCEPTIONS,
+                conflictDetectionManager,
+                sweepStrategyManager,
+                NoOpCleaner.INSTANCE,
+                TimestampTrackerImpl.createNoOpTracker(),
+                () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
+                false,
+                () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
+                AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
+                AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
+                SweepQueueWriter.NO_OP);
+
+        when(timelock.getFreshTimestamp()).thenReturn(1L);
+        when(timelock.lockImmutableTimestamp(any())).thenReturn(
+                LockImmutableTimestampResponse.of(2L, LockToken.of(UUID.randomUUID())));
+
+        txnManagerWithMocks.runTaskThrowOnConflict(txn -> {
+            get(txn, TEST_TABLE, "row1", "col1");
+            return null;
+        });
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -89,6 +89,11 @@ develop
          - Fixed a bug that can causes the background sweep thread to fail to shut down cleanly, hanging the application.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3023>`__)
 
+    *    - |improved|
+         - Remove a round trip from read only transactions
+           not involving thoroughly swept tables.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3020>`__)
+
 =======
 v0.77.0
 =======
@@ -123,7 +128,6 @@ v0.77.0
     *    - |fixed|
          - Fix ``SnapshotTransaction#getRows`` to apply ``ColumnSelection`` when there are local writes.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3008>`__)
-
 
 =======
 v0.76.0


### PR DESCRIPTION
remove a lock round trip for read only transactions that only involve non-thoroughly swept tables

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3020)
<!-- Reviewable:end -->
