### PR TITLE
Fix Eclipse bug in AutoDelegate

### DIFF
--- a/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
+++ b/atlasdb-processors/src/main/java/com/palantir/processors/AutoDelegateProcessor.java
@@ -16,6 +16,8 @@
 
 package com.palantir.processors;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -24,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
@@ -247,13 +250,18 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
         for (ExecutableElement methodElement : typeToExtend.getMethods()) {
             String returnStatement = (methodElement.getReturnType().getKind() == TypeKind.VOID) ? "" : "return ";
 
+            int numParams = methodElement.getParameters().size();
+            String callFormat = "$L$L().$L(" + joinMultiple("$L", numParams, ", ") + ")";
+            Object[] callArgs = new Object[3 + methodElement.getParameters().size()];
+            callArgs[0] = returnStatement;
+            callArgs[1] = DELEGATE_METHOD;
+            callArgs[2] = methodElement.getSimpleName();
+            for (int i = 0; i < methodElement.getParameters().size(); ++i) {
+                callArgs[i + 3] = methodElement.getParameters().get(i);
+            }
             MethodSpec.Builder method = MethodSpec
                     .overriding(methodElement)
-                    .addStatement("$L$L().$L($L)",
-                            returnStatement,
-                            DELEGATE_METHOD,
-                            methodElement.getSimpleName(),
-                            methodElement.getParameters());
+                    .addStatement(callFormat, callArgs);
             if (typeToExtend.isInterface()) {
                 method.addModifiers(Modifier.DEFAULT);
             }
@@ -285,5 +293,9 @@ public final class AutoDelegateProcessor extends AbstractProcessor {
      */
     private void error(Element element, String msg) {
         messager.printMessage(Diagnostic.Kind.ERROR, msg, element);
+    }
+
+    private static String joinMultiple(String string, int times, String delimiter) {
+        return Stream.generate(() -> string).limit(times).collect(joining(delimiter));
     }
 }


### PR DESCRIPTION
**Goals (and why)**:

AutoDelegate is generating invalid Java code in ECJ of the form:

```
return delegate().unlock([token]);
```

JavaPoet does not appear to support passing lists as `$L` (though it seems to work fine in Javac for whatever reason).

**Implementation Description (bullets)**:

 * Construct a format string and a varargs array explicitly.

**Concerns (what feedback would you like?)**:

Clear enough?

**Priority (whenever / two weeks / yesterday)**:

Soon :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3022)
<!-- Reviewable:end -->
