### PR TITLE
adding start time to slow log messages

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
@@ -133,8 +133,8 @@ public class ProfilingCassandraClient implements AutoDelegate_CassandraClient {
                                 LoggingArgs.sizeInBytes(size));
                     });
                     logger.log(") with consistency {} at time {}, on kvs.{} took {} ms",
-                            LoggingArgs.startTimeMillis(startTime),
                             SafeArg.of("consistency", consistency_level.toString()),
+                            LoggingArgs.startTimeMillis(startTime),
                             SafeArg.of("kvsMethodName", kvsMethodName),
                             LoggingArgs.durationMillis(timer));
                 });
@@ -188,7 +188,7 @@ public class ProfilingCassandraClient implements AutoDelegate_CassandraClient {
                 (KvsProfilingLogger.CallableCheckedException<CqlResult, TException>)
                         () -> client.execute_cql3_query(cqlQuery, compression, consistency),
                 (logger, timer) -> cqlQuery.logSlowResult(logger, timer),
-                (logger, cqlResult) -> logger.log("and returned {} rows, at time{}",
+                (logger, cqlResult) -> logger.log("and returned {} rows, at time {}",
                         SafeArg.of("numRows", cqlResult.getRows().size()),
                         LoggingArgs.startTimeMillis(startTime)));
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -77,9 +77,11 @@ public final class ProfilingKeyValueService implements KeyValueService {
     private static BiConsumer<LoggingFunction, Stopwatch> logCellsAndSize(String method,
             TableReference tableRef,
             int numCells, long sizeInBytes) {
+        long startTime = System.currentTimeMillis();
         return (logger, stopwatch) ->
-                logger.log("Call to KVS.{} on table {} for {} cells of overall size {} bytes took {} ms.",
+                logger.log("Call to KVS.{} at time {}, on table {} for {} cells of overall size {} bytes took {} ms.",
                         LoggingArgs.method(method),
+                        LoggingArgs.startTimeMillis(startTime),
                         LoggingArgs.tableRef(tableRef),
                         LoggingArgs.cellCount(numCells),
                         LoggingArgs.sizeInBytes(sizeInBytes),
@@ -87,31 +89,42 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     private static BiConsumer<LoggingFunction, Stopwatch> logTime(String method) {
+        long startTime = System.currentTimeMillis();
         return (logger, stopwatch) ->
-                logger.log("Call to KVS.{} took {} ms.", LoggingArgs.method(method),
+                logger.log("Call to KVS.{} at time {}, took {} ms.",
+                        LoggingArgs.method(method),
+                        LoggingArgs.startTimeMillis(startTime),
                         LoggingArgs.durationMillis(stopwatch));
     }
 
     private static BiConsumer<LoggingFunction, Stopwatch> logTimeAndTable(String method, TableReference tableRef) {
+        long startTime = System.currentTimeMillis();
         return (logger, stopwatch) ->
-                logger.log("Call to KVS.{} on table {} took {} ms.",
-                        LoggingArgs.method(method), LoggingArgs.tableRef(tableRef),
+                logger.log("Call to KVS.{} at time {}, on table {} took {} ms.",
+                        LoggingArgs.method(method),
+                        LoggingArgs.startTimeMillis(startTime),
+                        LoggingArgs.tableRef(tableRef),
                         LoggingArgs.durationMillis(stopwatch));
     }
 
     private static BiConsumer<LoggingFunction, Stopwatch> logTimeAndTableCount(String method, int tableCount) {
+        long startTime = System.currentTimeMillis();
         return (logger, stopwatch) ->
-                logger.log("Call to KVS.{} for {} tables took {} ms.",
-                        LoggingArgs.method(method), LoggingArgs.tableCount(tableCount),
+                logger.log("Call to KVS.{} at time {}, for {} tables took {} ms.",
+                        LoggingArgs.method(method),
+                        LoggingArgs.startTimeMillis(startTime),
+                        LoggingArgs.tableCount(tableCount),
                         LoggingArgs.durationMillis(stopwatch));
     }
 
     private static BiConsumer<LoggingFunction, Stopwatch> logTimeAndTableRange(String method,
             TableReference tableRef,
             RangeRequest range) {
+        long startTime = System.currentTimeMillis();
         return (logger, stopwatch) ->
-                logger.log("Call to KVS.{} on table {} with range {} took {} ms.",
+                logger.log("Call to KVS.{} at time {}, on table {} with range {} took {} ms.",
                         LoggingArgs.method(method),
+                        LoggingArgs.startTimeMillis(startTime),
                         LoggingArgs.tableRef(tableRef),
                         LoggingArgs.range(tableRef, range),
                         LoggingArgs.durationMillis(stopwatch));
@@ -130,9 +143,11 @@ public final class ProfilingKeyValueService implements KeyValueService {
 
     @Override
     public void addGarbageCollectionSentinelValues(TableReference tableRef, Iterable<Cell> cells) {
+        long startTime = System.currentTimeMillis();
         maybeLog(() -> delegate.addGarbageCollectionSentinelValues(tableRef, cells),
                 (logger, stopwatch) -> logger.log(
-                        "Call to KVS.addGarbageCollectionSentinelValues on table {} over {} cells took {} ms.",
+                        "Call to KVS.addGarbageCollectionSentinelValues at time {}, on table {} over {} cells took {} ms.",
+                        LoggingArgs.startTimeMillis(startTime),
                         LoggingArgs.tableRef(tableRef),
                         LoggingArgs.cellCount(Iterables.size(cells)),
                         LoggingArgs.durationMillis(stopwatch)));
@@ -183,9 +198,11 @@ public final class ProfilingKeyValueService implements KeyValueService {
 
     @Override
     public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
+        long startTime = System.currentTimeMillis();
         return KvsProfilingLogger.maybeLog(() -> delegate.get(tableRef, timestampByCell),
                 (logger, stopwatch) ->
-                        logger.log("Call to KVS.get on table {}, requesting {} cells took {} ms ",
+                        logger.log("Call to KVS.get at time {}, on table {}, requesting {} cells took {} ms ",
+                                LoggingArgs.startTimeMillis(startTime),
                                 LoggingArgs.tableRef(tableRef),
                                 LoggingArgs.cellCount(timestampByCell.size()),
                                 LoggingArgs.durationMillis(stopwatch)),
@@ -258,10 +275,12 @@ public final class ProfilingKeyValueService implements KeyValueService {
     @Override
     public Map<Cell, Value> getRows(TableReference tableRef, Iterable<byte[]> rows, ColumnSelection columnSelection,
             long timestamp) {
+        long startTime = System.currentTimeMillis();
         return KvsProfilingLogger.maybeLog(() -> delegate.getRows(tableRef, rows, columnSelection, timestamp),
                 (logger, stopwatch) ->
                         logger.log(
-                                "Call to KVS.getRows on table {} requesting {} columns from {} rows took {} ms ",
+                                "Call to KVS.getRows at time {}, on table {} requesting {} columns from {} rows took {} ms ",
+                                LoggingArgs.startTimeMillis(startTime),
                                 LoggingArgs.tableRef(tableRef),
                                 LoggingArgs.columnCount(columnSelection),
                                 LoggingArgs.rowCount(Iterables.size(rows)),
@@ -271,6 +290,7 @@ public final class ProfilingKeyValueService implements KeyValueService {
 
     @Override
     public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp) {
+        long startTime = System.currentTimeMillis();
         maybeLog(() -> delegate.multiPut(valuesByTable, timestamp),
                 (logger, stopwatch) -> {
                     int totalCells = 0;
@@ -280,7 +300,8 @@ public final class ProfilingKeyValueService implements KeyValueService {
                         totalBytes += byteSize(values);
                     }
                     logger.log(
-                            "Call to KVS.multiPut on {} tables putting {} total cells of {} total bytes took {} ms.",
+                            "Call to KVS.multiPut at time {}, on {} tables putting {} total cells of {} total bytes took {} ms.",
+                            LoggingArgs.startTimeMillis(startTime),
                             LoggingArgs.tableCount(valuesByTable.keySet().size()),
                             LoggingArgs.cellCount(totalCells),
                             LoggingArgs.sizeInBytes(totalBytes),
@@ -367,12 +388,15 @@ public final class ProfilingKeyValueService implements KeyValueService {
 
     @Override
     public void compactInternally(TableReference tableRef, boolean inMaintenanceMode) {
+        long startTime = System.currentTimeMillis();
         maybeLog(() -> delegate.compactInternally(tableRef, inMaintenanceMode), (logger, stopwatch) -> {
             if (inMaintenanceMode) {
                 // Log differently in maintenance mode - if a compactInternally is slow this might be bad in normal
                 // operational hours, but is probably okay in maintenance mode.
-                logger.log("Call to KVS.compactInternally (in maintenance mode) on table {} took {} ms.",
-                        LoggingArgs.tableRef(tableRef), LoggingArgs.durationMillis(stopwatch));
+                logger.log("Call to KVS.compactInternally (in maintenance mode) at time {}, on table {} took {} ms.",
+                        LoggingArgs.startTimeMillis(startTime),
+                        LoggingArgs.tableRef(tableRef),
+                        LoggingArgs.durationMillis(stopwatch));
             } else {
                 logTimeAndTable("compactInternally", tableRef);
             }
@@ -382,10 +406,12 @@ public final class ProfilingKeyValueService implements KeyValueService {
     @Override
     public Map<byte[], RowColumnRangeIterator> getRowsColumnRange(TableReference tableRef, Iterable<byte[]> rows,
             BatchColumnRangeSelection batchColumnRangeSelection, long timestamp) {
+        long startTime = System.currentTimeMillis();
         return maybeLog(() -> delegate.getRowsColumnRange(tableRef, rows,
                 batchColumnRangeSelection, timestamp),
                 (logger, stopwatch) ->
-                        logger.log("Call to KVS.getRowsColumnRange on table {} for {} rows with range {} took {} ms.",
+                        logger.log("Call to KVS.getRowsColumnRange at time {}, on table {} for {} rows with range {} took {} ms.",
+                                LoggingArgs.startTimeMillis(startTime),
                                 LoggingArgs.tableRef(tableRef),
                                 LoggingArgs.rowCount(Iterables.size(rows)),
                                 LoggingArgs.batchColumnRangeSelection(tableRef, batchColumnRangeSelection),
@@ -398,11 +424,13 @@ public final class ProfilingKeyValueService implements KeyValueService {
             ColumnRangeSelection columnRangeSelection,
             int cellBatchHint,
             long timestamp) {
+        long startTime = System.currentTimeMillis();
         return maybeLog(() ->
                         delegate.getRowsColumnRange(tableRef, rows, columnRangeSelection, cellBatchHint, timestamp),
                 (logger, stopwatch) -> logger.log(
-                        "Call to KVS.getRowsColumnRange - CellBatch on table {} for {} rows with range {} "
+                        "Call to KVS.getRowsColumnRange - CellBatch at time {}, on table {} for {} rows with range {} "
                                 + "and batch hint {} took {} ms.",
+                        LoggingArgs.startTimeMillis(startTime),
                         LoggingArgs.tableRef(tableRef),
                         LoggingArgs.rowCount(Iterables.size(rows)),
                         LoggingArgs.columnRangeSelection(tableRef, columnRangeSelection),

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -398,7 +398,11 @@ public final class ProfilingKeyValueService implements KeyValueService {
                         LoggingArgs.tableRef(tableRef),
                         LoggingArgs.durationMillis(stopwatch));
             } else {
-                logTimeAndTable("compactInternally", tableRef);
+                logger.log("Call to KVS.{} at time {}, on table {} took {} ms.",
+                        LoggingArgs.method("compactInternally"),
+                        LoggingArgs.startTimeMillis(startTime),
+                        LoggingArgs.tableRef(tableRef),
+                        LoggingArgs.durationMillis(stopwatch));
             }
         });
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -159,6 +159,10 @@ public final class LoggingArgs {
         return getArg("durationMillis", stopwatch.elapsed(TimeUnit.MILLISECONDS), true);
     }
 
+    public static Arg<Long> startTimeMillis(long startTime) {
+        return getArg("startTimeMillis", startTime, true);
+    }
+
     public static Arg<String> method(String method) {
         return getArg("method", method, true);
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -96,6 +96,10 @@ develop
            There currently isn't an API for declaring specific row or dynamic column components as safe; please contact the AtlasDB team if you have such a use case.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3093>`__)
 
+    *    - |improved| |logs|
+         - ``kvs-slow-log`` messages now also include start time of the operation for easier debugging.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3117>`__)
+
 =======
 v0.81.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
Adding start time to kvs-slow-log messages, for easier debugging.
**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:
- Is there a cleaner way to do this?
- There may be a slight difference between start time we log, and actual start time in this implementation.

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3117)
<!-- Reviewable:end -->
