### PR TITLE
We fixed the sstable size in 0.77, not 0.73.1

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -155,6 +155,12 @@ v0.77.0
          - Fix ``SnapshotTransaction#getRows`` to apply ``ColumnSelection`` when there are local writes.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3008>`__)
 
+    *    - |fixed|
+         - CassandraKVS sstable size in MB was not being correctly set.
+           This resulted in requirements on the entire cluster being up during startup of certain stacks.
+           CF metadata mismatch messages are also now correctly safety marked for logging.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/2989>`__)
+
 =======
 v0.76.0
 =======
@@ -400,12 +406,6 @@ v0.73.1
     *    - |devbreak|
          - Removed ``CassandraKeyValueServiceConfigManager``. If you're affected by this, please contact the AtlasDB team.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2872>`__)
-
-    *    - |fixed|
-         - CassandraKVS sstable size in MB was not being correctly set.
-           This resulted in requirements on the entire cluster being up during startup of certain stacks.
-           CF metadata mismatch messages are also now correctly safety marked for logging.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/2989>`__)
 
 =======
 v0.73.0


### PR DESCRIPTION
**Goals (and why)**: fix bad release notes

**Implementation Description (bullets)**: move the note

**Concerns (what feedback would you like?)**: I got this right, right?

**Where should we start reviewing?**: the one file

**Priority (whenever / two weeks / yesterday)**: soon please

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3044)
<!-- Reviewable:end -->
