### PR TITLE
[Oracle Compaction][Part 7] Configurable Compactions

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -38,6 +38,7 @@ import com.palantir.atlasdb.cleaner.Cleaner;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.compact.BackgroundCompactor;
+import com.palantir.atlasdb.compact.ImmutableCompactorConfig;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
@@ -266,9 +267,9 @@ public final class TransactionManagers {
         backgroundSweeper.runInBackground();
 
         BackgroundCompactor.createAndRun(transactionManager, kvs, lockAndTimestampServices.lock(),
-                () -> false); // TEMP: never in safe hours
+                () -> ImmutableCompactorConfig.builder().build()); // TEMP: never in safe hours
                 // TODO fixup config - does 0.39.x even have runtime config?
-//                JavaSuppliers.compose(o -> o.compact().inSafeHours(), runtimeConfigSupplier));
+//                JavaSuppliers.compose(o -> o.compact().inMaintenanceHours(), runtimeConfigSupplier));
 
         return transactionManager;
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -269,7 +269,7 @@ public final class TransactionManagers {
         BackgroundCompactor.createAndRun(transactionManager, kvs, lockAndTimestampServices.lock(),
                 () -> ImmutableCompactorConfig.builder().build()); // TEMP: never in safe hours
                 // TODO fixup config - does 0.39.x even have runtime config?
-//                JavaSuppliers.compose(o -> o.compact().inMaintenanceHours(), runtimeConfigSupplier));
+//                JavaSuppliers.compose(o -> o.compact().inMaintenanceMode(), runtimeConfigSupplier));
 
         return transactionManager;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
@@ -26,6 +26,10 @@ public interface CompactorConfig {
     long DEFAULT_COMPACT_PAUSE_ON_FAILURE_MILLIS = TimeUnit.SECONDS.toMillis(1800);
     long DEFAULT_COMPACT_PAUSE_MILLIS = TimeUnit.SECONDS.toMillis(10);
 
+    /**
+     * Indicates whether 
+     * @return
+     */
     @Value.Default
     default boolean enableCompaction() {
         return false;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
@@ -66,8 +66,8 @@ public interface CompactorConfig {
     @Value.Check
     default void checkIntervalsNonnegative() {
         Preconditions.checkState(compactPauseOnFailureMillis() >= 0,
-                "Compact pause-on-failure interval must be greater than 0 but found %s", compactPauseOnFailureMillis());
+                "Compact pause-on-failure interval must be nonnegative, but found %s", compactPauseOnFailureMillis());
         Preconditions.checkState(compactPauseMillis() >= 0,
-                "Compact pause interval must be greater than 0 but found %s", compactPauseMillis());
+                "Compact pause interval must be nonnegative, but found %s", compactPauseMillis());
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
@@ -16,13 +16,38 @@
 
 package com.palantir.atlasdb.compact;
 
+import java.util.concurrent.TimeUnit;
+
 import org.immutables.value.Value;
 
 @Value.Immutable
 public interface CompactorConfig {
-    boolean inSafeHours();
+    long DEFAULT_COMPACT_CONNECTION_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(10);
+    long DEFAULT_COMPACT_PAUSE_ON_FAILURE_MILLIS = TimeUnit.SECONDS.toMillis(1800);
+    long DEFAULT_COMPACT_PAUSE_MILLIS = TimeUnit.SECONDS.toMillis(10);
 
-    static CompactorConfig defaultCompactorConfig() {
-        return ImmutableCompactorConfig.builder().inSafeHours(true).build();
+    @Value.Default
+    default boolean enableCompaction() {
+        return false;
+    }
+
+    @Value.Default
+    default boolean inMaintenanceHours() {
+        return false;
+    }
+
+    @Value.Default
+    default long compactConnectionTimeoutMillis() {
+        return DEFAULT_COMPACT_CONNECTION_TIMEOUT_MILLIS;
+    }
+
+    @Value.Default
+    default long compactPauseOnFailureMillis() {
+        return DEFAULT_COMPACT_PAUSE_ON_FAILURE_MILLIS;
+    }
+
+    @Value.Default
+    default long compactPauseMillis() {
+        return DEFAULT_COMPACT_PAUSE_MILLIS;
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
@@ -22,34 +22,40 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface CompactorConfig {
-    long DEFAULT_COMPACT_CONNECTION_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(10);
     long DEFAULT_COMPACT_PAUSE_ON_FAILURE_MILLIS = TimeUnit.SECONDS.toMillis(1800);
     long DEFAULT_COMPACT_PAUSE_MILLIS = TimeUnit.SECONDS.toMillis(10);
 
     /**
-     * Indicates whether 
-     * @return
+     * Indicates whether background compaction should run at all.
      */
     @Value.Default
     default boolean enableCompaction() {
         return false;
     }
 
+    /**
+     * Indicates whether the background compactor is configured to run in maintenance mode.
+     *
+     * Compactors that are running in maintenance mode may perform more aggressive operations that could have
+     * significant impacts on other queries to the underlying key-value service (such as blocking, un-cancelable
+     * calls that acquire a table lock).
+     */
     @Value.Default
-    default boolean inMaintenanceHours() {
+    default boolean inMaintenanceMode() {
         return false;
     }
 
-    @Value.Default
-    default long compactConnectionTimeoutMillis() {
-        return DEFAULT_COMPACT_CONNECTION_TIMEOUT_MILLIS;
-    }
-
+    /**
+     * Indicates the time interval to wait after a failed compaction before trying again.
+     */
     @Value.Default
     default long compactPauseOnFailureMillis() {
         return DEFAULT_COMPACT_PAUSE_ON_FAILURE_MILLIS;
     }
 
+    /**
+     * Indicates the time interval to wait after a successful compaction before trying again (e.g. on a new table).
+     */
     @Value.Default
     default long compactPauseMillis() {
         return DEFAULT_COMPACT_PAUSE_MILLIS;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactorConfig.java
@@ -20,6 +20,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.immutables.value.Value;
 
+import com.google.common.base.Preconditions;
+
 @Value.Immutable
 public interface CompactorConfig {
     long DEFAULT_COMPACT_PAUSE_ON_FAILURE_MILLIS = TimeUnit.SECONDS.toMillis(1800);
@@ -59,5 +61,13 @@ public interface CompactorConfig {
     @Value.Default
     default long compactPauseMillis() {
         return DEFAULT_COMPACT_PAUSE_MILLIS;
+    }
+
+    @Value.Check
+    default void checkIntervalsNonnegative() {
+        Preconditions.checkState(compactPauseOnFailureMillis() >= 0,
+                "Compact pause-on-failure interval must be greater than 0 but found %s", compactPauseOnFailureMillis());
+        Preconditions.checkState(compactPauseMillis() >= 0,
+                "Compact pause interval must be greater than 0 but found %s", compactPauseMillis());
     }
 }


### PR DESCRIPTION
**Goals (and why)**:
- Avoid a regression and maintain configurability of compaction parameters

**Implementation Description (bullets)**:
- Expose a way to pass config parameters on sleeps to the background compactor

**Concerns (what feedback would you like?)**:
- There is some janky logic to handle the `NOTHING_TO_COMPACT` case. Does that make sense?

**Where should we start reviewing?**: BackgroundCompactor.java

**Priority (whenever / two weeks / yesterday)**: next 2 days please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3053)
<!-- Reviewable:end -->
