### PR TITLE
PersistentLockManager is swallowing thread interrupts

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/PersistentLockManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/PersistentLockManager.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.persistentlock.LockEntry;
 import com.palantir.atlasdb.persistentlock.PersistentLockId;
@@ -146,7 +145,8 @@ public class PersistentLockManager implements AutoCloseable {
         try {
             Thread.sleep(persistentLockRetryWaitMillis);
         } catch (InterruptedException e) {
-            throw Throwables.propagate(e);
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
         }
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -75,6 +75,10 @@ develop
          - Changes the default scrubber behavior to aggressive scrub (synchronous with scrub request).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3009>`__)
 
+    *    - |fixed|
+         - Fixed a bug that can causes the background sweep thread to fail to shut down cleanly, hanging the application.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3023>`__)
+
 =======
 v0.77.0
 =======


### PR DESCRIPTION
**Goals (and why)**:

The PersistentLockManager is catching InterruptedException and rethrowing it wrapped in a RuntimeException, causing the interrupted status of the thread to be lost. This is causing the BackgroundSweeper to fail to shutdown cleanly.

See also #3021.

**Implementation Description (bullets)**:

 * Call `currentThread().interrupt()` before wrapping the exception
 * `Throwables.propagate` is deprecated; in this case, we should just be creating our own RuntimeException.

**Priority (whenever / two weeks / yesterday)**:

Causing issues with an internal security product.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3023)
<!-- Reviewable:end -->
