### PR TITLE
Go/leader runtime config

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderRuntimeConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderRuntimeConfig.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonDeserialize(as = ImmutableLeaderRuntimeConfig.class)
-@JsonSerialize(as = ImmutableLeaderConfig.class)
+@JsonSerialize(as = ImmutableLeaderRuntimeConfig.class)
 @Value.Immutable
 public abstract class LeaderRuntimeConfig {
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderRuntimeConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderRuntimeConfig.java
@@ -18,11 +18,6 @@ package com.palantir.atlasdb.config;
 
 import org.immutables.value.Value;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
-@JsonDeserialize(as = ImmutableLeaderRuntimeConfig.class)
-@JsonSerialize(as = ImmutableLeaderRuntimeConfig.class)
 @Value.Immutable
 public abstract class LeaderRuntimeConfig {
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderRuntimeConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderRuntimeConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.config;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonDeserialize(as = ImmutableLeaderRuntimeConfig.class)
+@JsonSerialize(as = ImmutableLeaderConfig.class)
+@Value.Immutable
+public abstract class LeaderRuntimeConfig {
+
+    @Value.Default
+    public boolean logOnlyOnQuorumFailure() { return true; }
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderRuntimeConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/config/LeaderRuntimeConfig.java
@@ -27,5 +27,5 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public abstract class LeaderRuntimeConfig {
 
     @Value.Default
-    public boolean logOnlyOnQuorumFailure() { return true; }
+    public boolean onlyLogOnQuorumFailure() { return true; }
 }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -161,7 +161,7 @@ public final class Leaders {
                 .randomWaitBeforeProposingLeadershipMs(config.randomWaitBeforeProposingLeadershipMs())
                 .leaderPingResponseWaitMs(config.leaderPingResponseWaitMs())
                 .eventRecorder(leadershipEventRecorder)
-                .onlyLogOnQuorumFailure(JavaSuppliers.compose(LeaderRuntimeConfig::logOnlyOnQuorumFailure, runtime))
+                .onlyLogOnQuorumFailure(JavaSuppliers.compose(LeaderRuntimeConfig::onlyLogOnQuorumFailure, runtime))
                 .build();
 
         LeaderElectionService leaderElectionService = AtlasDbMetrics.instrument(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import javax.net.ssl.SSLSocketFactory;
 
@@ -36,10 +37,12 @@ import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.config.LeaderConfig;
+import com.palantir.atlasdb.config.LeaderRuntimeConfig;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
 import com.palantir.atlasdb.http.UserAgents;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
+import com.palantir.atlasdb.util.JavaSuppliers;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.leader.LeaderElectionService;
 import com.palantir.leader.PaxosLeaderElectionService;
@@ -62,17 +65,19 @@ public final class Leaders {
      * Creates a LeaderElectionService using the supplied configuration and
      * registers appropriate endpoints for that service.
      */
-    public static LeaderElectionService create(Consumer<Object> env, LeaderConfig config) {
-        return create(env, config, UserAgents.DEFAULT_USER_AGENT);
+    public static LeaderElectionService create(
+            Consumer<Object> env, LeaderConfig config, Supplier<LeaderRuntimeConfig> runtime) {
+        return create(env, config, runtime, UserAgents.DEFAULT_USER_AGENT);
     }
 
-    public static LeaderElectionService create(Consumer<Object> env, LeaderConfig config, String userAgent) {
-        return createAndRegisterLocalServices(env, config, userAgent).leaderElectionService();
+    public static LeaderElectionService create(
+            Consumer<Object> env, LeaderConfig config, Supplier<LeaderRuntimeConfig> runtime, String userAgent) {
+        return createAndRegisterLocalServices(env, config, runtime, userAgent).leaderElectionService();
     }
 
     public static LocalPaxosServices createAndRegisterLocalServices(
-            Consumer<Object> env, LeaderConfig config, String userAgent) {
-        LocalPaxosServices localPaxosServices = createInstrumentedLocalServices(config, userAgent);
+            Consumer<Object> env, LeaderConfig config, Supplier<LeaderRuntimeConfig> runtime, String userAgent) {
+        LocalPaxosServices localPaxosServices = createInstrumentedLocalServices(config, runtime, userAgent);
 
         env.accept(localPaxosServices.ourAcceptor());
         env.accept(localPaxosServices.ourLearner());
@@ -81,7 +86,8 @@ public final class Leaders {
         return localPaxosServices;
     }
 
-    public static LocalPaxosServices createInstrumentedLocalServices(LeaderConfig config, String userAgent) {
+    public static LocalPaxosServices createInstrumentedLocalServices(
+            LeaderConfig config, Supplier<LeaderRuntimeConfig> runtime, String userAgent) {
         Set<String> remoteLeaderUris = Sets.newHashSet(config.leaders());
         remoteLeaderUris.remove(config.localServer());
 
@@ -90,11 +96,12 @@ public final class Leaders {
                 .remoteAcceptorUris(remoteLeaderUris)
                 .remoteLearnerUris(remoteLeaderUris)
                 .build();
-        return createInstrumentedLocalServices(config, remotePaxosServerSpec, userAgent);
+        return createInstrumentedLocalServices(config, runtime, remotePaxosServerSpec, userAgent);
     }
 
     public static LocalPaxosServices createInstrumentedLocalServices(
             LeaderConfig config,
+            Supplier<LeaderRuntimeConfig> runtime,
             RemotePaxosServerSpec remotePaxosServerSpec,
             String userAgent) {
         UUID leaderUuid = UUID.randomUUID();
@@ -154,6 +161,7 @@ public final class Leaders {
                 .randomWaitBeforeProposingLeadershipMs(config.randomWaitBeforeProposingLeadershipMs())
                 .leaderPingResponseWaitMs(config.leaderPingResponseWaitMs())
                 .eventRecorder(leadershipEventRecorder)
+                .onlyLogOnQuorumFailure(JavaSuppliers.compose(LeaderRuntimeConfig::logOnlyOnQuorumFailure, runtime))
                 .build();
 
         LeaderElectionService leaderElectionService = AtlasDbMetrics.instrument(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -49,9 +49,11 @@ import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableAtlasDbConfig;
+import com.palantir.atlasdb.config.ImmutableLeaderRuntimeConfig;
 import com.palantir.atlasdb.config.ImmutableServerListConfig;
 import com.palantir.atlasdb.config.ImmutableTimeLockClientConfig;
 import com.palantir.atlasdb.config.LeaderConfig;
+import com.palantir.atlasdb.config.LeaderRuntimeConfig;
 import com.palantir.atlasdb.config.ServerListConfig;
 import com.palantir.atlasdb.config.ServerListConfigs;
 import com.palantir.atlasdb.config.SweepConfig;
@@ -678,7 +680,12 @@ public abstract class TransactionManagers {
             com.google.common.base.Supplier<TimestampService> time,
             String userAgent) {
         // Create local services, that may or may not end up being registered in an Consumer<Object>.
-        LocalPaxosServices localPaxosServices = Leaders.createAndRegisterLocalServices(env, leaderConfig, userAgent);
+        LeaderRuntimeConfig defaultRuntime = ImmutableLeaderRuntimeConfig.builder().build();
+        LocalPaxosServices localPaxosServices = Leaders.createAndRegisterLocalServices(
+                env,
+                leaderConfig,
+                () -> defaultRuntime,
+                userAgent);
         LeaderElectionService leader = localPaxosServices.leaderElectionService();
         LockService localLock = ServiceCreator.createInstrumentedService(
                 AwaitingLeadershipProxy.newProxyInstance(LockService.class, lock, leader),

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -79,6 +79,10 @@ develop
          - CleanCassLocksStateCommand is now using Atlas namespace if provided.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3035>`__)
 
+    *    - |improved| |logs|
+         - Logging exceptions in the case of quorum is runtime configurable now, using `logOnlyOnQuorumFailure` flag. Previously it was set to true by default.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3057>`__)
+
 =======
 v0.78.0
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -80,7 +80,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3035>`__)
 
     *    - |improved| |logs|
-         - Logging exceptions in the case of quorum is runtime configurable now, using `logOnlyOnQuorumFailure` flag. Previously it was set to true by default.
+         - Logging exceptions in the case of quorum is runtime configurable now, using `only-log-on-quorum-failure` flag, for external timelock services. Previously it was set to true by default.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3057>`__)
 
 =======

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
@@ -18,6 +18,7 @@ package com.palantir.leader;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
@@ -36,6 +37,7 @@ public class PaxosLeaderElectionServiceBuilder {
     private long randomWaitBeforeProposingLeadershipMs;
     private long leaderPingResponseWaitMs;
     private PaxosLeaderElectionEventRecorder eventRecorder = PaxosLeaderElectionEventRecorder.NO_OP;
+    private Supplier<Boolean> onlyLogOnQuorumFailure;
 
     public PaxosLeaderElectionServiceBuilder proposer(PaxosProposer proposer) {
         this.proposer = proposer;
@@ -92,6 +94,11 @@ public class PaxosLeaderElectionServiceBuilder {
         return this;
     }
 
+    public PaxosLeaderElectionServiceBuilder onlyLogOnQuorumFailure(Supplier<Boolean> onlyLogOnQuorumFailure) {
+        this.onlyLogOnQuorumFailure = onlyLogOnQuorumFailure;
+        return this;
+    }
+
     public PaxosLeaderElectionService build() {
         return new PaxosLeaderElectionService(
                 proposer,
@@ -103,6 +110,7 @@ public class PaxosLeaderElectionServiceBuilder {
                 pingRateMs,
                 randomWaitBeforeProposingLeadershipMs,
                 leaderPingResponseWaitMs,
-                eventRecorder);
+                eventRecorder,
+                onlyLogOnQuorumFailure);
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifierImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifierImpl.java
@@ -20,14 +20,9 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableList;
 
 public class PaxosLatestRoundVerifierImpl implements PaxosLatestRoundVerifier {
-    private static final Logger log = LoggerFactory.getLogger(PaxosLatestRoundVerifierImpl.class);
-
     private final ImmutableList<PaxosAcceptor> acceptors;
     private final int quorumSize;
     private final ExecutorService executor;
@@ -60,12 +55,7 @@ public class PaxosLatestRoundVerifierImpl implements PaxosLatestRoundVerifier {
     }
 
     private boolean acceptorAgreesIsLatestRound(PaxosAcceptor acceptor, long round) {
-        try {
-            return round >= acceptor.getLatestSequencePreparedOrAccepted();
-        } catch (Exception e) {
-            log.info("latest sequence retrieval failed", e);
-            throw e;
-        }
+        return round >= acceptor.getLatestSequencePreparedOrAccepted();
     }
 
     private PaxosQuorumStatus determineQuorumStatus(List<PaxosResponse> responses) {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifierImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifierImpl.java
@@ -18,6 +18,7 @@ package com.palantir.paxos;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,11 +31,15 @@ public class PaxosLatestRoundVerifierImpl implements PaxosLatestRoundVerifier {
     private final ImmutableList<PaxosAcceptor> acceptors;
     private final int quorumSize;
     private final ExecutorService executor;
+    private final Supplier<Boolean> onlyLogOnQuorumFailure;
 
-    public PaxosLatestRoundVerifierImpl(List<PaxosAcceptor> acceptors, int quorumSize, ExecutorService executor) {
+    public PaxosLatestRoundVerifierImpl(
+            List<PaxosAcceptor> acceptors, int quorumSize,
+            ExecutorService executor, Supplier<Boolean> onlyLogOnQuorumFailure) {
         this.acceptors = ImmutableList.copyOf(acceptors);
         this.quorumSize = quorumSize;
         this.executor = executor;
+        this.onlyLogOnQuorumFailure = onlyLogOnQuorumFailure;
     }
 
     @Override
@@ -51,7 +56,7 @@ public class PaxosLatestRoundVerifierImpl implements PaxosLatestRoundVerifier {
                 quorumSize,
                 executor,
                 PaxosQuorumChecker.DEFAULT_REMOTE_REQUESTS_TIMEOUT_IN_SECONDS,
-                true);
+                onlyLogOnQuorumFailure.get());
     }
 
     private boolean acceptorAgreesIsLatestRound(PaxosAcceptor acceptor, long round) {

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderElectionServiceTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderElectionServiceTest.java
@@ -44,6 +44,7 @@ public class PaxosLeaderElectionServiceTest {
                 .randomWaitBeforeProposingLeadershipMs(0L)
                 .leaderPingResponseWaitMs(0L)
                 .eventRecorder(mock(PaxosLeadershipEventRecorder.class))
+                .onlyLogOnQuorumFailure(() -> true)
                 .build();
 
         assertThat(service.getPotentialLeaders()).containsExactlyInAnyOrder(other, service);

--- a/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/PaxosLeaderEventsTest.java
@@ -46,6 +46,7 @@ public class PaxosLeaderEventsTest {
             .randomWaitBeforeProposingLeadershipMs(0L)
             .leaderPingResponseWaitMs(0L)
             .eventRecorder(recorder)
+            .onlyLogOnQuorumFailure(() -> true)
             .build();
 
     @Test

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosConsensusTestUtils.java
@@ -91,6 +91,7 @@ public final class PaxosConsensusTestUtils {
                     .pingRateMs(0L)
                     .randomWaitBeforeProposingLeadershipMs(0L)
                     .leaderPingResponseWaitMs(0L)
+                    .onlyLogOnQuorumFailure(() -> true)
                     .build();
             leaders.add(SimulatingFailingServerProxy.newProxyInstance(
                     LeaderElectionService.class,

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosLatestRoundVerifierTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosLatestRoundVerifierTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 
 import org.junit.Test;
 
@@ -43,8 +44,10 @@ public class PaxosLatestRoundVerifierTest {
             acceptor2,
             acceptor3);
 
+    private final Supplier<Boolean> onlyLogOnQuorumFailure = () -> false;
+
     private final PaxosLatestRoundVerifierImpl verifier = new PaxosLatestRoundVerifierImpl(acceptors, 2,
-            Executors.newCachedThreadPool());
+            Executors.newCachedThreadPool(), onlyLogOnQuorumFailure);
 
     @Test
     public void hasQuorumIfAllNodesAgree() {

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
@@ -33,7 +33,12 @@ public interface PaxosRuntimeConfiguration {
         return 5000L;
     }
 
-    @Value.Check
+    @JsonProperty("only-log-on-quorum-failure")
+    @Value.Default
+    default boolean onlyLogOnQuorumFailure() {
+        return true;
+    }
+
     default void check() {
         Preconditions.checkArgument(pingRateMs() > 0,
                 "Ping rate must be positive; found '%s'.", pingRateMs());

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/PaxosRuntimeConfiguration.java
@@ -39,6 +39,7 @@ public interface PaxosRuntimeConfiguration {
         return true;
     }
 
+    @Value.Check
     default void check() {
         Preconditions.checkArgument(pingRateMs() > 0,
                 "Ping rate must be positive; found '%s'.", pingRateMs());

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosLeadershipCreator.java
@@ -108,7 +108,7 @@ public class PaxosLeadershipCreator {
 
     private Function<PaxosRuntimeConfiguration, LeaderRuntimeConfig> getLeaderRuntimeConfig =
             runtime -> ImmutableLeaderRuntimeConfig.builder()
-                    .logOnlyOnQuorumFailure(runtime.onlyLogOnQuorumFailure())
+                    .onlyLogOnQuorumFailure(runtime.onlyLogOnQuorumFailure())
                     .build();
 
     public Supplier<LeaderPingHealthCheck> getHealthCheck() {


### PR DESCRIPTION
**Goals (and why)**:
Making `logOnlyOnQuorumFailure` runtime configurable
**Implementation Description (bullets)**:
Created `LeaderRuntimeConfig` which contains `logOnlyOnQuorumFailure`; passed to PaxosLeaderElectionService in a supplier.
**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`PaxosLeaderElectionService`
**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3057)
<!-- Reviewable:end -->
