### PR TITLE
[TS] Part 7.5: Fix Writes To Dedicated Rows

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCellsWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCellsWriter.java
@@ -84,13 +84,17 @@ public class SweepableCellsWriter extends KvsSweepQueueWriter {
                 .dedicatedRowNumber(dedicatedRow)
                 .build();
 
-        return SweepableCellsTable.SweepableCellsRow.of(
-                SweepQueueUtils.tsPartitionFine(info.timestamp()), metadata.persistToBytes());
+        return SweepableCellsTable.SweepableCellsRow.of(getTimestampOrPartition(info, dedicate),
+                metadata.persistToBytes());
     }
 
     private SweepableCellsTable.SweepableCellsColumnValue createColVal(long ts, long index, WriteReference writeRef) {
         SweepableCellsTable.SweepableCellsColumn col = SweepableCellsTable.SweepableCellsColumn.of(tsMod(ts), index);
         return SweepableCellsTable.SweepableCellsColumnValue.of(col, writeRef);
+    }
+
+    private long getTimestampOrPartition(PartitionInfo info, boolean dedicate) {
+        return dedicate ? info.timestamp() : SweepQueueUtils.tsPartitionFine(info.timestamp());
     }
 
     private long requiredDedicatedRows(List<WriteInfo> writes) {


### PR DESCRIPTION
**Goals (and why)**:
Make dedicated rows unique per transaction. Old impl was using the partition, which could clash in case we have multiple dedicated writes in transaction in the same partition. There was no correctness issue, as they were being written to separate columns, but the dedicated rows were able to grow out of proportion.

**Implementation Description (bullets)**:
Just use the whole timestamp as the row component instead of the partition for dedicated rows.

**Concerns (what feedback would you like?)**:
None, but we could use 0 for the column component if we like -- it would slightly reduce the byte size and we could have a tighter range for the range scan. Probably not worth the added code obfuscation?

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3129)
<!-- Reviewable:end -->
