### PR TITLE
Robustify background sweeper

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.sweep;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -54,6 +55,8 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
     private final SweepOutcomeMetrics sweepOutcomeMetrics = new SweepOutcomeMetrics();
 
     private Thread daemon;
+
+    private final CountDownLatch shuttingDown = new CountDownLatch(1);
 
     @VisibleForTesting
     BackgroundSweeperImpl(
@@ -120,7 +123,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
         try (SingleLockService locks = createSweepLocks()) {
             // Wait a while before starting so short lived clis don't try to sweep.
             waitUntilSpecificTableSweeperIsInitialized();
-            Thread.sleep(getBackoffTimeWhenSweepHasNotRun());
+            sleepForMillis(getBackoffTimeWhenSweepHasNotRun());
             log.info("Starting background sweeper.");
             while (true) {
                 // InterruptedException might be wrapped in RuntimeException (i.e. AtlasDbDependencyException),
@@ -155,7 +158,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
             log.info("Sweep Priority Table and Sweep Progress Table are not initialized yet. If you have enabled "
                     + "asynchronous initialization, these tables are being initialized asynchronously. Background "
                     + "sweeper will start once the initialization is complete.");
-            Thread.sleep(getBackoffTimeWhenSweepHasNotRun());
+            sleepForMillis(getBackoffTimeWhenSweepHasNotRun());
         }
     }
 
@@ -177,7 +180,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
         if (outcome == SweepOutcome.SUCCESS) {
             sleepDurationMillis = sweepPauseMillis.get();
         }
-        Thread.sleep(sleepDurationMillis);
+        sleepForMillis(sleepDurationMillis);
     }
 
     @VisibleForTesting
@@ -280,6 +283,12 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
         specificTableSweeper.getSweepProgressStore().clearProgress();
     }
 
+    private void sleepForMillis(long millis) throws InterruptedException {
+        if (shuttingDown.await(millis, TimeUnit.MILLISECONDS)) {
+            throw new InterruptedException();
+        }
+    }
+
     @VisibleForTesting
     SingleLockService createSweepLocks() {
         return new SingleLockService(lockService, "atlas sweep");
@@ -297,7 +306,11 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
             return;
         }
         log.info("Signalling background sweeper to shut down.");
+        // Interrupt the daemon, whatever lock it may be waiting on.
         daemon.interrupt();
+        // Ensure we do not accidentally abort shutdown if any code incorrectly swallows InterruptedExceptions
+        // on the daemon thread.
+        shuttingDown.countDown();
         try {
             daemon.join();
             daemon = null;


### PR DESCRIPTION
**Goals (and why)**:

Harden the background sweeper against InterruptedException bugs. The current implementation relies on all code everywhere correctly handling thread interruption; if any wait call anywhere erroneously swallows the interrupt, the daemon will continue to run, preventing clean shutdown.

See issue #3021.

**Implementation Description (bullets)**:

 * Trip a CountDownLatch after interrupting the thread
 * Replace all calls to `Thread.sleep` with a wait on this latch
 * Only wait for 10s for the background sweep thread

**Priority (whenever / two weeks / yesterday)**:

Causing issues with an internal security product.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3024)
<!-- Reviewable:end -->
