### PR TITLE
Include Cassandra semi-break in release notes

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,6 +53,8 @@ develop
     *    - |fixed|
          - The ``_locks`` table is now created with a deterministic column family ID.
            This means that multi-node installations will no longer create multiple locks tables on first start-up.
+           Note that new installations using versions of Cassandra prior to 2.1.13, 2.2.5, 3.0.3 or 3.2 will fail to create this table, as we rely on syntax introduced by the fix to `CASSANDRA-9179 <https://issues.apache.org/jira/browse/CASSANDRA-9179>`__.
+           Existing installations will be unaffected.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3088>`__)
 
     *    - |fixed| |improved|

--- a/docs/source/services/key_value_services/index.rst
+++ b/docs/source/services/key_value_services/index.rst
@@ -19,9 +19,9 @@ This matrix details the current state of available Key Value Services supported 
 
     *    - :ref:`Cassandra KVS <cassandra-configuration>`
          - Supported
-         - 2.0+
+         - 2.1.15+, 2.2.5+, 3.0.3+, 3.2+
          - 2.2.8
-         - 
+         -
 
     *    - :ref:`DB KVS (Postgres) <postgres-configuration>`
          - Supported


### PR DESCRIPTION
Existing installations are not broken, and internally we already require later versions of Cassandra 2.2, so this isn't strong enough for a USER-BREAK.

**Where should we start reviewing?**: release-notes.rst

**Priority (whenever / two weeks / yesterday)**: today, tiny PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3116)
<!-- Reviewable:end -->
