### PR TITLE
Adjust strategy to choose table to compact

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactPriorityCalculator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactPriorityCalculator.java
@@ -66,7 +66,7 @@ class CompactPriorityCalculator {
 
         Optional<String> tableToCompact = maybeChooseUncompactedTable(tableToLastTimeSwept, tableToLastTimeCompacted);
         if (!tableToCompact.isPresent()) {
-            tableToCompact = maybeChooseTableSweptAfterCompact(tableToLastTimeSwept,tableToLastTimeCompacted);
+            tableToCompact = maybeChooseTableSweptAfterCompact(tableToLastTimeSwept, tableToLastTimeCompacted);
         }
         if (!tableToCompact.isPresent()) {
             tableToCompact = maybeChooseTableCompactedOver1HourAgo(tableToLastTimeCompacted);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactPriorityCalculator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactPriorityCalculator.java
@@ -63,6 +63,24 @@ class CompactPriorityCalculator {
         Map<String, Long> tableToLastTimeSwept = sweepHistoryProvider.getHistory(tx);
         Map<String, Long> tableToLastTimeCompacted = compactionHistoryProvider.getHistory(tx);
 
+        Optional<String> tableToCompact = maybeChooseUncompactedTable(tableToLastTimeSwept, tableToLastTimeCompacted);
+        if (!tableToCompact.isPresent()) {
+            tableToCompact = maybeChooseTableSweptAfterCompact(tableToLastTimeSwept,tableToLastTimeCompacted);
+        }
+        if (!tableToCompact.isPresent()) {
+            tableToCompact = maybeChooseTableCompactedOver1HourAgo(tableToLastTimeSwept, tableToLastTimeCompacted);
+        }
+        if (!tableToCompact.isPresent()) {
+            log.info("Not compacting, because it does not appear that any table has been swept" +
+                    " or they were compacted too recently (the past hour).");
+        }
+        return tableToCompact;
+    }
+
+    private Optional<String> maybeChooseUncompactedTable(
+            Map<String, Long> tableToLastTimeSwept,
+            Map<String, Long> tableToLastTimeCompacted) {
+
         List<String> uncompactedTables = tableToLastTimeSwept.keySet().stream()
                 .filter(table -> !tableToLastTimeCompacted.keySet().contains(table))
                 .collect(Collectors.toList());
@@ -74,9 +92,15 @@ class CompactPriorityCalculator {
                     safeTableRef(randomlyChosenTable));
             return Optional.of(randomlyChosenTable);
         }
+        return Optional.empty();
+    }
+
+    private Optional<String> maybeChooseTableSweptAfterCompact(
+            Map<String, Long> tableToLastTimeSwept,
+            Map<String, Long> tableToLastTimeCompacted) {
 
         String tableToCompact = null;
-        long maxSweptAfterCompact = Long.MIN_VALUE;
+        long maxSweptAfterCompact = 0L;
         for (Map.Entry<String, Long> entry : tableToLastTimeSwept.entrySet()) {
             String table = entry.getKey();
             long lastSweptTime = entry.getValue();
@@ -89,25 +113,31 @@ class CompactPriorityCalculator {
             }
         }
 
-        if (tableToCompact == null) {
-            log.info("Not compacting, because it does not appear that any table has been swept.");
-        } else {
-            logCompactionChoice(tableToCompact, maxSweptAfterCompact);
-        }
-        return Optional.ofNullable(tableToCompact);
-    }
-
-    private void logCompactionChoice(String tableToCompact, long maxSweptAfterCompact) {
-        if (maxSweptAfterCompact > 0) {
+        if (tableToCompact != null) {
             log.info("Choosing to compact {}, because it was swept {} milliseconds after the last compaction",
                     safeTableRef(tableToCompact),
                     SafeArg.of("millisFromCompactionToSweep", maxSweptAfterCompact));
-        } else {
-            log.info("All swept tables have been compacted after the last sweep. Choosing to compact {} anyway - "
-                    + "this may be a no-op. It was last compacted {} milliseconds after it was last swept.",
-                    safeTableRef(tableToCompact),
-                    SafeArg.of("millisFromSweepToCompaction", Math.abs(maxSweptAfterCompact)));
+            return Optional.of(tableToCompact);
         }
+        return Optional.empty();
+    }
+
+    private Optional<String> maybeChooseTableCompactedOver1HourAgo(
+            Map<String, Long> tableToLastTimeSwept,
+            Map<String, Long> tableToLastTimeCompacted) {
+
+        List<String> filteredTablesCompactedAfterSweep = tableToLastTimeSwept.keySet().stream()
+                .filter(table -> tableToLastTimeCompacted.get(table) < System.currentTimeMillis() - 3_600_000)
+                .collect(Collectors.toList());
+        if (filteredTablesCompactedAfterSweep.size() > 0) {
+            int randomTableIndex = ThreadLocalRandom.current().nextInt(filteredTablesCompactedAfterSweep.size());
+            String randomlyChosenTable = filteredTablesCompactedAfterSweep.get(randomTableIndex);
+            log.info("All swept tables have been compacted after the last sweep. Choosing to compact {} at random" +
+                            " between tables which were compacted more than 1 hour ago.",
+                    safeTableRef(randomlyChosenTable));
+            return Optional.of(randomlyChosenTable);
+        }
+        return Optional.empty();
     }
 
     private Arg<String> safeTableRef(String fullyQualifiedName) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/compact/CompactPriorityCalculatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/compact/CompactPriorityCalculatorTest.java
@@ -62,8 +62,8 @@ public class CompactPriorityCalculatorTest {
     public void returnsTableWithBiggestSweepToCompactionPositiveTime() {
         // TABLE_1 is chosen because more time passed between its last compaction and its last sweep -
         // so without other information, we assume there's more to compact.
-        when(sweepHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 1L, TABLE_2, 5L));
-        when(compactionHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 5L, TABLE_2, 6L));
+        when(sweepHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 5L, TABLE_2, 6L));
+        when(compactionHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 1L, TABLE_2, 4L));
 
         Optional<String> table = calculator.selectTableToCompactInternal(mockTx);
         assertThat(table).isEqualTo(Optional.of(TABLE_1));
