### PR TITLE
Refresh okHttp client after exceptions in a row

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/ExceptionCountingRefreshingClient.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/ExceptionCountingRefreshingClient.java
@@ -74,7 +74,7 @@ public class ExceptionCountingRefreshingClient implements Client {
             try {
                 currentClient = refreshingSupplier.get();
             } catch (RuntimeException e) {
-                log.warn("An error occurred whilst trying to re-create an OkHttpClient, because {} exceptions have been thrown in a row by old client."
+                log.warn("An error occurred whilst trying to re-create an OkHttpClient."
                                 + " Continuing operation with the old client...",
                         SafeArg.of("count", currentCount),
                         e);

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/ExceptionCountingRefreshingClient.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/ExceptionCountingRefreshingClient.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.logsafe.SafeArg;
+
+import feign.Client;
+import feign.Request;
+import feign.Response;
+
+public class ExceptionCountingRefreshingClient implements Client {
+    private static final Logger log = LoggerFactory.getLogger(ExceptionCountingRefreshingClient.class);
+
+    private static final long DEFAULT_EXCEPTION_COUNT_BEFORE_REFRESH = 10_000L;
+
+    private final Supplier<Client> refreshingSupplier;
+    private final long exceptionCountBeforeRefresh;
+    private final AtomicLong counter;
+
+    private volatile Client currentClient;
+
+    @VisibleForTesting
+    ExceptionCountingRefreshingClient(Supplier<Client> baseClientSupplier,
+            long exceptionCountBeforeRefresh) {
+        this.refreshingSupplier = baseClientSupplier;
+        this.exceptionCountBeforeRefresh = exceptionCountBeforeRefresh;
+        this.counter = new AtomicLong();
+        this.currentClient = refreshingSupplier.get();
+    }
+
+    public static Client createRefreshingClient(Supplier<Client> baseClientSupplier) {
+        return new ExceptionCountingRefreshingClient(baseClientSupplier, DEFAULT_EXCEPTION_COUNT_BEFORE_REFRESH);
+    }
+
+    @Override
+    public Response execute(Request request, Request.Options options) throws IOException {
+        try {
+            Response response = delegate().execute(request, options);
+            counter.set(0);
+            return response;
+        } catch (Exception e) {
+            counter.incrementAndGet();
+            throw e;
+        }
+    }
+
+    private Client delegate() {
+        long currentCount = counter.get();
+        if (currentCount >= exceptionCountBeforeRefresh && counter.compareAndSet(currentCount, 0)) {
+            log.info("Creating a new Feign client, as {} exceptions have been thrown in a row by old client",
+                    SafeArg.of("count", currentCount));
+            try {
+                currentClient = refreshingSupplier.get();
+            } catch (RuntimeException e) {
+                log.warn("An error occurred whilst trying to re-create an OkHttpClient, because {} exceptions have been thrown in a row by old client."
+                                + " Continuing operation with the old client...",
+                        SafeArg.of("count", currentCount),
+                        e);
+            }
+        }
+        return currentClient;
+    }
+}

--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/FeignOkHttpClients.java
@@ -20,6 +20,7 @@ import java.net.ProxySelector;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import javax.net.ssl.SSLSocketFactory;
 
@@ -111,8 +112,10 @@ public final class FeignOkHttpClients {
             Optional<SSLSocketFactory> sslSocketFactory,
             Optional<ProxySelector> proxySelector,
             String userAgent) {
-        return CounterBackedRefreshingClient.createRefreshingClient(
+        Supplier<Client> clientSupplier = () -> CounterBackedRefreshingClient.createRefreshingClient(
                 () -> newOkHttpClient(sslSocketFactory, proxySelector, userAgent));
+
+        return ExceptionCountingRefreshingClient.createRefreshingClient(clientSupplier);
     }
 
     @VisibleForTesting

--- a/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/ExceptionCountingRefreshingClientTest.java
+++ b/atlasdb-feign/src/test/java/com/palantir/atlasdb/http/ExceptionCountingRefreshingClientTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.http;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import feign.Client;
+import feign.Request;
+import feign.Response;
+
+public class ExceptionCountingRefreshingClientTest {
+    private Supplier<Client> clientSupplier = (Supplier<Client>) mock(Supplier.class);
+    private Client client = mock(Client.class);
+
+    private Request request = Request.create("POST", "atlas.palantir.pt", ImmutableMap.of(), null, null);
+    private Response response = Response.create(204, "no content", ImmutableMap.of(), new byte[0]);
+    private Request.Options options = new Request.Options(1, 1);
+
+    private static final int EXCEPTION_COUNT_BEFORE_REFRESH = 2;
+    private static final RuntimeException CLIENT_EXCEPTION = new RuntimeException("bad");
+
+    @Test
+    public void passesRequestsThroughToTheDelegate() throws IOException {
+        when(clientSupplier.get()).thenReturn(client);
+        when(client.execute(request, options)).thenReturn(response);
+
+        Client refreshingClient = ExceptionCountingRefreshingClient.createRefreshingClient(clientSupplier);
+        callExecute(refreshingClient, 1);
+
+        verify(client, times(1)).execute(request, options);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    public void createsClientOnlyOnceIfMakingMultipleRequests() throws IOException {
+        when(clientSupplier.get()).thenReturn(client);
+        when(client.execute(request, options)).thenReturn(response);
+
+        Client refreshingClient = ExceptionCountingRefreshingClient.createRefreshingClient(clientSupplier);
+        callExecute(refreshingClient, 3);
+
+        verify(clientSupplier, times(1)).get();
+        verify(client, times(3)).execute(request, options);
+        verifyNoMoreInteractions(clientSupplier, client);
+    }
+
+    @Test
+    public void reinvokesSupplierAfterTheSpecifiedNumberOfExceptionsThrown() throws IOException {
+        when(clientSupplier.get()).thenReturn(client);
+        when(client.execute(request, options)).thenThrow(CLIENT_EXCEPTION);
+
+        Client refreshingClient = new ExceptionCountingRefreshingClient(clientSupplier, EXCEPTION_COUNT_BEFORE_REFRESH);
+
+        int numberOfExecutions = EXCEPTION_COUNT_BEFORE_REFRESH + 1;
+        callExecute(refreshingClient, numberOfExecutions);
+
+        verify(clientSupplier, times((numberOfExecutions / EXCEPTION_COUNT_BEFORE_REFRESH + 1))).get();
+        verify(client, times(numberOfExecutions)).execute(request, options);
+        verifyNoMoreInteractions(clientSupplier, client);
+    }
+
+    @Test
+    public void requestsContinueWithOldClientIfDelegateSupplierThrows() throws IOException {
+        when(clientSupplier.get()).thenReturn(client);
+        when(client.execute(request, options)).thenThrow(CLIENT_EXCEPTION);
+
+        Client refreshingClient = new ExceptionCountingRefreshingClient(clientSupplier, EXCEPTION_COUNT_BEFORE_REFRESH);
+        callExecute(refreshingClient,1);
+
+        when(clientSupplier.get()).thenThrow(new IllegalStateException("bad"));
+
+        int numberOfExecutions = EXCEPTION_COUNT_BEFORE_REFRESH + 1;
+        callExecute(refreshingClient, numberOfExecutions - 1);
+
+        verify(clientSupplier, times((numberOfExecutions / EXCEPTION_COUNT_BEFORE_REFRESH + 1))).get();
+        verify(client, times(numberOfExecutions)).execute(request, options);
+        verifyNoMoreInteractions(clientSupplier, client);
+    }
+
+    @Test
+    public void doesNotRefreshClientIfExceptionsAreNotThrownInARow() throws IOException {
+        when(clientSupplier.get()).thenReturn(client);
+        when(client.execute(request, options))
+                .thenThrow(CLIENT_EXCEPTION)
+                .thenReturn(response)
+                .thenThrow(CLIENT_EXCEPTION)
+                .thenReturn(response);
+
+        Client refreshingClient = new ExceptionCountingRefreshingClient(clientSupplier, EXCEPTION_COUNT_BEFORE_REFRESH);
+
+        int numberOfExecutions = 4;
+        callExecute(refreshingClient, numberOfExecutions);
+
+        verify(clientSupplier, times(1)).get();
+        verify(client, times(numberOfExecutions)).execute(request, options);
+    }
+
+    @Test
+    public void doesRefreshClientIfExceptionsAreThrownInARow() throws IOException {
+        when(clientSupplier.get()).thenReturn(client);
+        when(client.execute(request, options))
+                .thenReturn(response)
+                .thenThrow(CLIENT_EXCEPTION)
+                .thenThrow(CLIENT_EXCEPTION)
+                .thenReturn(response);
+
+        Client refreshingClient = new ExceptionCountingRefreshingClient(clientSupplier, EXCEPTION_COUNT_BEFORE_REFRESH);
+
+        int numberOfExecutions = 4;
+        callExecute(refreshingClient, numberOfExecutions);
+
+        verify(clientSupplier, times(2)).get();
+        verify(client, times(numberOfExecutions)).execute(request, options);
+    }
+
+    private void callExecute(Client client, int numberOfExecutions) throws IOException {
+        for (int i = 0; i < numberOfExecutions; i++) {
+            try {
+                client.execute(request, options);
+            } catch (RuntimeException e) {}
+        }
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -110,6 +110,11 @@ develop
          - AtlasDB internal tables will no longer produce warning messages about hotspotting.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3126>`__)
 
+    *    - |fixed|
+         - OkHttp is not handling ``Thread.interrupt()`` well, and calling interrupts repeatedly may cause corrupted clients.
+           To avoid this issue, feign client is now wrapped with an ``ExceptionCountingRefreshingClient``, which will detect and refresh corrupted clients.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3121>`__)
+
 =======
 v0.81.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
- We are observing an issue causing timelock follower nodes not to receive any request from leader. Root cause seems to be corrupted okHttp clients as a result of frequent interrupts in `QuorumChecker`. Refreshing the client after detecting a row of exceptions should be a feasible workaround
**Implementation Description (bullets)**:
- Wrapping the client with a `ExceptionCountingRefreshingClient`
**Concerns (what feedback would you like?)**:
**Where should we start reviewing?**:
- `ExceptionCountingRefreshingClient`
**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3121)
<!-- Reviewable:end -->
