### PR TITLE
lower log level to debug for silent timelock debugging messages

### DIFF
--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifierImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifierImpl.java
@@ -64,7 +64,7 @@ public class PaxosLatestRoundVerifierImpl implements PaxosLatestRoundVerifier {
         try {
             return round >= acceptor.getLatestSequencePreparedOrAccepted();
         } catch (Exception e) {
-            if (isPicked()) {
+            if (log.isDebugEnabled() && shouldLog()) {
                 log.debug("failed to get latest sequence", e);
             }
             throw e;
@@ -75,7 +75,7 @@ public class PaxosLatestRoundVerifierImpl implements PaxosLatestRoundVerifier {
         return PaxosQuorumChecker.getQuorumResult(responses, quorumSize);
     }
 
-    private boolean isPicked() {
+    private boolean shouldLog() {
         return Math.random() < SAMPLE_RATE;
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifierImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosLatestRoundVerifierImpl.java
@@ -65,7 +65,7 @@ public class PaxosLatestRoundVerifierImpl implements PaxosLatestRoundVerifier {
             return round >= acceptor.getLatestSequencePreparedOrAccepted();
         } catch (Exception e) {
             if (isPicked()) {
-                log.warn("failed to get latest sequence", e);
+                log.debug("failed to get latest sequence", e);
             }
             throw e;
         }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -235,7 +235,7 @@ public final class PaxosQuorumChecker {
             }
         }, OUTSTANDING_REQUEST_CANCELLATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
-        if (shouldLogCancellationStatus()) {
+        if (log.isDebugEnabled() && shouldLogCancellationStatus()) {
             log.debug("Quorum checker canceled pending requests"
                     + ". Rate of successful cancellations: {}, rate of no-op cancellations: {}",
                     SafeArg.of("rateCancelled", cancelOutstandingRequestSuccess.getOneMinuteRate()),

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosQuorumChecker.java
@@ -236,7 +236,7 @@ public final class PaxosQuorumChecker {
         }, OUTSTANDING_REQUEST_CANCELLATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
         if (shouldLogCancellationStatus()) {
-            log.warn("Quorum checker canceled pending requests"
+            log.debug("Quorum checker canceled pending requests"
                     + ". Rate of successful cancellations: {}, rate of no-op cancellations: {}",
                     SafeArg.of("rateCancelled", cancelOutstandingRequestSuccess.getOneMinuteRate()),
                     SafeArg.of("rateNoOpCancellation", cancelOutstandingRequestNoOp.getOneMinuteRate()));


### PR DESCRIPTION
**Goals (and why)**:
Reduce the logging noise by lowering log level to debug for the messages we used to debug silent timelock issue.

**Priority (whenever / two weeks / yesterday)**:
This week would be nice.
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3182)
<!-- Reviewable:end -->
