### PR TITLE
Clean up AbstractKeyValueService, put complexity into DbKvs

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -18,11 +18,7 @@ package com.palantir.atlasdb.keyvalue.impl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.NavigableMap;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -32,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -43,7 +38,6 @@ import com.palantir.atlasdb.AtlasDbPerformanceConstants;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
-import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
@@ -51,8 +45,6 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
-import com.palantir.common.base.Throwables;
-import com.palantir.common.collect.Maps2;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 
@@ -139,56 +131,6 @@ public abstract class AbstractKeyValueService implements KeyValueService {
 
     protected long getMultiPutBatchSizeBytes() {
         return AtlasDbPerformanceConstants.MAX_BATCH_SIZE_BYTES;
-    }
-
-    /* (non-Javadoc)
-     * @see com.palantir.atlasdb.keyvalue.api.KeyValueService#multiPut(java.util.Map, long)
-     */
-    @Override
-    public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, final long timestamp)
-            throws KeyAlreadyExistsException {
-        List<Callable<Void>> callables = Lists.newArrayList();
-        for (Entry<TableReference, ? extends Map<Cell, byte[]>> e : valuesByTable.entrySet()) {
-            final TableReference table = e.getKey();
-            // We sort here because some key value stores are more efficient if you store adjacent keys together.
-            NavigableMap<Cell, byte[]> sortedMap = ImmutableSortedMap.copyOf(e.getValue());
-
-            Iterable<List<Entry<Cell, byte[]>>> partitions = IterablePartitioner.partitionByCountAndBytes(
-                    sortedMap.entrySet(),
-                    getMultiPutBatchCount(),
-                    getMultiPutBatchSizeBytes(),
-                    table,
-                    entry -> entry == null ? 0 : entry.getValue().length + Cells.getApproxSizeOfCell(entry.getKey()));
-
-            for (final List<Entry<Cell, byte[]>> p : partitions) {
-                callables.add(() -> {
-                    String originalName = Thread.currentThread().getName();
-                    Thread.currentThread().setName("Atlas multiPut of " + p.size() + " cells into " + table);
-                    try {
-                        put(table, Maps2.fromEntries(p), timestamp);
-                        return null;
-                    } finally {
-                        Thread.currentThread().setName(originalName);
-                    }
-                });
-            }
-        }
-
-        List<Future<Void>> futures;
-        try {
-            futures = executor.invokeAll(callables);
-        } catch (InterruptedException e) {
-            throw Throwables.throwUncheckedException(e);
-        }
-        for (Future<Void> future : futures) {
-            try {
-                future.get();
-            } catch (InterruptedException e) {
-                throw Throwables.throwUncheckedException(e);
-            } catch (ExecutionException e) {
-                throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
-            }
-        }
     }
 
     @Override

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/DbKvs.java
@@ -33,7 +33,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +60,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -115,6 +119,7 @@ import com.palantir.common.annotation.Output;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.ClosableIterators;
 import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.Maps2;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.exception.PalantirSqlException;
@@ -402,6 +407,56 @@ public final class DbKvs extends AbstractKeyValueService {
             }
             return null;
         });
+    }
+
+    /* (non-Javadoc)
+     * @see com.palantir.atlasdb.keyvalue.api.KeyValueService#multiPut(java.util.Map, long)
+     */
+    @Override
+    public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, final long timestamp)
+            throws KeyAlreadyExistsException {
+        List<Callable<Void>> callables = Lists.newArrayList();
+        for (Entry<TableReference, ? extends Map<Cell, byte[]>> e : valuesByTable.entrySet()) {
+            final TableReference table = e.getKey();
+            // We sort here because some key value stores are more efficient if you store adjacent keys together.
+            NavigableMap<Cell, byte[]> sortedMap = ImmutableSortedMap.copyOf(e.getValue());
+
+            Iterable<List<Entry<Cell, byte[]>>> partitions = IterablePartitioner.partitionByCountAndBytes(
+                    sortedMap.entrySet(),
+                    getMultiPutBatchCount(),
+                    getMultiPutBatchSizeBytes(),
+                    table,
+                    entry -> entry == null ? 0 : entry.getValue().length + Cells.getApproxSizeOfCell(entry.getKey()));
+
+            for (final List<Entry<Cell, byte[]>> p : partitions) {
+                callables.add(() -> {
+                    String originalName = Thread.currentThread().getName();
+                    Thread.currentThread().setName("Atlas multiPut of " + p.size() + " cells into " + table);
+                    try {
+                        put(table, Maps2.fromEntries(p), timestamp);
+                        return null;
+                    } finally {
+                        Thread.currentThread().setName(originalName);
+                    }
+                });
+            }
+        }
+
+        List<Future<Void>> futures;
+        try {
+            futures = executor.invokeAll(callables);
+        } catch (InterruptedException e) {
+            throw Throwables.throwUncheckedException(e);
+        }
+        for (Future<Void> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                throw Throwables.throwUncheckedException(e);
+            } catch (ExecutionException e) {
+                throw Throwables.rewrapAndThrowUncheckedException(e.getCause());
+            }
+        }
     }
 
     @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -54,6 +54,10 @@ develop
          - If we make a successful request to a Cassandra client, we now remove it from the overall Cassandra service's blacklist.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3156>`__)
 
+    *    - |improved|
+         - Move a complicated and elsewhere overridden method from AbstractKeyValueService into DbKvsKeyValueService
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3159>`__)
+
     *    - |fixed|
          - The (Thrift-backed) ``CassandraKeyValueService`` now returns correctly for CQL queries that return null.
            Previously, they would throw an exception when we attempted to log information about the response.


### PR DESCRIPTION
There's a method (on a hot path) in AbstractKeyValueService called
multiPut. It isn't used on any codepath except in DbKvs, and
provides no benefit except in there.

Remove it from AbstractKeyValueService, push into DbKvs. Reimplement
more efficiently in a way that avoids tests all creating 16 threads
per test.

Reimplement in InMemoryKeyValueService; should purely speed things up in that and avoid 16 threads existing.

**Goals (and why)**: Less complexity

**Implementation Description (bullets)**: Move method

**Concerns (what feedback would you like?)**: No concerns

**Where should we start reviewing?**: Whenever

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
