### PR TITLE
Backport spaced vacuums to 0.39.x

### DIFF
--- a/atlasdb-cli-distribution/versions.lock
+++ b/atlasdb-cli-distribution/versions.lock
@@ -75,8 +75,10 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -104,7 +106,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
@@ -453,6 +456,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -470,6 +485,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -758,6 +779,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -57,6 +57,7 @@ import com.palantir.atlasdb.persistentlock.KvsBackedPersistentLockService;
 import com.palantir.atlasdb.persistentlock.NoOpPersistentLockService;
 import com.palantir.atlasdb.persistentlock.PersistentLockService;
 import com.palantir.atlasdb.schema.AtlasSchema;
+import com.palantir.atlasdb.schema.CompactSchema;
 import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
@@ -205,6 +206,7 @@ public final class TransactionManagers {
 
         Set<Schema> allSchemas = ImmutableSet.<Schema>builder()
                 .add(SweepSchema.INSTANCE.getLatestSchema())
+                .add(CompactSchema.INSTANCE.getLatestSchema())
                 .addAll(schemas)
                 .build();
         for (Schema schema : allSchemas) {

--- a/atlasdb-console-distribution/versions.lock
+++ b/atlasdb-console-distribution/versions.lock
@@ -75,8 +75,10 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -104,7 +106,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
@@ -442,6 +445,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -459,6 +474,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -764,6 +785,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-dbkvs-tests/versions.lock
+++ b/atlasdb-dbkvs-tests/versions.lock
@@ -44,8 +44,10 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
-                "com.palantir.remoting:ssl-config"
+                "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
@@ -58,7 +60,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
@@ -303,6 +306,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -318,6 +333,12 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -498,6 +519,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -564,8 +586,10 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
-                "com.palantir.remoting:ssl-config"
+                "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
@@ -578,7 +602,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
@@ -823,6 +848,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -838,6 +875,12 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1018,6 +1061,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -12,6 +12,8 @@ dependencies {
   compile project(':commons-db')
   compile project(':commons-api')
 
+  compile group: 'com.palantir.remoting-api', name: 'service-config'
+
   testCompile project(':atlasdb-config')
   testCompile project(path: ":atlasdb-client", configuration: "testArtifacts")
   testCompile group: 'org.hamcrest', name: 'hamcrest-library'

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/PostgresDdlConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.remoting.api.config.service.HumanReadableDuration;
 
 @JsonDeserialize(as = ImmutablePostgresDdlConfig.class)
 @JsonSerialize(as = ImmutablePostgresDdlConfig.class)
@@ -44,5 +45,10 @@ public abstract class PostgresDdlConfig extends DdlConfig {
     @Override
     public <T> T accept(Visitor<T> visitor) {
         return visitor.visit(this);
+    }
+
+    @Value.Default
+    public HumanReadableDuration compactInterval() {
+        return HumanReadableDuration.seconds(0);
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTable.java
@@ -15,11 +15,14 @@
  */
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
+import java.util.concurrent.Semaphore;
 import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.PostgresDdlConfig;
@@ -29,6 +32,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.TableValueStyle;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle.PrimaryKeyConstraintNames;
 import com.palantir.exception.PalantirSqlException;
+import com.palantir.nexus.db.sql.AgnosticResultRow;
 import com.palantir.nexus.db.sql.AgnosticResultSet;
 import com.palantir.nexus.db.sql.ExceptionCheck;
 import com.palantir.util.VersionStrings;
@@ -45,6 +49,7 @@ public class PostgresDdlTable implements DbDdlTable {
     private final TableReference tableName;
     private final ConnectionSupplier conns;
     private final PostgresDdlConfig config;
+    private final Semaphore compactionSemaphore = new Semaphore(1);
 
     public PostgresDdlTable(TableReference tableName,
                             ConnectionSupplier conns,
@@ -135,6 +140,48 @@ public class PostgresDdlTable implements DbDdlTable {
 
     @Override
     public void compactInternally(boolean unused) {
+        if (compactionSemaphore.tryAcquire()) {
+            try {
+                if (shouldRunCompaction()) {
+                    runCompactOnTable();
+                }
+            } finally {
+                compactionSemaphore.release();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    boolean shouldRunCompaction() {
+        long compactIntervalMillis = config.compactInterval().toMilliseconds();
+        return compactIntervalMillis <= 0 || getMillisSinceLastCompact() >= compactIntervalMillis;
+    }
+
+    /**
+     * Returns the number of milliseconds since the last compaction, or Long.MAX_VALUE if
+     * compaction has never run.
+     */
+    private long getMillisSinceLastCompact() {
+        AgnosticResultSet rs = conns.get().selectResultSetUnregisteredQuery(
+                "SELECT FLOOR(EXTRACT(EPOCH FROM GREATEST( "
+                        + "  last_vacuum, last_autovacuum, last_analyze, last_autoanalyze"
+                        + "))*1000) AS last, "
+                        + "FLOOR(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)*1000) AS current "
+                        + "FROM pg_stat_user_tables WHERE relname = ?",
+                prefixedTableName());
+
+        AgnosticResultRow row = Iterables.getOnlyElement(rs.rows());
+
+        // last could be null if vacuum has never run
+        long last = row.getLong("last", -1);
+        if (last == -1) {
+            return Long.MAX_VALUE;
+        }
+        long current = row.getLong("current");
+        return current - last;
+    }
+
+    private void runCompactOnTable() {
         // VACUUM FULL is /really/ what we want here, but it takes out a table lock
         conns.get().executeUnregisteredQuery("VACUUM ANALYZE " + prefixedTableName());
     }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
@@ -106,7 +106,7 @@ public class PostgresDdlTableTest {
     }
 
     @Test
-    public void shouldCompactIfVacuumTimestampExceedsNowTimestampByMoreThanCompactInterval() {
+    public void shouldNotCompactIfVacuumTimestampExceedsNowTimestampByMoreThanCompactInterval() {
         SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS + COMPACT_INTERVAL_MILLIS * SMALL_POSITIVE_FACTOR,
                 NOW_MILLIS);
         assertThatVacuumWasNotPerformed(sqlConnection);

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
@@ -151,7 +151,7 @@ public class PostgresDdlTableTest {
 
     private void assertThatVacuumWasPerformed(SqlConnection sqlConnection, boolean assertThatTimestampsWereChecked) {
         assertTrue(postgresDdlTable.shouldRunCompaction());
-        postgresDdlTable.compactInternally();
+        postgresDdlTable.compactInternally(false);
 
         if (assertThatTimestampsWereChecked) {
             verify(sqlConnection, times(2)).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
@@ -162,7 +162,7 @@ public class PostgresDdlTableTest {
 
     private void assertThatVacuumWasNotPerformed(SqlConnection sqlConnection) {
         assertFalse(postgresDdlTable.shouldRunCompaction());
-        postgresDdlTable.compactInternally();
+        postgresDdlTable.compactInternally(false);
 
         verify(sqlConnection, times(2)).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
 

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2018 Palantir Technologies
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresDdlTableTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.dbkvs.ImmutablePostgresDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
+import com.palantir.atlasdb.keyvalue.dbkvs.impl.DbKvs;
+import com.palantir.nexus.db.DBType;
+import com.palantir.nexus.db.sql.AgnosticResultSetImpl;
+import com.palantir.nexus.db.sql.SqlConnection;
+import com.palantir.remoting.api.config.service.HumanReadableDuration;
+
+public class PostgresDdlTableTest {
+    private PostgresDdlTable postgresDdlTable;
+    private static final ConnectionSupplier connectionSupplier = mock(ConnectionSupplier.class);
+    private static final TableReference TEST_TABLE = TableReference.createFromFullyQualifiedName("ns.test");
+
+    private static final long NOW_MILLIS = 1000;
+    private static final long COMPACT_INTERVAL_MILLIS = 100;
+    private static final long SMALL_POSITIVE_FACTOR = 10;
+
+    @Before
+    public void setUp() {
+        postgresDdlTable = new PostgresDdlTable(TEST_TABLE,
+                connectionSupplier,
+                ImmutablePostgresDdlConfig.builder()
+                        .compactInterval(HumanReadableDuration.milliseconds(COMPACT_INTERVAL_MILLIS))
+                        .build());
+    }
+
+    @Test
+    public void shouldCompactIfVacuumWasNeverPerformedAndTheDbTimeIsLessThanCompactInterval() throws Exception {
+        SqlConnection sqlConnection = setUpSqlConnection(null, COMPACT_INTERVAL_MILLIS / SMALL_POSITIVE_FACTOR);
+
+        assertThatVacuumWasPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfVacuumWasNeverPerformedAndTheDbTimeIsMoreThanCompactInterval() throws Exception {
+        SqlConnection sqlConnection = setUpSqlConnection(null, COMPACT_INTERVAL_MILLIS * SMALL_POSITIVE_FACTOR);
+
+        assertThatVacuumWasPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfVacuumWasPerformedExactlyBeforeCompactInterval() throws Exception {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS - COMPACT_INTERVAL_MILLIS, NOW_MILLIS);
+
+        assertThatVacuumWasPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfVacuumWasPerformedBeforeCompactInterval() throws Exception {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS - COMPACT_INTERVAL_MILLIS * SMALL_POSITIVE_FACTOR,
+                NOW_MILLIS);
+
+        assertThatVacuumWasPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldNotCompactIfVacuumWasPerformedWithinCompactInterval() {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS - COMPACT_INTERVAL_MILLIS / SMALL_POSITIVE_FACTOR,
+                NOW_MILLIS);
+        assertThatVacuumWasNotPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldNotCompactIfVacuumTimestampExceedsNowTimestampByLessThanCompactInterval() {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS + COMPACT_INTERVAL_MILLIS / SMALL_POSITIVE_FACTOR,
+                NOW_MILLIS);
+        assertThatVacuumWasNotPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfVacuumTimestampExceedsNowTimestampByMoreThanCompactInterval() {
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS + COMPACT_INTERVAL_MILLIS * SMALL_POSITIVE_FACTOR,
+                NOW_MILLIS);
+        assertThatVacuumWasNotPerformed(sqlConnection);
+    }
+
+    @Test
+    public void shouldCompactIfCompactMillisIsSetToZero() throws Exception {
+        postgresDdlTable = new PostgresDdlTable(TEST_TABLE,
+                connectionSupplier,
+                ImmutablePostgresDdlConfig.builder().compactInterval(HumanReadableDuration.valueOf("0 ms")).build());
+        SqlConnection sqlConnection = setUpSqlConnection(NOW_MILLIS - SMALL_POSITIVE_FACTOR, NOW_MILLIS);
+        assertThatVacuumWasPerformed(sqlConnection, false);
+
+        verify(sqlConnection, never()).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
+    }
+
+    private SqlConnection setUpSqlConnection(Long lastVacuumTimestamp, Long currentTimestamp) {
+        SqlConnection sqlConnection = mock(SqlConnection.class);
+        when(connectionSupplier.get()).thenReturn(sqlConnection);
+
+        List<List<Object>> selectResults = new ArrayList<>();
+        selectResults.add(Arrays.asList(new Object[] {lastVacuumTimestamp, currentTimestamp}));
+
+        Mockito.when(sqlConnection.selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any()))
+                .thenReturn(
+                        new AgnosticResultSetImpl(selectResults,
+                                DBType.POSTGRESQL,
+                                // This is the columnName to position mapping in the results map. Column Names are both
+                                // upper-case and lower-case, as postgres allows the query to have either of them.
+                                new ImmutableMap.Builder<String, Integer>()
+                                        .put("last", 0)
+                                        .put("LAST", 0)
+                                        .put("current", 1)
+                                        .put("CURRENT", 1)
+                                        .build()));
+        return sqlConnection;
+    }
+
+    private void assertThatVacuumWasPerformed(SqlConnection sqlConnection) {
+        assertThatVacuumWasPerformed(sqlConnection, true);
+    }
+
+    private void assertThatVacuumWasPerformed(SqlConnection sqlConnection, boolean assertThatTimestampsWereChecked) {
+        assertTrue(postgresDdlTable.shouldRunCompaction());
+        postgresDdlTable.compactInternally();
+
+        if (assertThatTimestampsWereChecked) {
+            verify(sqlConnection, times(2)).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
+        }
+
+        verify(sqlConnection).executeUnregisteredQuery(eq("VACUUM ANALYZE " + DbKvs.internalTableName(TEST_TABLE)));
+    }
+
+    private void assertThatVacuumWasNotPerformed(SqlConnection sqlConnection) {
+        assertFalse(postgresDdlTable.shouldRunCompaction());
+        postgresDdlTable.compactInternally();
+
+        verify(sqlConnection, times(2)).selectResultSetUnregisteredQuery(startsWith("SELECT FLOOR"), any());
+
+        verify(sqlConnection, never()).executeUnregisteredQuery(
+                eq("VACUUM ANALYZE " + DbKvs.internalTableName(TEST_TABLE)));
+    }
+}

--- a/atlasdb-dbkvs/versions.lock
+++ b/atlasdb-dbkvs/versions.lock
@@ -38,8 +38,10 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
-                "com.palantir.remoting:ssl-config"
+                "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
@@ -52,7 +54,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
@@ -267,6 +270,15 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0"
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -281,6 +293,12 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -418,6 +436,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -478,8 +497,10 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.atlasdb:atlasdb-persistent-lock-api",
                 "com.palantir.atlasdb:lock-api",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
-                "com.palantir.remoting:ssl-config"
+                "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
@@ -492,7 +513,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
@@ -707,6 +729,15 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0"
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -721,6 +752,12 @@
             "locked": "0.13.0",
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -858,6 +895,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -1261,8 +1261,10 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -1291,7 +1293,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
@@ -1688,6 +1691,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -1705,6 +1720,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -2412,6 +2433,7 @@
                 "com.palantir.atlasdb:atlasdb-commons",
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/atlasdb-perf/versions.lock
+++ b/atlasdb-perf/versions.lock
@@ -76,8 +76,10 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -105,7 +107,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
@@ -461,6 +464,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -478,6 +493,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -810,6 +831,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.docker.compose:docker-compose-rule-core",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",
@@ -914,8 +936,10 @@
                 "com.palantir.atlasdb:lock-api",
                 "com.palantir.config.crypto:encrypted-config-value",
                 "com.palantir.config.crypto:encrypted-config-value-module",
+                "com.palantir.remoting-api:ssl-config",
                 "com.palantir.remoting1:tracing",
                 "com.palantir.remoting:ssl-config",
+                "com.palantir.tokens:auth-tokens",
                 "io.dropwizard:dropwizard-jackson"
             ]
         },
@@ -943,7 +967,8 @@
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.6.7",
             "transitive": [
-                "com.palantir.atlasdb:atlasdb-impl-shared"
+                "com.palantir.atlasdb:atlasdb-impl-shared",
+                "com.palantir.tokens:auth-tokens"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-joda": {
@@ -1299,6 +1324,18 @@
                 "com.palantir.atlasdb:lock-impl"
             ]
         },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-dbkvs"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
         "com.palantir.remoting1:tracing": {
             "locked": "1.0.3",
             "transitive": [
@@ -1316,6 +1353,12 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-api",
                 "com.palantir.atlasdb:atlasdb-cassandra"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
             ]
         },
         "com.palantir.tritium:tritium-api": {
@@ -1648,6 +1691,7 @@
                 "com.palantir.atlasdb:commons-proxy",
                 "com.palantir.docker.compose:docker-compose-rule-core",
                 "com.palantir.remoting1:tracing",
+                "com.palantir.tokens:auth-tokens",
                 "com.palantir.tritium:tritium-core",
                 "com.palantir.tritium:tritium-lib",
                 "com.palantir.tritium:tritium-metrics",

--- a/versions.props
+++ b/versions.props
@@ -15,6 +15,7 @@ com.palantir.docker.compose:docker-compose-rule* = 0.31.0
 com.palantir.remoting1:* = 1.0.3
 com.palantir.remoting:* = 0.13.0
 com.palantir.remoting2:* = 2.3.0
+com.palantir.remoting-api:* = 1.7.0
 com.palantir.tritium:tritium-lib = 0.6.0-beta
 commons-cli:commons-cli = 1.2
 commons-codec:commons-codec = 1.10


### PR DESCRIPTION
**Goals (and why)**:
- Internal reference PDS-64798

**Implementation Description (bullets)**:
- Allow configurable minimum time between scheduling vacuums on a given table
- Still need to propagate a value of e.g. 24 or 48 hours on this; see #2808 

**Concerns (what feedback would you like?)**:
- Are there other things that unexpectedly explode?

**Where should we start reviewing?**: from the top down, probably comparing against #2767 

**Priority (whenever / two weeks / yesterday)**: soon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3031)
<!-- Reviewable:end -->
