### PR TITLE
[TS] Part 9: Better Sweep Granularity

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -236,7 +236,7 @@ class CassandraRequestExceptionHandler {
     }
 
     private static class Default implements RequestExceptionHandlerStrategy {
-        private static final RequestExceptionHandlerStrategy  INSTANCE = new Default();
+        private static final RequestExceptionHandlerStrategy INSTANCE = new Default();
 
         private static final long BACKOFF_DURATION = Duration.ofSeconds(1).toMillis();
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueue.java
@@ -32,7 +32,8 @@ import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 
 public class KvsSweepQueue implements MultiTableSweepQueueWriter {
     private final Supplier<Integer> numShards;
-    private KvsSweepQueueTables tables;
+    @VisibleForTesting
+    KvsSweepQueueTables tables;
     private KvsSweepQueuePersister writer;
     private Map<ShardAndStrategy, KvsSweepQueueReader> shardSpecificReaders;
     private Map<TableMetadataPersistence.SweepStrategy, KvsSweepDeleter> strategySpecificDeleters;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueProgress.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueProgress.java
@@ -59,11 +59,11 @@ public class KvsSweepQueueProgress {
         return increaseValueToAtLeast(ShardAndStrategy.conservative(SHARD_COUNT_INDEX), newNumber);
     }
 
-    public long getLastSweptTimestampPartition(ShardAndStrategy shardAndStrategy) {
+    public long getLastSweptTimestamp(ShardAndStrategy shardAndStrategy) {
         return getOrReturnInitial(shardAndStrategy, INITIAL_TIMESTAMP);
     }
 
-    public long updateLastSweptTimestampPartition(ShardAndStrategy shardAndStrategy, long timestamp) {
+    public long updateLastSweptTimestamp(ShardAndStrategy shardAndStrategy, long timestamp) {
         return increaseValueToAtLeast(shardAndStrategy, timestamp);
     }
 
@@ -94,7 +94,7 @@ public class KvsSweepQueueProgress {
     }
 
     private long increaseValueToAtLeast(ShardAndStrategy shardAndStrategy, long newVal) {
-        long oldVal = getLastSweptTimestampPartition(shardAndStrategy);
+        long oldVal = getLastSweptTimestamp(shardAndStrategy);
         byte[] colValNew = SweepShardProgressTable.Value.of(newVal).persistValue();
 
         while (oldVal < newVal) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueReader.java
@@ -17,11 +17,9 @@
 package com.palantir.atlasdb.sweep.queue;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Consumer;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.util.Pair;
 
 public final class KvsSweepQueueReader implements SweepQueueReader {
     private final SweepableCells sweepableCells;
@@ -53,7 +51,7 @@ public final class KvsSweepQueueReader implements SweepQueueReader {
 
     private SweepBatch getNextBatchAndSweptTimestamp(long lastSweptTs, long sweepTs) {
         return sweepableTimestamps.nextSweepableTimestampPartition(shardStrategy, lastSweptTs, sweepTs)
-                .map(fine -> sweepableCells.getWritesFromPartition(shardStrategy, fine, lastSweptTs, sweepTs))
+                .map(fine -> sweepableCells.getBatchForPartition(shardStrategy, fine, lastSweptTs, sweepTs))
                 .orElse(SweepBatch.of(ImmutableList.of(), sweepTs - 1L));
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueReader.java
@@ -45,15 +45,15 @@ public final class KvsSweepQueueReader implements SweepQueueReader {
 
     @Override
     public void consumeNextBatch(Consumer<Collection<WriteInfo>> consumer, long maxTsExclusive) {
-        long lastSweptTs = progress.getLastSweptTimestampPartition(shardStrategy);
-        Pair<List<WriteInfo>, Long> batchAndPartitionFine = getNextBatchAndPartitionFine(lastSweptTs, maxTsExclusive);
-        consumer.accept(batchAndPartitionFine.getLhSide());
-        scrubber.scrub(shardStrategy, lastSweptTs, batchAndPartitionFine.getRhSide());
+        long previousLastSweptTs = progress.getLastSweptTimestamp(shardStrategy);
+        SweepBatch sweepBatch = getNextBatchAndSweptTimestamp(previousLastSweptTs, maxTsExclusive);
+        consumer.accept(sweepBatch.writes());
+        scrubber.scrub(shardStrategy, previousLastSweptTs, sweepBatch.lastSweptTimestamp());
     }
 
-    private Pair<List<WriteInfo>, Long> getNextBatchAndPartitionFine(long previousFine, long sweepTs) {
-        return sweepableTimestamps.nextSweepableTimestampPartition(shardStrategy, previousFine, sweepTs)
-                .map(fine -> Pair.create(sweepableCells.getWritesFromPartition(fine, shardStrategy), fine))
-                .orElse(Pair.create(ImmutableList.of(), SweepQueueUtils.tsPartitionFine(sweepTs) - 1L));
+    private SweepBatch getNextBatchAndSweptTimestamp(long lastSweptTs, long sweepTs) {
+        return sweepableTimestamps.nextSweepableTimestampPartition(shardStrategy, lastSweptTs, sweepTs)
+                .map(fine -> sweepableCells.getWritesFromPartition(shardStrategy, fine, lastSweptTs, sweepTs))
+                .orElse(SweepBatch.of(ImmutableList.of(), sweepTs - 1L));
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueScrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueScrubber.java
@@ -41,11 +41,14 @@ public class KvsSweepQueueScrubber {
     }
 
     private void scrubSweepableCells(ShardAndStrategy shardStrategy, long oldProgress, long newProgress) {
-        long oldPartitionFine = SweepQueueUtils.tsPartitionFine(oldProgress);
-        long newPartitionFine = SweepQueueUtils.tsPartitionFine(newProgress);
-        if (newPartitionFine > oldPartitionFine) {
-            scrubDedicatedRows(shardStrategy, oldPartitionFine);
-            scrubNonDedicatedRow(shardStrategy, oldPartitionFine);
+        if (oldProgress < 0) {
+            return;
+        }
+        long oldLastSweptPartition = SweepQueueUtils.tsPartitionFine(oldProgress);
+        long newMinSweepPartition = SweepQueueUtils.tsPartitionFine(newProgress + 1);
+        if (newMinSweepPartition > oldLastSweptPartition) {
+            scrubDedicatedRows(shardStrategy, oldLastSweptPartition);
+            scrubNonDedicatedRow(shardStrategy, oldLastSweptPartition);
         }
     }
 
@@ -58,10 +61,13 @@ public class KvsSweepQueueScrubber {
     }
 
     private void scrubSweepableTimestamps(ShardAndStrategy shardStrategy, long oldProgress, long newProgress) {
-        long oldPartitionCoarse = SweepQueueUtils.tsPartitionCoarse(oldProgress);
-        long newPartitionCoarse = SweepQueueUtils.tsPartitionCoarse(newProgress);
-        if (newPartitionCoarse > oldPartitionCoarse) {
-            sweepableTimestamps.deleteRow(shardStrategy, oldProgress);
+        if (oldProgress < 0) {
+            return;
+        }
+        long oldLastSweptPartition = SweepQueueUtils.tsPartitionCoarse(oldProgress);
+        long newMinSweepPartition = SweepQueueUtils.tsPartitionCoarse(newProgress + 1);
+        if (newMinSweepPartition > oldLastSweptPartition) {
+            sweepableTimestamps.deleteRow(shardStrategy, oldLastSweptPartition);
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueScrubber.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueScrubber.java
@@ -31,35 +31,41 @@ public class KvsSweepQueueScrubber {
      * Cleans up all the sweep queue data from the last update of progress up to and including the given sweep
      * partition. Then, updates the sweep queue progress.
      * @param shardStrategy shard and strategy to scrub for.
-     * @param previousProgress previous last partition sweep has processed.
+     * @param oldProgress previous last partition sweep has processed.
      * @param newProgress last partition sweep has processed.
      */
-    public void scrub(ShardAndStrategy shardStrategy, long previousProgress, long newProgress) {
-        scrubSweepableCells(shardStrategy, newProgress);
-        scrubSweepableTimestamps(shardStrategy, previousProgress, newProgress);
+    public void scrub(ShardAndStrategy shardStrategy, long oldProgress, long newProgress) {
+        scrubSweepableCells(shardStrategy, oldProgress, newProgress);
+        scrubSweepableTimestamps(shardStrategy, oldProgress, newProgress);
         progressTo(shardStrategy, newProgress);
     }
 
-    private void scrubSweepableCells(ShardAndStrategy shardStrategy, long newProgress) {
-        scrubDedicatedRows(shardStrategy, newProgress);
-        scrubNonDedicatedRow(shardStrategy, newProgress);
-    }
-
-    private void scrubDedicatedRows(ShardAndStrategy shardStrategy, long partition) {
-        sweepableCells.deleteDedicatedRows(shardStrategy, partition);
-    }
-
-    private void scrubNonDedicatedRow(ShardAndStrategy shardStrategy, long partition) {
-        sweepableCells.deleteNonDedicatedRow(shardStrategy, partition);
-    }
-
-    private void scrubSweepableTimestamps(ShardAndStrategy shardStrategy, long oldPartition, long newPartition) {
-        if (SweepQueueUtils.partitionFineToCoarse(newPartition) > SweepQueueUtils.partitionFineToCoarse(oldPartition)) {
-            sweepableTimestamps.deleteRow(shardStrategy, oldPartition);
+    private void scrubSweepableCells(ShardAndStrategy shardStrategy, long oldProgress, long newProgress) {
+        long oldPartitionFine = SweepQueueUtils.tsPartitionFine(oldProgress);
+        long newPartitionFine = SweepQueueUtils.tsPartitionFine(newProgress);
+        if (newPartitionFine > oldPartitionFine) {
+            scrubDedicatedRows(shardStrategy, oldPartitionFine);
+            scrubNonDedicatedRow(shardStrategy, oldPartitionFine);
         }
     }
 
-    private void progressTo(ShardAndStrategy shardStrategy, long partition) {
-        progress.updateLastSweptTimestampPartition(shardStrategy, partition);
+    private void scrubDedicatedRows(ShardAndStrategy shardStrategy, long partitionToDelete) {
+        sweepableCells.deleteDedicatedRows(shardStrategy, partitionToDelete);
+    }
+
+    private void scrubNonDedicatedRow(ShardAndStrategy shardStrategy, long partitionToDelete) {
+        sweepableCells.deleteNonDedicatedRow(shardStrategy, partitionToDelete);
+    }
+
+    private void scrubSweepableTimestamps(ShardAndStrategy shardStrategy, long oldProgress, long newProgress) {
+        long oldPartitionCoarse = SweepQueueUtils.tsPartitionCoarse(oldProgress);
+        long newPartitionCoarse = SweepQueueUtils.tsPartitionCoarse(newProgress);
+        if (newPartitionCoarse > oldPartitionCoarse) {
+            sweepableTimestamps.deleteRow(shardStrategy, oldProgress);
+        }
+    }
+
+    private void progressTo(ShardAndStrategy shardStrategy, long lastSweptTs) {
+        progress.updateLastSweptTimestamp(shardStrategy, lastSweptTs);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatch.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatch.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface SweepBatch {
+    List<WriteInfo> writes();
+    long lastSweptTimestamp();
+
+    static SweepBatch of(Collection<WriteInfo> writes, long timestamp) {
+        return ImmutableSweepBatch.builder().writes(writes).lastSweptTimestamp(timestamp).build();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueReader.java
@@ -28,7 +28,6 @@ public interface SweepQueueReader {
      * on the next invocation.
      * @param consumer
      * @param maxTimestampExclusive
-     * @return
      */
     void consumeNextBatch(Consumer<Collection<WriteInfo>> consumer, long maxTimestampExclusive);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
@@ -48,6 +48,10 @@ public final class SweepQueueUtils {
         return partitionFine / (TS_COARSE_GRANULARITY / TS_FINE_GRANULARITY);
     }
 
+    public static long maxForFinePartition(long finePartition) {
+        return finePartition * SweepQueueUtils.TS_FINE_GRANULARITY + SweepQueueUtils.TS_FINE_GRANULARITY - 1;
+    }
+
     public static Cell toCell(Persistable row, ColumnValue<?> col) {
         return Cell.create(row.persistToBytes(), col.persistColumnName());
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
@@ -48,8 +48,12 @@ public final class SweepQueueUtils {
         return partitionFine / (TS_COARSE_GRANULARITY / TS_FINE_GRANULARITY);
     }
 
+    public static long minForFinePartition(long finePartition) {
+        return finePartition * TS_FINE_GRANULARITY;
+    }
+
     public static long maxForFinePartition(long finePartition) {
-        return finePartition * SweepQueueUtils.TS_FINE_GRANULARITY + SweepQueueUtils.TS_FINE_GRANULARITY - 1;
+        return minForFinePartition(finePartition) + SweepQueueUtils.TS_FINE_GRANULARITY - 1;
     }
 
     public static Cell toCell(Persistable row, ColumnValue<?> col) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -45,6 +45,7 @@ public class SweepableCells extends KvsSweepQueueWriter {
     static final int MAX_CELLS_DEDICATED = 100_000;
     private static final ColumnRangeSelection ALL_COLUMNS = allPossibleColumns();
     public static final long SWEEP_BATCH_SIZE = 1000L;
+    public static final int MINIMUM_WRITE_INDEX = -TargetedSweepMetadata.MAX_DEDICATED_ROWS;
 
     public SweepableCells(KeyValueService kvs, WriteInfoPartitioner partitioner) {
         super(kvs, TargetedSweepTableFactory.of().getSweepableCellsTable(null).getTableRef(), partitioner);
@@ -55,7 +56,7 @@ public class SweepableCells extends KvsSweepQueueWriter {
         boolean dedicate = writes.size() > MAX_CELLS_GENERIC;
 
         if (dedicate) {
-            addReferenceToDedicatedRows(partitionInfo, writes, cells);
+            cells = addReferenceToDedicatedRows(partitionInfo, writes, cells);
         }
 
         long index = 0;
@@ -65,65 +66,95 @@ public class SweepableCells extends KvsSweepQueueWriter {
         }
     }
 
-    SweepBatch getWritesFromPartition(ShardAndStrategy shardAndStrategy, long partitionFine, long minTsExclusive, long maxTsExclusive) {
-        if (minTsExclusive + 1 >= maxTsExclusive) {
-            return  SweepBatch.of(ImmutableList.of(), minTsExclusive);
-        }
-
-        SweepableCellsTable.SweepableCellsRow row = computeRow(partitionFine, shardAndStrategy);
-        RowColumnRangeIterator resultIterator = getColumnRangeForRow(row, minTsExclusive, maxTsExclusive);
-
-        Map<CellReference, WriteInfo> writes = new HashMap<>();
-        long lastSweptTs = 0L;
-
-        while (resultIterator.hasNext() && writes.size() <= SWEEP_BATCH_SIZE) {
-            Map.Entry<Cell, Value> entry = resultIterator.next();
-            populateWrites(row, entry, writes);
-            lastSweptTs = getTimestamp(row, computeColumn(entry));
-        }
-
-        if (!resultIterator.hasNext()) {
-            lastSweptTs = Math.min(SweepQueueUtils.maxForFinePartition(partitionFine), maxTsExclusive - 1);
-        }
-
-        return SweepBatch.of(writes.values(), lastSweptTs);
+    private Map<Cell, byte[]> addReferenceToDedicatedRows(PartitionInfo info, List<WriteInfo> writes,
+            Map<Cell, byte[]> cells) {
+        return addCell(info, WriteReference.DUMMY, false, 0, entryIndicatingNumberOfRequiredRows(writes), cells);
     }
 
-    void deleteDedicatedRows(ShardAndStrategy shardAndStrategy, long partitionFine) {
-        rangeRequestsDedicatedRows(shardAndStrategy, partitionFine).forEach(this::deleteRange);
+    private long entryIndicatingNumberOfRequiredRows(List<WriteInfo> writes) {
+        return -(1 + (writes.size() - 1) / MAX_CELLS_DEDICATED);
     }
 
-    void deleteNonDedicatedRow(ShardAndStrategy shardAndStrategy, long partitionFine) {
-        deleteRange(rangeRequestNonDedicatedRow(shardAndStrategy, partitionFine));
-    }
-
-    private void addReferenceToDedicatedRows(PartitionInfo info, List<WriteInfo> writes, Map<Cell, byte[]> cells) {
-        addCell(info, WriteReference.DUMMY, false, 0, -numberDedicatedRows(writes), cells);
-    }
-
-    private void addWrite(PartitionInfo info, WriteInfo write, boolean dedicate, long index, Map<Cell, byte[]> cells) {
-        addCell(info, write.writeRef(), dedicate, index / MAX_CELLS_DEDICATED, index % MAX_CELLS_DEDICATED, cells);
-    }
-
-    private void addCell(PartitionInfo info, WriteReference writeRef, boolean dedicate, long dedicatedRow,
-            long index, Map<Cell, byte[]> cells) {
-        SweepableCellsTable.SweepableCellsRow row = computeRow(info, dedicate, dedicatedRow);
-        SweepableCellsTable.SweepableCellsColumnValue colVal = createColVal(info.timestamp(), index, writeRef);
+    private Map<Cell, byte[]> addCell(PartitionInfo info, WriteReference writeRef, boolean isDedicatedRow,
+            long dedicatedRowNumber, long writeIndex, Map<Cell, byte[]> cells) {
+        SweepableCellsTable.SweepableCellsRow row = computeRow(info, isDedicatedRow, dedicatedRowNumber);
+        SweepableCellsTable.SweepableCellsColumnValue colVal = createColVal(info.timestamp(), writeIndex, writeRef);
         cells.put(SweepQueueUtils.toCell(row, colVal), colVal.persistValue());
+        return cells;
     }
 
-    private long numberDedicatedRows(List<WriteInfo> writes) {
-        return 1 + (writes.size() - 1) / MAX_CELLS_DEDICATED;
+    private SweepableCellsTable.SweepableCellsRow computeRow(PartitionInfo info, boolean isDedicatedRow,
+            long dedicatedRowNumber) {
+        TargetedSweepMetadata metadata = ImmutableTargetedSweepMetadata.builder()
+                .conservative(info.isConservative().isTrue())
+                .dedicatedRow(isDedicatedRow)
+                .shard(info.shard())
+                .dedicatedRowNumber(dedicatedRowNumber)
+                .build();
+
+        long tsOrPartition = getTimestampOrPartition(info, isDedicatedRow);
+        return SweepableCellsTable.SweepableCellsRow.of(tsOrPartition, metadata.persistToBytes());
     }
 
-    private static long tsMod(long timestamp) {
-        return timestamp % SweepQueueUtils.TS_FINE_GRANULARITY;
+    private long getTimestampOrPartition(PartitionInfo info, boolean isDedicatedRow) {
+        return isDedicatedRow ? info.timestamp() : SweepQueueUtils.tsPartitionFine(info.timestamp());
     }
 
     private SweepableCellsTable.SweepableCellsColumnValue createColVal(long ts, long index, WriteReference writeRef) {
         SweepableCellsTable.SweepableCellsColumn col = SweepableCellsTable.SweepableCellsColumn.of(tsMod(ts), index);
         return SweepableCellsTable.SweepableCellsColumnValue.of(col, writeRef);
     }
+
+    private static long tsMod(long timestamp) {
+        return timestamp % SweepQueueUtils.TS_FINE_GRANULARITY;
+    }
+
+    SweepBatch getBatchForPartition(ShardAndStrategy shardStrategy, long partitionFine, long minTsExclusive,
+            long maxTsExclusive) {
+        if (inconsistentBounds(minTsExclusive, maxTsExclusive)) {
+            return  SweepBatch.of(ImmutableList.of(), minTsExclusive);
+        }
+
+        SweepableCellsTable.SweepableCellsRow row = computeRow(partitionFine, shardStrategy);
+        RowColumnRangeIterator resultIterator = getRowColumnRange(row, partitionFine, minTsExclusive, maxTsExclusive);
+
+        Map<CellReference, WriteInfo> writes = new HashMap<>();
+        long lastSweptTs = 0L;
+
+        while (resultIterator.hasNext() && writes.size() < SWEEP_BATCH_SIZE) {
+            Map.Entry<Cell, Value> entry = resultIterator.next();
+            populateWrites(row, entry, writes);
+            lastSweptTs = getTimestamp(row, computeColumn(entry));
+        }
+
+        if (exhaustedAllColumns(resultIterator)) {
+            lastSweptTs = lastGuaranteedSwept(partitionFine, maxTsExclusive);
+        }
+
+        return SweepBatch.of(writes.values(), lastSweptTs);
+    }
+
+    private boolean inconsistentBounds(long minTsExclusive, long maxTsExclusive) {
+        return minTsExclusive + 1 >= maxTsExclusive;
+    }
+
+    private SweepableCellsTable.SweepableCellsRow computeRow(long partitionFine, ShardAndStrategy shardStrategy) {
+        TargetedSweepMetadata metadata = ImmutableTargetedSweepMetadata.builder()
+                .conservative(shardStrategy.isConservative())
+                .dedicatedRow(false)
+                .shard(shardStrategy.shard())
+                .dedicatedRowNumber(0)
+                .build();
+
+        return SweepableCellsTable.SweepableCellsRow.of(partitionFine, metadata.persistToBytes());
+    }
+
+    private RowColumnRangeIterator getRowColumnRange(SweepableCellsTable.SweepableCellsRow row, long partitionFine,
+            long minTsExclusive, long maxTsExclusive) {
+        return getRowsColumnRange(ImmutableList.of(row.persistToBytes()),
+                columnsBetween(minTsExclusive + 1, maxTsExclusive, partitionFine), MAX_CELLS_DEDICATED);
+    }
+
 
     private void populateWrites(SweepableCellsTable.SweepableCellsRow row, Map.Entry<Cell, Value> entry,
             Map<CellReference, WriteInfo> writes) {
@@ -143,13 +174,64 @@ public class SweepableCells extends KvsSweepQueueWriter {
     private void addWritesFromDedicated(SweepableCellsTable.SweepableCellsRow row,
             SweepableCellsTable.SweepableCellsColumn col, Map<CellReference, WriteInfo> writes) {
         List<byte[]> dedicatedRows = computeDedicatedRows(row, col);
-        RowColumnRangeIterator iterator = getColumnRangeAll(dedicatedRows);
+        RowColumnRangeIterator iterator = getWithColumnRangeAll(dedicatedRows);
         iterator.forEachRemaining(entry -> addWriteFromValue(getTimestamp(row, col), entry.getValue(), writes));
+    }
+
+    private List<byte[]> computeDedicatedRows(SweepableCellsTable.SweepableCellsRow row,
+            SweepableCellsTable.SweepableCellsColumn col) {
+        TargetedSweepMetadata metadata = TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(row.getMetadata());
+        long timestamp = getTimestamp(row, col);
+        int numberOfDedicatedRows = writeIndexToNumberOfDedicatedRows(col.getWriteIndex());
+        List<byte[]> dedicatedRows = new ArrayList<>();
+
+        for (int i = 0; i < numberOfDedicatedRows; i++) {
+            byte[]  dedicatedMetadata = ImmutableTargetedSweepMetadata.builder()
+                    .from(metadata)
+                    .dedicatedRow(true)
+                    .dedicatedRowNumber(i)
+                    .build()
+                    .persistToBytes();
+            dedicatedRows.add(SweepableCellsTable.SweepableCellsRow.of(timestamp, dedicatedMetadata).persistToBytes());
+        }
+        return dedicatedRows;
+    }
+
+    private long getTimestamp(SweepableCellsTable.SweepableCellsRow row, SweepableCellsTable.SweepableCellsColumn col) {
+        return row.getTimestampPartition() * SweepQueueUtils.TS_FINE_GRANULARITY + col.getTimestampModulus();
+    }
+
+    private int writeIndexToNumberOfDedicatedRows(long writeIndex) {
+        return (int) -writeIndex;
+    }
+
+    private RowColumnRangeIterator getWithColumnRangeAll(Iterable<byte[]> rows) {
+        return getRowsColumnRange(rows, ALL_COLUMNS, MAX_CELLS_DEDICATED);
     }
 
     private void addWriteFromValue(long timestamp, Value value, Map<CellReference, WriteInfo> writes) {
         WriteReference writeRef = SweepableCellsTable.SweepableCellsColumnValue.hydrateValue(value.getContents());
         updateLatestForCell(timestamp, writeRef, writes);
+    }
+
+    private boolean exhaustedAllColumns(RowColumnRangeIterator resultIterator) {
+        return !resultIterator.hasNext();
+    }
+
+    private long lastGuaranteedSwept(long partitionFine, long maxTsExclusive) {
+        return Math.min(SweepQueueUtils.maxForFinePartition(partitionFine), maxTsExclusive - 1);
+    }
+
+    void deleteDedicatedRows(ShardAndStrategy shardAndStrategy, long partitionFine) {
+        rangeRequestsDedicatedRows(shardAndStrategy, partitionFine).forEach(this::deleteRange);
+    }
+
+    void deleteNonDedicatedRow(ShardAndStrategy shardAndStrategy, long partitionFine) {
+        deleteRange(rangeRequestNonDedicatedRow(shardAndStrategy, partitionFine));
+    }
+
+    private void addWrite(PartitionInfo info, WriteInfo write, boolean dedicate, long index, Map<Cell, byte[]> cells) {
+        addCell(info, write.writeRef(), dedicate, index / MAX_CELLS_DEDICATED, index % MAX_CELLS_DEDICATED, cells);
     }
 
     private void updateLatestForCell(long ts, WriteReference writeRef, Map<CellReference, WriteInfo> writes) {
@@ -160,7 +242,7 @@ public class SweepableCells extends KvsSweepQueueWriter {
 
     private List<RangeRequest> rangeRequestsDedicatedRows(ShardAndStrategy shardAndStrategy, long partitionFine) {
         SweepableCellsTable.SweepableCellsRow startingRow = computeRow(partitionFine, shardAndStrategy);
-        RowColumnRangeIterator rowIterator = getColumnRangeAllForRow(startingRow);
+        RowColumnRangeIterator rowIterator = getWithColumnRangeAllForRow(startingRow);
         List<RangeRequest> requests = new ArrayList<>();
         rowIterator.forEachRemaining(entry -> addRangeRequestIfDedicated(startingRow, computeColumn(entry), requests));
         return requests;
@@ -190,88 +272,34 @@ public class SweepableCells extends KvsSweepQueueWriter {
                 .build();
     }
 
-    private SweepableCellsTable.SweepableCellsRow computeRow(PartitionInfo info, boolean dedicate, long dedicatedRow) {
-        TargetedSweepMetadata metadata = ImmutableTargetedSweepMetadata.builder()
-                .conservative(info.isConservative().isTrue())
-                .dedicatedRow(dedicate)
-                .shard(info.shard())
-                .dedicatedRowNumber(dedicatedRow)
-                .build();
-
-        return computeRow(getTimestampOrPartition(info, dedicate), metadata);
-    }
-
-    private SweepableCellsTable.SweepableCellsRow computeRow(long partitionFine, ShardAndStrategy shardStrategy) {
-        TargetedSweepMetadata metadata = ImmutableTargetedSweepMetadata.builder()
-                .conservative(shardStrategy.isConservative())
-                .dedicatedRow(false)
-                .shard(shardStrategy.shard())
-                .dedicatedRowNumber(0)
-                .build();
-
-        return computeRow(partitionFine, metadata);
-    }
-
-    private SweepableCellsTable.SweepableCellsRow computeRow(long timestamp, TargetedSweepMetadata metadata) {
-        return SweepableCellsTable.SweepableCellsRow.of(timestamp, metadata.persistToBytes());
-    }
-
-    private List<byte[]> computeDedicatedRows(SweepableCellsTable.SweepableCellsRow row,
-            SweepableCellsTable.SweepableCellsColumn col) {
-        TargetedSweepMetadata metadata = TargetedSweepMetadata.BYTES_HYDRATOR.hydrateFromBytes(row.getMetadata());
-        long timestamp = getTimestamp(row, col);
-        int numberOfDedicatedRows = (int) -col.getWriteIndex();
-        List<byte[]> dedicatedRows = new ArrayList<>();
-
-        for (int i = 0; i < numberOfDedicatedRows; i++) {
-            TargetedSweepMetadata dedicatedMetadata = ImmutableTargetedSweepMetadata.builder()
-                    .from(metadata)
-                    .dedicatedRow(true)
-                    .dedicatedRowNumber(i)
-                    .build();
-            dedicatedRows.add(computeRow(timestamp, dedicatedMetadata).persistToBytes());
-        }
-        return dedicatedRows;
-    }
-
     private SweepableCellsTable.SweepableCellsColumn computeColumn(Map.Entry<Cell, Value> entry) {
         return SweepableCellsTable.SweepableCellsColumn.BYTES_HYDRATOR
                 .hydrateFromBytes(entry.getKey().getColumnName());
     }
 
-    private RowColumnRangeIterator getColumnRangeAllForRow(SweepableCellsTable.SweepableCellsRow row) {
-        return getColumnRangeAll(ImmutableList.of(row.persistToBytes()));
+    private RowColumnRangeIterator getWithColumnRangeAllForRow(SweepableCellsTable.SweepableCellsRow row) {
+        return getWithColumnRangeAll(ImmutableList.of(row.persistToBytes()));
     }
 
-    private RowColumnRangeIterator getColumnRangeAll(Iterable<byte[]> rows) {
-        return getRowsColumnRange(rows, ALL_COLUMNS, MAX_CELLS_DEDICATED);
-    }
-
-    private RowColumnRangeIterator getColumnRangeForRow(SweepableCellsTable.SweepableCellsRow row, long minTsExclusive,
-            long maxTsExclusive) {
-        return getRowsColumnRange(ImmutableList.of(row.persistToBytes()), columnsBetween(minTsExclusive + 1, maxTsExclusive), MAX_CELLS_DEDICATED);
-    }
-
-    private long getTimestamp(SweepableCellsTable.SweepableCellsRow row, SweepableCellsTable.SweepableCellsColumn col) {
-        return row.getTimestampPartition() * SweepQueueUtils.TS_FINE_GRANULARITY + col.getTimestampModulus();
-    }
-
-    private long getTimestampOrPartition(PartitionInfo info, boolean dedicate) {
-        return dedicate ? info.timestamp() : SweepQueueUtils.tsPartitionFine(info.timestamp());
-    }
-
-    private ColumnRangeSelection columnsBetween(long startTsInclusive, long endTsExclusive) {
-        long startMod = tsMod(startTsInclusive);
-        byte[] startCol = SweepableCellsTable.SweepableCellsColumn.of(
-                startMod, -TargetedSweepMetadata.MAX_DEDICATED_ROWS).persistToBytes();
-        long end = Math.min(endTsExclusive - startTsInclusive + startMod, SweepQueueUtils.TS_FINE_GRANULARITY);
-        byte[] endCol = SweepableCellsTable.SweepableCellsColumn.of(
-                end, -TargetedSweepMetadata.MAX_DEDICATED_ROWS).persistToBytes();
+    private ColumnRangeSelection columnsBetween(long startTsInclusive, long endTsExclusive, long partitionFine) {
+        long startIncl = exactColumnOrElseBeginningOfRow(startTsInclusive, partitionFine);
+        byte[] startCol = SweepableCellsTable.SweepableCellsColumn.of(startIncl, MINIMUM_WRITE_INDEX).persistToBytes();
+        long endExcl = exactColumnOrElseOneBeyondEndOfRow(endTsExclusive, partitionFine);
+        byte[] endCol = SweepableCellsTable.SweepableCellsColumn.of(endExcl, MINIMUM_WRITE_INDEX).persistToBytes();
         return new ColumnRangeSelection(startCol, endCol);
     }
 
+    private long exactColumnOrElseOneBeyondEndOfRow(long endTsExclusive, long partitionFine) {
+        return Math.min(endTsExclusive - SweepQueueUtils.minForFinePartition(partitionFine),
+                SweepQueueUtils.TS_FINE_GRANULARITY);
+    }
+
+    private long exactColumnOrElseBeginningOfRow(long startTsInclusive, long partitionFine) {
+        return Math.max(startTsInclusive - SweepQueueUtils.minForFinePartition(partitionFine), 0);
+    }
+
     private static ColumnRangeSelection allPossibleColumns() {
-        byte[] startCol = SweepableCellsTable.SweepableCellsColumn.of(0L, -TargetedSweepMetadata.MAX_DEDICATED_ROWS)
+        byte[] startCol = SweepableCellsTable.SweepableCellsColumn.of(0L, MINIMUM_WRITE_INDEX)
                 .persistToBytes();
         byte[] endCol = SweepableCellsTable.SweepableCellsColumn.of(SweepQueueUtils.TS_FINE_GRANULARITY, 0L)
                 .persistToBytes();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -83,7 +83,7 @@ public class SweepableCells extends KvsSweepQueueWriter {
         }
 
         if (!resultIterator.hasNext()) {
-            lastSweptTs = Math.min(maxForFinePartition(partitionFine), maxTsExclusive - 1);
+            lastSweptTs = Math.min(SweepQueueUtils.maxForFinePartition(partitionFine), maxTsExclusive - 1);
         }
 
         return SweepBatch.of(writes.values(), lastSweptTs);
@@ -254,10 +254,6 @@ public class SweepableCells extends KvsSweepQueueWriter {
 
     private long getTimestamp(SweepableCellsTable.SweepableCellsRow row, SweepableCellsTable.SweepableCellsColumn col) {
         return row.getTimestampPartition() * SweepQueueUtils.TS_FINE_GRANULARITY + col.getTimestampModulus();
-    }
-
-    private long maxForFinePartition(long finePartition) {
-        return finePartition * SweepQueueUtils.TS_FINE_GRANULARITY + SweepQueueUtils.TS_FINE_GRANULARITY - 1;
     }
 
     private long getTimestampOrPartition(PartitionInfo info, boolean dedicate) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
@@ -51,35 +51,43 @@ public class SweepableTimestamps extends KvsSweepQueueWriter {
         cellsToWrite.put(SweepQueueUtils.toCell(row, colVal), colVal.persistValue());
     }
 
+    private SweepableTimestampsTable.SweepableTimestampsRow computeRow(PartitionInfo partitionInfo) {
+        return SweepableTimestampsTable.SweepableTimestampsRow.of(
+                partitionInfo.shard(),
+                SweepQueueUtils.tsPartitionCoarse(partitionInfo.timestamp()),
+                partitionInfo.isConservative().persistToBytes());
+    }
+
+    private SweepableTimestampsTable.SweepableTimestampsColumn computeColumn(PartitionInfo info) {
+        return SweepableTimestampsTable.SweepableTimestampsColumn.of(SweepQueueUtils.tsPartitionFine(info.timestamp()));
+    }
+
+    /**
+     * Returns fine partition that should have unprocessed entries in the Sweepable Cells table.
+     * @param shardStrategy desired shard and strategy
+     * @param lastSweptTs exclusive minimum timestamp to check for
+     * @param sweepTs exclusive maximum timestamp to check for
+     * @return Optional containing the fine partition, or Optional.empty() if there are no more candidates before
+     * sweepTs
+     */
     Optional<Long> nextSweepableTimestampPartition(ShardAndStrategy shardStrategy, long lastSweptTs, long sweepTs) {
         long minFineInclusive = SweepQueueUtils.tsPartitionFine(lastSweptTs + 1);
-        long maxFineInclusive = SweepQueueUtils.tsPartitionFine(sweepTs);
-        return nextSweepablePartition(shardStrategy, minFineInclusive, maxFineInclusive + 1);
+        long maxFineInclusive = SweepQueueUtils.tsPartitionFine(sweepTs - 1);
+        return nextSweepablePartition(shardStrategy, minFineInclusive, maxFineInclusive);
     }
 
-    void deleteRow(ShardAndStrategy shardStrategy, long partitionCoarse) {
-        byte[] row = computeRow(shardStrategy, partitionCoarse).persistToBytes();
-
-        RangeRequest request = RangeRequest.builder()
-                .startRowInclusive(row)
-                .endRowExclusive(RangeRequests.nextLexicographicName(row))
-                .retainColumns(ColumnSelection.all())
-                .build();
-
-        deleteRange(request);
-    }
-
-    private Optional<Long> nextSweepablePartition(ShardAndStrategy shardAndStrategy, long minFine, long maxFine) {
-        Optional<ColumnRangeSelection> range = getColRangeSelection(minFine, maxFine);
+    private Optional<Long> nextSweepablePartition(ShardAndStrategy shardAndStrategy, long minFineInclusive,
+            long maxFineInclusive) {
+        Optional<ColumnRangeSelection> range = getColRangeSelection(minFineInclusive, maxFineInclusive + 1);
 
         if (!range.isPresent()) {
             return Optional.empty();
         }
 
-        long current = SweepQueueUtils.partitionFineToCoarse(minFine);
-        long maxCoarse = SweepQueueUtils.partitionFineToCoarse(maxFine);
+        long current = SweepQueueUtils.partitionFineToCoarse(minFineInclusive);
+        long maxCoarseInclusive = SweepQueueUtils.partitionFineToCoarse(maxFineInclusive);
 
-        while (current <= maxCoarse) {
+        while (current <= maxCoarseInclusive) {
             Optional<Long> candidateFine = getCandidatesInCoarsePartition(shardAndStrategy, current, range.get());
             if (candidateFine.isPresent()) {
                 return candidateFine;
@@ -89,26 +97,33 @@ public class SweepableTimestamps extends KvsSweepQueueWriter {
         return Optional.empty();
     }
 
-    private Optional<ColumnRangeSelection> getColRangeSelection(long minFine, long maxFine) {
-        if (minFine >= maxFine) {
+    private Optional<Long> getCandidatesInCoarsePartition(ShardAndStrategy shardStrategy, long partitionCoarse,
+            ColumnRangeSelection colRange) {
+        byte[] rowBytes = computeRowBytes(shardStrategy, partitionCoarse);
+
+        RowColumnRangeIterator colIterator = getRowsColumnRange(ImmutableList.of(rowBytes), colRange, 1);
+        if (!colIterator.hasNext()) {
             return Optional.empty();
         }
-        byte[] start = SweepableTimestampsTable.SweepableTimestampsColumn.of(minFine).persistToBytes();
-        byte[] end = SweepableTimestampsTable.SweepableTimestampsColumn.of(maxFine).persistToBytes();
+        Map.Entry<Cell, Value> firstColumnEntry = colIterator.next();
+
+        return Optional.of(getFinePartitionFromEntry(firstColumnEntry));
+    }
+
+    private Optional<ColumnRangeSelection> getColRangeSelection(long minFineInclusive, long maxFineExclusive) {
+        if (minFineInclusive >= maxFineExclusive) {
+            return Optional.empty();
+        }
+        byte[] start = SweepableTimestampsTable.SweepableTimestampsColumn.of(minFineInclusive).persistToBytes();
+        byte[] end = SweepableTimestampsTable.SweepableTimestampsColumn.of(maxFineExclusive).persistToBytes();
         return Optional.of(new ColumnRangeSelection(start, end));
     }
 
-    private Optional<Long> getCandidatesInCoarsePartition(ShardAndStrategy shardStrategy, long partitionCoarse,
-            ColumnRangeSelection colRange) {
-        byte[] row = computeRow(shardStrategy, partitionCoarse).persistToBytes();
-
-        RowColumnRangeIterator col = getRowsColumnRange(ImmutableList.of(row), colRange, 1);
-        if (!col.hasNext()) {
-            return Optional.empty();
-        }
-        Map.Entry<Cell, Value> firstColumnEntry = col.next();
-
-        return Optional.of(getFinePartitionFromEntry(firstColumnEntry));
+    private byte[] computeRowBytes(ShardAndStrategy shardStrategy, long coarsePartition) {
+        SweepableTimestampsTable.SweepableTimestampsRow row = SweepableTimestampsTable.SweepableTimestampsRow.of(
+                shardStrategy.shard(), coarsePartition,
+                PersistableBoolean.of(shardStrategy.isConservative()).persistToBytes());
+        return row.persistToBytes();
     }
 
     private long getFinePartitionFromEntry(Map.Entry<Cell, Value> entry) {
@@ -117,21 +132,20 @@ public class SweepableTimestamps extends KvsSweepQueueWriter {
                 .getTimestampModulus();
     }
 
-    private SweepableTimestampsTable.SweepableTimestampsRow computeRow(PartitionInfo partitionInfo) {
-        return SweepableTimestampsTable.SweepableTimestampsRow.of(
-                partitionInfo.shard(),
-                SweepQueueUtils.tsPartitionCoarse(partitionInfo.timestamp()),
-                partitionInfo.isConservative().persistToBytes());
-    }
+    /**
+     * Deletes the entire row of the Sweepable Timestamps table.
+     * @param shardStrategy desired shard and strategy
+     * @param partitionCoarse coarse partition for which the row should be deleted
+     */
+    void deleteRow(ShardAndStrategy shardStrategy, long partitionCoarse) {
+        byte[] rowBytes = computeRowBytes(shardStrategy, partitionCoarse);
 
-    private SweepableTimestampsTable.SweepableTimestampsRow computeRow(ShardAndStrategy shardStrategy, long coarse) {
-        return SweepableTimestampsTable.SweepableTimestampsRow.of(
-                shardStrategy.shard(),
-                coarse,
-                PersistableBoolean.of(shardStrategy.isConservative()).persistToBytes());
-    }
+        RangeRequest request = RangeRequest.builder()
+                .startRowInclusive(rowBytes)
+                .endRowExclusive(RangeRequests.nextLexicographicName(rowBytes))
+                .retainColumns(ColumnSelection.all())
+                .build();
 
-    private SweepableTimestampsTable.SweepableTimestampsColumn computeColumn(PartitionInfo info) {
-        return SweepableTimestampsTable.SweepableTimestampsColumn.of(SweepQueueUtils.tsPartitionFine(info.timestamp()));
+        deleteRange(request);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
@@ -57,8 +57,8 @@ public class SweepableTimestamps extends KvsSweepQueueWriter {
         return nextSweepablePartition(shardStrategy, minFineInclusive, maxFineInclusive + 1);
     }
 
-    void deleteRow(ShardAndStrategy shardStrategy, long partitionFine) {
-        byte[] row = computeRow(shardStrategy, SweepQueueUtils.partitionFineToCoarse(partitionFine)).persistToBytes();
+    void deleteRow(ShardAndStrategy shardStrategy, long partitionCoarse) {
+        byte[] row = computeRow(shardStrategy, partitionCoarse).persistToBytes();
 
         RangeRequest request = RangeRequest.builder()
                 .startRowInclusive(row)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
@@ -51,10 +51,10 @@ public class SweepableTimestamps extends KvsSweepQueueWriter {
         cellsToWrite.put(SweepQueueUtils.toCell(row, colVal), colVal.persistValue());
     }
 
-    Optional<Long> nextSweepableTimestampPartition(ShardAndStrategy shardStrategy, long lastSweptFine, long sweepTs) {
-        long minFineExclusive = lastSweptFine;
-        long maxFineExclusive = SweepQueueUtils.tsPartitionFine(sweepTs);
-        return nextSweepablePartition(shardStrategy, minFineExclusive + 1, maxFineExclusive);
+    Optional<Long> nextSweepableTimestampPartition(ShardAndStrategy shardStrategy, long lastSweptTs, long sweepTs) {
+        long minFineInclusive = SweepQueueUtils.tsPartitionFine(lastSweptTs);
+        long maxFineInclusive = SweepQueueUtils.tsPartitionFine(sweepTs);
+        return nextSweepablePartition(shardStrategy, minFineInclusive, maxFineInclusive + 1);
     }
 
     void deleteRow(ShardAndStrategy shardStrategy, long partitionFine) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
@@ -52,7 +52,7 @@ public class SweepableTimestamps extends KvsSweepQueueWriter {
     }
 
     Optional<Long> nextSweepableTimestampPartition(ShardAndStrategy shardStrategy, long lastSweptTs, long sweepTs) {
-        long minFineInclusive = SweepQueueUtils.tsPartitionFine(lastSweptTs);
+        long minFineInclusive = SweepQueueUtils.tsPartitionFine(lastSweptTs + 1);
         long maxFineInclusive = SweepQueueUtils.tsPartitionFine(sweepTs);
         return nextSweepablePartition(shardStrategy, minFineInclusive, maxFineInclusive + 1);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueProgressTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueProgressTest.java
@@ -79,59 +79,59 @@ public class KvsSweepQueueProgressTest {
 
     @Test
     public void canReadInitialSweptTimestamp() {
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
     }
 
     @Test
     public void canUpdateSweptTimestamp() {
-        progress.updateLastSweptTimestampPartition(CONSERVATIVE_TEN, 1024L);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(1024L);
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 1024L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(1024L);
     }
 
     @Test
     public void attemptingToDecreaseSweptTimestampIsNoop() {
-        progress.updateLastSweptTimestampPartition(CONSERVATIVE_TEN, 1024L);
-        progress.updateLastSweptTimestampPartition(CONSERVATIVE_TEN, 512L);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(1024L);
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 1024L);
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 512L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(1024L);
     }
 
     @Test
     public void updatingTimestampForOneShardDoesNotAffectOthers() {
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TWENTY)).isEqualTo(INITIAL_TIMESTAMP);
-        progress.updateLastSweptTimestampPartition(CONSERVATIVE_TEN, 1024L);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TWENTY)).isEqualTo(INITIAL_TIMESTAMP);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TWENTY)).isEqualTo(INITIAL_TIMESTAMP);
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 1024L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TWENTY)).isEqualTo(INITIAL_TIMESTAMP);
 
-        progress.updateLastSweptTimestampPartition(CONSERVATIVE_TWENTY, 512L);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TWENTY)).isEqualTo(512L);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(1024L);
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TWENTY, 512L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TWENTY)).isEqualTo(512L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(1024L);
     }
 
     @Test
     public void updatingTimestampForOneConsistencyDoesNotAffectOther() {
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
-        assertThat(progress.getLastSweptTimestampPartition(THOROUGH_TEN)).isEqualTo(INITIAL_TIMESTAMP);
-        progress.updateLastSweptTimestampPartition(CONSERVATIVE_TEN, 128L);
-        assertThat(progress.getLastSweptTimestampPartition(THOROUGH_TEN)).isEqualTo(INITIAL_TIMESTAMP);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
+        assertThat(progress.getLastSweptTimestamp(THOROUGH_TEN)).isEqualTo(INITIAL_TIMESTAMP);
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 128L);
+        assertThat(progress.getLastSweptTimestamp(THOROUGH_TEN)).isEqualTo(INITIAL_TIMESTAMP);
 
-        progress.updateLastSweptTimestampPartition(THOROUGH_TEN, 32L);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(128L);
-        assertThat(progress.getLastSweptTimestampPartition(THOROUGH_TEN)).isEqualTo(32L);
+        progress.updateLastSweptTimestamp(THOROUGH_TEN, 32L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(128L);
+        assertThat(progress.getLastSweptTimestamp(THOROUGH_TEN)).isEqualTo(32L);
     }
 
     @Test
     public void updatingTimestampsDoesNotAffectShardsAndViceVersa() {
         assertThat(progress.getNumberOfShards()).isEqualTo(INITIAL_SHARDS);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
-        assertThat(progress.getLastSweptTimestampPartition(THOROUGH_TEN)).isEqualTo(INITIAL_TIMESTAMP);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(INITIAL_TIMESTAMP);
+        assertThat(progress.getLastSweptTimestamp(THOROUGH_TEN)).isEqualTo(INITIAL_TIMESTAMP);
 
         progress.updateNumberOfShards(64);
-        progress.updateLastSweptTimestampPartition(CONSERVATIVE_TEN, 32L);
-        progress.updateLastSweptTimestampPartition(THOROUGH_TEN, 128L);
+        progress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 32L);
+        progress.updateLastSweptTimestamp(THOROUGH_TEN, 128L);
 
         assertThat(progress.getNumberOfShards()).isEqualTo(64);
-        assertThat(progress.getLastSweptTimestampPartition(CONSERVATIVE_TEN)).isEqualTo(32L);
-        assertThat(progress.getLastSweptTimestampPartition(THOROUGH_TEN)).isEqualTo(128L);
+        assertThat(progress.getLastSweptTimestamp(CONSERVATIVE_TEN)).isEqualTo(32L);
+        assertThat(progress.getLastSweptTimestamp(THOROUGH_TEN)).isEqualTo(128L);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class KvsSweepQueueProgressTest {
         doThrow(new CheckAndSetException("sadness")).when(mockKvs).checkAndSet(any());
         KvsSweepQueueProgress instrumentedProgress = new KvsSweepQueueProgress(mockKvs);
 
-        assertThat(instrumentedProgress.updateLastSweptTimestampPartition(CONSERVATIVE_TEN, 12L))
+        assertThat(instrumentedProgress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 12L))
                 .isEqualTo(15L);
     }
 
@@ -160,7 +160,7 @@ public class KvsSweepQueueProgressTest {
         doThrow(new CheckAndSetException("sadness")).when(mockKvs).checkAndSet(any());
         KvsSweepQueueProgress instrumentedProgress = new KvsSweepQueueProgress(mockKvs);
 
-        assertThatThrownBy(() -> instrumentedProgress.updateLastSweptTimestampPartition(CONSERVATIVE_TEN, 12L))
+        assertThatThrownBy(() -> instrumentedProgress.updateLastSweptTimestamp(CONSERVATIVE_TEN, 12L))
                 .isInstanceOf(CheckAndSetException.class);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/KvsSweepQueueTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,7 +29,9 @@ import static com.palantir.atlasdb.protos.generated.TableMetadataPersistence.Swe
 import static com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy.NOTHING;
 import static com.palantir.atlasdb.protos.generated.TableMetadataPersistence.SweepStrategy.THOROUGH;
 import static com.palantir.atlasdb.sweep.queue.SweepQueueTablesTest.metadataBytes;
+import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.TS_COARSE_GRANULARITY;
 import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.TS_FINE_GRANULARITY;
+import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.tsPartitionFine;
 import static com.palantir.atlasdb.sweep.queue.WriteInfoPartitioner.SHARDS;
 
 import java.util.Map;
@@ -45,6 +47,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.sweep.Sweeper;
 
 public class KvsSweepQueueTest {
     private static final TableReference TABLE_CONSERVATIVE = TableReference.createFromFullyQualifiedName("test.cons");
@@ -66,8 +69,8 @@ public class KvsSweepQueueTest {
     @Before
     public void setup() {
         kvs = spy(new InMemoryKeyValueService(false));
-        unreadableTs = SweepQueueUtils.TS_COARSE_GRANULARITY;
-        immutableTs = SweepQueueUtils.TS_COARSE_GRANULARITY;
+        unreadableTs = TS_COARSE_GRANULARITY * 5;
+        immutableTs = TS_COARSE_GRANULARITY * 5;
         sweepQueue.initialize(provider, kvs);
         kvs.createTable(TABLE_CONSERVATIVE, metadataBytes(CONSERVATIVE));
         kvs.createTable(TABLE_THOROUGH, metadataBytes(THOROUGH));
@@ -134,7 +137,7 @@ public class KvsSweepQueueTest {
         sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
         assertReadAtTimestampReturnsSentinel(TABLE_CONSERVATIVE, numWrites);
         assertReadAtTimestampReturnsValue(TABLE_CONSERVATIVE, numWrites + 1, numWrites);
-        verify(kvs, times(1)).deleteAllTimestamps(eq(TABLE_CONSERVATIVE), anyMap());
+        verify(kvs, times(1)).deleteAllTimestamps(any(TableReference.class), anyMap());
     }
 
     @Test
@@ -185,6 +188,169 @@ public class KvsSweepQueueTest {
         assertReadAtTimestampReturnsValue(TABLE_CONSERVATIVE, TS2 + 1, TS2);
     }
 
+    @Test
+    public void sweepProgressesAndSkipsEmptyFinePartitions() {
+        long tsFineTwo = TS + TS_FINE_GRANULARITY;
+        long tsFineFour = TS + 3 * TS_FINE_GRANULARITY;
+        enqueueWrite(TABLE_CONSERVATIVE, TS);
+        enqueueWrite(TABLE_CONSERVATIVE, tsFineTwo);
+        enqueueWrite(TABLE_CONSERVATIVE, tsFineFour);
+        enqueueWrite(TABLE_CONSERVATIVE, tsFineFour + 1L);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertReadAtTimestampReturnsSentinel(TABLE_CONSERVATIVE, TS);
+        assertReadAtTimestampReturnsValue(TABLE_CONSERVATIVE, TS + 1, TS);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertReadAtTimestampReturnsSentinel(TABLE_CONSERVATIVE, tsFineTwo);
+        assertReadAtTimestampReturnsValue(TABLE_CONSERVATIVE, tsFineTwo + 1, tsFineTwo);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertReadAtTimestampReturnsSentinel(TABLE_CONSERVATIVE, tsFineFour + 1);
+        assertReadAtTimestampReturnsValue(TABLE_CONSERVATIVE, tsFineFour + 2, tsFineFour + 1);
+    }
+
+    @Test
+    public void sweepProgressesAcrossCoarsePartitions() {
+        long tsCoarseTwo = TS + TS_FINE_GRANULARITY + TS_COARSE_GRANULARITY;
+        long tsCoarseFour = TS + 3 * TS_COARSE_GRANULARITY;
+        enqueueWrite(TABLE_CONSERVATIVE, TS);
+        enqueueWrite(TABLE_CONSERVATIVE, tsCoarseTwo);
+        enqueueWrite(TABLE_CONSERVATIVE, tsCoarseFour);
+        enqueueWrite(TABLE_CONSERVATIVE, tsCoarseFour + 1L);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertReadAtTimestampReturnsSentinel(TABLE_CONSERVATIVE, TS);
+        assertReadAtTimestampReturnsValue(TABLE_CONSERVATIVE, TS + 1, TS);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertReadAtTimestampReturnsSentinel(TABLE_CONSERVATIVE, tsCoarseTwo);
+        assertReadAtTimestampReturnsValue(TABLE_CONSERVATIVE, tsCoarseTwo + 1, tsCoarseTwo);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertReadAtTimestampReturnsSentinel(TABLE_CONSERVATIVE, tsCoarseFour + 1);
+        assertReadAtTimestampReturnsValue(TABLE_CONSERVATIVE, tsCoarseFour + 2, tsCoarseFour + 1);
+    }
+
+    @Test
+    public void sweepProgressesToPartitionBeforeSweepTsWhenNothingToSweep() {
+        long finePartitionForSweepTs = tsPartitionFine(provider.getSweepTimestamp(Sweeper.CONSERVATIVE));
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+
+        assertProgressUpdatedToFineTimestampPartition(finePartitionForSweepTs - 1L);
+    }
+
+    @Test
+    public void sweepProgressesToPartitionOfJustSwept() {
+        long finePartitionForSweepTs = tsPartitionFine(provider.getSweepTimestamp(Sweeper.CONSERVATIVE));
+        long writeTs = provider.getSweepTimestamp(Sweeper.CONSERVATIVE) - 3 * TS_FINE_GRANULARITY;
+        enqueueWrite(TABLE_CONSERVATIVE, writeTs);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertProgressUpdatedToFineTimestampPartition(tsPartitionFine(writeTs));
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertProgressUpdatedToFineTimestampPartition(finePartitionForSweepTs - 1L);
+
+        assertThat(tsPartitionFine(writeTs)).isLessThan(finePartitionForSweepTs);
+    }
+
+    @Test
+    public void sweepCellOnlyOnceWhenInLastPartitionBeforeSweepTs() {
+        immutableTs = 2 * TS_COARSE_GRANULARITY - TS_FINE_GRANULARITY;
+        verify(kvs, never()).deleteAllTimestamps(any(TableReference.class), anyMap());
+
+        enqueueWrite(TABLE_CONSERVATIVE, immutableTs - 1);
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        verify(kvs, times(1)).deleteAllTimestamps(any(TableReference.class), anyMap());
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        verify(kvs, times(1)).deleteAllTimestamps(any(TableReference.class), anyMap());
+    }
+
+    @Test
+    public void sweepableTimestampsGetsScrubbedWhenNoMoreToSweepButSweepTsInNewCoarsePartition() {
+        long tsSecondPartitionFine = TS + TS_FINE_GRANULARITY;
+        long largestFirstPartitionCoarse = TS_COARSE_GRANULARITY - 1L;
+        enqueueWrite(TABLE_CONSERVATIVE, TS);
+        enqueueWrite(TABLE_CONSERVATIVE, tsSecondPartitionFine);
+        enqueueWrite(TABLE_CONSERVATIVE, largestFirstPartitionCoarse);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertLowestFinePartitionInSweepableTimestampsEquals(tsPartitionFine(TS));
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertLowestFinePartitionInSweepableTimestampsEquals(tsPartitionFine(TS));
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertLowestFinePartitionInSweepableTimestampsEquals(tsPartitionFine(TS));
+
+        // next sweep goes into a new coarse partition
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertNoEntriesInSweepableTimestampsBeforeImmutableTimestamp();
+    }
+
+    @Test
+    public void sweepableTimestampsGetsScrubbedWhenLastSweptProgressesInNewCoarsePartition2() {
+        long tsSecondPartitionFine = TS + TS_FINE_GRANULARITY;
+        long largestFirstPartitionCoarse = TS_COARSE_GRANULARITY - 1L;
+        long thirdPartitionCoarse = 2 * TS_COARSE_GRANULARITY;
+        enqueueWrite(TABLE_CONSERVATIVE, TS);
+        enqueueWrite(TABLE_CONSERVATIVE, tsSecondPartitionFine);
+        enqueueWrite(TABLE_CONSERVATIVE, largestFirstPartitionCoarse);
+        enqueueWrite(TABLE_CONSERVATIVE, thirdPartitionCoarse);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertLowestFinePartitionInSweepableTimestampsEquals(tsPartitionFine(TS));
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertLowestFinePartitionInSweepableTimestampsEquals(tsPartitionFine(TS));
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertLowestFinePartitionInSweepableTimestampsEquals(tsPartitionFine(TS));
+
+        // next sweep goes into a new coarse partition
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertLowestFinePartitionInSweepableTimestampsEquals(tsPartitionFine(thirdPartitionCoarse));
+    }
+
+    @Test
+    public void sweepableCellsGetsScrubbedAfterEachBatch() {
+        long tsSecondPartitionFine = TS + TS_FINE_GRANULARITY;
+        long largestBeforeSweepTs = provider.getSweepTimestamp(Sweeper.CONSERVATIVE) - 1L;
+        enqueueWrite(TABLE_CONSERVATIVE, TS);
+        enqueueWrite(TABLE_CONSERVATIVE, TS + 1L);
+        enqueueWrite(TABLE_CONSERVATIVE, tsSecondPartitionFine);
+        enqueueWrite(TABLE_CONSERVATIVE, largestBeforeSweepTs);
+
+        assertSweepableCellsHasEntryForTimestamp(TS + 1);
+        assertSweepableCellsHasEntryForTimestamp(tsSecondPartitionFine);
+        assertSweepableCellsHasEntryForTimestamp(largestBeforeSweepTs);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertSweepableCellsHasNoEntriesInFinePartitionOfTimestamp(TS + 1);
+        assertSweepableCellsHasEntryForTimestamp(tsSecondPartitionFine);
+        assertSweepableCellsHasEntryForTimestamp(largestBeforeSweepTs);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertSweepableCellsHasNoEntriesInFinePartitionOfTimestamp(TS + 1);
+        assertSweepableCellsHasNoEntriesInFinePartitionOfTimestamp(tsSecondPartitionFine);
+        assertSweepableCellsHasEntryForTimestamp(largestBeforeSweepTs);
+
+        sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(CONS_SHARD));
+        assertSweepableCellsHasNoEntriesInFinePartitionOfTimestamp(TS + 1);
+        assertSweepableCellsHasNoEntriesInFinePartitionOfTimestamp(tsSecondPartitionFine);
+        assertSweepableCellsHasNoEntriesInFinePartitionOfTimestamp(largestBeforeSweepTs);
+    }
+
+    private void assertSweepableCellsHasEntryForTimestamp(long timestamp) {
+        assertThat(sweepQueue.tables.sweepableCells
+                .getWritesFromPartition(tsPartitionFine(timestamp), ShardAndStrategy.conservative(CONS_SHARD)))
+                .containsExactly(WriteInfo.write(TABLE_CONSERVATIVE, DEFAULT_CELL, timestamp));
+    }
+
+    private void assertSweepableCellsHasNoEntriesInFinePartitionOfTimestamp(long timestamp) {
+        assertThat(sweepQueue.tables.sweepableCells
+                .getWritesFromPartition(tsPartitionFine(timestamp), ShardAndStrategy.conservative(CONS_SHARD)))
+                .isEmpty();
+    }
+
     private void enqueueWrite(TableReference tableRef, long ts) {
         sweepQueue.enqueue(writeToDefaultCell(tableRef, ts), ts);
     }
@@ -230,5 +396,22 @@ public class KvsSweepQueueTest {
     private Map<Cell, Value> readFromDefaultCell(TableReference tableRef, long ts) {
         Map<Cell, Long> singleRead = ImmutableMap.of(DEFAULT_CELL, ts);
         return kvs.get(tableRef, singleRead);
+    }
+
+    private void assertProgressUpdatedToFineTimestampPartition(long partitionFine) {
+        assertThat(sweepQueue.tables.progress.getLastSweptTimestampPartition(ShardAndStrategy.conservative(CONS_SHARD)))
+                .isEqualTo(partitionFine);
+    }
+
+    private void assertLowestFinePartitionInSweepableTimestampsEquals(long partitionFine) {
+        assertThat(sweepQueue.tables.sweepableTimestamps
+                .nextSweepableTimestampPartition(ShardAndStrategy.conservative(CONS_SHARD), -1L, immutableTs))
+                .contains(partitionFine);
+    }
+
+    private void assertNoEntriesInSweepableTimestampsBeforeImmutableTimestamp() {
+        assertThat(sweepQueue.tables.sweepableTimestamps
+                .nextSweepableTimestampPartition(ShardAndStrategy.conservative(CONS_SHARD), -1L, immutableTs))
+                .isEmpty();
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepQueueTablesTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepQueueTablesTest.java
@@ -48,6 +48,7 @@ public abstract class SweepQueueTablesTest {
     static final long TS2 = 2 * TS;
     static final long TS_REF = tsPartitionFine(TS);
     static final long TS2_REF = tsPartitionFine(TS2);
+    static final int FIXED_SHARD = WriteInfo.write(TABLE_CONS, getCellWithFixedHash(0), 0L).toShard(SHARDS);
 
     protected KeyValueService mockKvs = mock(KeyValueService.class);
     protected KeyValueService kvs = new InMemoryKeyValueService(true);
@@ -97,8 +98,13 @@ public abstract class SweepQueueTablesTest {
 
     public static List<WriteInfo> writeToCellsInFixedShard(KvsSweepQueueWriter writer, long timestamp, int number,
             TableReference tableRef) {
+        return writeToCellsInFixedShardStartWith(writer, timestamp, number, tableRef, 0L);
+    }
+
+    public static List<WriteInfo> writeToCellsInFixedShardStartWith(KvsSweepQueueWriter writer, long timestamp,
+            int number, TableReference tableRef, long startSeed) {
         List<WriteInfo> result = new ArrayList<>();
-        for (long i = 0; i < number; i++) {
+        for (long i = startSeed; i < startSeed + number; i++) {
             Cell cell = getCellWithFixedHash(i);
             result.add(WriteInfo.write(tableRef, cell, timestamp));
         }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepQueueTablesTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepQueueTablesTest.java
@@ -46,8 +46,8 @@ public abstract class SweepQueueTablesTest {
     static final Cell DEFAULT_CELL = Cell.create(new byte[] {'r'}, new byte[] {'c'});
     static final long TS = 1_000_000_100L;
     static final long TS2 = 2 * TS;
-    static final long TS_REF = tsPartitionFine(TS);
-    static final long TS2_REF = tsPartitionFine(TS2);
+    static final long TS_FINE_PARTITION = tsPartitionFine(TS);
+    static final long TS2_FINE_PARTITION = tsPartitionFine(TS2);
     static final int FIXED_SHARD = WriteInfo.write(TABLE_CONS, getCellWithFixedHash(0), 0L).toShard(SHARDS);
 
     protected KeyValueService mockKvs = mock(KeyValueService.class);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import static com.palantir.atlasdb.sweep.queue.ShardAndStrategy.conservative;
 import static com.palantir.atlasdb.sweep.queue.ShardAndStrategy.thorough;
+import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.tsPartitionFine;
 import static com.palantir.atlasdb.sweep.queue.SweepableCells.MAX_CELLS_DEDICATED;
 import static com.palantir.atlasdb.sweep.queue.SweepableCells.MAX_CELLS_GENERIC;
 import static com.palantir.atlasdb.sweep.queue.WriteInfoPartitioner.SHARDS;
@@ -32,6 +33,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class SweepableCellsTest extends SweepQueueTablesTest {
+    private static final long SWEEP_TS = TS + 200L;
+
     private SweepableCells sweepableCells;
 
     int shardCons;
@@ -48,32 +51,74 @@ public class SweepableCellsTest extends SweepQueueTablesTest {
 
     @Test
     public void canReadSingleEntryInSingleShardForCorrectPartitionAndRange() {
-        SweepBatch conservativeBatch = readConservative(shardCons, TS_REF, TS - 1, TS + 1);
+        SweepBatch conservativeBatch = readConservative(shardCons, TS_REF, TS - 1, SWEEP_TS);
         assertThat(conservativeBatch.writes()).containsExactly(WriteInfo.write(TABLE_CONS, DEFAULT_CELL, TS));
-        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(TS);
 
-        SweepBatch thoroughBatch = readThorough(TS2_REF, TS2 - 1, TS2 + 1);
+        SweepBatch thoroughBatch = readThorough(TS2_REF, TS2 - 1, Long.MAX_VALUE);
         assertThat(thoroughBatch.writes()).containsExactly(WriteInfo.write(TABLE_THOR, DEFAULT_CELL, TS2));
-        assertThat(thoroughBatch.lastSweptTimestamp()).isEqualTo(TS2);
+    }
+
+    @Test
+    public void lastSweptTimestampIsMinimumOfSweepTsAndEndOfFinePartitionWhenThereAreMatches() {
+        SweepBatch conservativeBatch = readConservative(shardCons, TS_REF, TS - 1, SWEEP_TS);
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(SWEEP_TS - 1);
+
+        conservativeBatch = readConservative(shardCons, TS_REF, TS - 1, Long.MAX_VALUE);
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(endOfFinePartitionForTs(TS));
+    }
+
+    @Test
+    public void cannotReadEntryForWrongPartition() {
+        SweepBatch conservativeBatch = readConservative(shardCons + 1, TS_REF, TS - 1, SWEEP_TS);
+        assertThat(conservativeBatch.writes()).isEmpty();
+    }
+
+    @Test
+    public void lastSweptTimestampIsMinimumOfSweepTsAndEndOfFinePartitionWhenNoMatches() {
+        SweepBatch conservativeBatch = readConservative(shardCons + 1, TS_REF, TS - 1, SWEEP_TS);
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(SWEEP_TS - 1);
+
+        conservativeBatch = readConservative(shardCons + 1, TS_REF, TS - 1, Long.MAX_VALUE);
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(endOfFinePartitionForTs(TS));
+    }
+
+    @Test
+    public void cannotReadEntryOutOfRange() {
+        SweepBatch conservativeBatch = readConservative(shardCons, TS_REF, TS, SWEEP_TS);
+        assertThat(conservativeBatch.writes()).isEmpty();
+
+        conservativeBatch = readConservative(shardCons, TS_REF, 0L, TS);
+        assertThat(conservativeBatch.writes()).isEmpty();
+    }
+
+    @Test
+    public void inconsistentRangeReturnsNoWritesAndSameLastSweptTimestamp() {
+        long lastSweptTs = 2 * TS;
+        SweepBatch conservativeBatch = readConservative(shardCons, tsPartitionFine(lastSweptTs), lastSweptTs, TS);
+        assertThat(conservativeBatch.writes()).isEmpty();
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(lastSweptTs);
     }
 
     @Test
     public void readTombstoneOnlyWhenLatestInShardAndRange() {
         int tombstoneShard = putTombstone(sweepableCells, TS + 1, DEFAULT_CELL, TABLE_CONS);
-        SweepBatch batch = readConservative(tombstoneShard, TS_REF, TS - 1, TS + 2);
+        SweepBatch batch = readConservative(tombstoneShard, TS_REF, TS - 1, SWEEP_TS);
         assertThat(batch.writes()).containsExactly(WriteInfo.tombstone(TABLE_CONS, DEFAULT_CELL, TS + 1));
-        assertThat(batch.lastSweptTimestamp()).isEqualTo(TS + 1);
     }
 
     @Test
-    public void getOnlyMostRecentTimestampForCellAndTableRef() {
+    public void getOnlyMostRecentTimestampForRange() {
         writeToDefault(sweepableCells, TS - 1, TABLE_CONS);
         writeToDefault(sweepableCells, TS + 2, TABLE_CONS);
         writeToDefault(sweepableCells, TS - 2, TABLE_CONS);
         writeToDefault(sweepableCells, TS + 1, TABLE_CONS);
-        SweepBatch conservativeBatch = readConservative(shardCons, TS_REF, TS - 3, TS + 3);
+        SweepBatch conservativeBatch = readConservative(shardCons, TS_REF, TS - 3, TS);
+        assertThat(conservativeBatch.writes()).containsExactly(WriteInfo.write(TABLE_CONS, DEFAULT_CELL, TS - 1));
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(TS - 1);
+
+        conservativeBatch = readConservative(shardCons, TS_REF, TS - 3, SWEEP_TS);
         assertThat(conservativeBatch.writes()).containsExactly(WriteInfo.write(TABLE_CONS, DEFAULT_CELL, TS + 2));
-        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(TS + 2);
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(SWEEP_TS - 1);
     }
 
     @Test
@@ -89,8 +134,7 @@ public class SweepableCellsTest extends SweepQueueTablesTest {
     @Test
     public void canReadMultipleEntriesInSingleShardSameTransactionNotDedicated() {
         List<WriteInfo> writes = writeToCellsInFixedShard(sweepableCells, TS, 10, TABLE_CONS);
-        int fixedShard = writes.get(0).toShard(SHARDS);
-        SweepBatch conservativeBatch = readConservative(fixedShard, TS_REF, TS - 1, TS + 1);
+        SweepBatch conservativeBatch = readConservative(FIXED_SHARD, TS_REF, TS - 1, TS + 1);
         assertThat(conservativeBatch.writes().size()).isEqualTo(10);
         assertThat(conservativeBatch.writes()).hasSameElementsAs(writes);
     }
@@ -98,8 +142,7 @@ public class SweepableCellsTest extends SweepQueueTablesTest {
     @Test
     public void canReadMultipleEntriesInSingleShardSameTransactionOneDedicated() {
         List<WriteInfo> writes = writeToCellsInFixedShard(sweepableCells, TS, MAX_CELLS_GENERIC * 2 + 1, TABLE_CONS);
-        int fixedShard = writes.get(0).toShard(SHARDS);
-        SweepBatch conservativeBatch = readConservative(fixedShard, TS_REF, TS - 1, TS + 1);
+        SweepBatch conservativeBatch = readConservative(FIXED_SHARD, TS_REF, TS - 1, TS + 1);
         assertThat(conservativeBatch.writes().size()).isEqualTo(MAX_CELLS_GENERIC * 2 + 1);
         assertThat(conservativeBatch.writes()).hasSameElementsAs(writes);
     }
@@ -110,17 +153,37 @@ public class SweepableCellsTest extends SweepQueueTablesTest {
         List<WriteInfo> last = writeToCellsInFixedShard(sweepableCells, TS + 2, 1, TABLE_CONS);
         List<WriteInfo> middle = writeToCellsInFixedShard(sweepableCells, TS + 1, MAX_CELLS_GENERIC + 1, TABLE_CONS);
         // The expected list of latest writes contains:
-        // ((0, 0), TS + 2
+        // ((0, 0), TS + 2)
         // ((1, 1), TS + 1) .. ((MAX_CELLS_GENERIC, MAX_CELLS_GENERIC), TS + 1)
         // ((MAX_CELLS_GENERIC + 1, MAX_CELLS_GENERIC) + 1, TS) .. ((2 * MAX_CELLS_GENERIC, 2 * MAX_CELLS_GENERIC), TS)
         List<WriteInfo> expectedResult = new ArrayList<>(last);
         expectedResult.addAll(middle.subList(last.size(), middle.size()));
         expectedResult.addAll(first.subList(middle.size(), first.size()));
 
-        int fixedShard = first.get(0).toShard(SHARDS);
-        SweepBatch conservativeBatch = readConservative(fixedShard, TS_REF, TS - 1, TS + 3);
+        SweepBatch conservativeBatch = readConservative(FIXED_SHARD, TS_REF, TS - 1, TS + 3);
         assertThat(conservativeBatch.writes().size()).isEqualTo(MAX_CELLS_GENERIC * 2 + 1);
         assertThat(conservativeBatch.writes()).hasSameElementsAs(expectedResult);
+    }
+
+    @Test
+    public void returnWhenMoreThanBatchSizeNonDedicated() {
+        for (int i = 0; i < 2 * SweepableCells.SWEEP_BATCH_SIZE; i++) {
+            writeToCell(sweepableCells, i, getCellWithFixedHash(i), TABLE_CONS);
+        }
+        SweepBatch conservativeBatch = readConservative(FIXED_SHARD, 0L, -1L, SWEEP_TS);
+        assertThat(conservativeBatch.writes().size()).isEqualTo((int) SweepableCells.SWEEP_BATCH_SIZE);
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(SweepableCells.SWEEP_BATCH_SIZE - 1);
+    }
+
+    // We read 5 dedicated entries until we pass 1K, for a total of 1005 writes
+    @Test
+    public void returnWhenMoreThanBatchSizeDedicated() {
+        for (int i = 0; i < 10; i++) {
+            writeToCellsInFixedShardStartWith(sweepableCells, i, 201, TABLE_CONS, i * 201);
+        }
+        SweepBatch conservativeBatch = readConservative(FIXED_SHARD, 0L, -1L, SWEEP_TS);
+        assertThat(conservativeBatch.writes().size()).isEqualTo(1005);
+        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(4);
     }
 
     @Test
@@ -133,10 +196,14 @@ public class SweepableCellsTest extends SweepQueueTablesTest {
     }
 
     private SweepBatch readConservative(int shard, long partition, long minExclusive, long maxExclusive) {
-        return sweepableCells.getWritesFromPartition(conservative(shard), partition, minExclusive, maxExclusive);
+        return sweepableCells.getBatchForPartition(conservative(shard), partition, minExclusive, maxExclusive);
     }
 
     private SweepBatch readThorough(long partition, long minExclusive, long maxExclusive) {
-            return sweepableCells.getWritesFromPartition(thorough(shardThor), partition, minExclusive, maxExclusive);
+        return sweepableCells.getBatchForPartition(thorough(shardThor), partition, minExclusive, maxExclusive);
+    }
+
+    private long endOfFinePartitionForTs(long timestamp) {
+        return SweepQueueUtils.maxForFinePartition(tsPartitionFine(timestamp));
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableTimestampsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableTimestampsTest.java
@@ -116,34 +116,34 @@ public class SweepableTimestampsTest extends SweepQueueTablesTest {
 
     @Test
     public void canReadNextIfNotProgressedBeyondForConservative() {
-        progress.updateLastSweptTimestampPartition(thorough(shardCons), TS_REF);
+        progress.updateLastSweptTimestamp(thorough(shardCons), TS_REF);
         assertThat(readConservative(shardCons)).contains(TS_REF);
 
-        progress.updateLastSweptTimestampPartition(conservative(shardCons), TS_REF - 1);
+        progress.updateLastSweptTimestamp(conservative(shardCons), TS_REF - 1);
         assertThat(readConservative(shardCons)).contains(TS_REF);
         assertThat(readThorough(shardThor)).contains(TS2_REF);
     }
 
     @Test
     public void noNextTimestampIfProgressedBeyondForConservative() {
-        progress.updateLastSweptTimestampPartition(conservative(shardCons), TS_REF);
+        progress.updateLastSweptTimestamp(conservative(shardCons), TS_REF);
         assertThat(readConservative(shardCons)).isEmpty();
         assertThat(readThorough(shardThor)).contains(TS2_REF);
     }
 
     @Test
     public void canReadNextIfNotProgressedBeyondForThorough() {
-        progress.updateLastSweptTimestampPartition(conservative(shardThor), TS2_REF);
+        progress.updateLastSweptTimestamp(conservative(shardThor), TS2_REF);
         assertThat(readThorough(shardThor)).contains(TS2_REF);
 
-        progress.updateLastSweptTimestampPartition(thorough(shardCons), TS2_REF - 1);
+        progress.updateLastSweptTimestamp(thorough(shardCons), TS2_REF - 1);
         assertThat(readConservative(shardCons)).contains(TS_REF);
         assertThat(readThorough(shardThor)).contains(TS2_REF);
     }
 
     @Test
     public void noNextTimestampIfProgressedBeyondForThorough() {
-        progress.updateLastSweptTimestampPartition(thorough(shardThor), TS2_REF);
+        progress.updateLastSweptTimestamp(thorough(shardThor), TS2_REF);
         assertThat(readConservative(shardCons)).contains(TS_REF);
         assertThat(readThorough(shardThor)).isEmpty();
     }
@@ -155,7 +155,7 @@ public class SweepableTimestampsTest extends SweepQueueTablesTest {
         }
         assertThat(readConservative(shardCons)).contains(tsPartitionFine(1000L));
 
-        progress.updateLastSweptTimestampPartition(conservative(shardCons), 2L);
+        progress.updateLastSweptTimestamp(conservative(shardCons), 2L);
         assertThat(readConservative(shardCons)).contains(3L);
 
         immutableTs = 4 * TS_FINE_GRANULARITY;
@@ -168,14 +168,14 @@ public class SweepableTimestampsTest extends SweepQueueTablesTest {
     private Optional<Long> readConservative(int shardNumber) {
         return sweepableTimestamps.nextSweepableTimestampPartition(
                 conservative(shardNumber),
-                progress.getLastSweptTimestampPartition(ShardAndStrategy.conservative(shardNumber)),
+                progress.getLastSweptTimestamp(ShardAndStrategy.conservative(shardNumber)),
                 provider.getSweepTimestamp(Sweeper.CONSERVATIVE));
     }
 
     private Optional<Long> readThorough(int shardNumber) {
         return sweepableTimestamps.nextSweepableTimestampPartition(
                 thorough(shardNumber),
-                progress.getLastSweptTimestampPartition(ShardAndStrategy.thorough(shardNumber)),
+                progress.getLastSweptTimestamp(ShardAndStrategy.thorough(shardNumber)),
                 provider.getSweepTimestamp(Sweeper.THOROUGH));
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableTimestampsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableTimestampsTest.java
@@ -126,7 +126,7 @@ public class SweepableTimestampsTest extends SweepQueueTablesTest {
 
     @Test
     public void noNextTimestampIfProgressedBeyondForConservative() {
-        progress.updateLastSweptTimestamp(conservative(shardCons), TS_REF);
+        progress.updateLastSweptTimestamp(conservative(shardCons), SweepQueueUtils.maxForFinePartition(TS_REF));
         assertThat(readConservative(shardCons)).isEmpty();
         assertThat(readThorough(shardThor)).contains(TS2_REF);
     }


### PR DESCRIPTION
**Goals (and why)**:
Improve granularity of sweeping. Also some refactoring to try and make SweepableCells and SweepableTimestamps less confusing.

**Implementation Description (bullets)**:
We now get the cells to sweep until we accumulate a predetermined batch size (currently a constant 1k, but we need to come up with a better number or make it configurable). We then put all remaining cells for that timestamp into the batch and return.

**Concerns (what feedback would you like?)**:
This still takes all cells from dedicated rows into a batch. We can relatively easy process row by row (or at an even finer granularity) by returning the information about where we  should continue in the next batch. On the other hand, if we are able to write them all in the first place, should be fine to read and process them in one batch too.

**Where should we start reviewing?**:
Maybe the new tests

**Priority (whenever / two weeks / yesterday)**:
Not that urgent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3146)
<!-- Reviewable:end -->
