### PR TITLE
Fix targeted sweep deletion timestamp

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
@@ -25,7 +25,7 @@ public final class Mutations {
 
     public static Mutation rangeTombstoneForColumn(byte[] columnName, long maxTimestampExclusive) {
         Deletion deletion = new Deletion()
-                .setTimestamp(Long.MAX_VALUE)
+                .setTimestamp(maxTimestampExclusive)
                 .setPredicate(SlicePredicates.rangeTombstoneForColumn(columnName, maxTimestampExclusive));
 
         return new Mutation().setDeletion(deletion);


### PR DESCRIPTION
**Goals (and why)**:
Avoid deleting values at `Long.MAX_VALUE` to allow compaction of tombstones. Early targeted sweep work deletes at `Long.MAX_VALUE`.

**Concerns (what feedback would you like?)**:
Is this correct? The timestamp bound is exclusive, so all deleted cells should be at timestamps less than the exclusive bound. I assume that ranged tombstones function as normal ones with respect to compaction rules and the highest timestamp winning.

**Priority (whenever / two weeks / yesterday)**: Soon

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3048)
<!-- Reviewable:end -->
