### PR TITLE
Fix/exception getting host for token

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.thrift.TokenRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Iterables;
@@ -130,6 +131,11 @@ public class CassandraService implements AutoCloseable {
             // return the set of servers we knew about last time we successfully constructed the tokenMap
             return tokenMap.asMapOfRanges().values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
         }
+    }
+
+    @VisibleForTesting
+    protected void setTokenMap(RangeMap<LightweightOppToken, List<InetSocketAddress>> map) {
+        this.tokenMap = map;
     }
 
     private List<TokenRange> getTokenRanges() throws Exception {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.thrift.TokenRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Iterables;
@@ -103,7 +104,7 @@ public class CassandraService implements AutoCloseable {
             } else { // normal case, large cluster with many vnodes
                 for (TokenRange tokenRange : tokenRanges) {
                     List<InetSocketAddress> hosts = tokenRange.getEndpoints().stream()
-                            .map(host -> getAddressForHostThrowUnchecked(host)).collect(Collectors.toList());
+                            .map(this::getAddressForHostThrowUnchecked).collect(Collectors.toList());
 
                     servers.addAll(hosts);
 
@@ -144,7 +145,8 @@ public class CassandraService implements AutoCloseable {
         }
     }
 
-    public InetSocketAddress getAddressForHost(String host) throws UnknownHostException {
+    @VisibleForTesting
+    InetSocketAddress getAddressForHost(String host) throws UnknownHostException {
         if (config.addressTranslation().containsKey(host)) {
             return config.addressTranslation().get(host);
         }
@@ -168,7 +170,7 @@ public class CassandraService implements AutoCloseable {
         }
     }
 
-    public List<InetSocketAddress> getHostsFor(byte[] key) {
+    private List<InetSocketAddress> getHostsFor(byte[] key) {
         return tokenMap.get(new LightweightOppToken(key));
     }
 
@@ -200,7 +202,7 @@ public class CassandraService implements AutoCloseable {
                 () -> new IllegalStateException("No hosts available."));
     }
 
-    public String getRingViewDescription() {
+    private String getRingViewDescription() {
         return CassandraLogHelper.tokenMap(tokenMap).toString();
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -34,7 +34,6 @@ import org.apache.cassandra.thrift.TokenRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Iterables;
@@ -131,11 +130,6 @@ public class CassandraService implements AutoCloseable {
             // return the set of servers we knew about last time we successfully constructed the tokenMap
             return tokenMap.asMapOfRanges().values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
         }
-    }
-
-    @VisibleForTesting
-    protected void setTokenMap(RangeMap<LightweightOppToken, List<InetSocketAddress>> map) {
-        this.tokenMap = map;
     }
 
     private List<TokenRange> getTokenRanges() throws Exception {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -26,13 +26,9 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Range;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
-import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.cassandra.Blacklist;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer;
 import com.palantir.atlasdb.qos.FakeQosClient;
@@ -114,23 +110,6 @@ public class CassandraServiceTest {
         Optional<CassandraClientPoolingContainer> container
                 = cassandra.getRandomGoodHostForPredicate(address -> address.equals(HOST_1));
         assertContainerHasHostOne(container);
-    }
-
-    // As of 0.78.0, we can get an exception if the token map somehow gets out of sync with our current view of the pool
-    // This can happen because the token map and current pools variables are NOT updated together, but the programmer
-    // must instead call refreshTokenRanges() after the pools have been updated.
-    // If they do not, and all the hosts for a given token are removed from the pool, we should return a random host.
-    // This matches behaviour in other host-picking methods where we pick a random host if we can't match our predicate.
-    @Test
-    public void shouldNotThrowIfTokenMapDoesNotMatchPool() {
-        CassandraService cassandra = clientPoolWithServersInCurrentPool(ImmutableSet.of(HOST_1, HOST_2));
-
-        cassandra.setTokenMap(ImmutableRangeMap.of(Range.all(), ImmutableList.of(HOST_1)));
-
-        cassandra.removePool(HOST_1);
-
-        InetSocketAddress key = cassandra.getRandomHostForKey(PtBytes.toBytes("key"));
-        assertThat(key, is(HOST_2));
     }
 
     @SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "ConstantConditions"})


### PR DESCRIPTION
**Goals (and why)**: Fix #3041 

**Implementation Description (bullets)**:
- Add hacky test to prove we can get the exception
- Have getRandomHostByActiveConnections return Optional
- Handle the empty case in both places where it's called
- Make the method private, since it was private originally
- Remove the hacky test

**Concerns (what feedback would you like?)**: 
- Should we actually have this hacky test?
- The root issue is that the token map and current pools are not actually updated together. Should we call refreshTokenRanges() each time the pool is updated, in order to avoid breaking the (unwritten) invariant that hosts referenced in the token map are present in the pool?

**Where should we start reviewing?**: Looking at the test would show the case where this exception can happen as the code stands.

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3061)
<!-- Reviewable:end -->
