### PR TITLE
[TS] Part 6: Reintroduce Tombstone Info

### DIFF
--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/WriteReferenceTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/WriteReferenceTest.java
@@ -26,14 +26,13 @@ public class WriteReferenceTest {
     public void persistingHydrationTest() throws IOException {
         TableReference tableReference = TableReference.createFromFullyQualifiedName("abc.def");
         Cell cell = Cell.create(new byte[] {0, 0}, new byte[] {1, 1});
-        WriteReference tableRefCell = ImmutableWriteReference.builder()
+        WriteReference writeRef = ImmutableWriteReference.builder()
                 .tableRef(tableReference)
                 .cell(cell)
                 .isTombstone(false)
                 .build();
 
-        byte[] valueAsBytes = tableRefCell.persistToBytes();
-        Assertions.assertThat(WriteReference.BYTES_HYDRATOR.hydrateFromBytes(valueAsBytes))
-                .isEqualTo(tableRefCell);
+        byte[] valueAsBytes = writeRef.persistToBytes();
+        Assertions.assertThat(WriteReference.BYTES_HYDRATOR.hydrateFromBytes(valueAsBytes)).isEqualTo(writeRef);
     }
 }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/WriteReferenceTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/WriteReferenceTest.java
@@ -21,18 +21,19 @@ import java.io.IOException;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-public class TableReferenceAndCellTest {
+public class WriteReferenceTest {
     @Test
     public void persistingHydrationTest() throws IOException {
         TableReference tableReference = TableReference.createFromFullyQualifiedName("abc.def");
         Cell cell = Cell.create(new byte[] {0, 0}, new byte[] {1, 1});
-        TableReferenceAndCell tableRefCell = ImmutableTableReferenceAndCell.builder()
+        WriteReference tableRefCell = ImmutableWriteReference.builder()
                 .tableRef(tableReference)
                 .cell(cell)
+                .isTombstone(false)
                 .build();
 
         byte[] valueAsBytes = tableRefCell.persistToBytes();
-        Assertions.assertThat(TableReferenceAndCell.BYTES_HYDRATOR.hydrateFromBytes(valueAsBytes))
+        Assertions.assertThat(WriteReference.BYTES_HYDRATOR.hydrateFromBytes(valueAsBytes))
                 .isEqualTo(tableRefCell);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
-import com.palantir.atlasdb.keyvalue.api.TableReferenceAndCell;
+import com.palantir.atlasdb.keyvalue.api.WriteReference;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.OptionalType;
 import com.palantir.atlasdb.table.description.Schema;
@@ -53,7 +53,7 @@ public enum TargetedSweepSchema implements AtlasSchema {
             dynamicColumns();
                 columnComponent("timestamp_modulus", ValueType.VAR_LONG);
                 columnComponent("write_index", ValueType.VAR_SIGNED_LONG);
-                value(TableReferenceAndCell.class);
+                value(WriteReference.class);
 
             sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING);
             conflictHandler(ConflictHandler.IGNORE_ALL);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/MultiTableSweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/MultiTableSweepQueueWriter.java
@@ -38,8 +38,8 @@ public interface MultiTableSweepQueueWriter {
 
     default List<WriteInfo> toWriteInfos(Map<TableReference, ? extends Map<Cell, byte[]>> writes, long timestamp) {
         return writes.entrySet().stream()
-                .flatMap(writesEntry -> writesEntry.getValue().keySet().stream()
-                        .map(cell -> WriteInfo.of(writesEntry.getKey(), cell, timestamp)))
+                .flatMap(entry -> entry.getValue().entrySet().stream()
+                        .map(singleWrite -> SweepQueueUtils.toWriteInfo(entry.getKey(), singleWrite, timestamp)))
                 .collect(Collectors.toList());
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDeleterImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepDeleterImpl.java
@@ -53,7 +53,7 @@ public class SweepDeleterImpl implements SweepDeleter {
 
         for (WriteInfo write : writes) {
             // todo(gmaretic): since we don't know about deletes, makes it awkward for thorough sweep?
-            deleteTimestampByCell.merge(write.tableRefCell().cell(), write.timestamp(), Long::max);
+            deleteTimestampByCell.merge(write.writeRef().cell(), write.timestamp(), Long::max);
         }
 
         return deleteTimestampByCell;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
@@ -16,10 +16,12 @@
 
 package com.palantir.atlasdb.sweep.queue;
 
+import java.util.Arrays;
+import java.util.Map;
+
+import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
-import com.palantir.atlasdb.keyvalue.api.RangeRequest;
-import com.palantir.atlasdb.keyvalue.api.RangeRequests;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.table.api.ColumnValue;
 import com.palantir.common.persist.Persistable;
 
@@ -46,5 +48,12 @@ public final class SweepQueueUtils {
 
     public static Cell toCell(Persistable row, ColumnValue<?> col) {
         return Cell.create(row.persistToBytes(), col.persistColumnName());
+    }
+
+    public static WriteInfo toWriteInfo(TableReference tableRef, Map.Entry<Cell, byte[]> write, long timestamp) {
+        Cell cell = write.getKey();
+        // todo(gmaretic): verify this is indeed how a tombstone is encoded
+        boolean isTombstone = Arrays.equals(write.getValue(), PtBytes.EMPTY_BYTE_ARRAY);
+        return WriteInfo.of(tableRef, cell, isTombstone, timestamp);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCellsReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCellsReader.java
@@ -118,11 +118,10 @@ public class SweepableCellsReader {
             SweepableCellsTable.SweepableCellsColumn col,
             Value value,
             Map<WriteReference, Long> results) {
-        WriteReference tableRefCell = SweepableCellsTable.SweepableCellsColumnValue
-                .hydrateValue(value.getContents());
+        WriteReference writeRef = SweepableCellsTable.SweepableCellsColumnValue.hydrateValue(value.getContents());
 
         long timestamp = row.getTimestampPartition() * SweepQueueUtils.TS_FINE_GRANULARITY + col.getTimestampModulus();
-        addIfMaxForCell(timestamp, tableRefCell, results);
+        addIfMaxForCell(timestamp, writeRef, results);
     }
 
     private void addIfMaxForCell(long ts, WriteReference refAndCell, Map<WriteReference, Long> result) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCellsWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCellsWriter.java
@@ -69,10 +69,10 @@ public class SweepableCellsWriter extends KvsSweepQueueWriter {
         insert(info, write.writeRef(), dedicate, index / MAX_CELLS_DEDICATED, index % MAX_CELLS_DEDICATED, result);
     }
 
-    private void insert(PartitionInfo info, WriteReference tableRefCell, boolean dedicate, long dedicatedRow,
+    private void insert(PartitionInfo info, WriteReference writeRef, boolean dedicate, long dedicatedRow,
             long index, Map<Cell, byte[]> result) {
         SweepableCellsTable.SweepableCellsRow row = createRow(info, dedicate, dedicatedRow);
-        SweepableCellsTable.SweepableCellsColumnValue colVal = createColVal(info.timestamp(), index, tableRefCell);
+        SweepableCellsTable.SweepableCellsColumnValue colVal = createColVal(info.timestamp(), index, writeRef);
         result.put(SweepQueueUtils.toCell(row, colVal), colVal.persistValue());
     }
 
@@ -88,10 +88,9 @@ public class SweepableCellsWriter extends KvsSweepQueueWriter {
                 SweepQueueUtils.tsPartitionFine(info.timestamp()), metadata.persistToBytes());
     }
 
-    private SweepableCellsTable.SweepableCellsColumnValue createColVal(long ts, long index,
-            WriteReference tableRefCell) {
+    private SweepableCellsTable.SweepableCellsColumnValue createColVal(long ts, long index, WriteReference writeRef) {
         SweepableCellsTable.SweepableCellsColumn col = SweepableCellsTable.SweepableCellsColumn.of(tsMod(ts), index);
-        return SweepableCellsTable.SweepableCellsColumnValue.of(col, tableRefCell);
+        return SweepableCellsTable.SweepableCellsColumnValue.of(col, writeRef);
     }
 
     private long requiredDedicatedRows(List<WriteInfo> writes) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCellsWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCellsWriter.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ImmutableTargetedSweepMetadata;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.keyvalue.api.TableReferenceAndCell;
 import com.palantir.atlasdb.keyvalue.api.TargetedSweepMetadata;
+import com.palantir.atlasdb.keyvalue.api.WriteReference;
 import com.palantir.atlasdb.schema.generated.SweepableCellsTable;
 import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
 
@@ -62,14 +62,14 @@ public class SweepableCellsWriter extends KvsSweepQueueWriter {
     }
 
     private void addReferenceToDedicatedRows(PartitionInfo info, List<WriteInfo> writes, Map<Cell, byte[]> result) {
-        insert(info, TableReferenceAndCell.DUMMY, false, 0, -requiredDedicatedRows(writes), result);
+        insert(info, WriteReference.DUMMY, false, 0, -requiredDedicatedRows(writes), result);
     }
 
     private void addWrite(PartitionInfo info, WriteInfo write, boolean dedicate, long index, Map<Cell, byte[]> result) {
-        insert(info, write.tableRefCell(), dedicate, index / MAX_CELLS_DEDICATED, index % MAX_CELLS_DEDICATED, result);
+        insert(info, write.writeRef(), dedicate, index / MAX_CELLS_DEDICATED, index % MAX_CELLS_DEDICATED, result);
     }
 
-    private void insert(PartitionInfo info, TableReferenceAndCell tableRefCell, boolean dedicate, long dedicatedRow,
+    private void insert(PartitionInfo info, WriteReference tableRefCell, boolean dedicate, long dedicatedRow,
             long index, Map<Cell, byte[]> result) {
         SweepableCellsTable.SweepableCellsRow row = createRow(info, dedicate, dedicatedRow);
         SweepableCellsTable.SweepableCellsColumnValue colVal = createColVal(info.timestamp(), index, tableRefCell);
@@ -89,7 +89,7 @@ public class SweepableCellsWriter extends KvsSweepQueueWriter {
     }
 
     private SweepableCellsTable.SweepableCellsColumnValue createColVal(long ts, long index,
-            TableReferenceAndCell tableRefCell) {
+            WriteReference tableRefCell) {
         SweepableCellsTable.SweepableCellsColumn col = SweepableCellsTable.SweepableCellsColumn.of(tsMod(ts), index);
         return SweepableCellsTable.SweepableCellsColumnValue.of(col, tableRefCell);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfo.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/WriteInfo.java
@@ -18,9 +18,11 @@ package com.palantir.atlasdb.sweep.queue;
 
 import org.immutables.value.Value;
 
+import com.google.common.math.IntMath;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.api.TableReferenceAndCell;
+import com.palantir.atlasdb.keyvalue.api.WriteReference;
+import com.palantir.atlasdb.sweep.Sweeper;
 
 /**
  * Contains information about a committed write, for use by the sweep queue.
@@ -28,16 +30,28 @@ import com.palantir.atlasdb.keyvalue.api.TableReferenceAndCell;
 @Value.Immutable
 public interface WriteInfo {
     long timestamp();
-    TableReferenceAndCell tableRefCell();
+    WriteReference writeRef();
 
-    static WriteInfo of(TableReferenceAndCell tableRefCell, long timestamp) {
+    default long timestampToDeleteAtExclusive(Sweeper sweeper) {
+        if (sweeper.shouldSweepLastCommitted() && writeRef().isTombstone()) {
+            return timestamp() + 1L;
+        }
+
+        return timestamp();
+    }
+
+    default int toShard(int numShards) {
+        return IntMath.mod(writeRef().hashCode(), numShards);
+    }
+
+    static WriteInfo of(WriteReference writeRef, long timestamp) {
         return ImmutableWriteInfo.builder()
-                .tableRefCell(tableRefCell)
+                .writeRef(writeRef)
                 .timestamp(timestamp)
                 .build();
     }
 
-    static WriteInfo of(TableReference tableRef, Cell cell, long timestamp) {
-        return WriteInfo.of(TableReferenceAndCell.of(tableRef, cell), timestamp);
+    static WriteInfo of(TableReference tableRef, Cell cell, boolean isTombstone, long timestamp) {
+        return WriteInfo.of(WriteReference.of(tableRef, cell, isTombstone), timestamp);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/test/InMemorySweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/test/InMemorySweepQueue.java
@@ -48,7 +48,7 @@ public final class InMemorySweepQueue implements SweepQueueReader, SweepQueueWri
     }
 
     public static MultiTableSweepQueueWriter writer() {
-        return writes -> instanceForTable(writes.get(0).tableRefCell().tableRef()).enqueue(writes);
+        return writes -> instanceForTable(writes.get(0).writeRef().tableRef()).enqueue(writes);
     }
 
     private InMemorySweepQueue() {}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableTimestampsReadWriteTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableTimestampsReadWriteTest.java
@@ -46,8 +46,8 @@ public class SweepableTimestampsReadWriteTest extends SweepQueueReadWriteTest{
         reader = new SweepableTimestampsReader(kvs, provider);
         progress = new KvsSweepQueueProgress(kvs);
 
-        shard = writeTs(writer, TS, true);
-        shard2 = writeTs(writer, TS2, false);
+        shard = writeToDefault(writer, TS, true);
+        shard2 = writeToDefault(writer, TS2, false);
 
         immutableTs = 10 * TS;
         unreadableTs = 10 * TS;
@@ -148,7 +148,7 @@ public class SweepableTimestampsReadWriteTest extends SweepQueueReadWriteTest{
     @Test
     public void getCorrectNextTimestampWhenMultipleCandidates() {
         for (long timestamp = 1000L; tsPartitionFine(timestamp) < 10L; timestamp += TS_FINE_GRANULARITY / 5) {
-            writeTs(writer, timestamp, true);
+            writeToDefault(writer, timestamp, true);
         }
         assertThat(reader.nextSweepableTimestampPartition(conservative(shard)))
                 .contains(tsPartitionFine(1000L));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoPartitionerTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import static com.palantir.atlasdb.sweep.queue.WriteInfoPartitioner.SHARDS;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -119,12 +121,12 @@ public class WriteInfoPartitionerTest {
     @Test
     public void partitionWritesByShardStrategyTimestampGroupsOnShardClash() {
         List<WriteInfo> writes = new ArrayList<>();
-        for (int i = 0; i <= WriteInfoPartitioner.SHARDS; i++) {
+        for (int i = 0; i <= SHARDS; i++) {
             writes.add(getWriteInfoWithFixedCellHash(CONSERVATIVE, i));
         }
         Map<PartitionInfo, List<WriteInfo>> partitions = partitioner.partitionWritesByShardStrategyTimestamp(writes);
         assertThat(partitions.keySet())
-                .containsExactly(PartitionInfo.of(WriteInfoPartitioner.getShard(writes.get(0)), true, 1L));
+                .containsExactly(PartitionInfo.of(writes.get(0).toShard(SHARDS), true, 1L));
         assertThat(partitions.values())
                 .containsExactly(writes);
     }
@@ -140,6 +142,6 @@ public class WriteInfoPartitionerTest {
 
     private WriteInfo getWriteInfo(TableReference tableRef, int rowIndex, int colIndex, long timestamp) {
         Cell cell = Cell.create(PtBytes.toBytes(rowIndex), PtBytes.toBytes(colIndex));
-        return WriteInfo.of(tableRef, cell, timestamp);
+        return WriteInfo.of(tableRef, cell, true, timestamp);
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/WriteInfoTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static com.palantir.atlasdb.sweep.queue.WriteInfoPartitioner.SHARDS;
+
+import org.junit.Test;
+
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.sweep.Sweeper;
+
+public class WriteInfoTest {
+    private static final TableReference TABLE_REF = TableReference.createFromFullyQualifiedName("test.test");
+    private static final Cell CELL = Cell.create(new byte[]{1}, new byte[]{2});
+    private static final long ONE = 1L;
+    private static final long TWO = 2L;
+
+    @Test
+    public void tombstoneStatusIsIgnoredForEqualityAndSharding() {
+        assertThat(getWriteAt(ONE)).isEqualTo(getTombstoneAt(ONE));
+        assertThat(getWriteAt(ONE).toShard(SHARDS)).isEqualTo(getTombstoneAt(ONE).toShard(SHARDS));
+    }
+
+    @Test
+    public void timestampIsIgnoredForShardingOnly() {
+        assertThat(getWriteAt(ONE)).isNotEqualTo(getWriteAt(TWO));
+        assertThat(getTombstoneAt(ONE)).isNotEqualTo(getTombstoneAt(TWO));
+
+        assertThat(getWriteAt(ONE).toShard(SHARDS)).isEqualTo(getWriteAt(TWO).toShard(SHARDS));
+        assertThat(getTombstoneAt(ONE).toShard(SHARDS)).isEqualTo(getTombstoneAt(TWO).toShard(SHARDS));
+    }
+
+    @Test
+    public void timestampToDeleteAtHigherForTombstoneAndThorough() {
+        assertThat(getWriteAt(ONE).timestampToDeleteAtExclusive(Sweeper.CONSERVATIVE)).isEqualTo(ONE);
+        assertThat(getWriteAt(ONE).timestampToDeleteAtExclusive(Sweeper.THOROUGH)).isEqualTo(ONE);
+        assertThat(getTombstoneAt(ONE).timestampToDeleteAtExclusive(Sweeper.CONSERVATIVE)).isEqualTo(ONE);
+
+        assertThat(getTombstoneAt(ONE).timestampToDeleteAtExclusive(Sweeper.THOROUGH)).isEqualTo(TWO);
+    }
+
+    private WriteInfo getWriteAt(long timestamp) {
+        return WriteInfo.of(TABLE_REF, CELL, false, timestamp);
+    }
+
+    private WriteInfo getTombstoneAt(long timestamp) {
+        return WriteInfo.of(TABLE_REF, CELL, true, timestamp);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
We need to know which writes were tombstones to properly set the ranged tombstone for thorough sweep

**Implementation Description (bullets)**:
Pretty straightforward

**Concerns (what feedback would you like?)**:
Is my assumption that writing a tombstone == putting an empty byte array into the KVS correct?
Is the treatment of isTombstone as auxiliary confusing?

**Where should we start reviewing?**:
`WriteReference.java`

**Priority (whenever / two weeks / yesterday)**:
ASAP, so it can get merged into part 5 before too much changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3124)
<!-- Reviewable:end -->
