### PR TITLE
Fix Atlas Cli reading deprecated keyspace

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/CleanCassLocksStateCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/CleanCassLocksStateCommand.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.atlasdb.cli.command;
 
+import java.util.Optional;
+
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfigs;
 import com.palantir.atlasdb.cli.output.OutputPrinter;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl;
@@ -30,6 +33,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.SchemaMutationLockTables;
 import com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner;
 import com.palantir.atlasdb.keyvalue.impl.TracingPrefsConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
+import com.palantir.util.OptionalResolver;
 
 import io.airlift.airline.Command;
 
@@ -65,7 +69,11 @@ public class CleanCassLocksStateCommand extends AbstractCommand {
                     String.format("KeyValueService must be of type %s, but yours is %s",
                             CassandraKeyValueServiceConfig.TYPE, kvsConfig.type()));
         }
-        return (CassandraKeyValueServiceConfig) kvsConfig;
+        CassandraKeyValueServiceConfig cassandraConfig = (CassandraKeyValueServiceConfig) kvsConfig;
+
+        Optional<String> namespace = getAtlasDbConfig().namespace();
+        String desiredKeyspace = OptionalResolver.resolve(namespace, cassandraConfig.keyspace());
+        return CassandraKeyValueServiceConfigs.copyWithKeyspace(cassandraConfig, desiredKeyspace);
     }
 
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,6 +54,8 @@ develop
          - The Cassandra client pool is now cleaned up in the event of a failure to construct the Cassandra KVS (e.g. because we lost our connection to Cassandra midway).
            Previously, the client pool was not shut down, leading to a thread leak.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3006>`__)
+         - CleanCassLocksStateCommand is now using Atlas namespace if provided.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3035>`__)
 
     *    - |improved| |logs|
          - Log an ERROR in the case of failure to create a Cell due to a key greater than 1500 bytes. Previously we logged at DEBUG.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,12 +54,14 @@ develop
          - The Cassandra client pool is now cleaned up in the event of a failure to construct the Cassandra KVS (e.g. because we lost our connection to Cassandra midway).
            Previously, the client pool was not shut down, leading to a thread leak.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3006>`__)
-         - CleanCassLocksStateCommand is now using Atlas namespace if provided.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3035>`__)
 
     *    - |improved| |logs|
          - Log an ERROR in the case of failure to create a Cell due to a key greater than 1500 bytes. Previously we logged at DEBUG.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3034>`)
+
+    *    - |fixed|
+         - CleanCassLocksStateCommand is now using Atlas namespace if provided.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3035>`__)
 
 =======
 v0.78.0


### PR DESCRIPTION

**Goals (and why)**:
Making clean-cass-locks-state command to utilize `namespace` from Atlas config
**Implementation Description (bullets)**:
CleanCassLocksState now takes both namespace and keyspace and resolves these values into a `desiredKeyspace`, instead of directly trying to use keyspace from KeyValueService config.
**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3035)
<!-- Reviewable:end -->
