### PR TITLE
better tablename validation

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ValidatingQueryRewritingKeyValueService.java
@@ -102,7 +102,7 @@ public class ValidatingQueryRewritingKeyValueService extends ForwardingKeyValueS
     protected void sanityCheckTableName(TableReference tableRef) {
         String tableName = tableRef.getQualifiedName();
         Validate.isTrue(
-                ((!tableName.startsWith("_") && (tableName.contains(".")))
+                (!tableName.startsWith("_") && tableName.contains(".")
                         && ALLOWED_TABLE_NAMES.matcher(tableName).matches())
                         || AtlasDbConstants.hiddenTables.contains(tableRef)
                         || tableName.startsWith(AtlasDbConstants.NAMESPACE_PREFIX),

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -42,6 +42,18 @@ develop
 =======
 
 .. replace this with the release date and the above with v<tag> (the v makes the permalinks nice)
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
+    *    - |changed|
+         - Added validation that forces alphanumeric + underscore only table names
+           in the name of forced cross-compat amongst backing stores.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3159>`__)
     
 =======
 v0.84.0
@@ -64,11 +76,6 @@ v0.84.0
          - The (Thrift-backed) ``CassandraKeyValueService`` now returns correctly for CQL queries that return null.
            Previously, they would throw an exception when we attempted to log information about the response.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3158>`__)
-
-    *    - |changed|
-         - Added validation that forces alphanumeric + underscore only table names
-           in the name of forced cross-compat amongst backing stores.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3159>`__)
 
 =======
 v0.83.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -59,6 +59,11 @@ develop
            Previously, they would throw an exception when we attempted to log information about the response.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3158>`__)
 
+    *    - |changed|
+         - Added validation that forces alphanumeric + underscore only table names
+           in the name of forced cross-compat amongst backing stores.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3159>`__)
+
 =======
 v0.83.0
 =======


### PR DESCRIPTION
note that I didn't force everyone to also fit inside the minimum of all of the allowed KVS table name identifier lengths; older Oracle identifier lengths are too abusively small and there are too many people who already have long table names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3159)
<!-- Reviewable:end -->
