### PR TITLE
Go/cassandra client pool fix

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -95,7 +95,7 @@ public class CassandraClientPoolIntegrationTest {
     public void testSanitiseReplicationFactorPassesForTheKeyspace() {
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client.rawClient(),
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client,
                         CassandraContainer.KVS_CONFIG);
             } catch (TException e) {
                 fail("currentRf On Keyspace does not Match DesiredRf");
@@ -108,7 +108,7 @@ public class CassandraClientPoolIntegrationTest {
     public void testSanitiseReplicationFactorFailsAfterManipulatingReplicationFactorInConfig() {
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client.rawClient(),
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client,
                         ImmutableCassandraKeyValueServiceConfig.copyOf(
                                 CassandraContainer.KVS_CONFIG).withReplicationFactor(
                                 MODIFIED_REPLICATION_FACTOR));
@@ -125,7 +125,7 @@ public class CassandraClientPoolIntegrationTest {
         changeReplicationFactor(MODIFIED_REPLICATION_FACTOR);
         clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client.rawClient(),
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client,
                         CassandraContainer.KVS_CONFIG);
                 fail("currentRf On Keyspace Matches DesiredRf after manipulating the cassandra keyspace");
             } catch (Exception e) {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -144,13 +144,13 @@ public class CassandraClientPoolIntegrationTest {
 
     private void changeReplicationFactor(int replicationFactor) throws TException {
         clientPool.run((FunctionCheckedException<CassandraClient, Void, TException>) client -> {
-            KsDef originalKsDef = client.rawClient().describe_keyspace(
+            KsDef originalKsDef = client.describe_keyspace(
                     CassandraContainer.KVS_CONFIG.getKeyspaceOrThrow());
             KsDef modifiedKsDef = originalKsDef.deepCopy();
             modifiedKsDef.setStrategy_class(CassandraConstants.NETWORK_STRATEGY);
             modifiedKsDef.setStrategy_options(ImmutableMap.of("dc1", Integer.toString(replicationFactor)));
             modifiedKsDef.setCf_defs(ImmutableList.of());
-            client.rawClient().system_update_keyspace(modifiedKsDef);
+            client.system_update_keyspace(modifiedKsDef);
             return null;
         });
     }
@@ -168,5 +168,5 @@ public class CassandraClientPoolIntegrationTest {
     }
 
     private FunctionCheckedException<CassandraClient, List<TokenRange>, Exception> describeRing =
-            client -> client.rawClient().describe_ring("atlasdb");
+            client -> client.describe_ring("atlasdb");
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -206,7 +206,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
 
     private void assertThatGcGraceSecondsIs(CassandraKeyValueService kvs, int gcGraceSeconds) throws TException {
         List<CfDef> knownCfs = kvs.getClientPool().runWithRetry(client ->
-                client.rawClient().describe_keyspace("atlasdb").getCf_defs());
+                client.describe_keyspace("atlasdb").getCf_defs());
         CfDef clusterSideCf = Iterables.getOnlyElement(knownCfs.stream()
                 .filter(cf -> cf.getName().equals(getInternalTestTableName()))
                 .collect(Collectors.toList()));
@@ -230,7 +230,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         kvs.createTable(testTable, tableMetadata);
 
         List<CfDef> knownCfs = kvs.getClientPool().runWithRetry(client ->
-                client.rawClient().describe_keyspace("atlasdb").getCf_defs());
+                client.describe_keyspace("atlasdb").getCf_defs());
         CfDef clusterSideCf = Iterables.getOnlyElement(knownCfs.stream()
                 .filter(cf -> cf.getName().equals(getInternalTestTableName()))
                 .collect(Collectors.toList()));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -120,4 +120,8 @@ public interface CassandraClient {
 
     Map<String, List<String>> describe_schema_versions() throws InvalidRequestException, TException;
 
+    String system_add_keyspace(KsDef ks_def) throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    List<KsDef> describe_keyspaces() throws InvalidRequestException, TException;
+
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -46,6 +46,8 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 @SuppressWarnings({"all"}) // thrift variable names.
 public interface CassandraClient {
+    boolean isValid();
+
     Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName,
             TableReference tableRef,
             List<ByteBuffer> keys,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -47,8 +47,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 @SuppressWarnings({"all"}) // thrift variable names.
 public interface CassandraClient {
-    Cassandra.Client rawClient();
-
     Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName,
             TableReference tableRef,
             List<ByteBuffer> keys,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -46,6 +46,12 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 
 @SuppressWarnings({"all"}) // thrift variable names.
 public interface CassandraClient {
+    /**
+     * Checks if the client has a valid connection to Cassandra cluster. Can be used by a client pool
+     * to eliminate clients in bad state.
+     *
+     * @return true if client is in good state.
+     */
     boolean isValid();
 
     Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName,
@@ -91,36 +97,43 @@ public interface CassandraClient {
 
     TProtocol getInputProtocol();
 
-    KsDef describe_keyspace(String keyspace)
-            throws NotFoundException, InvalidRequestException, TException;
-
-    String system_drop_column_family(String column_family)
-            throws InvalidRequestException, SchemaDisagreementException, TException;
-
-    void truncate(String cfname) throws InvalidRequestException, UnavailableException, TimedOutException, TException;
-
-    String system_add_column_family(CfDef cf_def) throws InvalidRequestException, SchemaDisagreementException, TException;
-
-    String system_update_column_family(CfDef cf_def) throws InvalidRequestException, SchemaDisagreementException, TException;
-
-    String describe_partitioner() throws TException;
-
     List<TokenRange> describe_ring(String keyspace) throws InvalidRequestException, TException;
 
     String describe_version() throws TException;
 
-    String system_update_keyspace(KsDef ks_def) throws InvalidRequestException, SchemaDisagreementException, TException;
+    Map<String, List<String>> describe_schema_versions() throws InvalidRequestException, TException;
 
-    CqlPreparedResult prepare_cql3_query(ByteBuffer query, Compression compression) throws InvalidRequestException, TException;
+    String describe_partitioner() throws TException;
 
-    CqlResult execute_prepared_cql3_query(int intemId, List<ByteBuffer> values, ConsistencyLevel consistency) throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException, TException;
+    KsDef describe_keyspace(String keyspace)
+            throws NotFoundException, InvalidRequestException, TException;
+
+    List<KsDef> describe_keyspaces() throws InvalidRequestException, TException;
+
+    String system_add_keyspace(KsDef ks_def)
+            throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    String system_update_keyspace(KsDef ks_def)
+            throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    String system_add_column_family(CfDef cf_def)
+            throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    String system_update_column_family(CfDef cf_def)
+            throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    String system_drop_column_family(String column_family)
+            throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    CqlPreparedResult prepare_cql3_query(ByteBuffer query, Compression compression)
+            throws InvalidRequestException, TException;
+
+    CqlResult execute_prepared_cql3_query(int intemId, List<ByteBuffer> values, ConsistencyLevel consistency)
+            throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException, TException;
 
     ByteBuffer trace_next_query() throws TException;
 
-    Map<String, List<String>> describe_schema_versions() throws InvalidRequestException, TException;
-
-    String system_add_keyspace(KsDef ks_def) throws InvalidRequestException, SchemaDisagreementException, TException;
-
-    List<KsDef> describe_keyspaces() throws InvalidRequestException, TException;
+    void truncate(String cfname)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException;
 
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -114,7 +114,7 @@ public interface CassandraClient {
 
     CqlPreparedResult prepare_cql3_query(ByteBuffer query, Compression compression) throws InvalidRequestException, TException;
 
-    CqlResult execute_prepared_cql3_query(int intemId, List<ByteBuffer> values, ConsistencyLevel consistency) throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException;
+    CqlResult execute_prepared_cql3_query(int intemId, List<ByteBuffer> values, ConsistencyLevel consistency) throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException, TException;
 
     ByteBuffer trace_next_query() throws TException;
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -22,20 +22,26 @@ import java.util.Map;
 
 import org.apache.cassandra.thrift.CASResult;
 import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlPreparedResult;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
+import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.Mutation;
 import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.SchemaDisagreementException;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.TimedOutException;
+import org.apache.cassandra.thrift.TokenRange;
 import org.apache.cassandra.thrift.UnavailableException;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocol;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
@@ -81,4 +87,37 @@ public interface CassandraClient {
             ConsistencyLevel consistency)
             throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException,
             org.apache.thrift.TException;
+
+    TProtocol getOutputProtocol();
+
+    TProtocol getInputProtocol();
+
+    KsDef describe_keyspace(String keyspace)
+            throws NotFoundException, InvalidRequestException, TException;
+
+    String system_drop_column_family(String column_family)
+            throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    void truncate(String cfname) throws InvalidRequestException, UnavailableException, TimedOutException, TException;
+
+    String system_add_column_family(CfDef cf_def) throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    String system_update_column_family(CfDef cf_def) throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    String describe_partitioner() throws TException;
+
+    List<TokenRange> describe_ring(String keyspace) throws InvalidRequestException, TException;
+
+    String describe_version() throws TException;
+
+    String system_update_keyspace(KsDef ks_def) throws InvalidRequestException, SchemaDisagreementException, TException;
+
+    CqlPreparedResult prepare_cql3_query(ByteBuffer query, Compression compression) throws InvalidRequestException, TException;
+
+    CqlResult execute_prepared_cql3_query(int intemId, List<ByteBuffer> values, ConsistencyLevel consistency) throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException;
+
+    ByteBuffer trace_next_query() throws TException;
+
+    Map<String, List<String>> describe_schema_versions() throws InvalidRequestException, TException;
+
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -187,7 +187,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     @Override
     public boolean validateObject(PooledObject<CassandraClient> client) {
-        return client.getObject().rawClient().getOutputProtocol().getTransport().isOpen();
+        return client.getObject().getOutputProtocol().getTransport().isOpen();
     }
 
     @Override
@@ -197,7 +197,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
 
     @Override
     public void destroyObject(PooledObject<CassandraClient> client) {
-        client.getObject().rawClient().getOutputProtocol().getTransport().close();
+        client.getObject().getOutputProtocol().getTransport().close();
         log.debug("Closed transport for client {} of host {}",
                 UnsafeArg.of("client", client),
                 SafeArg.of("cassandraClient", CassandraLogHelper.host(addr)));

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -84,7 +84,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
     @Override
     public CassandraClient create() throws Exception {
         try {
-            return instrumentClient(getRawClient(addr, config));
+            return instrumentClient(getRawClientWithKeyspace(addr, config));
         } catch (Exception e) {
             String message = String.format("Failed to construct client for %s/%s", addr, config.getKeyspaceOrThrow());
             if (config.usingSsl()) {
@@ -105,10 +105,10 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         return client;
     }
 
-    private static Cassandra.Client getRawClient(InetSocketAddress addr, CassandraKeyValueServiceConfig config)
+    private static Cassandra.Client getRawClientWithKeyspace(InetSocketAddress addr, CassandraKeyValueServiceConfig config)
             throws Exception {
 
-        Client ret = getClientInternal(addr, config);
+        Client ret = getRawClient(addr, config);
         try {
             ret.set_keyspace(config.getKeyspaceOrThrow());
             log.debug("Created new client for {}/{}{}{}",
@@ -124,7 +124,12 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         }
     }
 
-    static Cassandra.Client getClientInternal(InetSocketAddress addr, CassandraKeyValueServiceConfig config)
+    static CassandraClient getClientInternal(InetSocketAddress addr, CassandraKeyValueServiceConfig config)
+            throws TException {
+        return new CassandraClientImpl(getRawClient(addr, config));
+    }
+
+    private static Cassandra.Client getRawClient(InetSocketAddress addr, CassandraKeyValueServiceConfig config)
             throws TException {
         TSocket thriftSocket = new TSocket(addr.getHostString(), addr.getPort(), config.socketTimeoutMillis());
         thriftSocket.open();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -246,7 +246,7 @@ public class CassandraClientImpl implements CassandraClient {
             return supplier.apply();
         } catch (Exception e) {
             isValid = blackListedExceptions.stream()
-                    .anyMatch(b -> e.getClass().isInstance(b));
+                    .anyMatch(b -> b.isInstance(e));
             throw e;
         }
     }
@@ -257,7 +257,7 @@ public class CassandraClientImpl implements CassandraClient {
             supplier.apply();
         } catch (Exception e) {
             isValid = !blackListedExceptions.stream()
-                    .anyMatch(b -> e.getClass().isInstance(b));
+                    .anyMatch(b -> b.isInstance(e));
             throw e;
         }
     }
@@ -267,7 +267,7 @@ public class CassandraClientImpl implements CassandraClient {
             return supplier.get();
         } catch (Exception e) {
             isValid = !blackListedExceptions.stream()
-                    .anyMatch(b -> e.getClass().isInstance(b));
+                    .anyMatch(b -> b.isInstance(e));
             throw e;
         }
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -88,6 +88,17 @@ public class CassandraClientImpl implements CassandraClient {
     }
 
     @Override
+    public String system_add_keyspace(KsDef ks_def)
+            throws InvalidRequestException, SchemaDisagreementException, TException {
+        return client.system_add_keyspace(ks_def);
+    }
+
+    @Override
+    public List<KsDef> describe_keyspaces() throws InvalidRequestException, TException {
+        return client.describe_keyspaces();
+    }
+
+    @Override
     public void batch_mutate(String kvsMethodName,
             Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
             ConsistencyLevel consistency_level)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -58,11 +58,6 @@ public class CassandraClientImpl implements CassandraClient {
     }
 
     @Override
-    public Cassandra.Client rawClient() {
-        return client;
-    }
-
-    @Override
     public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(
             String kvsMethodName,
             TableReference tableRef,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -23,23 +23,28 @@ import java.util.Map;
 
 import org.apache.cassandra.thrift.CASResult;
 import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
 import org.apache.cassandra.thrift.ColumnPath;
 import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlPreparedResult;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
+import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.Mutation;
 import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.SchemaDisagreementException;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.TimedOutException;
+import org.apache.cassandra.thrift.TokenRange;
 import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocol;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
@@ -100,6 +105,88 @@ public class CassandraClientImpl implements CassandraClient {
         columnPath.setColumn(column);
 
         return client.get(key, columnPath, consistency_level);
+    }
+
+    @Override
+    public TProtocol getOutputProtocol() {
+        return client.getOutputProtocol();
+    }
+
+    @Override
+    public TProtocol getInputProtocol() {
+        return client.getInputProtocol();
+    }
+
+    @Override
+    public KsDef describe_keyspace(String keyspace) throws NotFoundException, InvalidRequestException, TException {
+        return client.describe_keyspace(keyspace);
+    }
+
+    @Override
+    public String system_drop_column_family(String column_family)
+            throws InvalidRequestException, SchemaDisagreementException, TException {
+        return client.system_drop_column_family(column_family);
+    }
+
+    @Override
+    public void truncate(String cfname)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        client.truncate(cfname);
+    }
+
+    @Override
+    public String system_add_column_family(CfDef cf_def)
+            throws InvalidRequestException, SchemaDisagreementException, TException {
+        return client.system_add_column_family(cf_def);
+    }
+
+    @Override
+    public String system_update_column_family(CfDef cf_def)
+            throws InvalidRequestException, SchemaDisagreementException, TException {
+        return client.system_update_column_family(cf_def);
+    }
+
+    @Override
+    public String describe_partitioner() throws TException {
+        return client.describe_partitioner();
+    }
+
+    @Override
+    public List<TokenRange> describe_ring(String keyspace) throws InvalidRequestException, TException {
+        return client.describe_ring(keyspace);
+    }
+
+    @Override
+    public String describe_version() throws TException {
+        return client.describe_version();
+    }
+
+    @Override
+    public String system_update_keyspace(KsDef ks_def)
+            throws InvalidRequestException, SchemaDisagreementException, TException {
+        return client.system_update_keyspace(ks_def);
+    }
+
+    @Override
+    public CqlPreparedResult prepare_cql3_query(ByteBuffer query, Compression compression)
+            throws InvalidRequestException, TException {
+        return client.prepare_cql3_query(query, compression);
+    }
+
+    @Override
+    public CqlResult execute_prepared_cql3_query(int intemId, List<ByteBuffer> values, ConsistencyLevel consistency)
+            throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException, TException {
+        return client.execute_prepared_cql3_query(intemId, values, consistency);
+    }
+
+    @Override
+    public ByteBuffer trace_next_query() throws TException {
+        return client.trace_next_query();
+    }
+
+    @Override
+    public Map<String, List<String>> describe_schema_versions() throws InvalidRequestException, TException {
+        return client.describe_schema_versions();
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -20,6 +20,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 import org.apache.cassandra.thrift.CASResult;
 import org.apache.cassandra.thrift.Cassandra;
@@ -45,16 +47,30 @@ import org.apache.cassandra.thrift.TokenRange;
 import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.transport.TTransportException;
 
+import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService;
+import com.palantir.common.base.Throwables;
 
 @SuppressWarnings({"all"}) // thrift variable names.
 public class CassandraClientImpl implements CassandraClient {
     private final Cassandra.Client client;
+    private boolean isValid;
+
+    private static final Set<Class> blackListedExceptions =
+            ImmutableSet.of(TTransportException.class,  TProtocolException.class, NoSuchElementException.class);
 
     public CassandraClientImpl(Cassandra.Client client) {
         this.client = client;
+        this.isValid = true;
+    }
+
+    @Override
+    public boolean isValid() {
+        return this.isValid;
     }
 
     @Override
@@ -67,7 +83,7 @@ public class CassandraClientImpl implements CassandraClient {
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         ColumnParent colFam = getColumnParent(tableRef);
 
-        return client.multiget_slice(keys, colFam, predicate, consistency_level);
+        return executeMethod(() -> client.multiget_slice(keys, colFam, predicate, consistency_level));
     }
 
     @Override
@@ -79,18 +95,18 @@ public class CassandraClientImpl implements CassandraClient {
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         ColumnParent colFam = getColumnParent(tableRef);
 
-        return client.get_range_slices(colFam, predicate, range, consistency_level);
+        return executeMethod(() -> client.get_range_slices(colFam, predicate, range, consistency_level));
     }
 
     @Override
     public String system_add_keyspace(KsDef ks_def)
             throws InvalidRequestException, SchemaDisagreementException, TException {
-        return client.system_add_keyspace(ks_def);
+        return executeMethod(() -> client.system_add_keyspace(ks_def));
     }
 
     @Override
     public List<KsDef> describe_keyspaces() throws InvalidRequestException, TException {
-        return client.describe_keyspaces();
+        return executeMethod(() -> client.describe_keyspaces());
     }
 
     @Override
@@ -98,7 +114,7 @@ public class CassandraClientImpl implements CassandraClient {
             Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
-        client.batch_mutate(mutation_map, consistency_level);
+        executeMethod(() -> client.batch_mutate(mutation_map, consistency_level));
     }
 
     @Override
@@ -110,89 +126,89 @@ public class CassandraClientImpl implements CassandraClient {
         ColumnPath columnPath = new ColumnPath(tableReference.getQualifiedName());
         columnPath.setColumn(column);
 
-        return client.get(key, columnPath, consistency_level);
+        return executeMethod(() -> client.get(key, columnPath, consistency_level));
     }
 
     @Override
     public TProtocol getOutputProtocol() {
-        return client.getOutputProtocol();
+        return executeMethod(() -> client.getOutputProtocol());
     }
 
     @Override
     public TProtocol getInputProtocol() {
-        return client.getInputProtocol();
+        return executeMethod(() -> client.getInputProtocol());
     }
 
     @Override
     public KsDef describe_keyspace(String keyspace) throws NotFoundException, InvalidRequestException, TException {
-        return client.describe_keyspace(keyspace);
+        return executeMethod(() -> client.describe_keyspace(keyspace));
     }
 
     @Override
     public String system_drop_column_family(String column_family)
             throws InvalidRequestException, SchemaDisagreementException, TException {
-        return client.system_drop_column_family(column_family);
+        return executeMethod(() -> client.system_drop_column_family(column_family));
     }
 
     @Override
     public void truncate(String cfname)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
-        client.truncate(cfname);
+        executeMethod(() -> client.truncate(cfname));
     }
 
     @Override
     public String system_add_column_family(CfDef cf_def)
             throws InvalidRequestException, SchemaDisagreementException, TException {
-        return client.system_add_column_family(cf_def);
+        return executeMethod(() -> client.system_add_column_family(cf_def));
     }
 
     @Override
     public String system_update_column_family(CfDef cf_def)
             throws InvalidRequestException, SchemaDisagreementException, TException {
-        return client.system_update_column_family(cf_def);
+        return executeMethod(() -> client.system_update_column_family(cf_def));
     }
 
     @Override
     public String describe_partitioner() throws TException {
-        return client.describe_partitioner();
+        return executeMethod(() -> client.describe_partitioner());
     }
 
     @Override
     public List<TokenRange> describe_ring(String keyspace) throws InvalidRequestException, TException {
-        return client.describe_ring(keyspace);
+        return executeMethod(() -> client.describe_ring(keyspace));
     }
 
     @Override
     public String describe_version() throws TException {
-        return client.describe_version();
+        return executeMethod(() -> client.describe_version());
     }
 
     @Override
     public String system_update_keyspace(KsDef ks_def)
             throws InvalidRequestException, SchemaDisagreementException, TException {
-        return client.system_update_keyspace(ks_def);
+        return executeMethod(() -> client.system_update_keyspace(ks_def));
     }
 
     @Override
     public CqlPreparedResult prepare_cql3_query(ByteBuffer query, Compression compression)
             throws InvalidRequestException, TException {
-        return client.prepare_cql3_query(query, compression);
+        return executeMethod(() -> client.prepare_cql3_query(query, compression));
     }
 
     @Override
     public CqlResult execute_prepared_cql3_query(int intemId, List<ByteBuffer> values, ConsistencyLevel consistency)
             throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException, TException {
-        return client.execute_prepared_cql3_query(intemId, values, consistency);
+        return executeMethod(() -> client.execute_prepared_cql3_query(intemId, values, consistency));
     }
 
     @Override
     public ByteBuffer trace_next_query() throws TException {
-        return client.trace_next_query();
+        return executeMethod(() -> client.trace_next_query());
     }
 
     @Override
     public Map<String, List<String>> describe_schema_versions() throws InvalidRequestException, TException {
-        return client.describe_schema_versions();
+        return executeMethod(() -> client.describe_schema_versions());
     }
 
     @Override
@@ -205,8 +221,8 @@ public class CassandraClientImpl implements CassandraClient {
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {
         String internalTableName = AbstractKeyValueService.internalTableName(tableReference);
 
-        return client.cas(key, internalTableName, expected, updates, serial_consistency_level,
-                commit_consistency_level);
+        return executeMethod(() -> client.cas(key, internalTableName, expected, updates, serial_consistency_level,
+                commit_consistency_level));
     }
 
     @Override
@@ -217,10 +233,40 @@ public class CassandraClientImpl implements CassandraClient {
             TException {
         ByteBuffer queryBytes = ByteBuffer.wrap(cqlQuery.toString().getBytes(StandardCharsets.UTF_8));
 
-        return client.execute_cql3_query(queryBytes, compression, consistency);
+        return executeMethod(() -> client.execute_cql3_query(queryBytes, compression, consistency));
     }
 
     private ColumnParent getColumnParent(TableReference tableRef) {
         return new ColumnParent(AbstractKeyValueService.internalTableName(tableRef));
+    }
+
+    private <T, E extends Throwable> T executeMethod(ThrowingSupplier<T, E> supplier)
+            throws E {
+        try {
+            return supplier.apply();
+        } catch (Exception e) {
+            isValid = blackListedExceptions.stream()
+                    .anyMatch(b -> e.getClass().isInstance(b));
+            throw e;
+        }
+    }
+
+    private <E extends Throwable> void executeMethod(ThrowingVoidSupplier<E> supplier)
+            throws E {
+        try {
+            supplier.apply();
+        } catch (Exception e) {
+            isValid = blackListedExceptions.stream()
+                    .anyMatch(b -> e.getClass().isInstance(b));
+            throw Throwables.rewrapAndThrowUncheckedException(e);
+        }
+    }
+
+    private interface ThrowingVoidSupplier<E extends Throwable> {
+        void apply() throws E;
+    }
+
+    private interface ThrowingSupplier<T, E extends Throwable> {
+        T apply() throws E;
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -440,7 +440,7 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
     private void sanityCheckRingConsistency() {
         Multimap<Set<TokenRange>, InetSocketAddress> tokenRangesToHost = HashMultimap.create();
         for (InetSocketAddress host : cassandra.getPools().keySet()) {
-            Cassandra.Client client = null;
+            CassandraClient client = null;
             try {
                 client = CassandraClientFactory.getClientInternal(host, config);
                 try {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.TokenRange;
 import org.slf4j.Logger;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -128,7 +128,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
             resource = clientPool.borrowObject();
             return fn.apply(resource);
         } catch (Exception e) {
-            if (isInvalidClientConnection(e)) {
+            if (isInvalidClientConnection(resource)) {
                 log.warn("Not reusing resource {} due to {} of host {}",
                         UnsafeArg.of("resource", resource),
                         UnsafeArg.of("exception", e.toString()),
@@ -179,10 +179,8 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
         }
     }
 
-    private static boolean isInvalidClientConnection(Exception ex) {
-        return ex instanceof TTransportException
-                || ex instanceof TProtocolException
-                || ex instanceof NoSuchElementException;
+    private static boolean isInvalidClientConnection(CassandraClient client) {
+        return client.isValid();
     }
 
     private void invalidateQuietly(CassandraClient resource) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -19,7 +19,6 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.NoSuchElementException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -27,7 +26,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.apache.thrift.protocol.TProtocolException;
 import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TMemoryInputTransport;
 import org.apache.thrift.transport.TTransport;
@@ -180,7 +178,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
     }
 
     private static boolean isInvalidClientConnection(CassandraClient client) {
-        return client.isValid();
+        return client != null && client.isValid();
     }
 
     private void invalidateQuietly(CassandraClient resource) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -160,7 +160,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
             InetSocketAddress host) {
         // eagerly cleanup idle-connection read buffer to keep a smaller memory footprint
         try {
-            TTransport transport = idleClient.rawClient().getInputProtocol().getTransport();
+            TTransport transport = idleClient.getInputProtocol().getTransport();
             if (transport instanceof TFramedTransport) {
                 Field readBuffer = ((TFramedTransport) transport).getClass().getDeclaredField("readBuffer_");
                 readBuffer.setAccessible(true);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -420,7 +420,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         try {
             dcs = clientPool.runWithRetry(client ->
                     CassandraVerifier.sanityCheckDatacenters(
-                            client.rawClient(),
+                            client,
                             config));
             KsDef ksDef = clientPool.runWithRetry(client ->
                     client.describe_keyspace(config.getKeyspaceOrThrow()));
@@ -1461,7 +1461,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
             CassandraKeyValueServices.waitForSchemaVersions(
                     config,
-                    client.rawClient(),
+                    client,
                     "(a call to createTables, filtered down to create: " + tableNamesToTableMetadata.keySet() + ")",
                     true);
             return null;
@@ -1669,7 +1669,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                     CassandraKeyValueServices.waitForSchemaVersions(
                             config,
-                            client.rawClient(),
+                            client,
                             "(all tables in a call to putMetadataForTables)");
                 }
                 // Done with actual schema mutation, push the metadata
@@ -1941,7 +1941,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     private boolean doesConfigReplicationFactorMatchWithCluster() {
         return clientPool.run(client -> {
             try {
-                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client.rawClient(), config);
+                CassandraVerifier.currentRfOnKeyspaceMatchesDesiredRf(client, config);
                 return true;
             } catch (Exception e) {
                 log.warn("The config and Cassandra cluster do not agree on the replication factor.", e);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -374,7 +374,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             final Collection<CfDef> updatedCfs = Lists.newArrayListWithExpectedSize(metadataForTables.size());
 
             List<CfDef> knownCfs = clientPool.runWithRetry(client ->
-                    client.rawClient().describe_keyspace(config.getKeyspaceOrThrow()).getCf_defs());
+                    client.describe_keyspace(config.getKeyspaceOrThrow()).getCf_defs());
 
             for (CfDef clusterSideCf : knownCfs) {
                 TableReference tableRef = CassandraKeyValueServices.tableReferenceFromCfDef(clusterSideCf);
@@ -423,7 +423,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                             client.rawClient(),
                             config));
             KsDef ksDef = clientPool.runWithRetry(client ->
-                    client.rawClient().describe_keyspace(config.getKeyspaceOrThrow()));
+                    client.describe_keyspace(config.getKeyspaceOrThrow()));
             strategyOptions = Maps.newHashMap(ksDef.getStrategy_options());
 
             if (dcs.size() == 1) {
@@ -1083,7 +1083,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             boolean successful = true;
             try {
                 queryRunner.run(client, tableRef, () -> {
-                    client.rawClient().truncate(internalTableName(tableRef));
+                    client.truncate(internalTableName(tableRef));
                     return true;
                 });
             } catch (TException e) {
@@ -1442,7 +1442,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         clientPool.runWithRetry(client -> {
             for (Entry<TableReference, byte[]> tableEntry : tableNamesToTableMetadata.entrySet()) {
                 try {
-                    client.rawClient().system_add_column_family(ColumnFamilyDefinitions.getCfDef(
+                    client.system_add_column_family(ColumnFamilyDefinitions.getCfDef(
                             config.getKeyspaceOrThrow(),
                             tableEntry.getKey(),
                             config.gcGraceSeconds(),
@@ -1664,7 +1664,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             clientPool.runWithRetry(client -> {
                 if (possiblyNeedToPerformSettingsChanges) {
                     for (CfDef cf : updatedCfs) {
-                        client.rawClient().system_update_column_family(cf);
+                        client.system_update_column_family(cf);
                     }
 
                     CassandraKeyValueServices.waitForSchemaVersions(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -66,7 +66,7 @@ public final class CassandraKeyValueServices {
 
     static void waitForSchemaVersions(
             CassandraKeyValueServiceConfig config,
-            Cassandra.Client client,
+            CassandraClient client,
             String tableName)
             throws TException {
         waitForSchemaVersions(config, client, tableName, false);
@@ -83,7 +83,7 @@ public final class CassandraKeyValueServices {
      */
     static void waitForSchemaVersions(
             CassandraKeyValueServiceConfig config,
-            Cassandra.Client client,
+            CassandraClient client,
             String tableName,
             boolean allowQuorumAgreement)
             throws TException {
@@ -183,7 +183,7 @@ public final class CassandraKeyValueServices {
             clientPool.run(client -> {
                 waitForSchemaVersions(
                         config,
-                        client.rawClient(),
+                        client,
                         "(none, just an initialization check)",
                         true);
                 return null;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableDropper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableDropper.java
@@ -67,7 +67,7 @@ class CassandraTableDropper {
         try {
             clientPool.runWithRetry(
                     (FunctionCheckedException<CassandraClient, Void, Exception>) client -> {
-                        KsDef ks = client.rawClient().describe_keyspace(
+                        KsDef ks = client.describe_keyspace(
                                 config.getKeyspaceOrThrow());
                         Set<TableReference> existingTables = Sets.newHashSet();
 
@@ -78,7 +78,7 @@ class CassandraTableDropper {
                         for (TableReference table : tablesToDrop) {
                             CassandraVerifier.sanityCheckTableName(table);
                             if (existingTables.contains(table)) {
-                                client.rawClient().system_drop_column_family(
+                                client.system_drop_column_family(
                                         CassandraKeyValueServiceImpl.internalTableName(table));
                                 putMetadataWithoutChangingSettings(table,
                                         AtlasDbConstants.EMPTY_TABLE_METADATA);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableDropper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableDropper.java
@@ -89,7 +89,7 @@ class CassandraTableDropper {
                         }
                         CassandraKeyValueServices.waitForSchemaVersions(
                                 config,
-                                client.rawClient(),
+                                client,
                                 "(all tables in a call to dropTables)");
                         return null;
                     });

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTables.java
@@ -74,7 +74,7 @@ class CassandraTables {
 
     private Set<String> getTableNames(CassandraClient client, String keyspace,
             Function<CfDef, String> nameGetter) throws TException {
-        KsDef ks = client.rawClient().describe_keyspace(keyspace);
+        KsDef ks = client.describe_keyspace(keyspace);
 
         return ks.getCf_defs().stream()
                 .map(nameGetter)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraUtils.java
@@ -29,13 +29,13 @@ public final class CassandraUtils {
     public static FunctionCheckedException<CassandraClient, Void, Exception> getValidatePartitioner(
             CassandraKeyValueServiceConfig config) {
         return client -> {
-            CassandraVerifier.validatePartitioner(client.rawClient().describe_partitioner(), config);
+            CassandraVerifier.validatePartitioner(client.describe_partitioner(), config);
             return null;
         };
     }
 
     public static FunctionCheckedException<CassandraClient, List<TokenRange>, Exception> getDescribeRing(
             CassandraKeyValueServiceConfig config) {
-        return client -> client.rawClient().describe_ring(config.getKeyspaceOrThrow());
+        return client -> client.describe_ring(config.getKeyspaceOrThrow());
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.cassandra.thrift.Cassandra;
-import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KsDef;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -57,7 +57,7 @@ public final class CassandraVerifier {
     }
 
     static final FunctionCheckedException<CassandraClient, Void, Exception> healthCheck = client -> {
-        client.rawClient().describe_version();
+        client.describe_version();
         return null;
     };
 
@@ -246,7 +246,7 @@ public final class CassandraVerifier {
     private static void updateExistingKeyspace(CassandraClientPool clientPool, CassandraKeyValueServiceConfig config)
             throws TException {
         clientPool.runWithRetry((FunctionCheckedException<CassandraClient, Void, TException>) client -> {
-            KsDef originalKsDef = client.rawClient().describe_keyspace(config.getKeyspaceOrThrow());
+            KsDef originalKsDef = client.describe_keyspace(config.getKeyspaceOrThrow());
             // there was an existing keyspace
             // check and make sure it's definition is up to date with our config
             KsDef modifiedKsDef = originalKsDef.deepCopy();
@@ -259,7 +259,7 @@ public final class CassandraVerifier {
             if (!modifiedKsDef.equals(originalKsDef)) {
                 // Can't call system_update_keyspace to update replication factor if CfDefs are set
                 modifiedKsDef.setCf_defs(ImmutableList.of());
-                client.rawClient().system_update_keyspace(modifiedKsDef);
+                client.system_update_keyspace(modifiedKsDef);
                 CassandraKeyValueServices.waitForSchemaVersions(
                         config,
                         client.rawClient(),
@@ -341,7 +341,7 @@ public final class CassandraVerifier {
     static final FunctionCheckedException<CassandraClient, Boolean, UnsupportedOperationException>
             underlyingCassandraClusterSupportsCASOperations = client -> {
                 try {
-                    CassandraApiVersion serverVersion = new CassandraApiVersion(client.rawClient().describe_version());
+                    CassandraApiVersion serverVersion = new CassandraApiVersion(client.describe_version());
                     log.debug("Connected cassandra thrift version is: {}",
                             SafeArg.of("cassandraVersion", serverVersion));
                     return serverVersion.supportsCheckAndSet();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -62,7 +62,7 @@ public final class CassandraVerifier {
     };
 
     static Set<String> sanityCheckDatacenters(
-            Cassandra.Client client, CassandraKeyValueServiceConfig config)
+            CassandraClient client, CassandraKeyValueServiceConfig config)
             throws TException {
         Set<String> hosts = Sets.newHashSet();
         Multimap<String, String> dataCenterToRack = HashMultimap.create();
@@ -198,7 +198,7 @@ public final class CassandraVerifier {
     private static boolean keyspaceAlreadyExists(InetSocketAddress host, CassandraKeyValueServiceConfig config)
             throws TException {
         try {
-            Client client = CassandraClientFactory.getClientInternal(host, config);
+            CassandraClient client = CassandraClientFactory.getClientInternal(host, config);
             client.describe_keyspace(config.getKeyspaceOrThrow());
             CassandraKeyValueServices.waitForSchemaVersions(
                     config,
@@ -213,7 +213,7 @@ public final class CassandraVerifier {
 
     private static void attemptToCreateKeyspaceOnHost(InetSocketAddress host, CassandraKeyValueServiceConfig config)
             throws TException {
-        Client client = CassandraClientFactory.getClientInternal(host, config);
+        CassandraClient client = CassandraClientFactory.getClientInternal(host, config);
         KsDef ks = new KsDef(config.getKeyspaceOrThrow(), CassandraConstants.NETWORK_STRATEGY,
                 ImmutableList.of());
         checkAndSetReplicationFactor(
@@ -251,7 +251,7 @@ public final class CassandraVerifier {
             // check and make sure it's definition is up to date with our config
             KsDef modifiedKsDef = originalKsDef.deepCopy();
             checkAndSetReplicationFactor(
-                    client.rawClient(),
+                    client,
                     modifiedKsDef,
                     false,
                     config);
@@ -262,7 +262,7 @@ public final class CassandraVerifier {
                 client.system_update_keyspace(modifiedKsDef);
                 CassandraKeyValueServices.waitForSchemaVersions(
                         config,
-                        client.rawClient(),
+                        client,
                         "(updating the existing keyspace)");
             }
 
@@ -271,7 +271,7 @@ public final class CassandraVerifier {
     }
 
     private static void checkAndSetReplicationFactor(
-            Cassandra.Client client,
+            CassandraClient client,
             KsDef ks,
             boolean freshInstance,
             CassandraKeyValueServiceConfig config) throws TException {
@@ -312,7 +312,7 @@ public final class CassandraVerifier {
         sanityCheckReplicationFactor(ks, config, dcs);
     }
 
-    static void currentRfOnKeyspaceMatchesDesiredRf(Cassandra.Client client, CassandraKeyValueServiceConfig config)
+    static void currentRfOnKeyspaceMatchesDesiredRf(CassandraClient client, CassandraKeyValueServiceConfig config)
             throws TException {
         KsDef ks = client.describe_keyspace(config.getKeyspaceOrThrow());
         Set<String> dcs = sanityCheckDatacenters(client, config);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorImpl.java
@@ -271,7 +271,7 @@ public class CqlExecutorImpl implements CqlExecutor {
         @Override
         public CqlPreparedResult prepare(ByteBuffer query, byte[] rowHintForHostSelection, Compression compression) {
             FunctionCheckedException<CassandraClient, CqlPreparedResult, TException> prepareFunction = client ->
-                    client.rawClient().prepare_cql3_query(query, compression);
+                    client.prepare_cql3_query(query, compression);
 
             try {
                 InetSocketAddress hostForRow = getHostForRow(rowHintForHostSelection);
@@ -287,7 +287,7 @@ public class CqlExecutorImpl implements CqlExecutor {
         @Override
         public CqlResult executePrepared(int queryId, List<ByteBuffer> values) {
             FunctionCheckedException<CassandraClient, CqlResult, TException> cqlFunction = client ->
-                    client.rawClient().execute_prepared_cql3_query(queryId, values, consistency);
+                    client.execute_prepared_cql3_query(queryId, values, consistency);
 
             InetSocketAddress host = hostsPerPreparedQuery.getOrDefault(queryId, getHostForRow(values.get(0).array()));
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.Compression;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
@@ -58,11 +58,6 @@ public class ProfilingCassandraClient implements AutoDelegate_CassandraClient {
     }
 
     @Override
-    public Cassandra.Client rawClient() {
-        return client.rawClient();
-    }
-
-    @Override
     public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName,
             TableReference tableRef,
             List<ByteBuffer> keys,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
@@ -45,11 +45,16 @@ import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.logsafe.SafeArg;
 
 @SuppressWarnings({"all"}) // thrift variable names.
-public class ProfilingCassandraClient implements CassandraClient {
+public class ProfilingCassandraClient implements AutoDelegate_CassandraClient {
     private final CassandraClient client;
 
     public ProfilingCassandraClient(CassandraClient client) {
         this.client = client;
+    }
+
+    @Override
+    public CassandraClient delegate() {
+        return this.client;
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -55,7 +55,7 @@ public class SchemaMutationLockTables {
     }
 
     private Set<TableReference> getAllLockTablesInternal(CassandraClient client) throws TException {
-        return client.rawClient().describe_keyspace(config.getKeyspaceOrThrow()).getCf_defs().stream()
+        return client.describe_keyspace(config.getKeyspaceOrThrow()).getCf_defs().stream()
                 .map(CfDef::getName)
                 .filter(IS_LOCK_TABLE)
                 .map(TableReference::createWithEmptyNamespace)
@@ -83,7 +83,7 @@ public class SchemaMutationLockTables {
         CfDef cf = ColumnFamilyDefinitions.getStandardCfDef(
                 config.getKeyspaceOrThrow(),
                 CassandraKeyValueServiceImpl.internalTableName(tableRef));
-        client.rawClient().system_add_column_family(cf);
+        client.system_add_column_family(cf);
         CassandraKeyValueServices.waitForSchemaVersions(
                 config,
                 client.rawClient(),

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLockTables.java
@@ -86,7 +86,7 @@ public class SchemaMutationLockTables {
         client.system_add_column_family(cf);
         CassandraKeyValueServices.waitForSchemaVersions(
                 config,
-                client.rawClient(),
+                client,
                 tableRef.getQualifiedName(),
                 true);
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -43,13 +43,18 @@ import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.tracing.CloseableTrace;
 
 @SuppressWarnings({"all"}) // thrift variable names.
-public class TracingCassandraClient implements CassandraClient {
+public class TracingCassandraClient implements AutoDelegate_CassandraClient {
     private static final String SERVICE_NAME = "cassandra-thrift-client";
 
     private final CassandraClient client;
 
     public TracingCassandraClient(CassandraClient client) {
         this.client = client;
+    }
+
+    @Override
+    public CassandraClient delegate() {
+        return this.client;
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.Compression;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -58,11 +58,6 @@ public class TracingCassandraClient implements AutoDelegate_CassandraClient {
     }
 
     @Override
-    public Cassandra.Client rawClient() {
-        return client.rawClient();
-    }
-
-    @Override
     public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName,
             TableReference tableRef,
             List<ByteBuffer> keys,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingQueryRunner.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingQueryRunner.java
@@ -60,7 +60,7 @@ public class TracingQueryRunner {
     }
 
     public  <V> V trace(Action<V> action, CassandraClient client, Set<TableReference> tableRefs) throws TException {
-        ByteBuffer traceId = client.rawClient().trace_next_query();
+        ByteBuffer traceId = client.trace_next_query();
         Stopwatch stopwatch = Stopwatch.createStarted();
         boolean failed = false;
         try {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.AutoDelegate_CassandraClient;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClient;
 import com.palantir.atlasdb.keyvalue.cassandra.CqlQuery;
 import com.palantir.atlasdb.keyvalue.cassandra.HiddenTables;
@@ -49,7 +50,7 @@ import com.palantir.atlasdb.qos.QosClient;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
 @SuppressWarnings({"all"}) // thrift variable names.
-public class QosCassandraClient implements CassandraClient {
+public class QosCassandraClient implements AutoDelegate_CassandraClient {
 
     private static final Logger log = LoggerFactory.getLogger(CassandraClient.class);
     private static final Function<TableReference, Boolean> ZERO_ESTIMATE_DETERMINING_FUNCTION = tRef ->
@@ -61,6 +62,11 @@ public class QosCassandraClient implements CassandraClient {
     public QosCassandraClient(CassandraClient client, QosClient qosClient) {
         this.client = client;
         this.qosClient = qosClient;
+    }
+
+    @Override
+    public CassandraClient delegate() {
+        return this.client;
     }
 
     @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
@@ -70,11 +70,6 @@ public class QosCassandraClient implements AutoDelegate_CassandraClient {
     }
 
     @Override
-    public Cassandra.Client rawClient() {
-        return client.rawClient();
-    }
-
-    @Override
     public Map<ByteBuffer, List<ColumnOrSuperColumn>> multiget_slice(String kvsMethodName, TableReference tableRef,
             List<ByteBuffer> keys, SlicePredicate predicate, ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.apache.cassandra.thrift.CASResult;
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.Compression;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesTest.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.cassandra.thrift.Cassandra;
 import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesTest.java
@@ -45,7 +45,7 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 public class CassandraKeyValueServicesTest {
     private static CassandraKeyValueServiceConfig config = mock(CassandraKeyValueServiceConfig.class);
     private static CassandraKeyValueServiceConfig waitingConfig = mock(CassandraKeyValueServiceConfig.class);
-    private static Cassandra.Client client = mock(Cassandra.Client.class);
+    private static CassandraClient client = mock(CassandraClient.class);
 
     private static final Set<InetSocketAddress> FIVE_SERVERS = ImmutableSet.of(
             new InetSocketAddress("1", 0),
@@ -144,7 +144,7 @@ public class CassandraKeyValueServicesTest {
 
     @Test
     public void waitWaitsForSchemaVersions() throws TException {
-        Cassandra.Client waitingClient = mock(Cassandra.Client.class);
+        CassandraClient waitingClient = mock(CassandraClient.class);
         when(waitingClient.describe_schema_versions()).thenReturn(
                 ImmutableMap.of(),
                 ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES),

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,10 @@ develop
            An exception is thrown to the service who made the request; this service has the opportunity to log at a higher level if desired.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3069>`__)
 
+    *    - |fixed|
+         - Fixed a bug that causes Cassandra clients to return to the pool even if they have thrown blacklisted exceptions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3063>`__)
+
 
 =======
 v0.79.0


### PR DESCRIPTION
**Goals (and why)**:
Adressing the issue: https://github.com/palantir/atlasdb/issues/2973
**Implementation Description (bullets)**:
`CassandraClient.rawClient()` method is removed, and all the methods used from `rawClient` is wrapped in `CassandraClient`. `CassandraClient` alters the state of `isValid` if a blacklisted exception is thrown by any method calls. 
**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:
`CassandraClient` may be the right place to start.
**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3063)
<!-- Reviewable:end -->
