### PR TITLE
Release schema mutation lock upon txn manager close

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceIntegrationTest.java
@@ -54,6 +54,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
@@ -332,7 +333,7 @@ public class CassandraKeyValueServiceIntegrationTest extends AbstractKeyValueSer
         try {
             kvs.createTable(TableReference.create(originalTable.getNamespace(),
                     "_locks_other"), AtlasDbConstants.EMPTY_TABLE_METADATA);
-        } catch (IllegalStateException ex) {
+        } catch (UncheckedExecutionException ex) {
             // expected - we just created another locks table
         }
 

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTableManipulationTest.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException;
@@ -63,7 +64,7 @@ public class OneNodeDownTableManipulationTest {
         assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).contains(OneNodeDownTestSuite.TEST_TABLE_TO_DROP);
         assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.dropTable(OneNodeDownTestSuite.TEST_TABLE_TO_DROP))
                 .isExactlyInstanceOf(AtlasDbDependencyException.class)
-                .hasCauseInstanceOf(IllegalStateException.class);
+                .hasCauseInstanceOf(UncheckedExecutionException.class);
         // This documents and verifies the current behaviour, dropping the table in spite of the exception
         // Seems to be inconsistent with the API
         assertThat(OneNodeDownTestSuite.kvs.getAllTableNames()).doesNotContain(OneNodeDownTestSuite.TEST_TABLE_TO_DROP);
@@ -75,7 +76,7 @@ public class OneNodeDownTableManipulationTest {
         assertThatThrownBy(() -> OneNodeDownTestSuite.kvs.dropTables(
                 ImmutableSet.of(OneNodeDownTestSuite.TEST_TABLE_TO_DROP_2)))
                 .isExactlyInstanceOf(AtlasDbDependencyException.class)
-                .hasCauseInstanceOf(IllegalStateException.class);
+                .hasCauseInstanceOf(UncheckedExecutionException.class);
         // This documents and verifies the current behaviour, dropping the table in spite of the exception
         // Seems to be inconsistent with the API
         assertThat(OneNodeDownTestSuite.kvs.getAllTableNames())

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1292,8 +1292,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to drop.
      *
-     * @throws IllegalStateException if not all hosts respond successfully, or if their schema versions do
+     * @throws AtlasDbDependencyException if not all hosts respond successfully, or if their schema versions do
      * not come to agreement in 1 minute.
+     * @throws UncheckedExecutionException if there are multiple schema mutation lock tables.
      */
     @Override
     public void dropTable(final TableReference tableRef) {
@@ -1315,8 +1316,9 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tablesToDrop the set of tables to drop.
      *
-     * @throws IllegalStateException if not all hosts respond successfully, or if their schema versions do
+     * @throws AtlasDbDependencyException if not all hosts respond successfully, or if their schema versions do
      * not come to agreement in 1 minute.
+     * @throws UncheckedExecutionException if there are multiple schema mutation lock tables.
      */
     @Override
     public void dropTables(final Set<TableReference> tablesToDrop) {
@@ -1335,7 +1337,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * @param tableRef the name of the table to create.
      * @param tableMetadata the metadata of the table to create.
      *
-     * @throws IllegalStateException if not all hosts respond successfully.
+     * @throws AtlasDbDependencyException if not all hosts respond successfully.
+     * @throws UncheckedExecutionException if there are multiple schema mutation lock tables.
      */
     @Override
     public void createTable(final TableReference tableRef, final byte[] tableMetadata) {
@@ -1363,7 +1366,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableNamesToTableMetadata a mapping of names of tables to create to their respective metadata.
      *
-     * @throws IllegalStateException if not all hosts respond successfully.
+     * @throws AtlasDbDependencyException if not all hosts respond successfully.
+     * @throws UncheckedExecutionException if there are multiple schema mutation lock tables.
      */
     @Override
     public void createTables(final Map<TableReference, byte[]> tableNamesToTableMetadata) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -30,7 +30,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/SchemaMutationLock.java
@@ -222,7 +222,6 @@ final class SchemaMutationLock {
                         throw Throwables.rewrapAndThrowUncheckedException(schemaLockTimeoutError);
                     }
 
-
                     currentTimeBetweenLockAttemptsMillis = getCappedTimeBetweenLockAttemptsWithBackoff(
                             currentTimeBetweenLockAttemptsMillis);
                     Thread.sleep(currentTimeBetweenLockAttemptsMillis);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,10 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - Any ongoing Cassandra schema mutations are now given two minutes to complete upon closing a
+           transaction manager, decreasing the chance that the schema mutation lock is lost. 
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3152>`__)
 
 =======
 v0.82.1


### PR DESCRIPTION
**Goals (and why)**:
Best-effort clean-up of the C* schema mutation lock when a transaction manager is shut down.

**Implementation Description (bullets)**:
Run `createTables` and `dropTables` calls on an executor service. When the txn manager is closed, any running task is given 2 minutes to complete before continuing to close the txn manager. 

**Concerns (what feedback would you like?)**:
Ideas for testing? Any concerns with interrupt handling?

**Priority (whenever / two weeks / yesterday)**:
This week.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3152)
<!-- Reviewable:end -->
