### PR TITLE
Avoid saying we're not the leader and hinting that we are

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,7 +58,12 @@ develop
            and on serializable tables, transactions that paradoxically conflict with themselves.
            Now, they are guaranteed to be returned in order, which removes this issue.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3174>`__)
-    
+
+    *    - |fixed|
+         - Fixed a race condition where requests to a node can fail with NotCurrentLeaderException,
+           even though that node just gained leadership.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3183>`__)
+
 =======
 v0.84.0
 =======


### PR DESCRIPTION
There's a small gap in between the time when we realise we're not the
leader and when we check for the leadership hint. In that time, it's
possible for us to become leader.

In this cases, I've added another chance for the request to proceed.

**Goals (and why)**: Fix something observed hundreds of times in Oracle ETE tests that got frozen.

**Implementation Description (bullets)**: See above

**Concerns (what feedback would you like?)**: I haven't written a test case for this, but probably should - wanted to throw up the idea quickly.

**Where should we start reviewing?**: The java code

**Priority (whenever / two weeks / yesterday)**: this week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3183)
<!-- Reviewable:end -->
