### PR TITLE
Stream Store Sweep ETE test

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/SweepResults.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/SweepResults.java
@@ -19,8 +19,13 @@ import java.util.Optional;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.atlasdb.encoding.PtBytes;
 
+@JsonDeserialize(as = ImmutableSweepResults.class)
+@JsonSerialize(as = ImmutableSweepResults.class)
 @Value.Immutable
 public abstract class SweepResults {
 
@@ -60,6 +65,7 @@ public abstract class SweepResults {
     @Value.Auxiliary
     public abstract long getTimeSweepStarted();
 
+    @JsonIgnore
     public long getTimeElapsedSinceStartedSweeping() {
         return System.currentTimeMillis() - getTimeSweepStarted();
     }

--- a/atlasdb-ete-test-utils/build.gradle
+++ b/atlasdb-ete-test-utils/build.gradle
@@ -1,7 +1,14 @@
 apply from: "../gradle/publish-jars.gradle"
 apply from: "../gradle/shared.gradle"
 
+schemas = [
+        'com.palantir.atlasdb.todo.TodoSchema'
+]
+
 dependencies {
+    compile project(':atlasdb-api')
+    compile project(':atlasdb-client')
+
     compile group: 'junit', name: 'junit'
     compile group: 'org.hamcrest', name: 'hamcrest-all'
     compile group: 'commons-io', name: 'commons-io'

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/TodoSchema.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/TodoSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the BSD-3 License (the "License");
  * you may not use this file except in compliance with the License.

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
@@ -1,0 +1,687 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class LatestSnapshotTable implements
+        AtlasDbMutablePersistentTable<LatestSnapshotTable.LatestSnapshotRow,
+                                         LatestSnapshotTable.LatestSnapshotNamedColumnValue<?>,
+                                         LatestSnapshotTable.LatestSnapshotRowResult>,
+        AtlasDbNamedMutableTable<LatestSnapshotTable.LatestSnapshotRow,
+                                    LatestSnapshotTable.LatestSnapshotNamedColumnValue<?>,
+                                    LatestSnapshotTable.LatestSnapshotRowResult> {
+    private final Transaction t;
+    private final List<LatestSnapshotTrigger> triggers;
+    private final static String rawTableName = "latest_snapshot";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(LatestSnapshotNamedColumn.values());
+
+    static LatestSnapshotTable of(Transaction t, Namespace namespace) {
+        return new LatestSnapshotTable(t, namespace, ImmutableList.<LatestSnapshotTrigger>of());
+    }
+
+    static LatestSnapshotTable of(Transaction t, Namespace namespace, LatestSnapshotTrigger trigger, LatestSnapshotTrigger... triggers) {
+        return new LatestSnapshotTable(t, namespace, ImmutableList.<LatestSnapshotTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static LatestSnapshotTable of(Transaction t, Namespace namespace, List<LatestSnapshotTrigger> triggers) {
+        return new LatestSnapshotTable(t, namespace, triggers);
+    }
+
+    private LatestSnapshotTable(Transaction t, Namespace namespace, List<LatestSnapshotTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * LatestSnapshotRow {
+     *   {@literal Long key};
+     * }
+     * </pre>
+     */
+    public static final class LatestSnapshotRow implements Persistable, Comparable<LatestSnapshotRow> {
+        private final long key;
+
+        public static LatestSnapshotRow of(long key) {
+            return new LatestSnapshotRow(key);
+        }
+
+        private LatestSnapshotRow(long key) {
+            this.key = key;
+        }
+
+        public long getKey() {
+            return key;
+        }
+
+        public static Function<LatestSnapshotRow, Long> getKeyFun() {
+            return new Function<LatestSnapshotRow, Long>() {
+                @Override
+                public Long apply(LatestSnapshotRow row) {
+                    return row.key;
+                }
+            };
+        }
+
+        public static Function<Long, LatestSnapshotRow> fromKeyFun() {
+            return new Function<Long, LatestSnapshotRow>() {
+                @Override
+                public LatestSnapshotRow apply(Long row) {
+                    return LatestSnapshotRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] keyBytes = PtBytes.toBytes(Long.MIN_VALUE ^ key);
+            return EncodingUtils.add(keyBytes);
+        }
+
+        public static final Hydrator<LatestSnapshotRow> BYTES_HYDRATOR = new Hydrator<LatestSnapshotRow>() {
+            @Override
+            public LatestSnapshotRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long key = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                __index += 8;
+                return new LatestSnapshotRow(key);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("key", key)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            LatestSnapshotRow other = (LatestSnapshotRow) obj;
+            return Objects.equal(key, other.key);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(key);
+        }
+
+        @Override
+        public int compareTo(LatestSnapshotRow o) {
+            return ComparisonChain.start()
+                .compare(this.key, o.key)
+                .result();
+        }
+    }
+
+    public interface LatestSnapshotNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class StreamId implements LatestSnapshotNamedColumnValue<Long> {
+        private final Long value;
+
+        public static StreamId of(Long value) {
+            return new StreamId(value);
+        }
+
+        private StreamId(Long value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "stream_id";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "i";
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = PtBytes.toBytes(Long.MIN_VALUE ^ value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("i");
+        }
+
+        public static final Hydrator<StreamId> BYTES_HYDRATOR = new Hydrator<StreamId>() {
+            @Override
+            public StreamId hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                return of(Long.MIN_VALUE ^ PtBytes.toLong(bytes, 0));
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface LatestSnapshotTrigger {
+        public void putLatestSnapshot(Multimap<LatestSnapshotRow, ? extends LatestSnapshotNamedColumnValue<?>> newRows);
+    }
+
+    public static final class LatestSnapshotRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static LatestSnapshotRowResult of(RowResult<byte[]> row) {
+            return new LatestSnapshotRowResult(row);
+        }
+
+        private LatestSnapshotRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public LatestSnapshotRow getRowName() {
+            return LatestSnapshotRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<LatestSnapshotRowResult, LatestSnapshotRow> getRowNameFun() {
+            return new Function<LatestSnapshotRowResult, LatestSnapshotRow>() {
+                @Override
+                public LatestSnapshotRow apply(LatestSnapshotRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, LatestSnapshotRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, LatestSnapshotRowResult>() {
+                @Override
+                public LatestSnapshotRowResult apply(RowResult<byte[]> rowResult) {
+                    return new LatestSnapshotRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasStreamId() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("i"));
+        }
+
+        public Long getStreamId() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("i"));
+            if (bytes == null) {
+                return null;
+            }
+            StreamId value = StreamId.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<LatestSnapshotRowResult, Long> getStreamIdFun() {
+            return new Function<LatestSnapshotRowResult, Long>() {
+                @Override
+                public Long apply(LatestSnapshotRowResult rowResult) {
+                    return rowResult.getStreamId();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("StreamId", getStreamId())
+                .toString();
+        }
+    }
+
+    public enum LatestSnapshotNamedColumn {
+        STREAM_ID {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("i");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<LatestSnapshotNamedColumn, byte[]> toShortName() {
+            return new Function<LatestSnapshotNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(LatestSnapshotNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<LatestSnapshotNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, LatestSnapshotNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(LatestSnapshotNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends LatestSnapshotNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends LatestSnapshotNamedColumnValue<?>>>builder()
+                .put("i", StreamId.BYTES_HYDRATOR)
+                .build();
+
+    public Map<LatestSnapshotRow, Long> getStreamIds(Collection<LatestSnapshotRow> rows) {
+        Map<Cell, LatestSnapshotRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (LatestSnapshotRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("i")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<LatestSnapshotRow, Long> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            Long val = StreamId.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putStreamId(LatestSnapshotRow row, Long value) {
+        put(ImmutableMultimap.of(row, StreamId.of(value)));
+    }
+
+    public void putStreamId(Map<LatestSnapshotRow, Long> map) {
+        Map<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<LatestSnapshotRow, Long> e : map.entrySet()) {
+            toPut.put(e.getKey(), StreamId.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    public void putStreamIdUnlessExists(LatestSnapshotRow row, Long value) {
+        putUnlessExists(ImmutableMultimap.of(row, StreamId.of(value)));
+    }
+
+    public void putStreamIdUnlessExists(Map<LatestSnapshotRow, Long> map) {
+        Map<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<LatestSnapshotRow, Long> e : map.entrySet()) {
+            toPut.put(e.getKey(), StreamId.of(e.getValue()));
+        }
+        putUnlessExists(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<LatestSnapshotRow, ? extends LatestSnapshotNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (LatestSnapshotTrigger trigger : triggers) {
+            trigger.putLatestSnapshot(rows);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<LatestSnapshotRow, ? extends LatestSnapshotNamedColumnValue<?>> rows) {
+        Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<LatestSnapshotRow, ? extends LatestSnapshotNamedColumnValue<?>> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    public void deleteStreamId(LatestSnapshotRow row) {
+        deleteStreamId(ImmutableSet.of(row));
+    }
+
+    public void deleteStreamId(Iterable<LatestSnapshotRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("i");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(LatestSnapshotRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<LatestSnapshotRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("i")));
+        t.delete(tableRef, cells);
+    }
+
+    public Optional<LatestSnapshotRowResult> getRow(LatestSnapshotRow row) {
+        return getRow(row, allColumns);
+    }
+
+    public Optional<LatestSnapshotRowResult> getRow(LatestSnapshotRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(LatestSnapshotRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<LatestSnapshotRowResult> getRows(Iterable<LatestSnapshotRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<LatestSnapshotRowResult> getRows(Iterable<LatestSnapshotRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<LatestSnapshotRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(LatestSnapshotRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<LatestSnapshotNamedColumnValue<?>> getRowColumns(LatestSnapshotRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<LatestSnapshotNamedColumnValue<?>> getRowColumns(LatestSnapshotRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<LatestSnapshotNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> getRowsMultimap(Iterable<LatestSnapshotRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> getRowsMultimap(Iterable<LatestSnapshotRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> getRowsMultimapInternal(Iterable<LatestSnapshotRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            LatestSnapshotRow row = LatestSnapshotRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<LatestSnapshotRow, BatchingVisitable<LatestSnapshotNamedColumnValue<?>>> getRowsColumnRange(Iterable<LatestSnapshotRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<LatestSnapshotRow, BatchingVisitable<LatestSnapshotNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            LatestSnapshotRow row = LatestSnapshotRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<LatestSnapshotNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>>> getRowsColumnRange(Iterable<LatestSnapshotRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            LatestSnapshotRow row = LatestSnapshotRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            LatestSnapshotNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<LatestSnapshotRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<LatestSnapshotRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, LatestSnapshotRowResult>() {
+            @Override
+            public LatestSnapshotRowResult apply(RowResult<byte[]> input) {
+                return LatestSnapshotRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "Z4JOlMtJnr6Ul0c6qTd/dQ==";
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsIndexCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsIndexCleanupTask.java
@@ -1,0 +1,36 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.util.Set;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class SnapshotsIndexCleanupTask implements OnCleanupTask {
+
+    private final TodoSchemaTableFactory tables;
+
+    public SnapshotsIndexCleanupTask(Namespace namespace) {
+        tables = TodoSchemaTableFactory.of(namespace);
+    }
+
+    @Override
+    public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
+        SnapshotsStreamIdxTable usersIndex = tables.getSnapshotsStreamIdxTable(t);
+        Set<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
+        for (Cell cell : cells) {
+            rows.add(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
+        }
+        Multimap<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue> rowsInDb = usersIndex.getRowsMultimap(rows);
+        Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.keySet().size());
+        for (SnapshotsStreamIdxTable.SnapshotsStreamIdxRow rowToDelete : Sets.difference(rows, rowsInDb.keySet())) {
+            toDelete.add(rowToDelete.getId());
+        }
+        SnapshotsStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsMetadataCleanupTask.java
@@ -1,0 +1,42 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class SnapshotsMetadataCleanupTask implements OnCleanupTask {
+
+    private final TodoSchemaTableFactory tables;
+
+    public SnapshotsMetadataCleanupTask(Namespace namespace) {
+        tables = TodoSchemaTableFactory.of(namespace);
+    }
+
+    @Override
+    public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
+        SnapshotsStreamMetadataTable metaTable = tables.getSnapshotsStreamMetadataTable(t);
+        Collection<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> rows = Lists.newArrayListWithCapacity(cells.size());
+        for (Cell cell : cells) {
+            rows.add(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
+        }
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> currentMetadata = metaTable.getMetadatas(rows);
+        Set<Long> toDelete = Sets.newHashSet();
+        for (Map.Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                toDelete.add(e.getKey().getId());
+            }
+        }
+        SnapshotsStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
@@ -1,0 +1,746 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class SnapshotsStreamHashAidxTable implements
+        AtlasDbDynamicMutablePersistentTable<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow,
+                                                SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumn,
+                                                SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue,
+                                                SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRowResult> {
+    private final Transaction t;
+    private final List<SnapshotsStreamHashAidxTrigger> triggers;
+    private final static String rawTableName = "snapshots_stream_hash_aidx";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = ColumnSelection.all();
+
+    static SnapshotsStreamHashAidxTable of(Transaction t, Namespace namespace) {
+        return new SnapshotsStreamHashAidxTable(t, namespace, ImmutableList.<SnapshotsStreamHashAidxTrigger>of());
+    }
+
+    static SnapshotsStreamHashAidxTable of(Transaction t, Namespace namespace, SnapshotsStreamHashAidxTrigger trigger, SnapshotsStreamHashAidxTrigger... triggers) {
+        return new SnapshotsStreamHashAidxTable(t, namespace, ImmutableList.<SnapshotsStreamHashAidxTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static SnapshotsStreamHashAidxTable of(Transaction t, Namespace namespace, List<SnapshotsStreamHashAidxTrigger> triggers) {
+        return new SnapshotsStreamHashAidxTable(t, namespace, triggers);
+    }
+
+    private SnapshotsStreamHashAidxTable(Transaction t, Namespace namespace, List<SnapshotsStreamHashAidxTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * SnapshotsStreamHashAidxRow {
+     *   {@literal Sha256Hash hash};
+     * }
+     * </pre>
+     */
+    public static final class SnapshotsStreamHashAidxRow implements Persistable, Comparable<SnapshotsStreamHashAidxRow> {
+        private final Sha256Hash hash;
+
+        public static SnapshotsStreamHashAidxRow of(Sha256Hash hash) {
+            return new SnapshotsStreamHashAidxRow(hash);
+        }
+
+        private SnapshotsStreamHashAidxRow(Sha256Hash hash) {
+            this.hash = hash;
+        }
+
+        public Sha256Hash getHash() {
+            return hash;
+        }
+
+        public static Function<SnapshotsStreamHashAidxRow, Sha256Hash> getHashFun() {
+            return new Function<SnapshotsStreamHashAidxRow, Sha256Hash>() {
+                @Override
+                public Sha256Hash apply(SnapshotsStreamHashAidxRow row) {
+                    return row.hash;
+                }
+            };
+        }
+
+        public static Function<Sha256Hash, SnapshotsStreamHashAidxRow> fromHashFun() {
+            return new Function<Sha256Hash, SnapshotsStreamHashAidxRow>() {
+                @Override
+                public SnapshotsStreamHashAidxRow apply(Sha256Hash row) {
+                    return SnapshotsStreamHashAidxRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] hashBytes = hash.getBytes();
+            return EncodingUtils.add(hashBytes);
+        }
+
+        public static final Hydrator<SnapshotsStreamHashAidxRow> BYTES_HYDRATOR = new Hydrator<SnapshotsStreamHashAidxRow>() {
+            @Override
+            public SnapshotsStreamHashAidxRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
+                __index += 32;
+                return new SnapshotsStreamHashAidxRow(hash);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("hash", hash)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            SnapshotsStreamHashAidxRow other = (SnapshotsStreamHashAidxRow) obj;
+            return Objects.equal(hash, other.hash);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(hash);
+        }
+
+        @Override
+        public int compareTo(SnapshotsStreamHashAidxRow o) {
+            return ComparisonChain.start()
+                .compare(this.hash, o.hash)
+                .result();
+        }
+    }
+
+    /**
+     * <pre>
+     * SnapshotsStreamHashAidxColumn {
+     *   {@literal Long streamId};
+     * }
+     * </pre>
+     */
+    public static final class SnapshotsStreamHashAidxColumn implements Persistable, Comparable<SnapshotsStreamHashAidxColumn> {
+        private final long streamId;
+
+        public static SnapshotsStreamHashAidxColumn of(long streamId) {
+            return new SnapshotsStreamHashAidxColumn(streamId);
+        }
+
+        private SnapshotsStreamHashAidxColumn(long streamId) {
+            this.streamId = streamId;
+        }
+
+        public long getStreamId() {
+            return streamId;
+        }
+
+        public static Function<SnapshotsStreamHashAidxColumn, Long> getStreamIdFun() {
+            return new Function<SnapshotsStreamHashAidxColumn, Long>() {
+                @Override
+                public Long apply(SnapshotsStreamHashAidxColumn row) {
+                    return row.streamId;
+                }
+            };
+        }
+
+        public static Function<Long, SnapshotsStreamHashAidxColumn> fromStreamIdFun() {
+            return new Function<Long, SnapshotsStreamHashAidxColumn>() {
+                @Override
+                public SnapshotsStreamHashAidxColumn apply(Long row) {
+                    return SnapshotsStreamHashAidxColumn.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] streamIdBytes = PtBytes.toBytes(Long.MIN_VALUE ^ streamId);
+            return EncodingUtils.add(streamIdBytes);
+        }
+
+        public static final Hydrator<SnapshotsStreamHashAidxColumn> BYTES_HYDRATOR = new Hydrator<SnapshotsStreamHashAidxColumn>() {
+            @Override
+            public SnapshotsStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long streamId = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                __index += 8;
+                return new SnapshotsStreamHashAidxColumn(streamId);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("streamId", streamId)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            SnapshotsStreamHashAidxColumn other = (SnapshotsStreamHashAidxColumn) obj;
+            return Objects.equal(streamId, other.streamId);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(streamId);
+        }
+
+        @Override
+        public int compareTo(SnapshotsStreamHashAidxColumn o) {
+            return ComparisonChain.start()
+                .compare(this.streamId, o.streamId)
+                .result();
+        }
+    }
+
+    public interface SnapshotsStreamHashAidxTrigger {
+        public void putSnapshotsStreamHashAidx(Multimap<SnapshotsStreamHashAidxRow, ? extends SnapshotsStreamHashAidxColumnValue> newRows);
+    }
+
+    /**
+     * <pre>
+     * Column name description {
+     *   {@literal Long streamId};
+     * }
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class SnapshotsStreamHashAidxColumnValue implements ColumnValue<Long> {
+        private final SnapshotsStreamHashAidxColumn columnName;
+        private final Long value;
+
+        public static SnapshotsStreamHashAidxColumnValue of(SnapshotsStreamHashAidxColumn columnName, Long value) {
+            return new SnapshotsStreamHashAidxColumnValue(columnName, value);
+        }
+
+        private SnapshotsStreamHashAidxColumnValue(SnapshotsStreamHashAidxColumn columnName, Long value) {
+            this.columnName = columnName;
+            this.value = value;
+        }
+
+        public SnapshotsStreamHashAidxColumn getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return columnName.persistToBytes();
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        public static Long hydrateValue(byte[] bytes) {
+            bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+            return EncodingUtils.decodeUnsignedVarLong(bytes, 0);
+        }
+
+        public static Function<SnapshotsStreamHashAidxColumnValue, SnapshotsStreamHashAidxColumn> getColumnNameFun() {
+            return new Function<SnapshotsStreamHashAidxColumnValue, SnapshotsStreamHashAidxColumn>() {
+                @Override
+                public SnapshotsStreamHashAidxColumn apply(SnapshotsStreamHashAidxColumnValue columnValue) {
+                    return columnValue.getColumnName();
+                }
+            };
+        }
+
+        public static Function<SnapshotsStreamHashAidxColumnValue, Long> getValueFun() {
+            return new Function<SnapshotsStreamHashAidxColumnValue, Long>() {
+                @Override
+                public Long apply(SnapshotsStreamHashAidxColumnValue columnValue) {
+                    return columnValue.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("ColumnName", this.columnName)
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public static final class SnapshotsStreamHashAidxRowResult implements TypedRowResult {
+        private final SnapshotsStreamHashAidxRow rowName;
+        private final ImmutableSet<SnapshotsStreamHashAidxColumnValue> columnValues;
+
+        public static SnapshotsStreamHashAidxRowResult of(RowResult<byte[]> rowResult) {
+            SnapshotsStreamHashAidxRow rowName = SnapshotsStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<SnapshotsStreamHashAidxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                SnapshotsStreamHashAidxColumn col = SnapshotsStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long value = SnapshotsStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                columnValues.add(SnapshotsStreamHashAidxColumnValue.of(col, value));
+            }
+            return new SnapshotsStreamHashAidxRowResult(rowName, ImmutableSet.copyOf(columnValues));
+        }
+
+        private SnapshotsStreamHashAidxRowResult(SnapshotsStreamHashAidxRow rowName, ImmutableSet<SnapshotsStreamHashAidxColumnValue> columnValues) {
+            this.rowName = rowName;
+            this.columnValues = columnValues;
+        }
+
+        @Override
+        public SnapshotsStreamHashAidxRow getRowName() {
+            return rowName;
+        }
+
+        public Set<SnapshotsStreamHashAidxColumnValue> getColumnValues() {
+            return columnValues;
+        }
+
+        public static Function<SnapshotsStreamHashAidxRowResult, SnapshotsStreamHashAidxRow> getRowNameFun() {
+            return new Function<SnapshotsStreamHashAidxRowResult, SnapshotsStreamHashAidxRow>() {
+                @Override
+                public SnapshotsStreamHashAidxRow apply(SnapshotsStreamHashAidxRowResult rowResult) {
+                    return rowResult.rowName;
+                }
+            };
+        }
+
+        public static Function<SnapshotsStreamHashAidxRowResult, ImmutableSet<SnapshotsStreamHashAidxColumnValue>> getColumnValuesFun() {
+            return new Function<SnapshotsStreamHashAidxRowResult, ImmutableSet<SnapshotsStreamHashAidxColumnValue>>() {
+                @Override
+                public ImmutableSet<SnapshotsStreamHashAidxColumnValue> apply(SnapshotsStreamHashAidxRowResult rowResult) {
+                    return rowResult.columnValues;
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("ColumnValues", getColumnValues())
+                .toString();
+        }
+    }
+
+    @Override
+    public void delete(SnapshotsStreamHashAidxRow row, SnapshotsStreamHashAidxColumn column) {
+        delete(ImmutableMultimap.of(row, column));
+    }
+
+    @Override
+    public void delete(Iterable<SnapshotsStreamHashAidxRow> rows) {
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumn> toRemove = HashMultimap.create();
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> result = getRowsMultimap(rows);
+        for (Entry<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> e : result.entries()) {
+            toRemove.put(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toRemove);
+    }
+
+    @Override
+    public void delete(Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumn> values) {
+        t.delete(tableRef, ColumnValues.toCells(values));
+    }
+
+    @Override
+    public void put(SnapshotsStreamHashAidxRow rowName, Iterable<SnapshotsStreamHashAidxColumnValue> values) {
+        put(ImmutableMultimap.<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(SnapshotsStreamHashAidxRow rowName, SnapshotsStreamHashAidxColumnValue... values) {
+        put(ImmutableMultimap.<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(Multimap<SnapshotsStreamHashAidxRow, ? extends SnapshotsStreamHashAidxColumnValue> values) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(values));
+        for (SnapshotsStreamHashAidxTrigger trigger : triggers) {
+            trigger.putSnapshotsStreamHashAidx(values);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(SnapshotsStreamHashAidxRow rowName, Iterable<SnapshotsStreamHashAidxColumnValue> values) {
+        putUnlessExists(ImmutableMultimap.<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(SnapshotsStreamHashAidxRow rowName, SnapshotsStreamHashAidxColumnValue... values) {
+        putUnlessExists(ImmutableMultimap.<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<SnapshotsStreamHashAidxRow, ? extends SnapshotsStreamHashAidxColumnValue> rows) {
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, SnapshotsStreamHashAidxColumnValue.getColumnNameFun());
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> existing = get(toGet);
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> toPut = HashMultimap.create();
+        for (Entry<SnapshotsStreamHashAidxRow, ? extends SnapshotsStreamHashAidxColumnValue> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    @Override
+    public void touch(Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumn> values) {
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> currentValues = get(values);
+        put(currentValues);
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> e : currentValues.entries()) {
+            toDelete.remove(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toDelete);
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<SnapshotsStreamHashAidxColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
+    }
+
+    public static ColumnSelection getColumnSelection(SnapshotsStreamHashAidxColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> get(Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumn> cells) {
+        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> rowMap = HashMultimap.create();
+        for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
+            if (e.getValue().length > 0) {
+                SnapshotsStreamHashAidxRow row = SnapshotsStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                SnapshotsStreamHashAidxColumn col = SnapshotsStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                Long val = SnapshotsStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, SnapshotsStreamHashAidxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public List<SnapshotsStreamHashAidxColumnValue> getRowColumns(SnapshotsStreamHashAidxRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<SnapshotsStreamHashAidxColumnValue> getRowColumns(SnapshotsStreamHashAidxRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<SnapshotsStreamHashAidxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                SnapshotsStreamHashAidxColumn col = SnapshotsStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = SnapshotsStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                ret.add(SnapshotsStreamHashAidxColumnValue.of(col, val));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> getRowsMultimap(Iterable<SnapshotsStreamHashAidxRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> getRowsMultimap(Iterable<SnapshotsStreamHashAidxRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<SnapshotsStreamHashAidxRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            SnapshotsStreamHashAidxRow row = SnapshotsStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                SnapshotsStreamHashAidxColumn col = SnapshotsStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = SnapshotsStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, SnapshotsStreamHashAidxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<SnapshotsStreamHashAidxRow, BatchingVisitable<SnapshotsStreamHashAidxColumnValue>> getRowsColumnRange(Iterable<SnapshotsStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SnapshotsStreamHashAidxRow, BatchingVisitable<SnapshotsStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SnapshotsStreamHashAidxRow row = SnapshotsStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<SnapshotsStreamHashAidxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                SnapshotsStreamHashAidxColumn col = SnapshotsStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = SnapshotsStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return SnapshotsStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue>> getRowsColumnRange(Iterable<SnapshotsStreamHashAidxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            SnapshotsStreamHashAidxRow row = SnapshotsStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            SnapshotsStreamHashAidxColumn col = SnapshotsStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            Long val = SnapshotsStreamHashAidxColumnValue.hydrateValue(e.getValue());
+            SnapshotsStreamHashAidxColumnValue colValue = SnapshotsStreamHashAidxColumnValue.of(col, val);
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<SnapshotsStreamHashAidxRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<SnapshotsStreamHashAidxRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, SnapshotsStreamHashAidxRowResult>() {
+            @Override
+            public SnapshotsStreamHashAidxRowResult apply(RowResult<byte[]> input) {
+                return SnapshotsStreamHashAidxRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "D9ccUt9MdOuoV3fKhAhC+A==";
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
@@ -1,0 +1,746 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class SnapshotsStreamIdxTable implements
+        AtlasDbDynamicMutablePersistentTable<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow,
+                                                SnapshotsStreamIdxTable.SnapshotsStreamIdxColumn,
+                                                SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue,
+                                                SnapshotsStreamIdxTable.SnapshotsStreamIdxRowResult> {
+    private final Transaction t;
+    private final List<SnapshotsStreamIdxTrigger> triggers;
+    private final static String rawTableName = "snapshots_stream_idx";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = ColumnSelection.all();
+
+    static SnapshotsStreamIdxTable of(Transaction t, Namespace namespace) {
+        return new SnapshotsStreamIdxTable(t, namespace, ImmutableList.<SnapshotsStreamIdxTrigger>of());
+    }
+
+    static SnapshotsStreamIdxTable of(Transaction t, Namespace namespace, SnapshotsStreamIdxTrigger trigger, SnapshotsStreamIdxTrigger... triggers) {
+        return new SnapshotsStreamIdxTable(t, namespace, ImmutableList.<SnapshotsStreamIdxTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static SnapshotsStreamIdxTable of(Transaction t, Namespace namespace, List<SnapshotsStreamIdxTrigger> triggers) {
+        return new SnapshotsStreamIdxTable(t, namespace, triggers);
+    }
+
+    private SnapshotsStreamIdxTable(Transaction t, Namespace namespace, List<SnapshotsStreamIdxTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * SnapshotsStreamIdxRow {
+     *   {@literal Long id};
+     * }
+     * </pre>
+     */
+    public static final class SnapshotsStreamIdxRow implements Persistable, Comparable<SnapshotsStreamIdxRow> {
+        private final long id;
+
+        public static SnapshotsStreamIdxRow of(long id) {
+            return new SnapshotsStreamIdxRow(id);
+        }
+
+        private SnapshotsStreamIdxRow(long id) {
+            this.id = id;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public static Function<SnapshotsStreamIdxRow, Long> getIdFun() {
+            return new Function<SnapshotsStreamIdxRow, Long>() {
+                @Override
+                public Long apply(SnapshotsStreamIdxRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<Long, SnapshotsStreamIdxRow> fromIdFun() {
+            return new Function<Long, SnapshotsStreamIdxRow>() {
+                @Override
+                public SnapshotsStreamIdxRow apply(Long row) {
+                    return SnapshotsStreamIdxRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = PtBytes.toBytes(Long.MIN_VALUE ^ id);
+            return EncodingUtils.add(idBytes);
+        }
+
+        public static final Hydrator<SnapshotsStreamIdxRow> BYTES_HYDRATOR = new Hydrator<SnapshotsStreamIdxRow>() {
+            @Override
+            public SnapshotsStreamIdxRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                __index += 8;
+                return new SnapshotsStreamIdxRow(id);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            SnapshotsStreamIdxRow other = (SnapshotsStreamIdxRow) obj;
+            return Objects.equal(id, other.id);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(id);
+        }
+
+        @Override
+        public int compareTo(SnapshotsStreamIdxRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .result();
+        }
+    }
+
+    /**
+     * <pre>
+     * SnapshotsStreamIdxColumn {
+     *   {@literal byte[] reference};
+     * }
+     * </pre>
+     */
+    public static final class SnapshotsStreamIdxColumn implements Persistable, Comparable<SnapshotsStreamIdxColumn> {
+        private final byte[] reference;
+
+        public static SnapshotsStreamIdxColumn of(byte[] reference) {
+            return new SnapshotsStreamIdxColumn(reference);
+        }
+
+        private SnapshotsStreamIdxColumn(byte[] reference) {
+            this.reference = reference;
+        }
+
+        public byte[] getReference() {
+            return reference;
+        }
+
+        public static Function<SnapshotsStreamIdxColumn, byte[]> getReferenceFun() {
+            return new Function<SnapshotsStreamIdxColumn, byte[]>() {
+                @Override
+                public byte[] apply(SnapshotsStreamIdxColumn row) {
+                    return row.reference;
+                }
+            };
+        }
+
+        public static Function<byte[], SnapshotsStreamIdxColumn> fromReferenceFun() {
+            return new Function<byte[], SnapshotsStreamIdxColumn>() {
+                @Override
+                public SnapshotsStreamIdxColumn apply(byte[] row) {
+                    return SnapshotsStreamIdxColumn.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] referenceBytes = EncodingUtils.encodeSizedBytes(reference);
+            return EncodingUtils.add(referenceBytes);
+        }
+
+        public static final Hydrator<SnapshotsStreamIdxColumn> BYTES_HYDRATOR = new Hydrator<SnapshotsStreamIdxColumn>() {
+            @Override
+            public SnapshotsStreamIdxColumn hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
+                __index += EncodingUtils.sizeOfSizedBytes(reference);
+                return new SnapshotsStreamIdxColumn(reference);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("reference", reference)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            SnapshotsStreamIdxColumn other = (SnapshotsStreamIdxColumn) obj;
+            return Arrays.equals(reference, other.reference);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(reference);
+        }
+
+        @Override
+        public int compareTo(SnapshotsStreamIdxColumn o) {
+            return ComparisonChain.start()
+                .compare(this.reference, o.reference, UnsignedBytes.lexicographicalComparator())
+                .result();
+        }
+    }
+
+    public interface SnapshotsStreamIdxTrigger {
+        public void putSnapshotsStreamIdx(Multimap<SnapshotsStreamIdxRow, ? extends SnapshotsStreamIdxColumnValue> newRows);
+    }
+
+    /**
+     * <pre>
+     * Column name description {
+     *   {@literal byte[] reference};
+     * }
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class SnapshotsStreamIdxColumnValue implements ColumnValue<Long> {
+        private final SnapshotsStreamIdxColumn columnName;
+        private final Long value;
+
+        public static SnapshotsStreamIdxColumnValue of(SnapshotsStreamIdxColumn columnName, Long value) {
+            return new SnapshotsStreamIdxColumnValue(columnName, value);
+        }
+
+        private SnapshotsStreamIdxColumnValue(SnapshotsStreamIdxColumn columnName, Long value) {
+            this.columnName = columnName;
+            this.value = value;
+        }
+
+        public SnapshotsStreamIdxColumn getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return columnName.persistToBytes();
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        public static Long hydrateValue(byte[] bytes) {
+            bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+            return EncodingUtils.decodeUnsignedVarLong(bytes, 0);
+        }
+
+        public static Function<SnapshotsStreamIdxColumnValue, SnapshotsStreamIdxColumn> getColumnNameFun() {
+            return new Function<SnapshotsStreamIdxColumnValue, SnapshotsStreamIdxColumn>() {
+                @Override
+                public SnapshotsStreamIdxColumn apply(SnapshotsStreamIdxColumnValue columnValue) {
+                    return columnValue.getColumnName();
+                }
+            };
+        }
+
+        public static Function<SnapshotsStreamIdxColumnValue, Long> getValueFun() {
+            return new Function<SnapshotsStreamIdxColumnValue, Long>() {
+                @Override
+                public Long apply(SnapshotsStreamIdxColumnValue columnValue) {
+                    return columnValue.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("ColumnName", this.columnName)
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public static final class SnapshotsStreamIdxRowResult implements TypedRowResult {
+        private final SnapshotsStreamIdxRow rowName;
+        private final ImmutableSet<SnapshotsStreamIdxColumnValue> columnValues;
+
+        public static SnapshotsStreamIdxRowResult of(RowResult<byte[]> rowResult) {
+            SnapshotsStreamIdxRow rowName = SnapshotsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<SnapshotsStreamIdxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                SnapshotsStreamIdxColumn col = SnapshotsStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long value = SnapshotsStreamIdxColumnValue.hydrateValue(e.getValue());
+                columnValues.add(SnapshotsStreamIdxColumnValue.of(col, value));
+            }
+            return new SnapshotsStreamIdxRowResult(rowName, ImmutableSet.copyOf(columnValues));
+        }
+
+        private SnapshotsStreamIdxRowResult(SnapshotsStreamIdxRow rowName, ImmutableSet<SnapshotsStreamIdxColumnValue> columnValues) {
+            this.rowName = rowName;
+            this.columnValues = columnValues;
+        }
+
+        @Override
+        public SnapshotsStreamIdxRow getRowName() {
+            return rowName;
+        }
+
+        public Set<SnapshotsStreamIdxColumnValue> getColumnValues() {
+            return columnValues;
+        }
+
+        public static Function<SnapshotsStreamIdxRowResult, SnapshotsStreamIdxRow> getRowNameFun() {
+            return new Function<SnapshotsStreamIdxRowResult, SnapshotsStreamIdxRow>() {
+                @Override
+                public SnapshotsStreamIdxRow apply(SnapshotsStreamIdxRowResult rowResult) {
+                    return rowResult.rowName;
+                }
+            };
+        }
+
+        public static Function<SnapshotsStreamIdxRowResult, ImmutableSet<SnapshotsStreamIdxColumnValue>> getColumnValuesFun() {
+            return new Function<SnapshotsStreamIdxRowResult, ImmutableSet<SnapshotsStreamIdxColumnValue>>() {
+                @Override
+                public ImmutableSet<SnapshotsStreamIdxColumnValue> apply(SnapshotsStreamIdxRowResult rowResult) {
+                    return rowResult.columnValues;
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("ColumnValues", getColumnValues())
+                .toString();
+        }
+    }
+
+    @Override
+    public void delete(SnapshotsStreamIdxRow row, SnapshotsStreamIdxColumn column) {
+        delete(ImmutableMultimap.of(row, column));
+    }
+
+    @Override
+    public void delete(Iterable<SnapshotsStreamIdxRow> rows) {
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumn> toRemove = HashMultimap.create();
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> result = getRowsMultimap(rows);
+        for (Entry<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> e : result.entries()) {
+            toRemove.put(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toRemove);
+    }
+
+    @Override
+    public void delete(Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumn> values) {
+        t.delete(tableRef, ColumnValues.toCells(values));
+    }
+
+    @Override
+    public void put(SnapshotsStreamIdxRow rowName, Iterable<SnapshotsStreamIdxColumnValue> values) {
+        put(ImmutableMultimap.<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(SnapshotsStreamIdxRow rowName, SnapshotsStreamIdxColumnValue... values) {
+        put(ImmutableMultimap.<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(Multimap<SnapshotsStreamIdxRow, ? extends SnapshotsStreamIdxColumnValue> values) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(values));
+        for (SnapshotsStreamIdxTrigger trigger : triggers) {
+            trigger.putSnapshotsStreamIdx(values);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(SnapshotsStreamIdxRow rowName, Iterable<SnapshotsStreamIdxColumnValue> values) {
+        putUnlessExists(ImmutableMultimap.<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(SnapshotsStreamIdxRow rowName, SnapshotsStreamIdxColumnValue... values) {
+        putUnlessExists(ImmutableMultimap.<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<SnapshotsStreamIdxRow, ? extends SnapshotsStreamIdxColumnValue> rows) {
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumn> toGet = Multimaps.transformValues(rows, SnapshotsStreamIdxColumnValue.getColumnNameFun());
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> existing = get(toGet);
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> toPut = HashMultimap.create();
+        for (Entry<SnapshotsStreamIdxRow, ? extends SnapshotsStreamIdxColumnValue> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    @Override
+    public void touch(Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumn> values) {
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> currentValues = get(values);
+        put(currentValues);
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> e : currentValues.entries()) {
+            toDelete.remove(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toDelete);
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<SnapshotsStreamIdxColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
+    }
+
+    public static ColumnSelection getColumnSelection(SnapshotsStreamIdxColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> get(Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumn> cells) {
+        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> rowMap = HashMultimap.create();
+        for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
+            if (e.getValue().length > 0) {
+                SnapshotsStreamIdxRow row = SnapshotsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                SnapshotsStreamIdxColumn col = SnapshotsStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                Long val = SnapshotsStreamIdxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, SnapshotsStreamIdxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public List<SnapshotsStreamIdxColumnValue> getRowColumns(SnapshotsStreamIdxRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<SnapshotsStreamIdxColumnValue> getRowColumns(SnapshotsStreamIdxRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<SnapshotsStreamIdxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                SnapshotsStreamIdxColumn col = SnapshotsStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = SnapshotsStreamIdxColumnValue.hydrateValue(e.getValue());
+                ret.add(SnapshotsStreamIdxColumnValue.of(col, val));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> getRowsMultimap(Iterable<SnapshotsStreamIdxRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> getRowsMultimap(Iterable<SnapshotsStreamIdxRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> getRowsMultimapInternal(Iterable<SnapshotsStreamIdxRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            SnapshotsStreamIdxRow row = SnapshotsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                SnapshotsStreamIdxColumn col = SnapshotsStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = SnapshotsStreamIdxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, SnapshotsStreamIdxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<SnapshotsStreamIdxRow, BatchingVisitable<SnapshotsStreamIdxColumnValue>> getRowsColumnRange(Iterable<SnapshotsStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SnapshotsStreamIdxRow, BatchingVisitable<SnapshotsStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SnapshotsStreamIdxRow row = SnapshotsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<SnapshotsStreamIdxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                SnapshotsStreamIdxColumn col = SnapshotsStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = SnapshotsStreamIdxColumnValue.hydrateValue(result.getValue());
+                return SnapshotsStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue>> getRowsColumnRange(Iterable<SnapshotsStreamIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            SnapshotsStreamIdxRow row = SnapshotsStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            SnapshotsStreamIdxColumn col = SnapshotsStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            Long val = SnapshotsStreamIdxColumnValue.hydrateValue(e.getValue());
+            SnapshotsStreamIdxColumnValue colValue = SnapshotsStreamIdxColumnValue.of(col, val);
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<SnapshotsStreamIdxRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<SnapshotsStreamIdxRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, SnapshotsStreamIdxRowResult>() {
+            @Override
+            public SnapshotsStreamIdxRowResult apply(RowResult<byte[]> input) {
+                return SnapshotsStreamIdxRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "1Z0UT5cHF4GCHwjaZ8WAyw==";
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
@@ -1,0 +1,711 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class SnapshotsStreamMetadataTable implements
+        AtlasDbMutablePersistentTable<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow,
+                                         SnapshotsStreamMetadataTable.SnapshotsStreamMetadataNamedColumnValue<?>,
+                                         SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRowResult>,
+        AtlasDbNamedMutableTable<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow,
+                                    SnapshotsStreamMetadataTable.SnapshotsStreamMetadataNamedColumnValue<?>,
+                                    SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRowResult> {
+    private final Transaction t;
+    private final List<SnapshotsStreamMetadataTrigger> triggers;
+    private final static String rawTableName = "snapshots_stream_metadata";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(SnapshotsStreamMetadataNamedColumn.values());
+
+    static SnapshotsStreamMetadataTable of(Transaction t, Namespace namespace) {
+        return new SnapshotsStreamMetadataTable(t, namespace, ImmutableList.<SnapshotsStreamMetadataTrigger>of());
+    }
+
+    static SnapshotsStreamMetadataTable of(Transaction t, Namespace namespace, SnapshotsStreamMetadataTrigger trigger, SnapshotsStreamMetadataTrigger... triggers) {
+        return new SnapshotsStreamMetadataTable(t, namespace, ImmutableList.<SnapshotsStreamMetadataTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static SnapshotsStreamMetadataTable of(Transaction t, Namespace namespace, List<SnapshotsStreamMetadataTrigger> triggers) {
+        return new SnapshotsStreamMetadataTable(t, namespace, triggers);
+    }
+
+    private SnapshotsStreamMetadataTable(Transaction t, Namespace namespace, List<SnapshotsStreamMetadataTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * SnapshotsStreamMetadataRow {
+     *   {@literal Long id};
+     * }
+     * </pre>
+     */
+    public static final class SnapshotsStreamMetadataRow implements Persistable, Comparable<SnapshotsStreamMetadataRow> {
+        private final long id;
+
+        public static SnapshotsStreamMetadataRow of(long id) {
+            return new SnapshotsStreamMetadataRow(id);
+        }
+
+        private SnapshotsStreamMetadataRow(long id) {
+            this.id = id;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public static Function<SnapshotsStreamMetadataRow, Long> getIdFun() {
+            return new Function<SnapshotsStreamMetadataRow, Long>() {
+                @Override
+                public Long apply(SnapshotsStreamMetadataRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<Long, SnapshotsStreamMetadataRow> fromIdFun() {
+            return new Function<Long, SnapshotsStreamMetadataRow>() {
+                @Override
+                public SnapshotsStreamMetadataRow apply(Long row) {
+                    return SnapshotsStreamMetadataRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = PtBytes.toBytes(Long.MIN_VALUE ^ id);
+            return EncodingUtils.add(idBytes);
+        }
+
+        public static final Hydrator<SnapshotsStreamMetadataRow> BYTES_HYDRATOR = new Hydrator<SnapshotsStreamMetadataRow>() {
+            @Override
+            public SnapshotsStreamMetadataRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                __index += 8;
+                return new SnapshotsStreamMetadataRow(id);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            SnapshotsStreamMetadataRow other = (SnapshotsStreamMetadataRow) obj;
+            return Objects.equal(id, other.id);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(id);
+        }
+
+        @Override
+        public int compareTo(SnapshotsStreamMetadataRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .result();
+        }
+    }
+
+    public interface SnapshotsStreamMetadataNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+     *   name: "StreamMetadata"
+     *   field {
+     *     name: "status"
+     *     number: 1
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_ENUM
+     *     type_name: ".com.palantir.atlasdb.protos.generated.Status"
+     *   }
+     *   field {
+     *     name: "length"
+     *     number: 2
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_INT64
+     *   }
+     *   field {
+     *     name: "hash"
+     *     number: 3
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_BYTES
+     *   }
+     * }
+     * </pre>
+     */
+    public static final class Metadata implements SnapshotsStreamMetadataNamedColumnValue<com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> {
+        private final com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value;
+
+        public static Metadata of(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+            return new Metadata(value);
+        }
+
+        private Metadata(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "metadata";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "md";
+        }
+
+        @Override
+        public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = value.toByteArray();
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("md");
+        }
+
+        public static final Hydrator<Metadata> BYTES_HYDRATOR = new Hydrator<Metadata>() {
+            @Override
+            public Metadata hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                try {
+                    return of(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata.parseFrom(bytes));
+                } catch (InvalidProtocolBufferException e) {
+                    throw Throwables.throwUncheckedException(e);
+                }
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface SnapshotsStreamMetadataTrigger {
+        public void putSnapshotsStreamMetadata(Multimap<SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataNamedColumnValue<?>> newRows);
+    }
+
+    public static final class SnapshotsStreamMetadataRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static SnapshotsStreamMetadataRowResult of(RowResult<byte[]> row) {
+            return new SnapshotsStreamMetadataRowResult(row);
+        }
+
+        private SnapshotsStreamMetadataRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public SnapshotsStreamMetadataRow getRowName() {
+            return SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<SnapshotsStreamMetadataRowResult, SnapshotsStreamMetadataRow> getRowNameFun() {
+            return new Function<SnapshotsStreamMetadataRowResult, SnapshotsStreamMetadataRow>() {
+                @Override
+                public SnapshotsStreamMetadataRow apply(SnapshotsStreamMetadataRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, SnapshotsStreamMetadataRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, SnapshotsStreamMetadataRowResult>() {
+                @Override
+                public SnapshotsStreamMetadataRowResult apply(RowResult<byte[]> rowResult) {
+                    return new SnapshotsStreamMetadataRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasMetadata() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("md"));
+        }
+
+        public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata getMetadata() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("md"));
+            if (bytes == null) {
+                return null;
+            }
+            Metadata value = Metadata.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<SnapshotsStreamMetadataRowResult, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> getMetadataFun() {
+            return new Function<SnapshotsStreamMetadataRowResult, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>() {
+                @Override
+                public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata apply(SnapshotsStreamMetadataRowResult rowResult) {
+                    return rowResult.getMetadata();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Metadata", getMetadata())
+                .toString();
+        }
+    }
+
+    public enum SnapshotsStreamMetadataNamedColumn {
+        METADATA {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("md");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<SnapshotsStreamMetadataNamedColumn, byte[]> toShortName() {
+            return new Function<SnapshotsStreamMetadataNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(SnapshotsStreamMetadataNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<SnapshotsStreamMetadataNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, SnapshotsStreamMetadataNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(SnapshotsStreamMetadataNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends SnapshotsStreamMetadataNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends SnapshotsStreamMetadataNamedColumnValue<?>>>builder()
+                .put("md", Metadata.BYTES_HYDRATOR)
+                .build();
+
+    public Map<SnapshotsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> getMetadatas(Collection<SnapshotsStreamMetadataRow> rows) {
+        Map<Cell, SnapshotsStreamMetadataRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (SnapshotsStreamMetadataRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("md")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<SnapshotsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata val = Metadata.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putMetadata(SnapshotsStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+        put(ImmutableMultimap.of(row, Metadata.of(value)));
+    }
+
+    public void putMetadata(Map<SnapshotsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
+        Map<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<SnapshotsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
+            toPut.put(e.getKey(), Metadata.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    public void putMetadataUnlessExists(SnapshotsStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
+    }
+
+    public void putMetadataUnlessExists(Map<SnapshotsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
+        Map<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<SnapshotsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
+            toPut.put(e.getKey(), Metadata.of(e.getValue()));
+        }
+        putUnlessExists(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (SnapshotsStreamMetadataTrigger trigger : triggers) {
+            trigger.putSnapshotsStreamMetadata(rows);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataNamedColumnValue<?>> rows) {
+        Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    public void deleteMetadata(SnapshotsStreamMetadataRow row) {
+        deleteMetadata(ImmutableSet.of(row));
+    }
+
+    public void deleteMetadata(Iterable<SnapshotsStreamMetadataRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("md");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(SnapshotsStreamMetadataRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<SnapshotsStreamMetadataRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
+        t.delete(tableRef, cells);
+    }
+
+    public Optional<SnapshotsStreamMetadataRowResult> getRow(SnapshotsStreamMetadataRow row) {
+        return getRow(row, allColumns);
+    }
+
+    public Optional<SnapshotsStreamMetadataRowResult> getRow(SnapshotsStreamMetadataRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(SnapshotsStreamMetadataRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<SnapshotsStreamMetadataRowResult> getRows(Iterable<SnapshotsStreamMetadataRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<SnapshotsStreamMetadataRowResult> getRows(Iterable<SnapshotsStreamMetadataRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<SnapshotsStreamMetadataRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(SnapshotsStreamMetadataRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<SnapshotsStreamMetadataNamedColumnValue<?>> getRowColumns(SnapshotsStreamMetadataRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<SnapshotsStreamMetadataNamedColumnValue<?>> getRowColumns(SnapshotsStreamMetadataRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<SnapshotsStreamMetadataNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<SnapshotsStreamMetadataRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<SnapshotsStreamMetadataRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<SnapshotsStreamMetadataRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            SnapshotsStreamMetadataRow row = SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<SnapshotsStreamMetadataRow, BatchingVisitable<SnapshotsStreamMetadataNamedColumnValue<?>>> getRowsColumnRange(Iterable<SnapshotsStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SnapshotsStreamMetadataRow, BatchingVisitable<SnapshotsStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SnapshotsStreamMetadataRow row = SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<SnapshotsStreamMetadataNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>>> getRowsColumnRange(Iterable<SnapshotsStreamMetadataRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            SnapshotsStreamMetadataRow row = SnapshotsStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            SnapshotsStreamMetadataNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<SnapshotsStreamMetadataRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<SnapshotsStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, SnapshotsStreamMetadataRowResult>() {
+            @Override
+            public SnapshotsStreamMetadataRowResult apply(RowResult<byte[]> input) {
+                return SnapshotsStreamMetadataRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "Clu6ft0rCGarQTmWAid/hA==";
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamStore.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamStore.java
@@ -1,0 +1,451 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Generated;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.CountingInputStream;
+import com.google.common.primitives.Ints;
+import com.google.protobuf.ByteString;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata.Builder;
+import com.palantir.atlasdb.stream.AbstractPersistentStreamStore;
+import com.palantir.atlasdb.stream.BlockConsumingInputStream;
+import com.palantir.atlasdb.stream.BlockGetter;
+import com.palantir.atlasdb.stream.BlockLoader;
+import com.palantir.atlasdb.stream.PersistentStreamStore;
+import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.TxTask;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.compression.LZ4CompressingInputStream;
+import com.palantir.common.io.ConcatenatedInputStream;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.ByteArrayIOStream;
+import com.palantir.util.Pair;
+import com.palantir.util.crypto.Sha256Hash;
+import com.palantir.util.file.DeleteOnCloseFileInputStream;
+import com.palantir.util.file.TempFileUtils;
+
+import net.jpountz.lz4.LZ4BlockInputStream;
+
+@Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
+@SuppressWarnings("all")
+public final class SnapshotsStreamStore extends AbstractPersistentStreamStore {
+    public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
+    public static final int IN_MEMORY_THRESHOLD = 4194304; // streams under this size are kept in memory when loaded
+    public static final String STREAM_FILE_PREFIX = "Snapshots_stream_";
+    public static final String STREAM_FILE_SUFFIX = ".tmp";
+
+    private static final Logger log = LoggerFactory.getLogger(SnapshotsStreamStore.class);
+
+    private final TodoSchemaTableFactory tables;
+
+    private SnapshotsStreamStore(TransactionManager txManager, TodoSchemaTableFactory tables) {
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private SnapshotsStreamStore(TransactionManager txManager, TodoSchemaTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, persistenceConfiguration);
+        this.tables = tables;
+    }
+
+    public static SnapshotsStreamStore of(TransactionManager txManager, TodoSchemaTableFactory tables) {
+        return new SnapshotsStreamStore(txManager, tables);
+    }
+
+    public static SnapshotsStreamStore of(TransactionManager txManager, TodoSchemaTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new SnapshotsStreamStore(txManager, tables, persistenceConfiguration);
+    }
+
+    /**
+     * This should only be used by test code or as a performance optimization.
+     */
+    static SnapshotsStreamStore of(TodoSchemaTableFactory tables) {
+        return new SnapshotsStreamStore(null, tables);
+    }
+
+    @Override
+    protected long getInMemoryThreshold() {
+        return IN_MEMORY_THRESHOLD;
+    }
+
+    @Override
+    protected void storeBlock(Transaction t, long id, long blockNumber, final byte[] block) {
+        Preconditions.checkArgument(block.length <= BLOCK_SIZE_IN_BYTES, "Block to store in DB must be less than BLOCK_SIZE_IN_BYTES");
+        final SnapshotsStreamValueTable.SnapshotsStreamValueRow row = SnapshotsStreamValueTable.SnapshotsStreamValueRow.of(id, blockNumber);
+        try {
+            // Do a touch operation on this table to ensure we get a conflict if someone cleans it up.
+            touchMetadataWhileStoringForConflicts(t, row.getId(), row.getBlockId());
+            tables.getSnapshotsStreamValueTable(t).putValue(row, block);
+        } catch (RuntimeException e) {
+            log.error("Error storing block {} for stream id {}", row.getBlockId(), row.getId(), e);
+            throw e;
+        }
+    }
+
+    private void touchMetadataWhileStoringForConflicts(Transaction t, Long id, long blockNumber) {
+        SnapshotsStreamMetadataTable metaTable = tables.getSnapshotsStreamMetadataTable(t);
+        SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow row = SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.of(id);
+        StreamMetadata metadata = metaTable.getMetadatas(ImmutableSet.of(row)).values().iterator().next();
+        Preconditions.checkState(metadata.getStatus() == Status.STORING, "This stream is being cleaned up while storing blocks: %s", id);
+        Builder builder = StreamMetadata.newBuilder(metadata);
+        builder.setLength(blockNumber * BLOCK_SIZE_IN_BYTES + 1);
+        metaTable.putMetadata(row, builder.build());
+    }
+
+    @Override
+    protected void putMetadataAndHashIndexTask(Transaction t, Map<Long, StreamMetadata> streamIdsToMetadata) {
+        SnapshotsStreamMetadataTable mdTable = tables.getSnapshotsStreamMetadataTable(t);
+        Map<Long, StreamMetadata> prevMetadatas = getMetadata(t, streamIdsToMetadata.keySet());
+
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> rowsToStoredMetadata = Maps.newHashMap();
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> rowsToUnstoredMetadata = Maps.newHashMap();
+        for (Entry<Long, StreamMetadata> e : streamIdsToMetadata.entrySet()) {
+            long streamId = e.getKey();
+            StreamMetadata metadata = e.getValue();
+            StreamMetadata prevMetadata = prevMetadatas.get(streamId);
+            if (metadata.getStatus() == Status.STORED) {
+                if (prevMetadata == null || prevMetadata.getStatus() != Status.STORING) {
+                    // This can happen if we cleanup old streams.
+                    throw new TransactionFailedRetriableException("Cannot mark a stream as stored that isn't currently storing: " + prevMetadata);
+                }
+                rowsToStoredMetadata.put(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.of(streamId), metadata);
+            } else if (metadata.getStatus() == Status.STORING) {
+                // This will prevent two users trying to store the same id.
+                if (prevMetadata != null) {
+                    throw new TransactionFailedRetriableException("Cannot reuse the same stream id: " + streamId);
+                }
+                rowsToUnstoredMetadata.put(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.of(streamId), metadata);
+            }
+        }
+        putHashIndexTask(t, rowsToStoredMetadata);
+
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> rowsToMetadata = Maps.newHashMap();
+        rowsToMetadata.putAll(rowsToStoredMetadata);
+        rowsToMetadata.putAll(rowsToUnstoredMetadata);
+        mdTable.putMetadata(rowsToMetadata);
+    }
+
+    private long getNumberOfBlocksFromMetadata(StreamMetadata metadata) {
+        return (metadata.getLength() + BLOCK_SIZE_IN_BYTES - 1) / BLOCK_SIZE_IN_BYTES;
+    }
+
+    @Override
+    protected File createTempFile(Long id) throws IOException {
+        File file = TempFileUtils.createTempFile(STREAM_FILE_PREFIX + id, STREAM_FILE_SUFFIX);
+        file.deleteOnExit();
+        return file;
+    }
+
+    @Override
+    protected void loadSingleBlockToOutputStream(Transaction t, Long streamId, long blockId, OutputStream os) {
+        SnapshotsStreamValueTable.SnapshotsStreamValueRow row = SnapshotsStreamValueTable.SnapshotsStreamValueRow.of(streamId, blockId);
+        try {
+            os.write(getBlock(t, row));
+        } catch (RuntimeException e) {
+            log.error("Error storing block {} for stream id {}", row.getBlockId(), row.getId(), e);
+            throw e;
+        } catch (IOException e) {
+            log.error("Error writing block {} to file when getting stream id {}", row.getBlockId(), row.getId(), e);
+            throw Throwables.rewrapAndThrowUncheckedException("Error writing blocks to file when creating stream.", e);
+        }
+    }
+
+    private byte[] getBlock(Transaction t, SnapshotsStreamValueTable.SnapshotsStreamValueRow row) {
+        SnapshotsStreamValueTable valueTable = tables.getSnapshotsStreamValueTable(t);
+        return valueTable.getValues(ImmutableSet.of(row)).get(row);
+    }
+
+    @Override
+    protected Map<Long, StreamMetadata> getMetadata(Transaction t, Set<Long> streamIds) {
+        if (streamIds.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        SnapshotsStreamMetadataTable table = tables.getSnapshotsStreamMetadataTable(t);
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(getMetadataRowsForIds(streamIds));
+        Map<Long, StreamMetadata> ret = Maps.newHashMap();
+        for (Map.Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            ret.put(e.getKey().getId(), e.getValue());
+        }
+        return ret;
+    }
+
+    @Override
+    public Map<Sha256Hash, Long> lookupStreamIdsByHash(Transaction t, final Set<Sha256Hash> hashes) {
+        if (hashes.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        SnapshotsStreamHashAidxTable idx = tables.getSnapshotsStreamHashAidxTable(t);
+        Set<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow> rows = getHashIndexRowsForHashes(hashes);
+
+        Multimap<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue> m = idx.getRowsMultimap(rows);
+        Map<Long, Sha256Hash> hashForStreams = Maps.newHashMap();
+        for (SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow r : m.keySet()) {
+            for (SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue v : m.get(r)) {
+                Long streamId = v.getColumnName().getStreamId();
+                Sha256Hash hash = r.getHash();
+                if (hashForStreams.containsKey(streamId)) {
+                    AssertUtils.assertAndLog(log, hashForStreams.get(streamId).equals(hash), "(BUG) Stream ID has 2 different hashes: " + streamId);
+                }
+                hashForStreams.put(streamId, hash);
+            }
+        }
+        Map<Long, StreamMetadata> metadata = getMetadata(t, hashForStreams.keySet());
+
+        Map<Sha256Hash, Long> ret = Maps.newHashMap();
+        for (Map.Entry<Long, StreamMetadata> e : metadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                continue;
+            }
+            Sha256Hash hash = hashForStreams.get(e.getKey());
+            ret.put(hash, e.getKey());
+        }
+
+        return ret;
+    }
+
+    private Set<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow> getHashIndexRowsForHashes(final Set<Sha256Hash> hashes) {
+        Set<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow> rows = Sets.newHashSet();
+        for (Sha256Hash h : hashes) {
+            rows.add(SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow.of(h));
+        }
+        return rows;
+    }
+
+    private Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> getMetadataRowsForIds(final Iterable<Long> ids) {
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> rows = Sets.newHashSet();
+        for (Long id : ids) {
+            rows.add(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.of(id));
+        }
+        return rows;
+    }
+
+    private void putHashIndexTask(Transaction t, Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> rowsToMetadata) {
+        Multimap<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue> indexMap = HashMultimap.create();
+        for (Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : rowsToMetadata.entrySet()) {
+            SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow row = e.getKey();
+            StreamMetadata metadata = e.getValue();
+            Preconditions.checkArgument(
+                    metadata.getStatus() == Status.STORED,
+                    "Should only index successfully stored streams.");
+
+            Sha256Hash hash = Sha256Hash.EMPTY;
+            if (metadata.getHash() != com.google.protobuf.ByteString.EMPTY) {
+                hash = new Sha256Hash(metadata.getHash().toByteArray());
+            }
+            SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow hashRow = SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow.of(hash);
+            SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumn column = SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumn.of(row.getId());
+            SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue columnValue = SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue.of(column, 0L);
+            indexMap.put(hashRow, columnValue);
+        }
+        SnapshotsStreamHashAidxTable hiTable = tables.getSnapshotsStreamHashAidxTable(t);
+        hiTable.put(indexMap);
+    }
+
+    /**
+     * This should only be used from the cleanup tasks.
+     */
+    void deleteStreams(Transaction t, final Set<Long> streamIds) {
+        if (streamIds.isEmpty()) {
+            return;
+        }
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> smRows = Sets.newHashSet();
+        Multimap<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumn> shToDelete = HashMultimap.create();
+        for (Long streamId : streamIds) {
+            smRows.add(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.of(streamId));
+        }
+        SnapshotsStreamMetadataTable table = tables.getSnapshotsStreamMetadataTable(t);
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(smRows);
+        Set<SnapshotsStreamValueTable.SnapshotsStreamValueRow> streamValueToDelete = Sets.newHashSet();
+        for (Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            Long streamId = e.getKey().getId();
+            long blocks = getNumberOfBlocksFromMetadata(e.getValue());
+            for (long i = 0; i < blocks; i++) {
+                streamValueToDelete.add(SnapshotsStreamValueTable.SnapshotsStreamValueRow.of(streamId, i));
+            }
+            ByteString streamHash = e.getValue().getHash();
+            Sha256Hash hash = Sha256Hash.EMPTY;
+            if (streamHash != com.google.protobuf.ByteString.EMPTY) {
+                hash = new Sha256Hash(streamHash.toByteArray());
+            } else {
+                log.error("Empty hash for stream {}", streamId);
+            }
+            SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow hashRow = SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow.of(hash);
+            SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumn column = SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumn.of(streamId);
+            shToDelete.put(hashRow, column);
+        }
+        tables.getSnapshotsStreamHashAidxTable(t).delete(shToDelete);
+        tables.getSnapshotsStreamValueTable(t).delete(streamValueToDelete);
+        table.delete(smRows);
+    }
+
+    @Override
+    protected void markStreamsAsUsedInternal(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
+        if (streamIdsToReference.isEmpty()) {
+            return;
+        }
+        SnapshotsStreamIdxTable index = tables.getSnapshotsStreamIdxTable(t);
+        Multimap<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue> rowsToValues = HashMultimap.create();
+        for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
+            Long streamId = entry.getKey();
+            byte[] reference = entry.getValue();
+            SnapshotsStreamIdxTable.SnapshotsStreamIdxColumn col = SnapshotsStreamIdxTable.SnapshotsStreamIdxColumn.of(reference);
+            SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue value = SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue.of(col, 0L);
+            rowsToValues.put(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow.of(streamId), value);
+        }
+        index.put(rowsToValues);
+    }
+
+    @Override
+    public void unmarkStreamsAsUsed(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
+        if (streamIdsToReference.isEmpty()) {
+            return;
+        }
+        SnapshotsStreamIdxTable index = tables.getSnapshotsStreamIdxTable(t);
+        Multimap<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, SnapshotsStreamIdxTable.SnapshotsStreamIdxColumn> toDelete = ArrayListMultimap.create(streamIdsToReference.size(), 1);
+        for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
+            Long streamId = entry.getKey();
+            byte[] reference = entry.getValue();
+            SnapshotsStreamIdxTable.SnapshotsStreamIdxColumn col = SnapshotsStreamIdxTable.SnapshotsStreamIdxColumn.of(reference);
+            toDelete.put(SnapshotsStreamIdxTable.SnapshotsStreamIdxRow.of(streamId), col);
+        }
+        index.delete(toDelete);
+    }
+
+    @Override
+    protected void touchMetadataWhileMarkingUsedForConflicts(Transaction t, Iterable<Long> ids) {
+        SnapshotsStreamMetadataTable metaTable = tables.getSnapshotsStreamMetadataTable(t);
+        Set<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> rows = Sets.newHashSet();
+        for (Long id : ids) {
+            rows.add(SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow.of(id));
+        }
+        Map<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> metadatas = metaTable.getMetadatas(rows);
+        for (Map.Entry<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            StreamMetadata metadata = e.getValue();
+            Preconditions.checkState(metadata.getStatus() == Status.STORED,
+            "Stream: %s has status: %s", e.getKey().getId(), metadata.getStatus());
+            metaTable.putMetadata(e.getKey(), metadata);
+        }
+        SetView<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow> missingRows = Sets.difference(rows, metadatas.keySet());
+        if (!missingRows.isEmpty()) {
+            throw new IllegalStateException("Missing metadata rows for:" + missingRows
+            + " rows: " + rows + " metadata: " + metadatas + " txn timestamp: " + t.getTimestamp());
+        }
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbstractPersistentStreamStore}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link BiConsumer}
+     * {@link BlockConsumingInputStream}
+     * {@link BlockGetter}
+     * {@link BlockLoader}
+     * {@link BufferedInputStream}
+     * {@link Builder}
+     * {@link ByteArrayIOStream}
+     * {@link ByteArrayInputStream}
+     * {@link ByteStreams}
+     * {@link ByteString}
+     * {@link Cell}
+     * {@link CheckForNull}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ConcatenatedInputStream}
+     * {@link CountingInputStream}
+     * {@link DeleteOnCloseFileInputStream}
+     * {@link DigestInputStream}
+     * {@link Entry}
+     * {@link File}
+     * {@link FileNotFoundException}
+     * {@link FileOutputStream}
+     * {@link Functions}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link IOException}
+     * {@link ImmutableMap}
+     * {@link ImmutableSet}
+     * {@link InputStream}
+     * {@link Ints}
+     * {@link LZ4BlockInputStream}
+     * {@link LZ4CompressingInputStream}
+     * {@link List}
+     * {@link Lists}
+     * {@link Logger}
+     * {@link LoggerFactory}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MessageDigest}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link Optional}
+     * {@link OutputStream}
+     * {@link Pair}
+     * {@link PersistentStreamStore}
+     * {@link Preconditions}
+     * {@link Set}
+     * {@link SetView}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link Status}
+     * {@link StreamCleanedException}
+     * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
+     * {@link TempFileUtils}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TransactionFailedRetriableException}
+     * {@link TransactionManager}
+     * {@link TransactionTask}
+     * {@link TxTask}
+     */
+    static final int dummy = 0;
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
@@ -1,0 +1,699 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class SnapshotsStreamValueTable implements
+        AtlasDbMutablePersistentTable<SnapshotsStreamValueTable.SnapshotsStreamValueRow,
+                                         SnapshotsStreamValueTable.SnapshotsStreamValueNamedColumnValue<?>,
+                                         SnapshotsStreamValueTable.SnapshotsStreamValueRowResult>,
+        AtlasDbNamedMutableTable<SnapshotsStreamValueTable.SnapshotsStreamValueRow,
+                                    SnapshotsStreamValueTable.SnapshotsStreamValueNamedColumnValue<?>,
+                                    SnapshotsStreamValueTable.SnapshotsStreamValueRowResult> {
+    private final Transaction t;
+    private final List<SnapshotsStreamValueTrigger> triggers;
+    private final static String rawTableName = "snapshots_stream_value";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(SnapshotsStreamValueNamedColumn.values());
+
+    static SnapshotsStreamValueTable of(Transaction t, Namespace namespace) {
+        return new SnapshotsStreamValueTable(t, namespace, ImmutableList.<SnapshotsStreamValueTrigger>of());
+    }
+
+    static SnapshotsStreamValueTable of(Transaction t, Namespace namespace, SnapshotsStreamValueTrigger trigger, SnapshotsStreamValueTrigger... triggers) {
+        return new SnapshotsStreamValueTable(t, namespace, ImmutableList.<SnapshotsStreamValueTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static SnapshotsStreamValueTable of(Transaction t, Namespace namespace, List<SnapshotsStreamValueTrigger> triggers) {
+        return new SnapshotsStreamValueTable(t, namespace, triggers);
+    }
+
+    private SnapshotsStreamValueTable(Transaction t, Namespace namespace, List<SnapshotsStreamValueTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * SnapshotsStreamValueRow {
+     *   {@literal Long id};
+     *   {@literal Long blockId};
+     * }
+     * </pre>
+     */
+    public static final class SnapshotsStreamValueRow implements Persistable, Comparable<SnapshotsStreamValueRow> {
+        private final long id;
+        private final long blockId;
+
+        public static SnapshotsStreamValueRow of(long id, long blockId) {
+            return new SnapshotsStreamValueRow(id, blockId);
+        }
+
+        private SnapshotsStreamValueRow(long id, long blockId) {
+            this.id = id;
+            this.blockId = blockId;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public long getBlockId() {
+            return blockId;
+        }
+
+        public static Function<SnapshotsStreamValueRow, Long> getIdFun() {
+            return new Function<SnapshotsStreamValueRow, Long>() {
+                @Override
+                public Long apply(SnapshotsStreamValueRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<SnapshotsStreamValueRow, Long> getBlockIdFun() {
+            return new Function<SnapshotsStreamValueRow, Long>() {
+                @Override
+                public Long apply(SnapshotsStreamValueRow row) {
+                    return row.blockId;
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = PtBytes.toBytes(Long.MIN_VALUE ^ id);
+            byte[] blockIdBytes = EncodingUtils.encodeUnsignedVarLong(blockId);
+            return EncodingUtils.add(idBytes, blockIdBytes);
+        }
+
+        public static final Hydrator<SnapshotsStreamValueRow> BYTES_HYDRATOR = new Hydrator<SnapshotsStreamValueRow>() {
+            @Override
+            public SnapshotsStreamValueRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                __index += 8;
+                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                return new SnapshotsStreamValueRow(id, blockId);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .add("blockId", blockId)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            SnapshotsStreamValueRow other = (SnapshotsStreamValueRow) obj;
+            return Objects.equal(id, other.id) && Objects.equal(blockId, other.blockId);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Arrays.deepHashCode(new Object[]{ id, blockId });
+        }
+
+        @Override
+        public int compareTo(SnapshotsStreamValueRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .compare(this.blockId, o.blockId)
+                .result();
+        }
+    }
+
+    public interface SnapshotsStreamValueNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: byte[];
+     * }
+     * </pre>
+     */
+    public static final class Value implements SnapshotsStreamValueNamedColumnValue<byte[]> {
+        private final byte[] value;
+
+        public static Value of(byte[] value) {
+            return new Value(value);
+        }
+
+        private Value(byte[] value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "value";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "v";
+        }
+
+        @Override
+        public byte[] getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = value;
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("v");
+        }
+
+        public static final Hydrator<Value> BYTES_HYDRATOR = new Hydrator<Value>() {
+            @Override
+            public Value hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                return of(EncodingUtils.getBytesFromOffsetToEnd(bytes, 0));
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface SnapshotsStreamValueTrigger {
+        public void putSnapshotsStreamValue(Multimap<SnapshotsStreamValueRow, ? extends SnapshotsStreamValueNamedColumnValue<?>> newRows);
+    }
+
+    public static final class SnapshotsStreamValueRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static SnapshotsStreamValueRowResult of(RowResult<byte[]> row) {
+            return new SnapshotsStreamValueRowResult(row);
+        }
+
+        private SnapshotsStreamValueRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public SnapshotsStreamValueRow getRowName() {
+            return SnapshotsStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<SnapshotsStreamValueRowResult, SnapshotsStreamValueRow> getRowNameFun() {
+            return new Function<SnapshotsStreamValueRowResult, SnapshotsStreamValueRow>() {
+                @Override
+                public SnapshotsStreamValueRow apply(SnapshotsStreamValueRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, SnapshotsStreamValueRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, SnapshotsStreamValueRowResult>() {
+                @Override
+                public SnapshotsStreamValueRowResult apply(RowResult<byte[]> rowResult) {
+                    return new SnapshotsStreamValueRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasValue() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("v"));
+        }
+
+        public byte[] getValue() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("v"));
+            if (bytes == null) {
+                return null;
+            }
+            Value value = Value.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<SnapshotsStreamValueRowResult, byte[]> getValueFun() {
+            return new Function<SnapshotsStreamValueRowResult, byte[]>() {
+                @Override
+                public byte[] apply(SnapshotsStreamValueRowResult rowResult) {
+                    return rowResult.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Value", getValue())
+                .toString();
+        }
+    }
+
+    public enum SnapshotsStreamValueNamedColumn {
+        VALUE {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("v");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<SnapshotsStreamValueNamedColumn, byte[]> toShortName() {
+            return new Function<SnapshotsStreamValueNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(SnapshotsStreamValueNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<SnapshotsStreamValueNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, SnapshotsStreamValueNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(SnapshotsStreamValueNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends SnapshotsStreamValueNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends SnapshotsStreamValueNamedColumnValue<?>>>builder()
+                .put("v", Value.BYTES_HYDRATOR)
+                .build();
+
+    public Map<SnapshotsStreamValueRow, byte[]> getValues(Collection<SnapshotsStreamValueRow> rows) {
+        Map<Cell, SnapshotsStreamValueRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (SnapshotsStreamValueRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("v")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<SnapshotsStreamValueRow, byte[]> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            byte[] val = Value.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putValue(SnapshotsStreamValueRow row, byte[] value) {
+        put(ImmutableMultimap.of(row, Value.of(value)));
+    }
+
+    public void putValue(Map<SnapshotsStreamValueRow, byte[]> map) {
+        Map<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<SnapshotsStreamValueRow, byte[]> e : map.entrySet()) {
+            toPut.put(e.getKey(), Value.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    public void putValueUnlessExists(SnapshotsStreamValueRow row, byte[] value) {
+        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
+    }
+
+    public void putValueUnlessExists(Map<SnapshotsStreamValueRow, byte[]> map) {
+        Map<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<SnapshotsStreamValueRow, byte[]> e : map.entrySet()) {
+            toPut.put(e.getKey(), Value.of(e.getValue()));
+        }
+        putUnlessExists(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<SnapshotsStreamValueRow, ? extends SnapshotsStreamValueNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (SnapshotsStreamValueTrigger trigger : triggers) {
+            trigger.putSnapshotsStreamValue(rows);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<SnapshotsStreamValueRow, ? extends SnapshotsStreamValueNamedColumnValue<?>> rows) {
+        Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<SnapshotsStreamValueRow, ? extends SnapshotsStreamValueNamedColumnValue<?>> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    public void deleteValue(SnapshotsStreamValueRow row) {
+        deleteValue(ImmutableSet.of(row));
+    }
+
+    public void deleteValue(Iterable<SnapshotsStreamValueRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("v");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(SnapshotsStreamValueRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<SnapshotsStreamValueRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
+        t.delete(tableRef, cells);
+    }
+
+    public Optional<SnapshotsStreamValueRowResult> getRow(SnapshotsStreamValueRow row) {
+        return getRow(row, allColumns);
+    }
+
+    public Optional<SnapshotsStreamValueRowResult> getRow(SnapshotsStreamValueRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(SnapshotsStreamValueRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<SnapshotsStreamValueRowResult> getRows(Iterable<SnapshotsStreamValueRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<SnapshotsStreamValueRowResult> getRows(Iterable<SnapshotsStreamValueRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<SnapshotsStreamValueRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(SnapshotsStreamValueRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<SnapshotsStreamValueNamedColumnValue<?>> getRowColumns(SnapshotsStreamValueRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<SnapshotsStreamValueNamedColumnValue<?>> getRowColumns(SnapshotsStreamValueRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<SnapshotsStreamValueNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<SnapshotsStreamValueRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<SnapshotsStreamValueRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<SnapshotsStreamValueRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            SnapshotsStreamValueRow row = SnapshotsStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<SnapshotsStreamValueRow, BatchingVisitable<SnapshotsStreamValueNamedColumnValue<?>>> getRowsColumnRange(Iterable<SnapshotsStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<SnapshotsStreamValueRow, BatchingVisitable<SnapshotsStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            SnapshotsStreamValueRow row = SnapshotsStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<SnapshotsStreamValueNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>>> getRowsColumnRange(Iterable<SnapshotsStreamValueRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            SnapshotsStreamValueRow row = SnapshotsStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            SnapshotsStreamValueNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<SnapshotsStreamValueRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<SnapshotsStreamValueRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, SnapshotsStreamValueRowResult>() {
+            @Override
+            public SnapshotsStreamValueRowResult apply(RowResult<byte[]> input) {
+                return SnapshotsStreamValueRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "/lfyhHtLlWQGInqUF2nAwQ==";
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoSchemaTableFactory.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoSchemaTableFactory.java
@@ -1,0 +1,107 @@
+package com.palantir.atlasdb.todo.generated;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.table.generation.Triggers;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
+public final class TodoSchemaTableFactory {
+    private static final Namespace defaultNamespace = Namespace.create("default", Namespace.UNCHECKED_NAME);
+
+    private final List<Function<? super Transaction, SharedTriggers>> sharedTriggers;
+
+    private final Namespace namespace;
+
+    private TodoSchemaTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+            Namespace namespace) {
+        this.sharedTriggers = sharedTriggers;
+        this.namespace = namespace;
+    }
+
+    public static TodoSchemaTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+            Namespace namespace) {
+        return new TodoSchemaTableFactory(sharedTriggers, namespace);
+    }
+
+    public static TodoSchemaTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
+        return new TodoSchemaTableFactory(sharedTriggers, defaultNamespace);
+    }
+
+    public static TodoSchemaTableFactory of(Namespace namespace) {
+        return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), namespace);
+    }
+
+    public static TodoSchemaTableFactory of() {
+        return of(ImmutableList.<Function<? super Transaction, SharedTriggers>>of(), defaultNamespace);
+    }
+
+    public LatestSnapshotTable getLatestSnapshotTable(Transaction t,
+            LatestSnapshotTable.LatestSnapshotTrigger... triggers) {
+        return LatestSnapshotTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public SnapshotsStreamHashAidxTable getSnapshotsStreamHashAidxTable(Transaction t,
+            SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxTrigger... triggers) {
+        return SnapshotsStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public SnapshotsStreamIdxTable getSnapshotsStreamIdxTable(Transaction t,
+            SnapshotsStreamIdxTable.SnapshotsStreamIdxTrigger... triggers) {
+        return SnapshotsStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public SnapshotsStreamMetadataTable getSnapshotsStreamMetadataTable(Transaction t,
+            SnapshotsStreamMetadataTable.SnapshotsStreamMetadataTrigger... triggers) {
+        return SnapshotsStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public SnapshotsStreamValueTable getSnapshotsStreamValueTable(Transaction t,
+            SnapshotsStreamValueTable.SnapshotsStreamValueTrigger... triggers) {
+        return SnapshotsStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public TodoTable getTodoTable(Transaction t, TodoTable.TodoTrigger... triggers) {
+        return TodoTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public interface SharedTriggers extends LatestSnapshotTable.LatestSnapshotTrigger, SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxTrigger, SnapshotsStreamIdxTable.SnapshotsStreamIdxTrigger, SnapshotsStreamMetadataTable.SnapshotsStreamMetadataTrigger, SnapshotsStreamValueTable.SnapshotsStreamValueTrigger, TodoTable.TodoTrigger {
+    }
+
+    public abstract static class NullSharedTriggers implements SharedTriggers {
+        @Override
+        public void putLatestSnapshot(Multimap<LatestSnapshotTable.LatestSnapshotRow, ? extends LatestSnapshotTable.LatestSnapshotNamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putSnapshotsStreamHashAidx(Multimap<SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxRow, ? extends SnapshotsStreamHashAidxTable.SnapshotsStreamHashAidxColumnValue> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putSnapshotsStreamIdx(Multimap<SnapshotsStreamIdxTable.SnapshotsStreamIdxRow, ? extends SnapshotsStreamIdxTable.SnapshotsStreamIdxColumnValue> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putSnapshotsStreamMetadata(Multimap<SnapshotsStreamMetadataTable.SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataTable.SnapshotsStreamMetadataNamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putSnapshotsStreamValue(Multimap<SnapshotsStreamValueTable.SnapshotsStreamValueRow, ? extends SnapshotsStreamValueTable.SnapshotsStreamValueNamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putTodo(Multimap<TodoTable.TodoRow, ? extends TodoTable.TodoNamedColumnValue<?>> newRows) {
+            // do nothing
+        }
+    }
+}

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
@@ -1,0 +1,687 @@
+package com.palantir.atlasdb.todo.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import javax.annotation.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings("all")
+public final class TodoTable implements
+        AtlasDbMutablePersistentTable<TodoTable.TodoRow,
+                                         TodoTable.TodoNamedColumnValue<?>,
+                                         TodoTable.TodoRowResult>,
+        AtlasDbNamedMutableTable<TodoTable.TodoRow,
+                                    TodoTable.TodoNamedColumnValue<?>,
+                                    TodoTable.TodoRowResult> {
+    private final Transaction t;
+    private final List<TodoTrigger> triggers;
+    private final static String rawTableName = "todo";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(TodoNamedColumn.values());
+
+    static TodoTable of(Transaction t, Namespace namespace) {
+        return new TodoTable(t, namespace, ImmutableList.<TodoTrigger>of());
+    }
+
+    static TodoTable of(Transaction t, Namespace namespace, TodoTrigger trigger, TodoTrigger... triggers) {
+        return new TodoTable(t, namespace, ImmutableList.<TodoTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static TodoTable of(Transaction t, Namespace namespace, List<TodoTrigger> triggers) {
+        return new TodoTable(t, namespace, triggers);
+    }
+
+    private TodoTable(Transaction t, Namespace namespace, List<TodoTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * TodoRow {
+     *   {@literal Long id};
+     * }
+     * </pre>
+     */
+    public static final class TodoRow implements Persistable, Comparable<TodoRow> {
+        private final long id;
+
+        public static TodoRow of(long id) {
+            return new TodoRow(id);
+        }
+
+        private TodoRow(long id) {
+            this.id = id;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public static Function<TodoRow, Long> getIdFun() {
+            return new Function<TodoRow, Long>() {
+                @Override
+                public Long apply(TodoRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<Long, TodoRow> fromIdFun() {
+            return new Function<Long, TodoRow>() {
+                @Override
+                public TodoRow apply(Long row) {
+                    return TodoRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = PtBytes.toBytes(Long.MIN_VALUE ^ id);
+            return EncodingUtils.add(idBytes);
+        }
+
+        public static final Hydrator<TodoRow> BYTES_HYDRATOR = new Hydrator<TodoRow>() {
+            @Override
+            public TodoRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                __index += 8;
+                return new TodoRow(id);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TodoRow other = (TodoRow) obj;
+            return Objects.equal(id, other.id);
+        }
+
+        @SuppressWarnings("ArrayHashCode")
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(id);
+        }
+
+        @Override
+        public int compareTo(TodoRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .result();
+        }
+    }
+
+    public interface TodoNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: String;
+     * }
+     * </pre>
+     */
+    public static final class Text implements TodoNamedColumnValue<String> {
+        private final String value;
+
+        public static Text of(String value) {
+            return new Text(value);
+        }
+
+        private Text(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "text";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "t";
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = PtBytes.toBytes(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("t");
+        }
+
+        public static final Hydrator<Text> BYTES_HYDRATOR = new Hydrator<Text>() {
+            @Override
+            public Text hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                return of(PtBytes.toString(bytes, 0, bytes.length-0));
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface TodoTrigger {
+        public void putTodo(Multimap<TodoRow, ? extends TodoNamedColumnValue<?>> newRows);
+    }
+
+    public static final class TodoRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static TodoRowResult of(RowResult<byte[]> row) {
+            return new TodoRowResult(row);
+        }
+
+        private TodoRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public TodoRow getRowName() {
+            return TodoRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<TodoRowResult, TodoRow> getRowNameFun() {
+            return new Function<TodoRowResult, TodoRow>() {
+                @Override
+                public TodoRow apply(TodoRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, TodoRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, TodoRowResult>() {
+                @Override
+                public TodoRowResult apply(RowResult<byte[]> rowResult) {
+                    return new TodoRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasText() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("t"));
+        }
+
+        public String getText() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("t"));
+            if (bytes == null) {
+                return null;
+            }
+            Text value = Text.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<TodoRowResult, String> getTextFun() {
+            return new Function<TodoRowResult, String>() {
+                @Override
+                public String apply(TodoRowResult rowResult) {
+                    return rowResult.getText();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Text", getText())
+                .toString();
+        }
+    }
+
+    public enum TodoNamedColumn {
+        TEXT {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("t");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<TodoNamedColumn, byte[]> toShortName() {
+            return new Function<TodoNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(TodoNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<TodoNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, TodoNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(TodoNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends TodoNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends TodoNamedColumnValue<?>>>builder()
+                .put("t", Text.BYTES_HYDRATOR)
+                .build();
+
+    public Map<TodoRow, String> getTexts(Collection<TodoRow> rows) {
+        Map<Cell, TodoRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (TodoRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("t")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<TodoRow, String> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            String val = Text.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putText(TodoRow row, String value) {
+        put(ImmutableMultimap.of(row, Text.of(value)));
+    }
+
+    public void putText(Map<TodoRow, String> map) {
+        Map<TodoRow, TodoNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<TodoRow, String> e : map.entrySet()) {
+            toPut.put(e.getKey(), Text.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    public void putTextUnlessExists(TodoRow row, String value) {
+        putUnlessExists(ImmutableMultimap.of(row, Text.of(value)));
+    }
+
+    public void putTextUnlessExists(Map<TodoRow, String> map) {
+        Map<TodoRow, TodoNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<TodoRow, String> e : map.entrySet()) {
+            toPut.put(e.getKey(), Text.of(e.getValue()));
+        }
+        putUnlessExists(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<TodoRow, ? extends TodoNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (TodoTrigger trigger : triggers) {
+            trigger.putTodo(rows);
+        }
+    }
+
+    /** @deprecated Use separate read and write in a single transaction instead. */
+    @Deprecated
+    @Override
+    public void putUnlessExists(Multimap<TodoRow, ? extends TodoNamedColumnValue<?>> rows) {
+        Multimap<TodoRow, TodoNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
+        Multimap<TodoRow, TodoNamedColumnValue<?>> toPut = HashMultimap.create();
+        for (Entry<TodoRow, ? extends TodoNamedColumnValue<?>> entry : rows.entries()) {
+            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
+                toPut.put(entry.getKey(), entry.getValue());
+            }
+        }
+        put(toPut);
+    }
+
+    public void deleteText(TodoRow row) {
+        deleteText(ImmutableSet.of(row));
+    }
+
+    public void deleteText(Iterable<TodoRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("t");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(TodoRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<TodoRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("t")));
+        t.delete(tableRef, cells);
+    }
+
+    public Optional<TodoRowResult> getRow(TodoRow row) {
+        return getRow(row, allColumns);
+    }
+
+    public Optional<TodoRowResult> getRow(TodoRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(TodoRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<TodoRowResult> getRows(Iterable<TodoRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<TodoRowResult> getRows(Iterable<TodoRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<TodoRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(TodoRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<TodoNamedColumnValue<?>> getRowColumns(TodoRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<TodoNamedColumnValue<?>> getRowColumns(TodoRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<TodoNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<TodoRow, TodoNamedColumnValue<?>> getRowsMultimap(Iterable<TodoRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<TodoRow, TodoNamedColumnValue<?>> getRowsMultimap(Iterable<TodoRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<TodoRow, TodoNamedColumnValue<?>> getRowsMultimapInternal(Iterable<TodoRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<TodoRow, TodoNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<TodoRow, TodoNamedColumnValue<?>> rowMap = HashMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            TodoRow row = TodoRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<TodoRow, BatchingVisitable<TodoNamedColumnValue<?>>> getRowsColumnRange(Iterable<TodoRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<TodoRow, BatchingVisitable<TodoNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            TodoRow row = TodoRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<TodoNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<TodoRow, TodoNamedColumnValue<?>>> getRowsColumnRange(Iterable<TodoRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            TodoRow row = TodoRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            TodoNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    public BatchingVisitableView<TodoRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<TodoRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder().retainColumns(columns).build()),
+                new Function<RowResult<byte[]>, TodoRowResult>() {
+            @Override
+            public TodoRowResult apply(RowResult<byte[]> input) {
+                return TodoRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "eVIIA61NiFNq1bfAA4tx1A==";
+}

--- a/atlasdb-ete-test-utils/versions.lock
+++ b/atlasdb-ete-test-utils/versions.lock
@@ -1,16 +1,473 @@
 {
     "compileClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.netflix.feign:feign-jackson",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:qos-service-api",
+                "com.palantir.remoting-api:errors",
+                "com.palantir.remoting-api:ssl-config",
+                "com.palantir.remoting-api:tracing",
+                "com.palantir.remoting3:jackson-support",
+                "com.palantir.remoting3:keystores",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tokens:auth-tokens"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting3:jackson-support"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting3:jackson-support",
+                "com.palantir.remoting3:tracing"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting3:jackson-support",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tokens:auth-tokens"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting3:jackson-support"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-afterburner": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting3:jackson-support",
+                "com.palantir.remoting3:tracing"
+            ]
+        },
         "com.google.code.findbugs:annotations": {
-            "locked": "3.0.1"
+            "locked": "3.0.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-executors-api",
+                "com.palantir.atlasdb:qos-service-api",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.tritium:tritium-api",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing"
+            ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.1",
             "transitive": [
-                "com.google.code.findbugs:annotations"
+                "com.google.code.findbugs:annotations",
+                "com.google.guava:guava",
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.6-jre",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.remoting3:error-handling",
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:keystores",
+                "com.palantir.remoting3:okhttp-clients",
+                "com.palantir.remoting3:refresh-utils",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.5.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.json-simple:json-simple": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.googlecode.protobuf-java-format:protobuf-java-format": {
+            "locked": "1.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.netflix.feign:feign-core": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.netflix.feign:feign-jackson",
+                "com.netflix.feign:feign-jaxrs",
+                "com.netflix.feign:feign-okhttp",
+                "com.netflix.feign:feign-slf4j"
+            ]
+        },
+        "com.netflix.feign:feign-jackson": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.netflix.feign:feign-jaxrs": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.netflix.feign:feign-okhttp": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.netflix.feign:feign-slf4j": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-client": {
+            "project": true
+        },
+        "com.palantir.atlasdb:atlasdb-client-protobufs": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-commons": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.palantir.atlasdb:commons-executors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.palantir.atlasdb:commons-executors-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-executors"
+            ]
+        },
+        "com.palantir.atlasdb:qos-service-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:timestamp-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.remoting-api:errors": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting3:error-handling"
+            ]
+        },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting3:http-clients"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.remoting-api:service-config",
+                "com.palantir.remoting3:keystores"
+            ]
+        },
+        "com.palantir.remoting-api:tracing": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting3:tracing"
+            ]
+        },
+        "com.palantir.remoting3:error-handling": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.palantir.remoting3:http-clients": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.palantir.remoting3:jackson-support": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:error-handling",
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:tracing"
+            ]
+        },
+        "com.palantir.remoting3:jaxrs-clients": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:qos-service-api"
+            ]
+        },
+        "com.palantir.remoting3:keystores": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:http-clients",
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.palantir.remoting3:okhttp-clients": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.palantir.remoting3:refresh-utils": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.palantir.remoting3:tracing": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.remoting3:tracing-okhttp3"
+            ]
+        },
+        "com.palantir.remoting3:tracing-okhttp3": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:qos-service-api",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.remoting-api:errors",
+                "com.palantir.remoting3:http-clients",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-registry",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
+        "com.palantir.tritium:tritium-api": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing"
+            ]
+        },
+        "com.palantir.tritium:tritium-core": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing"
+            ]
+        },
+        "com.palantir.tritium:tritium-lib": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.tritium:tritium-metrics": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-proxy": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-registry": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.palantir.tritium:tritium-slf4j": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-tracing": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.squareup.okhttp3:logging-interceptor": {
+            "locked": "3.8.1",
+            "transitive": [
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.squareup.okhttp3:okhttp": {
+            "locked": "3.8.1",
+            "transitive": [
+                "com.netflix.feign:feign-okhttp",
+                "com.palantir.remoting3:okhttp-clients",
+                "com.palantir.remoting3:tracing-okhttp3",
+                "com.squareup.okhttp3:logging-interceptor"
+            ]
+        },
+        "com.squareup.okio:okio": {
+            "locked": "1.13.0",
+            "transitive": [
+                "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "commons-io:commons-io": {
             "locked": "2.1"
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "io.dropwizard.metrics:metrics-core": {
+            "locked": "3.2.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.remoting3:okhttp-clients",
+                "com.palantir.tritium:tritium-registry"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "javax.ws.rs:javax.ws.rs-api": {
+            "locked": "2.0.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:qos-service-api",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.remoting-api:errors",
+                "com.palantir.remoting3:error-handling",
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
         },
         "junit:junit": {
             "locked": "4.12"
@@ -21,6 +478,36 @@
                 "com.google.code.findbugs:annotations"
             ]
         },
+        "net.jpountz.lz4:lz4": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.4",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
         "org.hamcrest:hamcrest-all": {
             "locked": "1.3"
         },
@@ -28,21 +515,520 @@
             "locked": "1.3",
             "transitive": [
                 "junit:junit"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.10",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "org.jvnet:animal-sniffer-annotation": {
+            "locked": "1.0",
+            "transitive": [
+                "com.netflix.feign:feign-core"
+            ]
+        },
+        "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
+            "locked": "1.1.2",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.25",
+            "transitive": [
+                "com.netflix.feign:feign-slf4j",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.remoting3:error-handling",
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:okhttp-clients",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tokens:auth-tokens",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing",
+                "io.dropwizard.metrics:metrics-core"
+            ]
+        },
+        "org.xerial.snappy:snappy-java": {
+            "locked": "1.1.1.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         }
     },
     "runtime": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:timestamp-api"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-afterburner",
+                "com.netflix.feign:feign-jackson",
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:qos-service-api",
+                "com.palantir.remoting-api:errors",
+                "com.palantir.remoting-api:ssl-config",
+                "com.palantir.remoting-api:tracing",
+                "com.palantir.remoting3:jackson-support",
+                "com.palantir.remoting3:keystores",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tokens:auth-tokens"
+            ]
+        },
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting3:jackson-support"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-guava": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting3:jackson-support",
+                "com.palantir.remoting3:tracing"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting3:jackson-support",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tokens:auth-tokens"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting3:jackson-support"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-afterburner": {
+            "locked": "2.6.7",
+            "transitive": [
+                "com.palantir.remoting3:jackson-support",
+                "com.palantir.remoting3:tracing"
+            ]
+        },
         "com.google.code.findbugs:annotations": {
-            "locked": "3.0.1"
+            "locked": "3.0.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:commons-annotations",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.atlasdb:commons-executors-api",
+                "com.palantir.atlasdb:qos-service-api",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.tritium:tritium-api",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing"
+            ]
         },
         "com.google.code.findbugs:jsr305": {
             "locked": "3.0.1",
             "transitive": [
-                "com.google.code.findbugs:annotations"
+                "com.google.code.findbugs:annotations",
+                "com.google.guava:guava",
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "23.6-jre",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-guava",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.remoting3:error-handling",
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:keystores",
+                "com.palantir.remoting3:okhttp-clients",
+                "com.palantir.remoting3:refresh-utils",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.5.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-client-protobufs"
+            ]
+        },
+        "com.googlecode.json-simple:json-simple": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.googlecode.protobuf-java-format:protobuf-java-format": {
+            "locked": "1.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.netflix.feign:feign-core": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.netflix.feign:feign-jackson",
+                "com.netflix.feign:feign-jaxrs",
+                "com.netflix.feign:feign-okhttp",
+                "com.netflix.feign:feign-slf4j"
+            ]
+        },
+        "com.netflix.feign:feign-jackson": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.netflix.feign:feign-jaxrs": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.netflix.feign:feign-okhttp": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.netflix.feign:feign-slf4j": {
+            "locked": "8.17.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-client": {
+            "project": true
+        },
+        "com.palantir.atlasdb:atlasdb-client-protobufs": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:atlasdb-commons": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:commons-annotations": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.palantir.atlasdb:commons-executors": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "com.palantir.atlasdb:commons-executors-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:commons-executors"
+            ]
+        },
+        "com.palantir.atlasdb:qos-service-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.atlasdb:timestamp-api": {
+            "project": true,
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "com.palantir.remoting-api:errors": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting3:error-handling"
+            ]
+        },
+        "com.palantir.remoting-api:service-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting3:http-clients"
+            ]
+        },
+        "com.palantir.remoting-api:ssl-config": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.remoting-api:service-config",
+                "com.palantir.remoting3:keystores"
+            ]
+        },
+        "com.palantir.remoting-api:tracing": {
+            "locked": "1.7.0",
+            "transitive": [
+                "com.palantir.remoting3:tracing"
+            ]
+        },
+        "com.palantir.remoting3:error-handling": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.palantir.remoting3:http-clients": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.palantir.remoting3:jackson-support": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:error-handling",
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:tracing"
+            ]
+        },
+        "com.palantir.remoting3:jaxrs-clients": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:qos-service-api"
+            ]
+        },
+        "com.palantir.remoting3:keystores": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:http-clients",
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.palantir.remoting3:okhttp-clients": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.palantir.remoting3:refresh-utils": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
+        },
+        "com.palantir.remoting3:tracing": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:commons-executors",
+                "com.palantir.remoting3:tracing-okhttp3"
+            ]
+        },
+        "com.palantir.remoting3:tracing-okhttp3": {
+            "locked": "3.14.0",
+            "transitive": [
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.palantir.safe-logging:safe-logging": {
+            "locked": "0.1.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:qos-service-api",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.remoting-api:errors",
+                "com.palantir.remoting3:http-clients",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-registry",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing"
+            ]
+        },
+        "com.palantir.tokens:auth-tokens": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.palantir.remoting-api:service-config"
+            ]
+        },
+        "com.palantir.tritium:tritium-api": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing"
+            ]
+        },
+        "com.palantir.tritium:tritium-core": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing"
+            ]
+        },
+        "com.palantir.tritium:tritium-lib": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "com.palantir.tritium:tritium-metrics": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-proxy": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-registry": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client",
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.palantir.tritium:tritium-slf4j": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.palantir.tritium:tritium-tracing": {
+            "locked": "0.9.0",
+            "transitive": [
+                "com.palantir.tritium:tritium-lib"
+            ]
+        },
+        "com.squareup.okhttp3:logging-interceptor": {
+            "locked": "3.8.1",
+            "transitive": [
+                "com.palantir.remoting3:okhttp-clients"
+            ]
+        },
+        "com.squareup.okhttp3:okhttp": {
+            "locked": "3.8.1",
+            "transitive": [
+                "com.netflix.feign:feign-okhttp",
+                "com.palantir.remoting3:okhttp-clients",
+                "com.palantir.remoting3:tracing-okhttp3",
+                "com.squareup.okhttp3:logging-interceptor"
+            ]
+        },
+        "com.squareup.okio:okio": {
+            "locked": "1.13.0",
+            "transitive": [
+                "com.squareup.okhttp3:okhttp"
+            ]
+        },
+        "com.squareup:javapoet": {
+            "locked": "1.9.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         },
         "commons-io:commons-io": {
             "locked": "2.1"
+        },
+        "commons-lang:commons-lang": {
+            "locked": "2.6",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "io.dropwizard.metrics:metrics-core": {
+            "locked": "3.2.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.remoting3:okhttp-clients",
+                "com.palantir.tritium:tritium-registry"
+            ]
+        },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "javax.ws.rs:javax.ws.rs-api": {
+            "locked": "2.0.1",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.atlasdb:qos-service-api",
+                "com.palantir.atlasdb:timestamp-api",
+                "com.palantir.remoting-api:errors",
+                "com.palantir.remoting3:error-handling",
+                "com.palantir.remoting3:jaxrs-clients"
+            ]
         },
         "junit:junit": {
             "locked": "4.12"
@@ -53,6 +1039,36 @@
                 "com.google.code.findbugs:annotations"
             ]
         },
+        "net.jpountz.lz4:lz4": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.4",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-api"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.2",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-commons"
+            ]
+        },
+        "org.checkerframework:checker-compat-qual": {
+            "locked": "2.0.0",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
         "org.hamcrest:hamcrest-all": {
             "locked": "1.3"
         },
@@ -60,6 +1076,48 @@
             "locked": "1.3",
             "transitive": [
                 "junit:junit"
+            ]
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "locked": "2.1.10",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
+            ]
+        },
+        "org.jvnet:animal-sniffer-annotation": {
+            "locked": "1.0",
+            "transitive": [
+                "com.netflix.feign:feign-core"
+            ]
+        },
+        "org.mpierce.metrics.reservoir:hdrhistogram-metrics-reservoir": {
+            "locked": "1.1.2",
+            "transitive": [
+                "com.palantir.tritium:tritium-metrics"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.25",
+            "transitive": [
+                "com.netflix.feign:feign-slf4j",
+                "com.palantir.atlasdb:atlasdb-commons",
+                "com.palantir.remoting3:error-handling",
+                "com.palantir.remoting3:jaxrs-clients",
+                "com.palantir.remoting3:okhttp-clients",
+                "com.palantir.remoting3:tracing",
+                "com.palantir.tokens:auth-tokens",
+                "com.palantir.tritium:tritium-core",
+                "com.palantir.tritium:tritium-lib",
+                "com.palantir.tritium:tritium-metrics",
+                "com.palantir.tritium:tritium-slf4j",
+                "com.palantir.tritium:tritium-tracing",
+                "io.dropwizard.metrics:metrics-core"
+            ]
+        },
+        "org.xerial.snappy:snappy-java": {
+            "locked": "1.1.1.7",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-client"
             ]
         }
     }

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -6,8 +6,7 @@ apply plugin: 'org.inferred.processors'
 
 schemas = [
         'com.palantir.atlasdb.cas.CheckAndSetSchema',
-        'com.palantir.atlasdb.blob.BlobSchema',
-        'com.palantir.atlasdb.todo.TodoSchema'
+        'com.palantir.atlasdb.blob.BlobSchema'
 ]
 
 dependencies {
@@ -15,6 +14,7 @@ dependencies {
     compile project(':leader-election-impl')
     compile project(':atlasdb-config')
     compile project(':atlasdb-dropwizard-bundle')
+    compile project(':atlasdb-ete-test-utils')
     compile project(':atlasdb-hikari')
 
     compile group: 'org.awaitility', name: 'awaitility'

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -6,7 +6,8 @@ apply plugin: 'org.inferred.processors'
 
 schemas = [
         'com.palantir.atlasdb.cas.CheckAndSetSchema',
-        'com.palantir.atlasdb.blob.BlobSchema'
+        'com.palantir.atlasdb.blob.BlobSchema',
+        'com.palantir.atlasdb.todo.TodoSchema'
 ]
 
 dependencies {

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.blob.BlobSchema;
@@ -86,7 +88,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
     @Override
     public void run(AtlasDbEteConfiguration config, final Environment environment) throws Exception {
         SerializableTransactionManager transactionManager = tryToCreateTransactionManager(config, environment);
-        SweepTaskRunner sweepTaskRunner = getSweepTaskRunner(transactionManager);
+        Supplier<SweepTaskRunner> sweepTaskRunner = Suppliers.memoize(() -> getSweepTaskRunner(transactionManager));
 
         environment.jersey().register(new SimpleTodoResource(new TodoClient(transactionManager, sweepTaskRunner)));
         environment.jersey().register(new SimpleCheckAndSetResource(new CheckAndSetClient(transactionManager)));

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,22 +26,33 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.blob.BlobSchema;
 import com.palantir.atlasdb.cas.CheckAndSetClient;
 import com.palantir.atlasdb.cas.CheckAndSetSchema;
 import com.palantir.atlasdb.cas.SimpleCheckAndSetResource;
+import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
 import com.palantir.atlasdb.dropwizard.AtlasDbBundle;
 import com.palantir.atlasdb.factory.TransactionManagers;
 import com.palantir.atlasdb.http.NotInitializedExceptionMapper;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.persistentlock.NoOpPersistentLockService;
 import com.palantir.atlasdb.schema.CleanupMetadataResourceImpl;
+import com.palantir.atlasdb.sweep.CellsSweeper;
+import com.palantir.atlasdb.sweep.PersistentLockManager;
+import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.todo.SimpleTodoResource;
 import com.palantir.atlasdb.todo.TodoClient;
 import com.palantir.atlasdb.todo.TodoSchema;
-import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
+import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
+import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.remoting3.servers.jersey.HttpRemotingJerseyFeature;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 
@@ -73,8 +85,10 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
 
     @Override
     public void run(AtlasDbEteConfiguration config, final Environment environment) throws Exception {
-        TransactionManager transactionManager = tryToCreateTransactionManager(config, environment);
-        environment.jersey().register(new SimpleTodoResource(new TodoClient(transactionManager)));
+        SerializableTransactionManager transactionManager = tryToCreateTransactionManager(config, environment);
+        SweepTaskRunner sweepTaskRunner = getSweepTaskRunner(transactionManager);
+
+        environment.jersey().register(new SimpleTodoResource(new TodoClient(transactionManager, sweepTaskRunner)));
         environment.jersey().register(new SimpleCheckAndSetResource(new CheckAndSetClient(transactionManager)));
         environment.jersey().register(HttpRemotingJerseyFeature.INSTANCE);
         environment.jersey().register(new NotInitializedExceptionMapper());
@@ -83,7 +97,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
                 config.getAtlasDbConfig().initializeAsync()));
     }
 
-    private TransactionManager tryToCreateTransactionManager(AtlasDbEteConfiguration config, Environment environment)
+    private SerializableTransactionManager tryToCreateTransactionManager(AtlasDbEteConfiguration config, Environment environment)
             throws InterruptedException {
         if (config.getAtlasDbConfig().initializeAsync()) {
             return createTransactionManager(config.getAtlasDbConfig(), config.getAtlasDbRuntimeConfig(), environment);
@@ -94,8 +108,21 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         }
     }
 
+    private SweepTaskRunner getSweepTaskRunner(SerializableTransactionManager transactionManager) {
+        KeyValueService kvs = transactionManager.getKeyValueService();
+        LongSupplier ts = transactionManager.getTimestampService()::getFreshTimestamp;
+        TransactionService txnService = TransactionServices.createTransactionService(kvs);
+        SweepStrategyManager ssm = SweepStrategyManagers.completelyConservative(kvs); // maybe createDefault
+        PersistentLockManager noLocks = new PersistentLockManager(
+                new NoOpPersistentLockService(),
+                AtlasDbConstants.DEFAULT_SWEEP_PERSISTENT_LOCK_WAIT_MILLIS);
+        CleanupFollower follower = CleanupFollower.create(ETE_SCHEMAS);
+        CellsSweeper cellsSweeper = new CellsSweeper(transactionManager, kvs, noLocks, ImmutableList.of(follower));
+        return new SweepTaskRunner(kvs, ts, ts, txnService, ssm, cellsSweeper);
+    }
+
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private TransactionManager createTransactionManagerWithRetry(AtlasDbConfig config,
+    private SerializableTransactionManager createTransactionManagerWithRetry(AtlasDbConfig config,
             Optional<AtlasDbRuntimeConfig> atlasDbRuntimeConfig,
             Environment environment)
             throws InterruptedException {
@@ -112,7 +139,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private TransactionManager createTransactionManager(AtlasDbConfig config,
+    private SerializableTransactionManager createTransactionManager(AtlasDbConfig config,
             Optional<AtlasDbRuntimeConfig> atlasDbRuntimeConfigOptional, Environment environment) {
         return TransactionManagers.builder()
                 .config(config)

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/SimpleTodoResource.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/SimpleTodoResource.java
@@ -15,9 +15,12 @@
  */
 package com.palantir.atlasdb.todo;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.List;
 
 import com.google.common.base.Preconditions;
+import com.palantir.atlasdb.keyvalue.api.SweepResults;
 
 public class SimpleTodoResource implements TodoResource {
     private TodoClient atlas;
@@ -39,6 +42,22 @@ public class SimpleTodoResource implements TodoResource {
     @Override
     public void isHealthy() {
         Preconditions.checkState(atlas.getTodoList() != null);
+    }
+
+    @Override
+    public void storeSnapshot(String snapshot) {
+        InputStream snapshotStream = new ByteArrayInputStream(snapshot.getBytes());
+        atlas.storeSnapshot(snapshotStream);
+    }
+
+    @Override
+    public SweepResults sweepSnapshotIndices() {
+        return atlas.sweepSnapshotIndices();
+    }
+
+    @Override
+    public SweepResults sweepSnapshotValues() {
+        return atlas.sweepSnapshotValues();
     }
 }
 

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -51,10 +52,10 @@ public class TodoClient {
     private static final Logger log = LoggerFactory.getLogger(TodoClient.class);
 
     private final TransactionManager transactionManager;
-    private final SweepTaskRunner sweepTaskRunner;
+    private final Supplier<SweepTaskRunner> sweepTaskRunner;
     private final Random random = new Random();
 
-    public TodoClient(TransactionManager transactionManager, SweepTaskRunner sweepTaskRunner) {
+    public TodoClient(TransactionManager transactionManager, Supplier<SweepTaskRunner> sweepTaskRunner) {
         this.transactionManager = transactionManager;
         this.sweepTaskRunner = sweepTaskRunner;
     }
@@ -132,7 +133,7 @@ public class TodoClient {
                 .deleteBatchSize(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
                 .maxCellTsPairsToExamine(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
                 .build();
-        return sweepTaskRunner.run(indexTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
+        return sweepTaskRunner.get().run(indexTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
     }
 
     public SweepResults sweepSnapshotValues() {
@@ -143,6 +144,6 @@ public class TodoClient {
                 .deleteBatchSize(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
                 .maxCellTsPairsToExamine(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
                 .build();
-        return sweepTaskRunner.run(indexTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
+        return sweepTaskRunner.get().run(indexTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
@@ -138,12 +138,12 @@ public class TodoClient {
         return sweepTable(valueTable);
     }
 
-    SweepResults sweepTable(TableReference valueTable) {
+    SweepResults sweepTable(TableReference table) {
         SweepBatchConfig sweepConfig = ImmutableSweepBatchConfig.builder()
                 .candidateBatchSize(AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT)
                 .deleteBatchSize(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
                 .maxCellTsPairsToExamine(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
                 .build();
-        return sweepTaskRunner.get().run(valueTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
+        return sweepTaskRunner.get().run(table, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
@@ -92,6 +92,7 @@ public class TodoClient {
                 .collect(Collectors.toList());
     }
 
+    // Stores a new snapshot, marking the previous one as unused. We thus have at most one used stream at any time
     public void storeSnapshot(InputStream snapshot) {
         byte[] streamReference = "EteTest".getBytes();
 
@@ -128,22 +129,21 @@ public class TodoClient {
     public SweepResults sweepSnapshotIndices() {
         TodoSchemaTableFactory tableFactory = TodoSchemaTableFactory.of(Namespace.DEFAULT_NAMESPACE);
         TableReference indexTable = tableFactory.getSnapshotsStreamIdxTable(null).getTableRef();
-        SweepBatchConfig sweepConfig = ImmutableSweepBatchConfig.builder()
-                .candidateBatchSize(AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT)
-                .deleteBatchSize(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
-                .maxCellTsPairsToExamine(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
-                .build();
-        return sweepTaskRunner.get().run(indexTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
+        return sweepTable(indexTable);
     }
 
     public SweepResults sweepSnapshotValues() {
         TodoSchemaTableFactory tableFactory = TodoSchemaTableFactory.of(Namespace.DEFAULT_NAMESPACE);
-        TableReference indexTable = tableFactory.getSnapshotsStreamValueTable(null).getTableRef();
+        TableReference valueTable = tableFactory.getSnapshotsStreamValueTable(null).getTableRef();
+        return sweepTable(valueTable);
+    }
+
+    SweepResults sweepTable(TableReference valueTable) {
         SweepBatchConfig sweepConfig = ImmutableSweepBatchConfig.builder()
                 .candidateBatchSize(AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT)
                 .deleteBatchSize(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
                 .maxCellTsPairsToExamine(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
                 .build();
-        return sweepTaskRunner.get().run(indexTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
+        return sweepTaskRunner.get().run(valueTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoClient.java
@@ -15,26 +15,48 @@
  */
 package com.palantir.atlasdb.todo;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.SweepResults;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.sweep.ImmutableSweepBatchConfig;
+import com.palantir.atlasdb.sweep.SweepBatchConfig;
+import com.palantir.atlasdb.sweep.SweepTaskRunner;
 import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.todo.generated.LatestSnapshotTable;
+import com.palantir.atlasdb.todo.generated.SnapshotsStreamStore;
+import com.palantir.atlasdb.todo.generated.TodoSchemaTableFactory;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.common.base.BatchingVisitable;
+import com.palantir.util.Pair;
+import com.palantir.util.crypto.Sha256Hash;
 
 public class TodoClient {
+    private static final Logger log = LoggerFactory.getLogger(TodoClient.class);
+
     private final TransactionManager transactionManager;
+    private final SweepTaskRunner sweepTaskRunner;
     private final Random random = new Random();
 
-    public TodoClient(TransactionManager transactionManager) {
+    public TodoClient(TransactionManager transactionManager, SweepTaskRunner sweepTaskRunner) {
         this.transactionManager = transactionManager;
+        this.sweepTaskRunner = sweepTaskRunner;
     }
 
     public void addTodo(Todo todo) {
@@ -67,5 +89,60 @@ public class TodoClient {
                 .map(ValueType.STRING::convertToString)
                 .map(ImmutableTodo::of)
                 .collect(Collectors.toList());
+    }
+
+    public void storeSnapshot(InputStream snapshot) {
+        byte[] streamReference = "EteTest".getBytes();
+
+        TodoSchemaTableFactory tableFactory = TodoSchemaTableFactory.of(Namespace.DEFAULT_NAMESPACE);
+        SnapshotsStreamStore streamStore = SnapshotsStreamStore.of(transactionManager, tableFactory);
+        log.info("Storing stream...");
+        Pair<Long, Sha256Hash> storedStream = streamStore.storeStream(snapshot);
+        Long newStreamId = storedStream.getLhSide();
+        log.info("Stored stream with ID {}", newStreamId);
+
+        transactionManager.runTaskWithRetry(transaction -> {
+            // Load previous stream, and unmark it as used
+            LatestSnapshotTable.LatestSnapshotRow row = LatestSnapshotTable.LatestSnapshotRow.of(0L);
+            LatestSnapshotTable latestSnapshotTable = tableFactory.getLatestSnapshotTable(transaction);
+            Optional<LatestSnapshotTable.LatestSnapshotRowResult> maybeRow = latestSnapshotTable.getRow(row);
+            maybeRow.ifPresent(latestSnapshot -> {
+                Long latestStreamId = maybeRow.get().getStreamId();
+
+                log.info("Marking stream {}, ref {}, as unused", latestStreamId, PtBytes.toString(streamReference));
+                Map<Long, byte[]> theMap = ImmutableMap.of(latestStreamId, streamReference);
+                streamStore.unmarkStreamsAsUsed(transaction, theMap);
+            });
+
+            streamStore.markStreamAsUsed(transaction, newStreamId, streamReference);
+            log.info("Marked stream {} as used with reference {}", newStreamId, PtBytes.toString(streamReference));
+
+            // Record the latest snapshot
+            latestSnapshotTable.putStreamId(row, newStreamId);
+
+            return null;
+        });
+    }
+
+    public SweepResults sweepSnapshotIndices() {
+        TodoSchemaTableFactory tableFactory = TodoSchemaTableFactory.of(Namespace.DEFAULT_NAMESPACE);
+        TableReference indexTable = tableFactory.getSnapshotsStreamIdxTable(null).getTableRef();
+        SweepBatchConfig sweepConfig = ImmutableSweepBatchConfig.builder()
+                .candidateBatchSize(AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT)
+                .deleteBatchSize(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
+                .maxCellTsPairsToExamine(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
+                .build();
+        return sweepTaskRunner.run(indexTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
+    }
+
+    public SweepResults sweepSnapshotValues() {
+        TodoSchemaTableFactory tableFactory = TodoSchemaTableFactory.of(Namespace.DEFAULT_NAMESPACE);
+        TableReference indexTable = tableFactory.getSnapshotsStreamValueTable(null).getTableRef();
+        SweepBatchConfig sweepConfig = ImmutableSweepBatchConfig.builder()
+                .candidateBatchSize(AtlasDbConstants.DEFAULT_SWEEP_CANDIDATE_BATCH_HINT)
+                .deleteBatchSize(AtlasDbConstants.DEFAULT_SWEEP_DELETE_BATCH_HINT)
+                .maxCellTsPairsToExamine(AtlasDbConstants.DEFAULT_SWEEP_READ_LIMIT)
+                .build();
+        return sweepTaskRunner.run(indexTable, sweepConfig, PtBytes.EMPTY_BYTE_ARRAY);
     }
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoResource.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoResource.java
@@ -24,6 +24,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.palantir.atlasdb.keyvalue.api.SweepResults;
+
 @Path("/todos")
 public interface TodoResource {
     @POST
@@ -39,4 +41,19 @@ public interface TodoResource {
     @GET
     @Path("/healthcheck")
     void isHealthy();
+
+    @POST
+    @Path("/snapshot")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void storeSnapshot(String snapshot);
+
+    @POST
+    @Path("/sweep-snapshot-indices")
+    @Produces(MediaType.APPLICATION_JSON)
+    SweepResults sweepSnapshotIndices();
+
+    @POST
+    @Path("/sweep-snapshot-values")
+    @Produces(MediaType.APPLICATION_JSON)
+    SweepResults sweepSnapshotValues();
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoSchema.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/todo/TodoSchema.java
@@ -17,10 +17,12 @@ package com.palantir.atlasdb.todo;
 
 import java.io.File;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.schema.AtlasSchema;
+import com.palantir.atlasdb.schema.stream.StreamStoreDefinitionBuilder;
 import com.palantir.atlasdb.table.description.OptionalType;
 import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.table.description.TableDefinition;
@@ -28,8 +30,10 @@ import com.palantir.atlasdb.table.description.ValueType;
 
 public class TodoSchema implements AtlasSchema {
     private static final Schema INDEX_TEST_SCHEMA = generateSchema();
-    public static final String TODO_TABLE = "todo";
-    public static final String TEXT_COLUMN = "text";
+    private static final String TODO_TABLE = "todo";
+    private static final String TEXT_COLUMN = "text";
+    private static final String LATEST_STREAM_TABLE = "latest_snapshot";
+    private static final String STREAM_TABLE = "snapshots";
 
     private static Schema generateSchema() {
         Schema schema = new Schema(
@@ -46,6 +50,20 @@ public class TodoSchema implements AtlasSchema {
             }
         });
 
+        schema.addTableDefinition(LATEST_STREAM_TABLE, new TableDefinition() {{
+                rowName();
+                rowComponent("key", ValueType.FIXED_LONG);
+                columns();
+                column("stream_id", "i", ValueType.FIXED_LONG);
+            }
+        });
+
+        schema.addStreamStoreDefinition(
+                new StreamStoreDefinitionBuilder(STREAM_TABLE, "Snapshots", ValueType.FIXED_LONG)
+                        .inMemoryThreshold(AtlasDbConstants.DEFAULT_STREAM_IN_MEMORY_THRESHOLD)
+                        .build()
+        );
+
         return schema;
     }
 
@@ -58,7 +76,7 @@ public class TodoSchema implements AtlasSchema {
     }
 
     public static void main(String[] args) throws Exception {
-        INDEX_TEST_SCHEMA.renderTables(new File("src/test/java"));
+        INDEX_TEST_SCHEMA.renderTables(new File("src/main/java"));
     }
 
     @Override

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TodoEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TodoEteTest.java
@@ -15,11 +15,16 @@
  */
 package com.palantir.atlasdb.ete;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
+import java.util.Random;
+
 import org.junit.Test;
 
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.todo.ImmutableTodo;
 import com.palantir.atlasdb.todo.Todo;
 import com.palantir.atlasdb.todo.TodoResource;
@@ -33,5 +38,39 @@ public class TodoEteTest {
 
         todoClient.addTodo(TODO);
         assertThat(todoClient.getTodoList(), hasItem(TODO));
+    }
+
+    @Test
+    public void shouldSweepStreamIndices() {
+        TodoResource todoClient = EteSetup.createClientToSingleNode(TodoResource.class);
+
+        storeFiveStreams(todoClient, 4321);
+
+        SweepResults firstSweep = todoClient.sweepSnapshotIndices();
+        assertThat(firstSweep.getCellTsPairsExamined(), equalTo(9L));
+        assertThat(firstSweep.getStaleValuesDeleted(), equalTo(4L));
+
+        SweepResults valueSweep = todoClient.sweepSnapshotValues();
+        assertThat(valueSweep.getCellTsPairsExamined(), equalTo(9L));
+        assertThat(valueSweep.getStaleValuesDeleted(), equalTo(4L));
+
+        storeFiveStreams(todoClient, 7654321);
+
+        SweepResults secondSweep = todoClient.sweepSnapshotIndices();
+        assertThat(secondSweep.getCellTsPairsExamined(), equalTo(15L));
+        assertThat(secondSweep.getStaleValuesDeleted(), equalTo(5L));
+
+        SweepResults secondValueSweep = todoClient.sweepSnapshotValues();
+        assertThat(secondValueSweep.getCellTsPairsExamined(), equalTo(177L)); // 6L + 19 * 8L + 19L));
+        assertThat(secondValueSweep.getStaleValuesDeleted(), equalTo(1L + 19 * 4L));
+    }
+
+    private void storeFiveStreams(TodoResource todoClient, int streamSize) {
+        Random random = new Random();
+        byte[] bytes = new byte[streamSize];
+        for (int i = 0; i < 5; i++) {
+            random.nextBytes(bytes);
+            todoClient.storeSnapshot(PtBytes.toString(bytes));
+        }
     }
 }

--- a/atlasdb-ete-tests/versions.lock
+++ b/atlasdb-ete-tests/versions.lock
@@ -245,6 +245,7 @@
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-console",
                 "com.palantir.atlasdb:atlasdb-dropwizard-bundle",
+                "com.palantir.atlasdb:atlasdb-ete-test-utils",
                 "com.palantir.atlasdb:atlasdb-hikari",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
@@ -398,6 +399,7 @@
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
+                "com.palantir.atlasdb:atlasdb-ete-test-utils",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api"
             ]
@@ -418,6 +420,7 @@
             "project": true,
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
+                "com.palantir.atlasdb:atlasdb-ete-test-utils",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:qos-service-impl",
@@ -465,6 +468,9 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-dropwizard-bundle": {
+            "project": true
+        },
+        "com.palantir.atlasdb:atlasdb-ete-test-utils": {
             "project": true
         },
         "com.palantir.atlasdb:atlasdb-feign": {
@@ -906,6 +912,7 @@
         "commons-io:commons-io": {
             "locked": "2.1",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-ete-test-utils",
                 "com.palantir.atlasdb:leader-election-impl"
             ]
         },
@@ -1187,6 +1194,12 @@
                 "com.palantir.atlasdb:lock-impl",
                 "com.papertrail:profiler",
                 "io.dropwizard:dropwizard-util"
+            ]
+        },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-ete-test-utils"
             ]
         },
         "net.jcip:jcip-annotations": {
@@ -1481,9 +1494,16 @@
                 "io.dropwizard:dropwizard-validation"
             ]
         },
+        "org.hamcrest:hamcrest-all": {
+            "locked": "1.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-ete-test-utils"
+            ]
+        },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
+                "junit:junit",
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-library"
             ]
@@ -1909,6 +1929,7 @@
                 "com.palantir.atlasdb:atlasdb-dbkvs",
                 "com.palantir.atlasdb:atlasdb-dbkvs-hikari",
                 "com.palantir.atlasdb:atlasdb-dropwizard-bundle",
+                "com.palantir.atlasdb:atlasdb-ete-test-utils",
                 "com.palantir.atlasdb:atlasdb-hikari",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
@@ -2078,6 +2099,7 @@
                 "com.palantir.atlasdb:atlasdb-client",
                 "com.palantir.atlasdb:atlasdb-config",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-ete-test-utils",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:atlasdb-lock-api"
             ]
@@ -2099,6 +2121,7 @@
             "transitive": [
                 "com.palantir.atlasdb:atlasdb-cassandra",
                 "com.palantir.atlasdb:atlasdb-dbkvs",
+                "com.palantir.atlasdb:atlasdb-ete-test-utils",
                 "com.palantir.atlasdb:atlasdb-impl-shared",
                 "com.palantir.atlasdb:atlasdb-jdbc",
                 "com.palantir.atlasdb:qos-service-impl",
@@ -2155,6 +2178,9 @@
             ]
         },
         "com.palantir.atlasdb:atlasdb-dropwizard-bundle": {
+            "project": true
+        },
+        "com.palantir.atlasdb:atlasdb-ete-test-utils": {
             "project": true
         },
         "com.palantir.atlasdb:atlasdb-feign": {
@@ -2628,6 +2654,7 @@
         "commons-io:commons-io": {
             "locked": "2.1",
             "transitive": [
+                "com.palantir.atlasdb:atlasdb-ete-test-utils",
                 "com.palantir.atlasdb:commons-db",
                 "com.palantir.atlasdb:leader-election-impl"
             ]
@@ -2912,6 +2939,12 @@
                 "com.palantir.atlasdb:lock-impl",
                 "com.papertrail:profiler",
                 "io.dropwizard:dropwizard-util"
+            ]
+        },
+        "junit:junit": {
+            "locked": "4.12",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-ete-test-utils"
             ]
         },
         "net.jcip:jcip-annotations": {
@@ -3207,9 +3240,16 @@
                 "io.dropwizard:dropwizard-validation"
             ]
         },
+        "org.hamcrest:hamcrest-all": {
+            "locked": "1.3",
+            "transitive": [
+                "com.palantir.atlasdb:atlasdb-ete-test-utils"
+            ]
+        },
         "org.hamcrest:hamcrest-core": {
             "locked": "1.3",
             "transitive": [
+                "junit:junit",
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-library"
             ]

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamStore.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
@@ -53,6 +54,7 @@ import com.palantir.atlasdb.stream.BlockGetter;
 import com.palantir.atlasdb.stream.BlockLoader;
 import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -83,12 +85,20 @@ public final class StreamTestMaxMemStreamStore extends AbstractPersistentStreamS
     private final StreamTestTableFactory tables;
 
     private StreamTestMaxMemStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        super(txManager);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private StreamTestMaxMemStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, persistenceConfiguration);
         this.tables = tables;
     }
 
     public static StreamTestMaxMemStreamStore of(TransactionManager txManager, StreamTestTableFactory tables) {
         return new StreamTestMaxMemStreamStore(txManager, tables);
+    }
+
+    public static StreamTestMaxMemStreamStore of(TransactionManager txManager, StreamTestTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new StreamTestMaxMemStreamStore(txManager, tables, persistenceConfiguration);
     }
 
     /**
@@ -426,6 +436,8 @@ public final class StreamTestMaxMemStreamStore extends AbstractPersistentStreamS
      * {@link Status}
      * {@link StreamCleanedException}
      * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
      * {@link TempFileUtils}
      * {@link Throwables}
      * {@link TimeUnit}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamStore.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
@@ -53,6 +54,7 @@ import com.palantir.atlasdb.stream.BlockGetter;
 import com.palantir.atlasdb.stream.BlockLoader;
 import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -83,12 +85,20 @@ public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
     private final StreamTestTableFactory tables;
 
     private StreamTestStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        super(txManager);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private StreamTestStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, persistenceConfiguration);
         this.tables = tables;
     }
 
     public static StreamTestStreamStore of(TransactionManager txManager, StreamTestTableFactory tables) {
         return new StreamTestStreamStore(txManager, tables);
+    }
+
+    public static StreamTestStreamStore of(TransactionManager txManager, StreamTestTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new StreamTestStreamStore(txManager, tables, persistenceConfiguration);
     }
 
     /**
@@ -426,6 +436,8 @@ public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
      * {@link Status}
      * {@link StreamCleanedException}
      * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
      * {@link TempFileUtils}
      * {@link Throwables}
      * {@link TimeUnit}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamStore.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
@@ -53,6 +54,7 @@ import com.palantir.atlasdb.stream.BlockGetter;
 import com.palantir.atlasdb.stream.BlockLoader;
 import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -83,12 +85,20 @@ public final class StreamTestWithHashStreamStore extends AbstractPersistentStrea
     private final StreamTestTableFactory tables;
 
     private StreamTestWithHashStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        super(txManager);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private StreamTestWithHashStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, persistenceConfiguration);
         this.tables = tables;
     }
 
     public static StreamTestWithHashStreamStore of(TransactionManager txManager, StreamTestTableFactory tables) {
         return new StreamTestWithHashStreamStore(txManager, tables);
+    }
+
+    public static StreamTestWithHashStreamStore of(TransactionManager txManager, StreamTestTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new StreamTestWithHashStreamStore(txManager, tables, persistenceConfiguration);
     }
 
     /**
@@ -484,6 +494,8 @@ public final class StreamTestWithHashStreamStore extends AbstractPersistentStrea
      * {@link Status}
      * {@link StreamCleanedException}
      * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
      * {@link TempFileUtils}
      * {@link Throwables}
      * {@link TimeUnit}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamStore.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamStore.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
@@ -53,6 +54,7 @@ import com.palantir.atlasdb.stream.BlockGetter;
 import com.palantir.atlasdb.stream.BlockLoader;
 import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -83,12 +85,20 @@ public final class TestHashComponentsStreamStore extends AbstractPersistentStrea
     private final StreamTestTableFactory tables;
 
     private TestHashComponentsStreamStore(TransactionManager txManager, StreamTestTableFactory tables) {
-        super(txManager);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private TestHashComponentsStreamStore(TransactionManager txManager, StreamTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, persistenceConfiguration);
         this.tables = tables;
     }
 
     public static TestHashComponentsStreamStore of(TransactionManager txManager, StreamTestTableFactory tables) {
         return new TestHashComponentsStreamStore(txManager, tables);
+    }
+
+    public static TestHashComponentsStreamStore of(TransactionManager txManager, StreamTestTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new TestHashComponentsStreamStore(txManager, tables, persistenceConfiguration);
     }
 
     /**
@@ -426,6 +436,8 @@ public final class TestHashComponentsStreamStore extends AbstractPersistentStrea
      * {@link Status}
      * {@link StreamCleanedException}
      * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
      * {@link TempFileUtils}
      * {@link Throwables}
      * {@link TimeUnit}

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamStore.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Generated;
@@ -53,6 +54,7 @@ import com.palantir.atlasdb.stream.BlockGetter;
 import com.palantir.atlasdb.stream.BlockLoader;
 import com.palantir.atlasdb.stream.PersistentStreamStore;
 import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -83,12 +85,20 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
     private final ProfileTableFactory tables;
 
     private UserPhotosStreamStore(TransactionManager txManager, ProfileTableFactory tables) {
-        super(txManager);
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private UserPhotosStreamStore(TransactionManager txManager, ProfileTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, persistenceConfiguration);
         this.tables = tables;
     }
 
     public static UserPhotosStreamStore of(TransactionManager txManager, ProfileTableFactory tables) {
         return new UserPhotosStreamStore(txManager, tables);
+    }
+
+    public static UserPhotosStreamStore of(TransactionManager txManager, ProfileTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new UserPhotosStreamStore(txManager, tables, persistenceConfiguration);
     }
 
     /**
@@ -426,6 +436,8 @@ public final class UserPhotosStreamStore extends AbstractPersistentStreamStore {
      * {@link Status}
      * {@link StreamCleanedException}
      * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
      * {@link TempFileUtils}
      * {@link Throwables}
      * {@link TimeUnit}


### PR DESCRIPTION
**Goals (and why)**: Prove that stream store sweep works as expected, and prevent future breaks

**Implementation Description (bullets)**:
- Added a sweep task runner to TodoClient
- Added methods to add/sweep snapshots, using the same design as the internal citrus product
- Wrote ETE test

**Concerns (what feedback would you like?)**: Just noting that I had to push the TodoSchema down into ete-test-utils, and opted to do this rather than spin it out into a brand new module.

**Where should we start reviewing?**: TodoEteTest.java

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3119)
<!-- Reviewable:end -->
