### PR TITLE
Instrument kvs executor + Increase number of threads for CKVS

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -309,7 +309,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             Optional<CassandraJmxCompactionManager> compactionManager,
             Optional<LeaderConfig> leaderConfig) {
         super(AbstractKeyValueService.createFixedThreadPool("Atlas Cassandra KVS",
-                config.poolSize() * config.servers().size()));
+                config.maxConnectionBurstSize() * config.servers().size()));
         this.log = log;
         this.config = config;
         this.clientPool = clientPool;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -29,6 +29,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -50,6 +52,7 @@ import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.collect.Maps2;
@@ -88,7 +91,10 @@ public abstract class AbstractKeyValueService implements KeyValueService {
         ThreadPoolExecutor executor = PTExecutors.newFixedThreadPool(poolSize,
                 new NamedThreadFactory(threadNamePrefix, false));
         executor.setKeepAliveTime(1, TimeUnit.MINUTES);
-        return executor;
+        return new InstrumentedExecutorService(
+                executor,
+                AtlasDbMetrics.getMetricRegistry(),
+                MetricRegistry.name(AbstractKeyValueService.class, "kvsExecutorService"));
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -94,7 +94,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
         return new InstrumentedExecutorService(
                 executor,
                 AtlasDbMetrics.getMetricRegistry(),
-                MetricRegistry.name(AbstractKeyValueService.class, "kvsExecutorService"));
+                MetricRegistry.name(AbstractKeyValueService.class, "executorService"));
     }
 
     @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -83,6 +83,18 @@ develop
          - Logging exceptions in the case of quorum is runtime configurable now, using `only-log-on-quorum-failure` flag, for external timelock services. Previously it was set to true by default.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3057>`__)
 
+    *    - |improved| |logs|
+         - CassandraKVS's and DbKVS's ``ExecutorService``s are now instrumented.
+           This ExecutorService is responsible for submitting queries to the underlying DB. It being throttled will increase the latency of queries and transactions.
+           The following metrics are available:
+
+              - ``com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService.executorService.submitted``
+              - ``com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService.executorService.running``
+              - ``com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService.executorService.completed``
+              - ``com.palantir.atlasdb.keyvalue.impl.AbstractKeyValueService.executorService.duration``
+
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3064>`__)
+
 =======
 v0.78.0
 =======


### PR DESCRIPTION
**Goals (and why)**: Following up on #2534 and #2637.

**Concerns (what feedback would you like?)**: Should we have `config.maxConnectionBurstSize() * config.servers().size()` all the times? By default, `config.maxConnectionBurstSize() = 100`, so on a 3 Cassandra node cluster we would have 300 threads allocated.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3064)
<!-- Reviewable:end -->
