### PR TITLE
PaxosLeaderElectionServiceBuilder set default for onlyLogOnQuorumFailure

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,10 @@ develop
            An exception is thrown to the service who made the request; this service has the opportunity to log at a higher level if desired.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3069>`__)
 
+    *    - |fixed|
+         - Fix NPE if PaxosLeaderElectionServiceBuilder's new field onlyLogOnQuorumFailure is never set.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3074>`__)
+
 
 =======
 v0.79.0

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionServiceBuilder.java
@@ -37,7 +37,7 @@ public class PaxosLeaderElectionServiceBuilder {
     private long randomWaitBeforeProposingLeadershipMs;
     private long leaderPingResponseWaitMs;
     private PaxosLeaderElectionEventRecorder eventRecorder = PaxosLeaderElectionEventRecorder.NO_OP;
-    private Supplier<Boolean> onlyLogOnQuorumFailure;
+    private Supplier<Boolean> onlyLogOnQuorumFailure = () -> true;
 
     public PaxosLeaderElectionServiceBuilder proposer(PaxosProposer proposer) {
         this.proposer = proposer;


### PR DESCRIPTION
Prevent NPE for external users already using PaxosLeaderElectionServiceBuilder

**Goals (and why)**:

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3074)
<!-- Reviewable:end -->
