### PR TITLE
Tagged Metrics for TimeLock: Clients and Leadership

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TaggedMetricsInvocationEventHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.tritium.api.functions.BooleanSupplier;
+import com.palantir.tritium.event.AbstractInvocationEventHandler;
+import com.palantir.tritium.event.DefaultInvocationContext;
+import com.palantir.tritium.event.InstrumentationProperties;
+import com.palantir.tritium.event.InvocationContext;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+
+/**
+ * A simplified and yet extended version of Tritium's MetricsInvocationEventHandler. This class supports augmenting
+ * metric data with tags, possibly as a function of the method's invocation context.
+ *
+ * Note that this class does not yet offer support for processing of specific metric groups, unlike
+ * MetricsInvocationEventHandler.
+ */
+public class TaggedMetricsInvocationEventHandler extends AbstractInvocationEventHandler<InvocationContext> {
+
+    private static final Logger logger = LoggerFactory.getLogger(TaggedMetricsInvocationEventHandler.class);
+
+    private final TaggedMetricRegistry taggedMetricRegistry;
+    private final String serviceName;
+
+    private final Function<InvocationContext, Map<String, String>> tagFunction;
+
+    public TaggedMetricsInvocationEventHandler(
+            TaggedMetricRegistry taggedMetricRegistry,
+            String serviceName) {
+        this(taggedMetricRegistry, serviceName, unused -> ImmutableMap.of());
+    }
+
+    public TaggedMetricsInvocationEventHandler(
+            TaggedMetricRegistry taggedMetricRegistry,
+            String serviceName,
+            Function<InvocationContext, Map<String, String>> tagFunction) {
+        super(getEnabledSupplier(serviceName));
+        this.taggedMetricRegistry = checkNotNull(taggedMetricRegistry, "metricRegistry");
+        this.serviceName = checkNotNull(serviceName, "serviceName");
+        this.tagFunction = tagFunction;
+    }
+
+    private static String failuresMetricName() {
+        return "failures";
+    }
+
+    private static BooleanSupplier getEnabledSupplier(final String serviceName) {
+        return InstrumentationProperties.getSystemPropertySupplier(serviceName);
+    }
+
+    @Override
+    public InvocationContext preInvocation(Object instance, Method method, Object[] args) {
+        return DefaultInvocationContext.of(instance, method, args);
+    }
+
+    @Override
+    public void onSuccess(@Nullable InvocationContext context, @Nullable Object result) {
+        if (context == null) {
+            logger.debug("Encountered null metric context likely due to exception in preInvocation");
+            return;
+        }
+
+        long nanos = System.nanoTime() - context.getStartTimeNanos();
+        MetricName finalMetricName = MetricName.builder()
+                .safeName(MetricRegistry.name(serviceName, context.getMethod().getName()))
+                .putAllSafeTags(tagFunction.apply(context))
+                .build();
+        taggedMetricRegistry.timer(finalMetricName)
+                .update(nanos, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void onFailure(@Nullable InvocationContext context, @Nonnull Throwable cause) {
+        markGlobalFailure();
+        if (context == null) {
+            logger.debug("Encountered null metric context likely due to exception in preInvocation: {}",
+                    UnsafeArg.of("exception", cause),
+                    cause);
+            return;
+        }
+
+        String failuresMetricName = MetricRegistry.name(getBaseMetricName(context), failuresMetricName());
+        taggedMetricRegistry.meter(MetricName.builder().safeName(failuresMetricName).build()).mark();
+        taggedMetricRegistry.meter(MetricName.builder().safeName(
+                MetricRegistry.name(failuresMetricName, cause.getClass().getName())).build())
+                .mark();
+
+    }
+
+    private String getBaseMetricName(InvocationContext context) {
+        return MetricRegistry.name(serviceName, context.getMethod().getName());
+    }
+
+    private void markGlobalFailure() {
+        taggedMetricRegistry.meter(MetricName.builder().safeName(failuresMetricName()).build()).mark();
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,10 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |improved| |metrics|
+         - Async TimeLock Service metric timers are now tagged with (1) the relevant clients, and (2) whether the current node is the leader or not.
+           This allows for easier analysis and consumption of these metrics.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3075>`__)
 
 =======
 v0.80.0
@@ -119,9 +121,9 @@ v0.80.0
            jackson
            logback
            netty (indirectly via cassandra lib bump)
-
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3084>`__)
-            
+
+
 =======
 v0.79.0
 =======

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/AsyncTimeLockServicesCreator.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.InstrumentedScheduledExecutorService;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.palantir.atlasdb.timelock.AsyncTimelockResource;
 import com.palantir.atlasdb.timelock.AsyncTimelockService;
@@ -102,8 +103,10 @@ public class AsyncTimeLockServicesCreator implements TimeLockServicesCreator {
         return instrument(serviceClass, leadershipCreator.wrapInLeadershipProxy(serviceSupplier, serviceClass), client);
     }
 
-    private static <T> T instrument(Class<T> serviceClass, T service, String client) {
-        // TODO(nziebart): tag with the client name, when tritium supports it
-        return AtlasDbMetrics.instrument(serviceClass, service, MetricRegistry.name(serviceClass));
+    private <T> T instrument(Class<T> serviceClass, T service, String client) {
+        return AtlasDbMetrics.instrumentWithTaggedMetrics(serviceClass, service, MetricRegistry.name(serviceClass),
+                context -> ImmutableMap.of(
+                        "client", client,
+                        "isCurrentSuspectedLeader", String.valueOf(leadershipCreator.isCurrentSuspectedLeader())));
     }
 }

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -438,10 +438,7 @@ public class PaxosTimeLockServerIntegrationTest {
 
         MetricsOutput metrics = getMetricsOutput();
 
-        // time / lock services
-        metrics.assertContainsTimer(
-                "com.palantir.atlasdb.timelock.AsyncTimelockService.getFreshTimestamp");
-        metrics.assertContainsTimer("com.palantir.lock.LockService.currentTimeMillis");
+        // Note that time/lock services are logged to the tagged metrics registry, which isn't a thing in Dropwizard.
 
         // local leader election classes
         metrics.assertContainsTimer("com.palantir.paxos.PaxosLearner.learn");


### PR DESCRIPTION
- [x] Needs smoketest/verification.

**Goals (and why)**:
- Current timelock server-side metrics are an aggregate across all clients, and don't expose leadership information. This makes reading and debugging timelock metrics cleaner and easier. See internal ticket 138.

**Implementation Description (bullets)**:
- Implement a `TaggedMetricsEventInvocationHandler` based off Tritium's `MetricsEventInvocationHandler`, though with somewhat simplified functionality
- Instrument async timelock services (`TimeLockServices`, to be clear) on the server side with two tags: client -> the relevant timelock client, and isCurrentSuspectedLeader -> boolean

**Concerns (what feedback would you like?)**:
- This encodes an assumption that there is only one leader. Though I guess we can change PaxosLeadershipCreator.isCurrentSuspectedLeader() to be a function of client name.
- I tried to preserve the existing metric names, but was there an inadvertent break here?

**Where should we start reviewing?**: TaggedMetricsEventInvocationHandler

**Priority (whenever / two weeks / yesterday)**: not so high, unless TomP thinks otherwise / we encounter serious support issues that are difficult to troubleshoot because the metrics we have aren't clear.

@tpetracca for SA in general
@schlosna for SA / sanity check on event-invocation-handler.
Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3075)
<!-- Reviewable:end -->
