### PR TITLE
Make Sweep Priority Override Configs Deserializable

### DIFF
--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
@@ -52,6 +52,12 @@ public class AtlasDbRuntimeConfigDeserializationTest {
                     assertThat(persistenceConfig.numBlocksToWriteBeforePause()).isEqualTo(7);
                     assertThat(persistenceConfig.writePauseDurationMillis()).isEqualTo(77);
                 });
+        assertThat(runtimeConfig.sweep().sweepPriorityOverrides()).satisfies(
+                overrides -> {
+                    assertThat(overrides.priorityTables()).containsExactlyInAnyOrder("atlas.mission_critical_table");
+                    assertThat(overrides.blacklistTables()).containsExactlyInAnyOrder(
+                            "atlas.bad_table", "atlas2.immutable_log");
+                });
     }
 
     private void assertSslConfigDeserializedCorrectly(SslConfiguration sslConfiguration) {

--- a/atlasdb-config/src/test/resources/runtime-config-block.yml
+++ b/atlasdb-config/src/test/resources/runtime-config-block.yml
@@ -15,3 +15,11 @@ timelockRuntime:
 streamStorePersistence:
   numBlocksToWriteBeforePause: 7
   writePauseDurationMillis: 77
+
+sweep:
+  sweepPriorityOverrides:
+    blacklistTables:
+      - "atlas.bad_table"
+      - "atlas2.immutable_log"
+    priorityTables:
+      - "atlas.mission_critical_table"

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityOverrideConfig.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/priority/SweepPriorityOverrideConfig.java
@@ -22,12 +22,16 @@ import java.util.stream.Stream;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 
+@JsonSerialize(as = ImmutableSweepPriorityOverrideConfig.class)
+@JsonDeserialize(as = ImmutableSweepPriorityOverrideConfig.class)
 @Value.Immutable
 public abstract class SweepPriorityOverrideConfig {
     /**

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,10 +57,10 @@ develop
 v0.82.1
 =======
 
-.. replace this with the release date and the above with v<tag> (the v makes the permalinks nice)
+1 May 2018
 
 .. list-table::
-:widths: 5 40
+    :widths: 5 40
     :header-rows: 1
 
         *    - Type

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,6 +54,24 @@ develop
          -
 
 =======
+v0.82.1
+=======
+
+.. replace this with the release date and the above with v<tag> (the v makes the permalinks nice)
+
+.. list-table::
+:widths: 5 40
+    :header-rows: 1
+
+        *    - Type
+             - Change
+
+        *    - |fixed|
+             - Specifying tables in configuration for sweep priority overrides now works properly.
+               Previously, attempting to deserialize configurations with these overrides would cause errors.
+               (`Pull Request <https://github.com/palantir/atlasdb/pull/3136>`__)
+
+=======
 v0.82.0
 =======
 


### PR DESCRIPTION
**NEEDS VERIFICATION** on internal stack before merge

**Goals (and why)**:
- Actually make the sweep priority override configs usable

**Implementation Description (bullets)**:
- Add the required annotations
- Add a deserialization test

**Concerns (what feedback would you like?)**:
- Nothing in particular.

**Where should we start reviewing?**: the test, probably

**Priority (whenever / two weeks / yesterday)**: yesterday
