### PR TITLE
Stream Store Backoff Between Blocks

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractPersistentStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractPersistentStreamStore.java
@@ -201,8 +201,17 @@ public abstract class AbstractPersistentStreamStore extends AbstractGenericStrea
                 storeBlockWithNonNullTransaction(tx, id, blockNumber, bytesToStore);
             }
             blockNumber++;
-            backoffStrategy.accept(blockNumber);
+            if (!streamOperationIsTransactional(tx)) {
+                backoffStrategy.accept(blockNumber);
+            }
         }
+    }
+
+    private boolean streamOperationIsTransactional(@Nullable Transaction tx) {
+        // TODO (jkong): I'm using tx == null as a proxy for whether the entire operation should be done
+        // transactionally or not (null implies nontransactional).
+        // This is not ideal, but was done in the interest of time.
+        return tx != null;
     }
 
     protected void storeBlockWithNonNullTransaction(@Nullable Transaction tx, final long id, final long blockNumber,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractPersistentStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractPersistentStreamStore.java
@@ -205,6 +205,10 @@ public abstract class AbstractPersistentStreamStore extends AbstractGenericStrea
     }
 
     private void backoffBetweenBlocksIfRequired(long blockNumber) {
+        if (persistenceConfiguration.writePauseDurationMillis() == 0) {
+            return;
+        }
+
         if (shouldBackoffBeforeWritingBlockNumber(blockNumber)) {
             try {
                 Thread.sleep(persistenceConfiguration.writePauseDurationMillis());

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StandardPeriodicBackoffStrategy.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StandardPeriodicBackoffStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.stream;
+
+import java.util.function.Supplier;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class StandardPeriodicBackoffStrategy implements StreamStoreBackoffStrategy {
+    private final Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration;
+    private final BackoffMechanism backoff;
+
+    @VisibleForTesting
+    StandardPeriodicBackoffStrategy(Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration,
+            BackoffMechanism backoff) {
+        this.persistenceConfiguration = persistenceConfiguration;
+        this.backoff = backoff;
+    }
+
+    public static StandardPeriodicBackoffStrategy create(
+            Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new StandardPeriodicBackoffStrategy(persistenceConfiguration, Thread::sleep);
+    }
+
+    @Override
+    public void accept(long blockNumber) {
+        if (persistenceConfiguration.get().writePauseDurationMillis() == 0) {
+            return;
+        }
+
+        if (shouldBackoffBeforeWritingBlockNumber(blockNumber)) {
+            try {
+                backoff.backoff(persistenceConfiguration.get().writePauseDurationMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                // Preserving uninterruptibility, which is current behaviour.
+            }
+        }
+    }
+
+    private boolean shouldBackoffBeforeWritingBlockNumber(long blockNumber) {
+        return blockNumber % persistenceConfiguration.get().numBlocksToWriteBeforePause() == 0;
+    }
+
+    interface BackoffMechanism {
+        void backoff(long backoffAmount) throws InterruptedException;
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StandardPeriodicBackoffStrategy.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StandardPeriodicBackoffStrategy.java
@@ -50,11 +50,11 @@ public class StandardPeriodicBackoffStrategy implements StreamStoreBackoffStrate
 
         if (shouldBackoffBeforeWritingBlockNumber(blockNumber)) {
             try {
-                long sweepPauseMillis = persistenceConfiguration.get().writePauseDurationMillis();
+                long writePauseDurationMillis = persistenceConfiguration.get().writePauseDurationMillis();
                 log.info("Invoking backoff for {} ms, because we are writing block {} of a stream",
                         SafeArg.of("blockNumber", blockNumber),
-                        SafeArg.of("sweepPauseMillis", sweepPauseMillis));
-                backoff.backoff(sweepPauseMillis);
+                        SafeArg.of("writePauseDurationMillis", writePauseDurationMillis));
+                backoff.backoff(writePauseDurationMillis);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 // Preserving uninterruptibility, which is current behaviour.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStoreBackoffStrategy.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStoreBackoffStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.stream;
+
+import java.util.function.LongConsumer;
+
+interface StreamStoreBackoffStrategy extends LongConsumer {
+    // marker interface
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStorePersistenceConfiguration.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStorePersistenceConfiguration.java
@@ -29,11 +29,28 @@ public interface StreamStorePersistenceConfiguration {
     StreamStorePersistenceConfiguration DEFAULT_CONFIG = ImmutableStreamStorePersistenceConfiguration.builder()
             .build();
 
+    /**
+     * The number of blocks that a nontransactional storeStream() will store before pausing for
+     * writePauseDurationMillis. For example, if a value of 5 is specified, then storeStream() will
+     * write blocks 0 through 4 (inclusive) of a stream before sleeping; then 5 through 9, etc.
+     *
+     * This parameter is live reloadable. If live reloaded, we guarantee that after the next sleep, storeStream()
+     * will store the new number of blocks to write before pausing. The number of blocks written from the time the
+     * config parameter is reloaded until the next pause is guaranteed to be bounded by the sum of the old and new
+     * numbers of blocks.
+     */
     @Value.Default
     default long numBlocksToWriteBeforePause() {
         return 1;
     }
 
+    /**
+     * The number of milliseconds to pause nontransactional storeStream() operations for, following the
+     * back-pressure mechanism described under numBlocksToWriteBeforePause.
+     *
+     * This parameter is live reloadable. If live reloaded, we guarantee that future pauses will sleep for the new
+     * value in configuration. However, no guarantees are made if the storeStream() call in flight is currently asleep.
+     */
     @Value.Default
     default long writePauseDurationMillis() {
         return 0;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStorePersistenceConfiguration.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStorePersistenceConfiguration.java
@@ -18,8 +18,12 @@ package com.palantir.atlasdb.stream;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 
+@JsonSerialize(as = ImmutableStreamStorePersistenceConfiguration.class)
+@JsonDeserialize(as = ImmutableStreamStorePersistenceConfiguration.class)
 @Value.Immutable
 public interface StreamStorePersistenceConfiguration {
     StreamStorePersistenceConfiguration DEFAULT_CONFIG = ImmutableStreamStorePersistenceConfiguration.builder()

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStorePersistenceConfiguration.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStorePersistenceConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.stream;
+
+import org.immutables.value.Value;
+
+import com.google.common.base.Preconditions;
+
+@Value.Immutable
+public interface StreamStorePersistenceConfiguration {
+    StreamStorePersistenceConfiguration DEFAULT_CONFIG = ImmutableStreamStorePersistenceConfiguration.builder()
+            .build();
+
+    @Value.Default
+    default int numBlocksToWriteBeforePause() {
+        return 1;
+    }
+
+    @Value.Default
+    default long writePauseDurationMillis() {
+        return 0;
+    }
+
+    @Value.Check
+    default void check() {
+        Preconditions.checkState(numBlocksToWriteBeforePause() > 0,
+                "Number of blocks to write before pausing must be positive");
+        Preconditions.checkState(writePauseDurationMillis() >= 0,
+                "Pause duration between batches of writes must be non-negative");
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStorePersistenceConfiguration.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/StreamStorePersistenceConfiguration.java
@@ -30,7 +30,7 @@ public interface StreamStorePersistenceConfiguration {
             .build();
 
     @Value.Default
-    default int numBlocksToWriteBeforePause() {
+    default long numBlocksToWriteBeforePause() {
         return 1;
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -221,12 +221,22 @@ public class StreamStoreRenderer {
 
             private void constructors() {
                 line("private ", StreamStore, "(TransactionManager txManager, ", TableFactory, " tables) {"); {
-                    line("super(txManager);");
+                    line("this(txManager, tables, StreamStoreBlockWriterConfiguration.DEFAULT_CONFIG);");
+                } line("}");
+                line();
+                line("private ", StreamStore, "(TransactionManager txManager, ", TableFactory, " tables, ",
+                        "StreamStoreBlockWriterConfiguration blockWriterConfiguration) {"); {
+                    line("super(txManager, blockWriterConfiguration);");
                     line("this.tables = tables;");
                 } line("}");
                 line();
                 line("public static ", StreamStore, " of(TransactionManager txManager, ", TableFactory, " tables) {"); {
                     line("return new ", StreamStore, "(txManager, tables);");
+                } line("}");
+                line();
+                line("public static ", StreamStore, " of(TransactionManager txManager, ", TableFactory, " tables, ",
+                        " StreamStoreBlockWriterConfiguration blockWriterConfiguration) {"); {
+                    line("return new ", StreamStore, "(txManager, tables, blockWriterConfiguration);");
                 } line("}");
                 line();
                 line("/**");

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
@@ -66,6 +67,7 @@ import com.palantir.atlasdb.stream.BlockGetter;
 import com.palantir.atlasdb.stream.BlockLoader;
 import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
@@ -221,12 +223,12 @@ public class StreamStoreRenderer {
 
             private void constructors() {
                 line("private ", StreamStore, "(TransactionManager txManager, ", TableFactory, " tables) {"); {
-                    line("this(txManager, tables, StreamStoreBlockWriterConfiguration.DEFAULT_CONFIG);");
+                    line("this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);");
                 } line("}");
                 line();
                 line("private ", StreamStore, "(TransactionManager txManager, ", TableFactory, " tables, ",
-                        "StreamStoreBlockWriterConfiguration blockWriterConfiguration) {"); {
-                    line("super(txManager, blockWriterConfiguration);");
+                        "Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {"); {
+                    line("super(txManager, persistenceConfiguration);");
                     line("this.tables = tables;");
                 } line("}");
                 line();
@@ -235,8 +237,8 @@ public class StreamStoreRenderer {
                 } line("}");
                 line();
                 line("public static ", StreamStore, " of(TransactionManager txManager, ", TableFactory, " tables, ",
-                        " StreamStoreBlockWriterConfiguration blockWriterConfiguration) {"); {
-                    line("return new ", StreamStore, "(txManager, tables, blockWriterConfiguration);");
+                        " Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {"); {
+                    line("return new ", StreamStore, "(txManager, tables, persistenceConfiguration);");
                 } line("}");
                 line();
                 line("/**");
@@ -832,5 +834,7 @@ public class StreamStoreRenderer {
         Pair.class,
         Functions.class,
         ByteStreams.class,
+        Supplier.class,
+        StreamStorePersistenceConfiguration.class,
     };
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/stream/StandardPeriodicBackoffStrategyTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/stream/StandardPeriodicBackoffStrategyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.stream;
+
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+public class StandardPeriodicBackoffStrategyTest {
+    private final StandardPeriodicBackoffStrategy.BackoffMechanism backoffMechanism
+            = mock(StandardPeriodicBackoffStrategy.BackoffMechanism.class);
+
+    @Test
+    public void doesNotInvokeBackoffIfCalledWithZeroTime() {
+        StreamStoreBackoffStrategy backoffStrategy = createStaticBackoffStrategy(1, 0);
+        backoffStrategy.accept(1);
+        verifyNoMoreInteractions(backoffMechanism);
+    }
+
+    @Test
+    public void invokesBackoffIfCalledWithNonZeroTime() throws InterruptedException {
+        StreamStoreBackoffStrategy backoffStrategy = createStaticBackoffStrategy(1, 100);
+        backoffStrategy.accept(1);
+        verify(backoffMechanism).backoff(100L);
+    }
+
+    @Test
+    public void invokesBackoffMultipleTimesIfCalledWithNonZeroTime() throws InterruptedException {
+        StreamStoreBackoffStrategy backoffStrategy = createStaticBackoffStrategy(1, 100);
+        backoffStrategy.accept(1);
+        backoffStrategy.accept(2);
+        backoffStrategy.accept(3);
+        backoffStrategy.accept(4);
+        verify(backoffMechanism, times(4)).backoff(100L);
+    }
+
+    @Test
+    public void invokesBackoffOnlyAfterWritingMultipleOfBlocksToWriteBeforePause() throws InterruptedException {
+        StreamStoreBackoffStrategy backoffStrategy = createStaticBackoffStrategy(3, 100);
+        backoffStrategy.accept(1);
+        backoffStrategy.accept(2);
+        verify(backoffMechanism, never()).backoff(anyLong());
+        backoffStrategy.accept(3);
+        verify(backoffMechanism).backoff(100L);
+
+    }
+
+    @Test
+    public void invokesBackoffBasedOnFreshConfigValues() throws InterruptedException {
+        StreamStorePersistenceConfiguration config1 = getStreamStorePersistenceConfiguration(1, 100);
+        StreamStorePersistenceConfiguration config2 = getStreamStorePersistenceConfiguration(2, 200);
+        AtomicReference<StreamStorePersistenceConfiguration> activeConfig = new AtomicReference<>(config1);
+
+        StreamStoreBackoffStrategy backoffStrategy
+                = new StandardPeriodicBackoffStrategy(activeConfig::get, backoffMechanism);
+
+        backoffStrategy.accept(1);
+        verify(backoffMechanism).backoff(100L);
+        backoffStrategy.accept(2);
+        verify(backoffMechanism, times(2)).backoff(100L);
+
+        activeConfig.set(config2);
+        backoffStrategy.accept(3);
+        verify(backoffMechanism, never()).backoff(200L);
+        backoffStrategy.accept(4);
+        verify(backoffMechanism).backoff(200L);
+        verifyNoMoreInteractions(backoffMechanism);
+
+    }
+
+    private StreamStoreBackoffStrategy createStaticBackoffStrategy(
+            long blocksToWriteBeforePause, long pauseDurationMillis) {
+        return new StandardPeriodicBackoffStrategy(
+                () -> getStreamStorePersistenceConfiguration(blocksToWriteBeforePause, pauseDurationMillis),
+                backoffMechanism);
+    }
+
+    private static StreamStorePersistenceConfiguration getStreamStorePersistenceConfiguration(
+            long blocksToWriteBeforePause, long pauseDurationMillis) {
+        return ImmutableStreamStorePersistenceConfiguration.builder()
+                .numBlocksToWriteBeforePause(blocksToWriteBeforePause)
+                .writePauseDurationMillis(pauseDurationMillis)
+                .build();
+    }
+}

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.compact.CompactorConfig;
 import com.palantir.atlasdb.qos.config.QosClientConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 
 @JsonDeserialize(as = ImmutableAtlasDbRuntimeConfig.class)
 @JsonSerialize(as = ImmutableAtlasDbRuntimeConfig.class)
@@ -84,6 +85,11 @@ public abstract class AtlasDbRuntimeConfig {
      * We do not currently support live reloading from a leader block or using embedded services to using TimeLock.
      */
     public abstract Optional<TimeLockRuntimeConfig> timelockRuntime();
+
+    @Value.Default
+    public StreamStorePersistenceConfiguration streamStorePersistence() {
+        return StreamStorePersistenceConfiguration.DEFAULT_CONFIG;
+    }
 
     public static ImmutableAtlasDbRuntimeConfig defaultRuntimeConfig() {
         return ImmutableAtlasDbRuntimeConfig.builder().build();

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
@@ -47,6 +47,11 @@ public class AtlasDbRuntimeConfigDeserializationTest {
                         "https://foo3:9421");
         assertThat(runtimeConfig.timelockRuntime().get().serversList().sslConfiguration()).satisfies(
                 sslConfiguration -> sslConfiguration.ifPresent(this::assertSslConfigDeserializedCorrectly));
+        assertThat(runtimeConfig.streamStorePersistence()).satisfies(
+                persistenceConfig -> {
+                    assertThat(persistenceConfig.numBlocksToWriteBeforePause()).isEqualTo(7);
+                    assertThat(persistenceConfig.writePauseDurationMillis()).isEqualTo(77);
+                });
     }
 
     private void assertSslConfigDeserializedCorrectly(SslConfiguration sslConfiguration) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigTest.java
@@ -16,10 +16,13 @@
 
 package com.palantir.atlasdb.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 
 public class AtlasDbRuntimeConfigTest {
     @Test
@@ -32,5 +35,11 @@ public class AtlasDbRuntimeConfigTest {
     public void configWithoutSweepHasSweepDisabled() throws Exception {
         AtlasDbRuntimeConfig config = AtlasDbRuntimeConfig.withSweepDisabled();
         assertFalse(config.sweep().enabled());
+    }
+
+    @Test
+    public void configWithoutSpecifyingStreamPersistenceConfigHasDefaultConfig() {
+        AtlasDbRuntimeConfig config = AtlasDbRuntimeConfig.defaultRuntimeConfig();
+        assertThat(config.streamStorePersistence()).isEqualTo(StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
     }
 }

--- a/atlasdb-config/src/test/resources/runtime-config-block.yml
+++ b/atlasdb-config/src/test/resources/runtime-config-block.yml
@@ -11,3 +11,7 @@ timelockRuntime:
       trustStorePath: var/security/trustStore.jks
       keyStorePath: var/security/keyStore.jks
       keyStorePassword: 0987654321
+
+streamStorePersistence:
+  numBlocksToWriteBeforePause: 7
+  writePauseDurationMillis: 77

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamStore.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamStore.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
@@ -53,6 +54,7 @@ import com.palantir.atlasdb.stream.BlockGetter;
 import com.palantir.atlasdb.stream.BlockLoader;
 import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -83,12 +85,20 @@ public final class DataStreamStore extends AbstractPersistentStreamStore {
     private final BlobSchemaTableFactory tables;
 
     private DataStreamStore(TransactionManager txManager, BlobSchemaTableFactory tables) {
-        super(txManager);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private DataStreamStore(TransactionManager txManager, BlobSchemaTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, persistenceConfiguration);
         this.tables = tables;
     }
 
     public static DataStreamStore of(TransactionManager txManager, BlobSchemaTableFactory tables) {
         return new DataStreamStore(txManager, tables);
+    }
+
+    public static DataStreamStore of(TransactionManager txManager, BlobSchemaTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new DataStreamStore(txManager, tables, persistenceConfiguration);
     }
 
     /**
@@ -426,6 +436,8 @@ public final class DataStreamStore extends AbstractPersistentStreamStore {
      * {@link Status}
      * {@link StreamCleanedException}
      * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
      * {@link TempFileUtils}
      * {@link Throwables}
      * {@link TimeUnit}

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamStore.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamStore.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
@@ -53,6 +54,7 @@ import com.palantir.atlasdb.stream.BlockGetter;
 import com.palantir.atlasdb.stream.BlockLoader;
 import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -83,12 +85,20 @@ public final class HotspottyDataStreamStore extends AbstractPersistentStreamStor
     private final BlobSchemaTableFactory tables;
 
     private HotspottyDataStreamStore(TransactionManager txManager, BlobSchemaTableFactory tables) {
-        super(txManager);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private HotspottyDataStreamStore(TransactionManager txManager, BlobSchemaTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, persistenceConfiguration);
         this.tables = tables;
     }
 
     public static HotspottyDataStreamStore of(TransactionManager txManager, BlobSchemaTableFactory tables) {
         return new HotspottyDataStreamStore(txManager, tables);
+    }
+
+    public static HotspottyDataStreamStore of(TransactionManager txManager, BlobSchemaTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new HotspottyDataStreamStore(txManager, tables, persistenceConfiguration);
     }
 
     /**
@@ -426,6 +436,8 @@ public final class HotspottyDataStreamStore extends AbstractPersistentStreamStor
      * {@link Status}
      * {@link StreamCleanedException}
      * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
      * {@link TempFileUtils}
      * {@link Throwables}
      * {@link TimeUnit}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,22 @@ develop
            An exception is thrown to the service who made the request; this service has the opportunity to log at a higher level if desired.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3069>`__)
 
+    *    - |new|
+         - AtlasDB now supports runtime configuration of throttling for stream stores when streams are written block by block in a non-transactional fashion.
+           Previously, such streams would be written using a separate transaction for each block, though in cases where data volume is high this may still cause load on the key-value-service Atlas is using.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3073>`__)
+
+    *    - |new|
+         - AtlasDB now schedules KVS compactions on a background thread, as opposed to triggering a compaction after each table was swept.
+           This allows for better control over KVS load arising from compactions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3058>`__)
+
+    *    - |new|
+         - AtlasDB now supports configuration of a maintenance mode for compactions.
+           If compactions are run in maintenance mode, AtlasDB may perform more costly operations which may be able to recover more space.
+           For example, for Oracle KVS, ``SHRINK SPACE`` (which acquires locks on the entire table) will only be run if compactions are carried out in maintenance mode.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3058>`__)
+
 
 =======
 v0.79.0
@@ -96,17 +112,6 @@ v0.79.0
     *    - |fixed|
          - ``clean-cass-locks-state`` command is now using Atlas namespace as Cassandra keyspace if provided.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3035>`__)
-
-    *    - |new|
-         - AtlasDB now schedules KVS compactions on a background thread, as opposed to triggering a compaction after each table was swept.
-           This allows for better control over KVS load arising from compactions.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3058>`__)
-
-    *    - |new|
-         - AtlasDB now supports configuration of a maintenance mode for compactions.
-           If compactions are run in maintenance mode, AtlasDB may perform more costly operations which may be able to recover more space.
-           For example, for Oracle KVS, ``SHRINK SPACE`` (which acquires locks on the entire table) will only be run if compactions are carried out in maintenance mode.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3058>`__)
 
     *    - |improved| |logs|
          - Logging exceptions in the case of quorum is runtime configurable now, using ``only-log-on-quorum-failure`` flag, for external timelock services. Previously it was set to true by default.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,6 +58,8 @@ develop
     *    - |new|
          - AtlasDB now supports runtime configuration of throttling for stream stores when streams are written block by block in a non-transactional fashion.
            Previously, such streams would be written using a separate transaction for each block, though in cases where data volume is high this may still cause load on the key-value-service Atlas is using.
+           Please note that if you wish to use this feature, you will need to regenerate your Atlas schemas and suitably inject the stream persistence configuration into your stream stores.
+           However, if you do not intend to use this feature, no action is required, and your stream stores' behaviour will not be changed.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3073>`__)
 
     *    - |new|

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,7 @@ develop
            Previously, such streams would be written using a separate transaction for each block, though in cases where data volume is high this may still cause load on the key-value-service Atlas is using.
            Please note that if you wish to use this feature, you will need to regenerate your Atlas schemas and suitably inject the stream persistence configuration into your stream stores.
            However, if you do not intend to use this feature, no action is required, and your stream stores' behaviour will not be changed.
+           Note that enabling throttling may make nontransactional ``storeStream`` operations take longer, though the length of constituent transactions should not be affected.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3073>`__)
 
     *    - |new|


### PR DESCRIPTION
**Goals (and why)**:
- Allow a configurable backoff between writing blocks to a stream store
- Allow configuration of the number of blocks to write before triggering the backoff

**Implementation Description (bullets)**:
- Create a `StandardPeriodicBackoffStrategy` that given a number of blocks to write before backoff and a pause interval from live reloadable config, does any necessary backoff for a provided block number.
- Extend AtlasDbRuntimeConfig to include the live reloadable configs mentioned above
- Note that there is a drive by fix to the release notes for 0.79.0 (Oracle compaction should be on develop, not 0.79.0).

**Concerns (what feedback would you like?)**:
- There is a more complicated way of maintaining a tighter bound on the number of blocks written between sleeps in the event of live reloading (keep a counter), but I deemed this unimportant. Does that make sense?
- The intention here was to achieve the change I was looking for without forcing a dev break, though search product / products wanting to make use of this feature will need to regenerate their schemas (see release notes for discussion). Is this the right goal, and does this implementation achieve that?

**Where should we start reviewing?**: StandardPeriodicBackoffStrategy

**Priority (whenever / two weeks / yesterday)**: this week, ideally quickly - we're trying to test this with internal search product.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3073)
<!-- Reviewable:end -->
