### PR TITLE
[Oracle Compaction][Part 6] Protect from Thread Death

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/BackgroundCompactor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/BackgroundCompactor.java
@@ -130,7 +130,14 @@ public final class BackgroundCompactor implements AutoCloseable {
     }
 
     private void runOnceRecordingOutcome(SingleLockService compactorLock) throws InterruptedException {
-        CompactionOutcome outcome = grabLockAndRunOnce(compactorLock);
+        CompactionOutcome outcome = CompactionOutcome.FAILED_TO_COMPACT; // default is failed, unless we know otherwise
+        try {
+            outcome  = grabLockAndRunOnce(compactorLock);
+        } catch (InterruptedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Unexpected exception occurred whilst performing background compaction!", e);
+        }
         compactionOutcomeMetrics.registerOccurrenceOf(outcome);
         Thread.sleep(outcome.getSleepTime());
     }
@@ -138,13 +145,24 @@ public final class BackgroundCompactor implements AutoCloseable {
     @VisibleForTesting
     CompactionOutcome grabLockAndRunOnce(SingleLockService compactorLock)
             throws InterruptedException {
-        compactorLock.lockOrRefresh();
+        try {
+            compactorLock.lockOrRefresh();
+        } catch (Exception e) {
+            log.warn("Encountered exception when attempting to acquire the compaction lock.", e);
+            return CompactionOutcome.UNABLE_TO_ACQUIRE_LOCKS;
+        }
         if (!compactorLock.haveLocks()) {
             log.info("Failed to get the compaction lock. Probably, another host is running compaction.");
             return CompactionOutcome.UNABLE_TO_ACQUIRE_LOCKS;
         }
 
-        Optional<String> tableToCompactOptional = compactPriorityCalculator.selectTableToCompact();
+        Optional<String> tableToCompactOptional;
+        try {
+            tableToCompactOptional = compactPriorityCalculator.selectTableToCompact();
+        } catch (Exception e) {
+            log.warn("Encountered exception when attempting to determine which table should be compacted.", e);
+            return CompactionOutcome.NOTHING_TO_COMPACT;
+        }
         if (!tableToCompactOptional.isPresent()) {
             log.info("No table to compact");
             return CompactionOutcome.NOTHING_TO_COMPACT;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactPriorityCalculator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactPriorityCalculator.java
@@ -86,7 +86,11 @@ class CompactPriorityCalculator {
             }
         }
 
-        logCompactionChoice(tableToCompact, maxSweptAfterCompact);
+        if (tableToCompact == null) {
+            log.info("Not compacting, because it does not appear that any table has been swept.");
+        } else {
+            logCompactionChoice(tableToCompact, maxSweptAfterCompact);
+        }
         return Optional.ofNullable(tableToCompact);
     }
 
@@ -99,7 +103,7 @@ class CompactPriorityCalculator {
             log.info("All swept tables have been compacted after the last sweep. Choosing to compact {} anyway - "
                     + "this may be a no-op. It was last compacted {} milliseconds after it was last swept.",
                     tableToCompact,
-                    maxSweptAfterCompact);
+                    -maxSweptAfterCompact);
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactPriorityCalculator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactPriorityCalculator.java
@@ -103,7 +103,7 @@ class CompactPriorityCalculator {
             log.info("All swept tables have been compacted after the last sweep. Choosing to compact {} anyway - "
                     + "this may be a no-op. It was last compacted {} milliseconds after it was last swept.",
                     tableToCompact,
-                    -maxSweptAfterCompact);
+                    Math.abs(maxSweptAfterCompact));
         }
     }
 


### PR DESCRIPTION
**Goals (and why)**:
- Be resilient to the case where the kvs / timelock isn't available when the background compactor starts

**Implementation Description (bullets)**:
- Catch Exceptions and keep running the main loop, much like Sweep

**Concerns (what feedback would you like?)**:
- Are there still places which can throw and cause the background compactor to stop?

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: today please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3037)
<!-- Reviewable:end -->
