### PR TITLE
Exclude swept time from SweepResults.equals

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/SweepResults.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/SweepResults.java
@@ -21,6 +21,7 @@ import org.immutables.value.Value;
 
 import com.palantir.atlasdb.encoding.PtBytes;
 
+// Note that this class has an Auxiliary field, and therefore serialization might not work as expected
 @Value.Immutable
 public abstract class SweepResults {
 
@@ -57,6 +58,7 @@ public abstract class SweepResults {
     /**
      * Time in milliseconds when we started sweeping this table.
      */
+    @Value.Auxiliary
     public abstract long getTimeSweepStarted();
 
     public long getTimeElapsedSinceStartedSweeping() {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/SweepResults.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/SweepResults.java
@@ -21,7 +21,6 @@ import org.immutables.value.Value;
 
 import com.palantir.atlasdb.encoding.PtBytes;
 
-// Note that this class has an Auxiliary field, and therefore serialization might not work as expected
 @Value.Immutable
 public abstract class SweepResults {
 

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/SweepResultsTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/SweepResultsTest.java
@@ -112,4 +112,14 @@ public class SweepResultsTest {
                         .timeSweepStarted(1_000L)
                         .build()));
     }
+
+    @Test
+    public void equalsIgnoresTimeSweepStarted() {
+        SweepResults emptySweepResult = SweepResults.createEmptySweepResult(Optional.empty());
+        SweepResults laterEmptySweepResult = SweepResults.builder().from(emptySweepResult)
+                .timeSweepStarted(emptySweepResult.getTimeSweepStarted() + 1)
+                .build();
+
+        Assert.assertThat(emptySweepResult, Matchers.equalTo(laterEmptySweepResult));
+    }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
     }
 
     @Test(timeout = 50000)
-    public void testSweepStrategyNothing() throws InterruptedException {
+    public void testSweepStrategyNothing() {
         createTable(SweepStrategy.NOTHING);
         putIntoDefaultColumn("foo", "bar", 50);
         putUncommitted("foo", "bad", 75);
@@ -80,7 +80,6 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
                 PtBytes.EMPTY_BYTE_ARRAY);
-        Thread.sleep(1);
         assertEquals(SweepResults.createEmptySweepResult(Optional.empty()), results);
         assertEquals(ImmutableSet.of(50L, 75L, 100L, 125L, 150L), getAllTsFromDefaultColumn("foo"));
     }
@@ -226,7 +225,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
     }
 
     @Test(timeout = 50000)
-    public void testSweeperFailsHalfwayThroughOnDeleteTable() throws InterruptedException {
+    public void testSweeperFailsHalfwayThroughOnDeleteTable() {
         createTable(SweepStrategy.CONSERVATIVE);
         putIntoDefaultColumn("foo", "bar", 50);
         putIntoDefaultColumn("foo2", "bang", 75);
@@ -244,7 +243,6 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
                 nextStartRow);
-        Thread.sleep(1);
         assertEquals(SweepResults.createEmptySweepResult(Optional.empty()), results);
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractSweepTaskRunnerTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
     }
 
     @Test(timeout = 50000)
-    public void testSweepStrategyNothing() {
+    public void testSweepStrategyNothing() throws InterruptedException {
         createTable(SweepStrategy.NOTHING);
         putIntoDefaultColumn("foo", "bar", 50);
         putUncommitted("foo", "bad", 75);
@@ -80,6 +80,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
                 PtBytes.EMPTY_BYTE_ARRAY);
+        Thread.sleep(1);
         assertEquals(SweepResults.createEmptySweepResult(Optional.empty()), results);
         assertEquals(ImmutableSet.of(50L, 75L, 100L, 125L, 150L), getAllTsFromDefaultColumn("foo"));
     }
@@ -225,7 +226,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
     }
 
     @Test(timeout = 50000)
-    public void testSweeperFailsHalfwayThroughOnDeleteTable() {
+    public void testSweeperFailsHalfwayThroughOnDeleteTable() throws InterruptedException {
         createTable(SweepStrategy.CONSERVATIVE);
         putIntoDefaultColumn("foo", "bar", 50);
         putIntoDefaultColumn("foo2", "bang", 75);
@@ -243,6 +244,7 @@ public abstract class AbstractSweepTaskRunnerTest extends AbstractSweepTest {
                         .maxCellTsPairsToExamine(DEFAULT_BATCH_SIZE)
                         .build(),
                 nextStartRow);
+        Thread.sleep(1);
         assertEquals(SweepResults.createEmptySweepResult(Optional.empty()), results);
     }
 


### PR DESCRIPTION

**Goals (and why)**: Fixes #3059 

A few tests break because we create a couple of empty results, which
have System.currentTimeMillis as the started time, and then expect them
to equals() each other. Adding Value.Auxiliary excludes this field from
equals().

As a side-effect, the field is also excluded from toString(), but since
this class isn't serialised, we don't mind.

[no release notes]

**Concerns (what feedback would you like?)**: Should we stop using currentTimeMillis in createEmptySweepResults instead?

**Priority (whenever / two weeks / yesterday)**: ASAP, causing tests to flake including external project tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3062)
<!-- Reviewable:end -->
