### PR TITLE
Fix LoggingArgs NPE

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/logging/LoggingArgs.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
 import org.immutables.value.Value;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -97,7 +99,7 @@ public final class LoggingArgs {
     /**
      * Returns a safe or unsafe arg corresponding to the supplied table reference, with name "tableRef".
      */
-    public static Arg<String> tableRef(TableReference tableReference) {
+    public static Arg<String> tableRef(@Nullable TableReference tableReference) {
         return tableRef("tableRef", tableReference);
     }
 
@@ -135,7 +137,10 @@ public final class LoggingArgs {
         }
     }
 
-    public static Arg<String> tableRef(String argName, TableReference tableReference) {
+    public static Arg<String> tableRef(String argName, @Nullable TableReference tableReference) {
+        if (tableReference == null) {
+            return SafeArg.of(argName, "null TableReference");
+        }
         return getArg(argName, tableReference.toString(), logArbitrator.isTableReferenceSafe(tableReference));
     }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/logging/LoggingArgsTest.java
@@ -263,4 +263,9 @@ public class LoggingArgsTest {
         LoggingArgs.hydrate(ImmutableMap.of(SAFE_TABLE_REFERENCE, AtlasDbConstants.EMPTY_TABLE_METADATA));
         LoggingArgs.setLogArbitrator(arbitrator);
     }
+
+    @Test
+    public void nullTableReferenceDoesNotThrow() {
+        assertThat(LoggingArgs.tableRef(null)).isInstanceOf(SafeArg.class);
+    }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,11 @@ develop
          - Change
 
     *    - |fixed|
+         - Fixed an issue occurring after a failure to putUnlessExists a commit timestamp that was causing an NPE leading to a confusing error message.
+           Previously, the method determining whether the transaction was aborted or whether in fact it had committed successfully would hit a code path that would always result in an NPE.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3176>`__)
+
+    *    - |fixed|
          - Snapshot transaction is now guaranteed to return getRowsColumnRange results in the correct order.
            Previously while paging over row dynamic columns, if uncommitted or aborted transaction data was
            seen, it would be placed at the end of the list, instead of at the start, meaning that the results


### PR DESCRIPTION
**Goals (and why)**:
Fix the issue arising from `SnapshotTransaction.getCommitTimestamps` hitting this method with a null TableReference causing an NPE.

**Implementation Description (bullets)**:
We deal explicitly with the case where the argument is null

**Concerns (what feedback would you like?)**:
LoggingArgs should never throw exceptions, being an logging utility class, and this is the second such issue. Are there any other methods that can end up biting us?
Also, we need better test coverage!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3176)
<!-- Reviewable:end -->
