### PR TITLE
whitelist internal tables from hotspot logging

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeWritesLogger.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TokenRangeWritesLogger.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.logging.LoggingArgs;
@@ -69,11 +70,15 @@ public final class TokenRangeWritesLogger {
     }
 
     public void markWritesForTable(Set<Cell> entries, TableReference tableRef) {
+        if (AtlasDbConstants.hiddenTables.contains(tableRef)) {
+            return;
+        }
+
         if (!statsPerTable.containsKey(tableRef)) {
             statsPerTable.put(tableRef, new TokenRangeWrites(tableRef, ranges));
         }
         TokenRangeWrites tokenRangeWrites = statsPerTable.get(tableRef);
-        entries.forEach(entry -> tokenRangeWrites.markWrite(entry));
+        entries.forEach(tokenRangeWrites::markWrite);
         tokenRangeWrites.maybeEmitTelemetry();
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -102,6 +102,10 @@ develop
          - ``kvs-slow-log`` messages now also include start time of the operation for easier debugging.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3117>`__)
 
+    *    - |improved| |logs|
+         - AtlasDB internal tables will no longer produce warning messages about hotspotting.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3126>`__)
+
 =======
 v0.81.0
 =======


### PR DESCRIPTION
notably every deployment is currently warnlogging on _transactions and
_punch, since both logical and wallclock timestamps are naturally hotspotted and these tables will always get enough writes to be considered worth logging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3126)
<!-- Reviewable:end -->