@@ -84,9 +84,9 @@ public class CompactPriorityCalculatorTest {
         // Returns empty when all tables were swept and then compacted, and each compact time is the past hour
         Long currentTime = System.currentTimeMillis();
         when(sweepHistoryProvider.getHistory(mockTx))
-                .thenReturn(ImmutableMap.of(TABLE_1, currentTime, TABLE_2, currentTime + 1));
+                .thenReturn(ImmutableMap.of(TABLE_1, currentTime - 5, TABLE_2, currentTime - 4 ));
         when(compactionHistoryProvider.getHistory(mockTx))
-                .thenReturn(ImmutableMap.of(TABLE_1, currentTime  + 2, TABLE_2, currentTime + 3));
+                .thenReturn(ImmutableMap.of(TABLE_1, currentTime  - 1, TABLE_2, currentTime - 2));
 
         Optional<String> table = calculator.selectTableToCompactInternal(mockTx);
         assertThat(table).isEmpty();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/compact/CompactPriorityCalculatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/compact/CompactPriorityCalculatorTest.java
@@ -59,11 +59,11 @@ public class CompactPriorityCalculatorTest {
     }
 
     @Test
-    public void returnsTableWithBiggestCompactionToSweepTime() {
-        // TABLE_1 was compacted more recently, but was also swept more recently, and more time passed between its last
+    public void returnsTableWithBiggestSweepToCompactionPositiveTime() {
+        // TABLE_1 was swept more recently, and more time passed between its last
         // compaction and its last sweep - so without other information, we assume there's more to compact.
-        when(sweepHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 7L, TABLE_2, 5L));
-        when(compactionHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 4L, TABLE_2, 3L));
+        when(sweepHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 1L, TABLE_2, 5L));
+        when(compactionHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 5L, TABLE_2, 6L));
 
         Optional<String> table = calculator.selectTableToCompactInternal(mockTx);
         assertThat(table).isEqualTo(Optional.of(TABLE_1));
