### PR TITLE
[TS] Part 1: Targeted sweep data structures

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReferenceAndCell.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TableReferenceAndCell.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonDeserialize(as = ImmutableTableReferenceAndCell.class)
+@JsonSerialize(as = ImmutableTableReferenceAndCell.class)
+@Value.Immutable
+public interface TableReferenceAndCell {
+    TableReference tableRef();
+    Cell cell();
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadata.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadata.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import org.immutables.value.Value;
+import com.palantir.common.persist.Persistable;
+
+@Value.Immutable
+public abstract class TargetedSweepMetadata implements Persistable {
+    public abstract boolean conservative();
+    public abstract boolean dedicatedRow();
+    public abstract int shard();
+    public abstract int dedicatedRowNumber();
+
+    public static final Hydrator<TargetedSweepMetadata> BYTES_HYDRATOR = input ->
+            ImmutableTargetedSweepMetadata.builder()
+                    .conservative((input[0] & 0x80) != 0)
+                    .dedicatedRow((input[0] & 0x40) != 0)
+                    .shard((input[0] << 2 | input[1] >> 6) & 0xFF)
+                    .dedicatedRowNumber(input[1] & 0x3F)
+                    .build();
+
+    @Override
+    public byte[] persistToBytes() {
+        byte[] result = new byte[4];
+        if (conservative()) {
+            result[0] = (byte) 0x80;
+        }
+        if (dedicatedRow()) {
+            result[0] |= 0x40;
+        }
+        result[0] |= shard() >> 2;
+        result[1] = (byte) (shard() << 6);
+        result[1] |= dedicatedRowNumber();
+        return result;
+    }
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadata.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadata.java
@@ -36,15 +36,15 @@ public abstract class TargetedSweepMetadata implements Persistable {
 
     @Override
     public byte[] persistToBytes() {
-        byte[] result = new byte[4];
+        byte[] result = new byte[] { 0, 0, 0, 0};
         if (conservative()) {
-            result[0] = (byte) 0x80;
+            result[0] |= 0x80;
         }
         if (dedicatedRow()) {
             result[0] |= 0x40;
         }
         result[0] |= shard() >> 2;
-        result[1] = (byte) (shard() << 6);
+        result[1] |= shard() << 6;
         result[1] |= dedicatedRowNumber();
         return result;
     }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadata.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadata.java
@@ -17,6 +17,8 @@
 package com.palantir.atlasdb.keyvalue.api;
 
 import org.immutables.value.Value;
+
+import com.google.common.base.Preconditions;
 import com.palantir.common.persist.Persistable;
 
 @Value.Immutable
@@ -25,6 +27,18 @@ public abstract class TargetedSweepMetadata implements Persistable {
     public abstract boolean dedicatedRow();
     public abstract int shard();
     public abstract int dedicatedRowNumber();
+
+    @Value.Check
+    void checkShardSize() {
+        Preconditions.checkArgument(shard() >= 0 && shard() <= 255,
+                "Shard number must be between 0 and 255 inclusive, but it is %s.", shard());
+    }
+
+    @Value.Check
+    void checkRowNumber() {
+        Preconditions.checkArgument(dedicatedRowNumber() >= 0 && dedicatedRowNumber() <= 63,
+                "Dedicated row number must be between 0 and 63 inclusive, but it is %s.", dedicatedRowNumber());
+    }
 
     public static final Hydrator<TargetedSweepMetadata> BYTES_HYDRATOR = input ->
             ImmutableTargetedSweepMetadata.builder()
@@ -36,7 +50,7 @@ public abstract class TargetedSweepMetadata implements Persistable {
 
     @Override
     public byte[] persistToBytes() {
-        byte[] result = new byte[] { 0, 0, 0, 0};
+        byte[] result = new byte[] { 0, 0, 0, 0 };
         if (conservative()) {
             result[0] |= 0x80;
         }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TableReferenceAndCellTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TableReferenceAndCellTest.java
@@ -21,17 +21,9 @@ import java.io.IOException;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
-
 public class TableReferenceAndCellTest {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module())
-            .registerModule(new AfterburnerModule());
-
     @Test
-    public void serializationDeserializationTest() throws IOException {
+    public void persistingHydrationTest() throws IOException {
         TableReference tableReference = TableReference.createFromFullyQualifiedName("abc.def");
         Cell cell = Cell.create(new byte[] {0, 0}, new byte[] {1, 1});
         TableReferenceAndCell tableRefCell = ImmutableTableReferenceAndCell.builder()
@@ -39,8 +31,8 @@ public class TableReferenceAndCellTest {
                 .cell(cell)
                 .build();
 
-        byte[] valueAsBytes = OBJECT_MAPPER.writeValueAsBytes(tableRefCell);
-        Assertions.assertThat(OBJECT_MAPPER.readValue(valueAsBytes, TableReferenceAndCell.class))
+        byte[] valueAsBytes = tableRefCell.persistToBytes();
+        Assertions.assertThat(TableReferenceAndCell.BYTES_HYDRATOR.hydrateFromBytes(valueAsBytes))
                 .isEqualTo(tableRefCell);
     }
 }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TableReferenceAndCellTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TableReferenceAndCellTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+
+public class TableReferenceAndCellTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new Jdk8Module())
+            .registerModule(new AfterburnerModule());
+
+    @Test
+    public void serializationDeserializationTest() throws IOException {
+        TableReference tableReference = TableReference.createFromFullyQualifiedName("abc.def");
+        Cell cell = Cell.create(new byte[] {0, 0}, new byte[] {1, 1});
+        TableReferenceAndCell tableRefCell = ImmutableTableReferenceAndCell.builder()
+                .tableRef(tableReference)
+                .cell(cell)
+                .build();
+
+        byte[] valueAsBytes = OBJECT_MAPPER.writeValueAsBytes(tableRefCell);
+        Assertions.assertThat(OBJECT_MAPPER.readValue(valueAsBytes, TableReferenceAndCell.class))
+                .isEqualTo(tableRefCell);
+    }
+}

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadataTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/TargetedSweepMetadataTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class TargetedSweepMetadataTest {
+    private static final byte[] ALL_ZERO = new byte[] { 0, 0, 0, 0 };
+    private static final byte[] ALL_ONE = new byte[] { -1, -1, -1, -1 };
+
+    private static final TargetedSweepMetadata MIN_METADATA = ImmutableTargetedSweepMetadata.builder()
+            .conservative(false)
+            .dedicatedRow(false)
+            .shard(0)
+            .dedicatedRowNumber(0)
+            .build();
+
+    private static final TargetedSweepMetadata MAX_METADATA = ImmutableTargetedSweepMetadata.builder()
+            .conservative(true)
+            .dedicatedRow(true)
+            .shard(255)
+            .dedicatedRowNumber(63)
+            .build();
+
+    @Test
+    public void hydrateAllZero() {
+        assertThat(TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(ALL_ZERO)).isEqualTo(MIN_METADATA);
+    }
+
+    @Test
+    public void hydrateAllOne() {
+        assertThat(TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(ALL_ONE)).isEqualTo(MAX_METADATA);
+    }
+
+    @Test
+    public void persistAndHydrateMin() {
+        assertThat(TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(MIN_METADATA.persistToBytes()))
+                .isEqualTo(MIN_METADATA);
+    }
+
+    @Test
+    public void persistAndHydrateMax() {
+        assertThat(TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(MAX_METADATA.persistToBytes()))
+                .isEqualTo(MAX_METADATA);
+    }
+
+    @Test
+    public void persistAndHydrate() {
+        TargetedSweepMetadata metadata = ImmutableTargetedSweepMetadata.builder()
+                .conservative(false)
+                .dedicatedRow(true)
+                .shard(196)
+                .dedicatedRowNumber(17)
+                .build();
+        assertThat(TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadata.persistToBytes()))
+                .isEqualTo(metadata);
+    }
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
@@ -52,7 +52,7 @@ public enum TargetedSweepSchema implements AtlasSchema {
             dynamicColumns();
                 columnComponent("timestamp_modulus", ValueType.VAR_LONG);
                 columnComponent("write_index", ValueType.VAR_LONG);
-                value(ValueType.BLOB);
+                value(ValueType.STRING);
 
             sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING);
             conflictHandler(ConflictHandler.IGNORE_ALL);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReferenceAndCell;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.OptionalType;
 import com.palantir.atlasdb.table.description.Schema;
@@ -52,7 +53,7 @@ public enum TargetedSweepSchema implements AtlasSchema {
             dynamicColumns();
                 columnComponent("timestamp_modulus", ValueType.VAR_LONG);
                 columnComponent("write_index", ValueType.VAR_LONG);
-                value(ValueType.STRING);
+                value(TableReferenceAndCell.class);
 
             sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING);
             conflictHandler(ConflictHandler.IGNORE_ALL);


### PR DESCRIPTION
**Goals (and why)**:
Implement necessary data structures for persisting targeted sweep info.

**Implementation Description (bullets)**:
TableReferenceAndCell self-explanatory
TargetedSweepMetadata:

- 1 bit for conservative vs. thorough sweep
- 1 bit for combined timestamp rows vs. dedicated rows for transactions with more than Y cells
- 8 bits for the shard number
- 6 bits for the number of the row if it's a dedicated row (max of 64 rows)
- 16 bits unused for future use

**Concerns (what feedback would you like?)**:
Open to naming suggestions, this is just a rough draft. Can the awful bitwise logic be made clearer, or is it enough to document it?

**Where should we start reviewing?**:
Anywhere

**Priority (whenever / two weeks / yesterday)**:
When you have time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3097)
<!-- Reviewable:end -->
