### PR TITLE
Better logging on lock ExtenralLocksCondition#throwIfConditionInvalid()

### DIFF
--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
@@ -121,7 +120,6 @@ import com.palantir.lock.LockClient;
 import com.palantir.lock.LockCollections;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.LockMode;
-import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleTimeDuration;
@@ -771,8 +769,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             });
             fail();
         } catch (TransactionLockTimeoutNonRetriableException e) {
-            Set<LockRefreshToken> expectedTokens = ImmutableSet.of(expiredLockToken.getLockRefreshToken());
-            assertThat(e.getMessage(), containsString(expectedTokens.toString()));
+            LockDescriptor descriptor = Iterables.getFirst(expiredLockToken.getLockDescriptors(), null);
+            assertThat(e.getMessage(), containsString(descriptor.toString()));
             assertThat(e.getMessage(), containsString("Retry is not possible."));
         }
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |logs|
+         - Expired lock refreshes now tell you which locks expired, instead of just their refreshing token id.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3125>`__)
+
     *    - |fixed|
          - Transaction managers now shut down threads associated with the QoS client and TimeLock lock refresher when they are closed.
            Previously, these threads would continue running and needlessly using resources.


### PR DESCRIPTION
**Goals (and why)**:
better ability to identify which locks failed when a lock fails to refresh...refresh token ids are kinda hard to map back to an actual lock

**Priority (whenever / two weeks / yesterday)**:
whenever
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3125)
<!-- Reviewable:end -->