@@ -71,10 +71,24 @@ public class CompactPriorityCalculatorTest {
 
     @Test
     public void canReturnTableEvenIfItWasCompactedAfterTheLastSweep() {
+        // TABLE_1 was compacted too recently, chooses randomly one compacted over one hour ago
         when(sweepHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 4L, TABLE_2, 3L));
-        when(compactionHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 7L, TABLE_2, 5L));
+        when(compactionHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, System.currentTimeMillis(), TABLE_2, 5L));
 
         Optional<String> table = calculator.selectTableToCompactInternal(mockTx);
         assertThat(table).isEqualTo(Optional.of(TABLE_2));
+    }
+
+    @Test
+    public void returnsEmptyWhenTablesWereCompactedRecently() {
+        // Returns empty when all tables were swept and then compacted, and each compact time is the past hour
+        Long currentTime = System.currentTimeMillis();
+        when(sweepHistoryProvider.getHistory(mockTx))
+                .thenReturn(ImmutableMap.of(TABLE_1, currentTime, TABLE_2, currentTime + 1));
+        when(compactionHistoryProvider.getHistory(mockTx))
+                .thenReturn(ImmutableMap.of(TABLE_1, currentTime  + 2, TABLE_2, currentTime + 3));
+
+        Optional<String> table = calculator.selectTableToCompactInternal(mockTx);
+        assertThat(table).isEmpty();
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/compact/CompactPriorityCalculatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/compact/CompactPriorityCalculatorTest.java
@@ -60,8 +60,8 @@ public class CompactPriorityCalculatorTest {
 
     @Test
     public void returnsTableWithBiggestSweepToCompactionPositiveTime() {
-        // TABLE_1 was swept more recently, and more time passed between its last
-        // compaction and its last sweep - so without other information, we assume there's more to compact.
+        // TABLE_1 is chosen because more time passed between its last compaction and its last sweep -
+        // so without other information, we assume there's more to compact.
         when(sweepHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 1L, TABLE_2, 5L));
         when(compactionHistoryProvider.getHistory(mockTx)).thenReturn(ImmutableMap.of(TABLE_1, 5L, TABLE_2, 6L));
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,23 @@ develop
            Also, previously, partitioning would require time quadratic in the number of versions present in the row; it now takes linear time.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3095>`__)
 
+    *    - |fixed| |improved|
+         - The strategy for choosing the table to compact was adjusted to avoid the case when the same table is chosen multiple times in a row, even if it was not swept between compactions
+           Previously, the strategy to choose the table to compact was:
+
+             1. if possible choose a table that was swept but not compacted
+             2. otherwise choose a table for which the time passed between last compact and last swept was longer
+
+           (when all tables are swept and afterward compacted, last point above could choose to compact the same table beacuse ``lastSweptTime`` - ``lastCompactTime`` is negative and largest among all tables)
+
+           The new strategy is:
+
+            1. if possible choose a table that was swept but not compacted
+            2. if there is no uncompacted table then choose a table swept further after it was compacted
+            3. otherwise, randomly choose a table after filtering out the ones compacted in the past hour
+
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3100>`__)
+
 =======
 v0.81.0
 =======


### PR DESCRIPTION

**Goals (and why)**: Fix for special case when selecting the same table to compact even when we could benefit from compacting other tables.

**Implementation Description (bullets)**:
- Extract the cases to methods
- Adjust logic to choose table compacted longest time after last swept
- Add logic when all tables were compacted after swept, chooses randomly between the tables compacted more than 1hr ago
- Update existing tests and add new test for the new strategy option

**Concerns (what feedback would you like?)**:
Is there any problem that we ignore the tables swept in the past hour? Is there a special case for write/delete intensive workflows?
Is the random selection good enough?

**Where should we start reviewing?**:
CompactPriorityCalculator.java

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3100)
<!-- Reviewable:end -->
