### PR TITLE
Fix sweep metrics to be updated by iteration results instead of cumulative results

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SpecificTableSweeper.java
@@ -177,9 +177,9 @@ public class SpecificTableSweeper {
     }
 
     private void processSweepResults(TableToSweep tableToSweep, SweepResults currentIteration) {
-        SweepResults cumulativeResults = getCumulativeSweepResults(tableToSweep, currentIteration);
+        updateMetricsOneIteration(currentIteration, tableToSweep.getTableRef());
 
-        updateMetricsOneIteration(cumulativeResults, tableToSweep.getTableRef());
+        SweepResults cumulativeResults = getCumulativeSweepResults(tableToSweep, currentIteration);
 
         if (currentIteration.getNextStartRow().isPresent()) {
             saveIntermediateSweepResults(tableToSweep, cumulativeResults);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweeperServiceImpl.java
@@ -124,8 +124,8 @@ public final class SweeperServiceImpl implements SweeperService {
                     cumulativeResults.getNextStartRow().get(),
                     sweepBatchConfig);
 
+            specificTableSweeper.updateMetricsOneIteration(results, tableRef);
             cumulativeResults = cumulativeResults.accumulateWith(results);
-            specificTableSweeper.updateMetricsOneIteration(cumulativeResults, tableRef);
         }
 
         return cumulativeResults;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
@@ -202,7 +202,7 @@ public class BackgroundSweeperFastTest extends SweeperTestSetup {
     }
 
     @Test
-    public void testPerIterationMetricsAccumulateResults() {
+    public void testMetricsUseIntermediateResultsPerIteration() {
         setProgress(ImmutableSweepProgress.builder()
                         .tableRef(TABLE_REF)
                         .staleValuesDeleted(3)

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/BackgroundSweeperFastTest.java
@@ -221,17 +221,10 @@ public class BackgroundSweeperFastTest extends SweeperTestSetup {
                 .timeInMillis(20L)
                 .timeSweepStarted(50L)
                 .build();
-        SweepResults fullResults = ImmutableSweepResults.builder()
-                .staleValuesDeleted(5)
-                .cellTsPairsExamined(21)
-                .minSweptTimestamp(4567L)
-                .timeInMillis(30L)
-                .timeSweepStarted(20L)
-                .build();
 
         setupTaskRunner(intermediateResults);
         backgroundSweeper.runOnce();
-        Mockito.verify(sweepMetricsManager).updateMetrics(fullResults, TABLE_REF);
+        Mockito.verify(sweepMetricsManager).updateMetrics(intermediateResults, TABLE_REF);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,12 @@ develop
     *    - Type
          - Change
 
+    *    - |changed| |metrics|
+         - Sweep metrics are now updated to the result value of the last run iteration of sweep instead of the cumulative values for the run of sweep on the table.
+           This has been done in order to improve the granularity of the metrics, since cumulative results can be several orders of magnitude larger, thus obfuscating the delta.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3054>`__)
+
+
     *    - |new|
          - Added a new parameter ``addressTranslation`` to ``CassandraKeyValueServiceConfig``.
            This parameter is a static map specifying how internal Cassandra endpoints should be translated to InetSocketAddresses.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,7 +53,7 @@ develop
     *    - |changed| |metrics|
          - Sweep metrics are now updated to the result value of the last run iteration of sweep instead of the cumulative values for the run of sweep on the table.
            This has been done in order to improve the granularity of the metrics, since cumulative results can be several orders of magnitude larger, thus obfuscating the delta.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3054>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3055>`__)
 
 
     *    - |new|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,7 +50,7 @@ develop
     *    - Type
          - Change
 
-    *    - |changed| |metrics|
+    *    - |improved| |metrics|
          - Sweep metrics are now updated to the result value of the last run iteration of sweep instead of the cumulative values for the run of sweep on the table.
            This has been done in order to improve the granularity of the metrics, since cumulative results can be several orders of magnitude larger, thus obfuscating the delta.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3055>`__)


### PR DESCRIPTION
**Goals (and why)**:
Part one of https://github.com/palantir/atlasdb/issues/3051. Since the cumulative results can be orders of magnitude larger, the delta is hard to see. Also, makes the per batch delete metrics work as intended.

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3055)
<!-- Reviewable:end -->
