### PR TITLE
bumping log level to warn from info

### DIFF
--- a/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/ExceptionCountingRefreshingClient.java
+++ b/atlasdb-feign/src/main/java/com/palantir/atlasdb/http/ExceptionCountingRefreshingClient.java
@@ -69,7 +69,7 @@ public class ExceptionCountingRefreshingClient implements Client {
     private Client delegate() {
         long currentCount = counter.get();
         if (currentCount >= exceptionCountBeforeRefresh && counter.compareAndSet(currentCount, 0)) {
-            log.info("Creating a new Feign client, as {} exceptions have been thrown in a row by old client",
+            log.warn("Creating a new Feign client, as {} exceptions have been thrown in a row by old client",
                     SafeArg.of("count", currentCount));
             try {
                 currentClient = refreshingSupplier.get();


### PR DESCRIPTION
**Goals (and why)**:
Refreshing the client because of exceptions thrown shouldn't happen in ideal case. Considering that, I would like to bump logging creation message to warn from info.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
