### PR TITLE
Comprehensive table metadata info for atlasConsole

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/TableMetadata.java
@@ -62,6 +62,7 @@ public class TableMetadata implements Persistable {
                 LogSafety.UNSAFE);
     }
 
+    // NOTE: if you change the defaults here, make sure to change them in TableMetadataDeserializer as well!
     public TableMetadata(NameMetadataDescription rowMetadata,
             ColumnMetadataDescription columns,
             ConflictHandler conflictHandler,

--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/TableMetadataSerializer.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/jackson/TableMetadataSerializer.java
@@ -73,6 +73,14 @@ public class TableMetadataSerializer extends StdSerializer<TableMetadata> {
             }
             jgen.writeEndArray();
         }
+        jgen.writeStringField("sweepStrategy", value.getSweepStrategy().name());
+        jgen.writeStringField("conflictHandler", value.getConflictHandler().name());
+        jgen.writeStringField("cachePriority", value.getCachePriority().name());
+        jgen.writeBooleanField("rangeScanAllowed", value.isRangeScanAllowed());
+        jgen.writeNumberField("explicitCompressionBlockSizeKB", value.getExplicitCompressionBlockSizeKB());
+        jgen.writeBooleanField("negativeLookups", value.hasNegativeLookups());
+        jgen.writeBooleanField("appendHeavyAndReadLight", value.isAppendHeavyAndReadLight());
+        jgen.writeStringField("nameLogSafety", value.getNameLogSafety().name());
         jgen.writeEndObject();
     }
 


### PR DESCRIPTION
**Goals (and why)**:

Cause otherwise atlasconsole doesn't give me metadata beyond the rows/columns.
