### PR TITLE
Resiliency to Cassandra Rolling Restarts + Respect for maxTriesOnHost()

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -381,7 +381,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             CassandraClientPoolingContainer hostPool = getPreferredHostOrFallBack(req);
 
             try {
-                return runWithPooledResourceRecordingMetrics(hostPool, req.getFunction());
+                V response = runWithPooledResourceRecordingMetrics(hostPool, req.getFunction());
+                blacklist.remove(hostPool.getHost()); // successful request -> can un-blacklist
+                return response;
             } catch (Exception ex) {
                 exceptionHandler.handleExceptionFromRequest(req, hostPool.getHost(), ex);
             }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -415,7 +415,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
     public <V, K extends Exception> V runOnHost(InetSocketAddress specifiedHost,
             FunctionCheckedException<CassandraClient, V, K> fn) throws K {
         CassandraClientPoolingContainer hostPool = cassandra.getPools().get(specifiedHost);
-        return runWithPooledResourceRecordingMetrics(hostPool, fn);
+        V response = runWithPooledResourceRecordingMetrics(hostPool, fn);
+        blacklist.remove(specifiedHost);
+        return response;
     }
 
     private <V, K extends Exception> V runWithPooledResourceRecordingMetrics(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -202,6 +202,7 @@ class CassandraRequestExceptionHandler {
     }
 
     static boolean isIndicativeOfCassandraLoad(Throwable ex) {
+        // TODO (jkong): Make NoSuchElementException its own thing - that is NOT necessarily indicative of C* load.
         return ex != null
                 // pool for this node is fully in use
                 && (ex instanceof NoSuchElementException

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -253,9 +253,7 @@ class CassandraRequestExceptionHandler {
 
         @Override
         public boolean shouldRetryOnDifferentHost(Exception ex, int maxTriesSameHost, int numberOfAttempts) {
-            return isFastFailoverException(ex)
-                    || (numberOfAttempts >= maxTriesSameHost
-                    && (isConnectionException(ex) || isIndicativeOfCassandraLoad(ex)));
+            return isFastFailoverException(ex) || numberOfAttempts >= maxTriesSameHost;
         }
     }
 
@@ -276,7 +274,7 @@ class CassandraRequestExceptionHandler {
         @Override
         public boolean shouldRetryOnDifferentHost(Exception ex, int maxTriesSameHost, int numberOfAttempts) {
             return isFastFailoverException(ex) || isIndicativeOfCassandraLoad(ex)
-                    || (numberOfAttempts >= maxTriesSameHost && isConnectionException(ex));
+                    || numberOfAttempts >= maxTriesSameHost;
         }
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -187,7 +187,6 @@ public class CassandraClientPoolTest {
         verifyBlacklistMetric(1);
     }
 
-    @SuppressWarnings("unchecked") // We know the types are correct within this test.
     @Test
     public void successfulRequestCausesHostToBeRemovedFromBlacklist() {
         CassandraClientPool cassandraClientPool = clientPoolWithServersInCurrentPool(ImmutableSet.of(HOST_1));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -217,7 +217,7 @@ public class CassandraClientPoolTest {
 
         downHost.set(HOST_2);
 
-        runNoopWithRetryOnHost(HOST_1, cassandraClientPool);
+        runNoopWithRetryOnHost(HOST_2, cassandraClientPool);
         assertThat(blacklist.contains(HOST_1), is(false));
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 
 import java.net.SocketTimeoutException;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,7 +36,6 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
 
@@ -180,13 +178,7 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void retryableExceptionsAreRetryableConservative() {
-        Set<Exception> allExceptions = new HashSet<>();
-        allExceptions = Sets.union(allExceptions, CONNECTION_EXCEPTIONS);
-        allExceptions = Sets.union(allExceptions, TRANSIENT_EXCEPTIONS);
-        allExceptions = Sets.union(allExceptions, INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS);
-        allExceptions = Sets.union(allExceptions, FAST_FAILOVER_EXCEPTIONS);
-
-        for (Exception ex : allExceptions) {
+        for (Exception ex : ALL_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should be retryable", ex), handlerConservative.isRetryable(ex));
         }
         assertFalse("RuntimeException is not retryable", handlerConservative.isRetryable(new RuntimeException()));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
@@ -21,9 +21,12 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.net.SocketTimeoutException;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.TimedOutException;
@@ -32,6 +35,7 @@ import org.apache.thrift.transport.TTransportException;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
@@ -44,12 +48,23 @@ public class CassandraRequestExceptionHandlerTest {
     private static final int MAX_RETRIES_PER_HOST = 3;
     private static final int MAX_RETRIES_TOTAL = 6;
 
-    private static Set<Exception> connectionExceptions = Sets.newHashSet(new SocketTimeoutException(MESSAGE),
+    private static final Set<Exception> CONNECTION_EXCEPTIONS = ImmutableSet.of(new SocketTimeoutException(MESSAGE),
             new CassandraClientFactory.ClientCreationFailedException(MESSAGE, CAUSE));
-    private static Set<Exception> transientExceptions = Sets.newHashSet(new TTransportException());
-    private static Set<Exception> indicativeOfCassandraLoadException = Sets.newHashSet(new NoSuchElementException(),
-            new TimedOutException(), new UnavailableException(), new InsufficientConsistencyException(MESSAGE));
-    private static Set<Exception> fastFailoverExceptions = Sets.newHashSet(new InvalidRequestException());
+    private static final Set<Exception> TRANSIENT_EXCEPTIONS = ImmutableSet.of(new TTransportException());
+    private static final Set<Exception> INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS =
+            ImmutableSet.of(
+                    new NoSuchElementException(),
+                    new TimedOutException(),
+                    new UnavailableException(),
+                    new InsufficientConsistencyException(MESSAGE));
+    private static final Set<Exception> FAST_FAILOVER_EXCEPTIONS = ImmutableSet.of(new InvalidRequestException());
+    private static final Set<Exception> ALL_EXCEPTIONS = Stream.of(
+            CONNECTION_EXCEPTIONS,
+            TRANSIENT_EXCEPTIONS,
+            INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS,
+            FAST_FAILOVER_EXCEPTIONS)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
 
     private boolean currentMode = true;
     private CassandraRequestExceptionHandler handlerDefault;
@@ -72,13 +87,7 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void retryableExceptionsAreRetryableDefault() {
-        Set<Exception> allExceptions = new HashSet<>();
-        allExceptions = Sets.union(allExceptions, connectionExceptions);
-        allExceptions = Sets.union(allExceptions, transientExceptions);
-        allExceptions = Sets.union(allExceptions, indicativeOfCassandraLoadException);
-        allExceptions = Sets.union(allExceptions, fastFailoverExceptions);
-
-        for (Exception ex : allExceptions) {
+        for (Exception ex : ALL_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should be retryable", ex), handlerDefault.isRetryable(ex));
         }
         assertFalse("RuntimeException is not retryable", handlerDefault.isRetryable(new RuntimeException()));
@@ -86,24 +95,24 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void connectionExceptionsWithSufficientAttemptsShouldBlacklistDefault() {
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertFalse("MAX_RETRIES_PER_HOST - 1 attempts should not blacklist",
                     handlerDefault.shouldBlacklist(ex, MAX_RETRIES_PER_HOST - 1));
         }
 
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("MAX_RETRIES_PER_HOST attempts with exception %s should blacklist", ex),
                     handlerDefault.shouldBlacklist(ex, MAX_RETRIES_PER_HOST));
         }
 
-        Exception ffException = Iterables.get(fastFailoverExceptions, 0);
+        Exception ffException = Iterables.get(FAST_FAILOVER_EXCEPTIONS, 0);
         assertFalse(String.format("Exception %s should not blacklist", ffException),
                 handlerDefault.shouldBlacklist(ffException, MAX_RETRIES_PER_HOST));
     }
 
     @Test
     public void connectionExceptionsShouldBackoffDefault() {
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should backoff", ex),
                     handlerDefault.shouldBackoff(ex, handlerDefault.getStrategy()));
         }
@@ -111,7 +120,7 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void cassandraLoadExceptionsShouldBackoffDefault() {
-        for (Exception ex : indicativeOfCassandraLoadException) {
+        for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should backoff", ex),
                     handlerDefault.shouldBackoff(ex, handlerDefault.getStrategy()));
         }
@@ -119,14 +128,14 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void transientExceptionsShouldNotBackoffDefault() {
-        for (Exception ex : transientExceptions) {
+        for (Exception ex : TRANSIENT_EXCEPTIONS) {
             assertFalse(handlerDefault.shouldBackoff(ex, handlerDefault.getStrategy()));
         }
     }
 
     @Test
     public void fastFailoverExceptionsShouldNotBackoffDefault() {
-        for (Exception ex : fastFailoverExceptions) {
+        for (Exception ex : FAST_FAILOVER_EXCEPTIONS) {
             assertFalse(String.format("Exception %s should not backoff", ex),
                     handlerDefault.shouldBackoff(ex, handlerDefault.getStrategy()));
         }
@@ -134,13 +143,13 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void connectionExceptionRetriesOnDifferentHostAfterSufficientRetriesDefault() {
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertFalse(String.format("Exception %s should not retry on different host", ex),
                     handlerDefault.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST - 1,
                             handlerDefault.getStrategy()));
         }
 
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should retry on different host", ex),
                     handlerDefault.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST, handlerDefault.getStrategy()));
         }
@@ -148,14 +157,14 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void cassandraLoadExceptionRetriesOnSameHostDefault() {
-        for (Exception ex : indicativeOfCassandraLoadException) {
+        for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
             assertFalse(handlerDefault.shouldRetryOnDifferentHost(ex, 0, handlerDefault.getStrategy()));
         }
     }
 
     @Test
     public void cassandraLoadExceptionRetriesOnDifferentHostAfterSufficientRetriesDefault() {
-        for (Exception ex : indicativeOfCassandraLoadException) {
+        for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should retry on different host", ex),
                     handlerDefault.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST, handlerDefault.getStrategy()));
         }
@@ -163,7 +172,7 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void fastFailoverExceptionAlwaysRetriesOnDifferentHostDefault() {
-        for (Exception ex : fastFailoverExceptions) {
+        for (Exception ex : FAST_FAILOVER_EXCEPTIONS) {
             assertTrue(String.format("Fast failover exception %s should always retry on different host", ex),
                     handlerDefault.shouldRetryOnDifferentHost(ex, 0, handlerDefault.getStrategy()));
         }
@@ -172,10 +181,10 @@ public class CassandraRequestExceptionHandlerTest {
     @Test
     public void retryableExceptionsAreRetryableConservative() {
         Set<Exception> allExceptions = new HashSet<>();
-        allExceptions = Sets.union(allExceptions, connectionExceptions);
-        allExceptions = Sets.union(allExceptions, transientExceptions);
-        allExceptions = Sets.union(allExceptions, indicativeOfCassandraLoadException);
-        allExceptions = Sets.union(allExceptions, fastFailoverExceptions);
+        allExceptions = Sets.union(allExceptions, CONNECTION_EXCEPTIONS);
+        allExceptions = Sets.union(allExceptions, TRANSIENT_EXCEPTIONS);
+        allExceptions = Sets.union(allExceptions, INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS);
+        allExceptions = Sets.union(allExceptions, FAST_FAILOVER_EXCEPTIONS);
 
         for (Exception ex : allExceptions) {
             assertTrue(String.format("Exception %s should be retryable", ex), handlerConservative.isRetryable(ex));
@@ -185,24 +194,24 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void connectionExceptionsWithSufficientAttemptsShouldBlacklistConservative() {
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertFalse("MAX_RETRIES_PER_HOST - 1 attempts should not blacklist",
                     handlerConservative.shouldBlacklist(ex, MAX_RETRIES_PER_HOST - 1));
         }
 
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("MAX_RETRIES_PER_HOST attempts with exception %s should blacklist", ex),
                     handlerConservative.shouldBlacklist(ex, MAX_RETRIES_PER_HOST));
         }
 
-        Exception ffException = Iterables.get(fastFailoverExceptions, 0);
+        Exception ffException = Iterables.get(FAST_FAILOVER_EXCEPTIONS, 0);
         assertFalse(String.format("Exception %s should not blacklist", ffException),
                 handlerConservative.shouldBlacklist(ffException, MAX_RETRIES_PER_HOST));
     }
 
     @Test
     public void connectionExceptionsShouldBackoffConservative() {
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should backoff", ex),
                     handlerConservative.shouldBackoff(ex, handlerConservative.getStrategy()));
         }
@@ -210,7 +219,7 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void cassandraLoadExceptionsShouldBackoffConservative() {
-        for (Exception ex : indicativeOfCassandraLoadException) {
+        for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should backoff", ex),
                     handlerConservative.shouldBackoff(ex, handlerConservative.getStrategy()));
         }
@@ -218,14 +227,14 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void transientExceptionsShouldBackoffConservative() {
-        for (Exception ex : transientExceptions) {
+        for (Exception ex : TRANSIENT_EXCEPTIONS) {
             assertTrue(handlerConservative.shouldBackoff(ex, handlerConservative.getStrategy()));
         }
     }
 
     @Test
     public void fastFailoverExceptionsShouldNotBackoffConservative() {
-        for (Exception ex : fastFailoverExceptions) {
+        for (Exception ex : FAST_FAILOVER_EXCEPTIONS) {
             assertFalse(String.format("Exception %s should not backoff", ex),
                     handlerConservative.shouldBackoff(ex, handlerConservative.getStrategy()));
         }
@@ -233,13 +242,13 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void connectionExceptionRetriesOnDifferentHostAfterSufficientRetriesConservative() {
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertFalse(String.format("Exception %s should not retry on different host", ex),
                     handlerConservative.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST - 1,
                             handlerConservative.getStrategy()));
         }
 
-        for (Exception ex : connectionExceptions) {
+        for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should retry on different host", ex),
                     handlerConservative.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST,
                             handlerConservative.getStrategy()));
@@ -248,14 +257,14 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void cassandraLoadExceptionRetriesOnDifferentHostWithoutRetryingConservative() {
-        for (Exception ex : indicativeOfCassandraLoadException) {
+        for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
             assertTrue(handlerConservative.shouldRetryOnDifferentHost(ex, 0, handlerConservative.getStrategy()));
         }
     }
 
     @Test
     public void cassandraLoadExceptionRetriesOnDifferentHostAfterSufficientRetriesConservative() {
-        for (Exception ex : indicativeOfCassandraLoadException) {
+        for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should retry on different host", ex),
                     handlerConservative.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST,
                             handlerConservative.getStrategy()));
@@ -264,7 +273,7 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void fastFailoverExceptionAlwaysRetriesOnDifferentHostConservative() {
-        for (Exception ex : fastFailoverExceptions) {
+        for (Exception ex : FAST_FAILOVER_EXCEPTIONS) {
             assertTrue(String.format("Fast failover exception %s should always retry on different host", ex),
                     handlerConservative.shouldRetryOnDifferentHost(ex, 0, handlerConservative.getStrategy()));
         }
@@ -272,7 +281,7 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void changingHandlerModeHasNoEffectWithoutGetStrategy() {
-        Exception ex = Iterables.get(transientExceptions, 0);
+        Exception ex = Iterables.get(TRANSIENT_EXCEPTIONS, 0);
         CassandraRequestExceptionHandler handler = new CassandraRequestExceptionHandler(
                 () -> MAX_RETRIES_PER_HOST,
                 () -> MAX_RETRIES_TOTAL,
@@ -284,6 +293,11 @@ public class CassandraRequestExceptionHandlerTest {
         flipMode();
         assertTrue(handler.shouldBackoff(ex, conservativeStrategy));
         assertFalse(handler.shouldBackoff(ex, handler.getStrategy()));
+    }
+
+    @Test
+    public void exceptionAfterMaxRetriesPerHostAlwaysRetriesOnDifferentHostConservative() {
+
     }
 
     private boolean mutableMode() {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
@@ -297,7 +297,22 @@ public class CassandraRequestExceptionHandlerTest {
 
     @Test
     public void exceptionAfterMaxRetriesPerHostAlwaysRetriesOnDifferentHostConservative() {
+        for (Exception ex : ALL_EXCEPTIONS) {
+            assertTrue(String.format("If the max retries per host has been exceeded, we should always retry on a"
+                            + " different host - but we didn't for exception %s", ex),
+                    handlerConservative.shouldRetryOnDifferentHost(
+                            ex, MAX_RETRIES_PER_HOST + 1, handlerConservative.getStrategy()));
+        }
+    }
 
+    @Test
+    public void exceptionAfterMaxRetriesPerHostAlwaysRetriesOnDifferentHostDefault() {
+        for (Exception ex : ALL_EXCEPTIONS) {
+            assertTrue(String.format("If the max retries per host has been exceeded, we should always retry on a"
+                            + " different host - but we didn't for exception %s", ex),
+                    handlerConservative.shouldRetryOnDifferentHost(
+                            ex, MAX_RETRIES_PER_HOST + 1, handlerDefault.getStrategy()));
+        }
     }
 
     private boolean mutableMode() {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,15 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |improved|
+         - If we make a successful request to a Cassandra client, we now remove it from the Cassandra client pool's blacklist.
+           Previously, removal from the blacklist would only occur after a background thread successfully refreshed the pool, meaning that requests may become stuck if Cassandra was rolling restarted.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/nnnn>`__)
+
+    *    - |fixed|
+         - The Cassandra client pool now respects the ``maxRetriesOnHost`` config option, and will not try a single operation beyond that many times on the same node.
+           Previously, under certain kinds of exceptions (such as ``TTransportException``s), we would repeatedly retry the operation on the same node up to ``maxTriesTotal`` times.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/nnnn>`__)
 
 =======
 v0.82.1

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,12 +53,12 @@ develop
     *    - |improved|
          - If we make a successful request to a Cassandra client, we now remove it from the Cassandra client pool's blacklist.
            Previously, removal from the blacklist would only occur after a background thread successfully refreshed the pool, meaning that requests may become stuck if Cassandra was rolling restarted.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/nnnn>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3145>`__)
 
     *    - |fixed|
          - The Cassandra client pool now respects the ``maxRetriesOnHost`` config option, and will not try a single operation beyond that many times on the same node.
-           Previously, under certain kinds of exceptions (such as ``TTransportException``s), we would repeatedly retry the operation on the same node up to ``maxTriesTotal`` times.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/nnnn>`__)
+           Previously, under certain kinds of exceptions (such as ``TTransportException``), we would repeatedly retry the operation on the same node up to ``maxTriesTotal`` times.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3145>`__)
 
 =======
 v0.82.1


### PR DESCRIPTION
**Goals (and why)**: Fix #3139.

**Implementation Description (bullets)**:
- Respect the `maxTriesOnHost()` configuration option even when dealing with 'transient' exceptions - it is apparently possible for six `TTransportException`s to crush a request.
- In addition to having the background thread refresh the blacklist, after a successful operation has completed we also un-blacklist a node.

**Concerns (what feedback would you like?)**:
- Is a successful request completion sufficient in place of running the health-check / are there reasons we might want a node that can answer a client request but cannot answer our health-check to stay on the blacklist?
- What was the intention of `maxTriesOfHost()` not actually being the maximum number of tries on a given host? It's clearly simpler to not have a check on exception type, meaning that initially it was desired that we re-try on the same node in the event of a `TTransportException`.

**Where should we start reviewing?**: CassandraRequestExceptionHandler / CassandraClientPoolImpl.

**Priority (whenever / two weeks / yesterday)**: tomorrow would be great; if not early next week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3145)
<!-- Reviewable:end -->
