### PR TITLE
Row paging hands back in hashmap order from the second page and beyond

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -807,12 +807,15 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                         if (results.isEmpty()) {
                             return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
                         }
-                        Map<Cell, Value> ret = Maps.newHashMap();
-                        new ValueExtractor(ret).extractResults(results, startTs, ColumnSelection.all());
                         List<ColumnOrSuperColumn> values = Iterables.getOnlyElement(results.values());
                         if (values.isEmpty()) {
                             return SimpleTokenBackedResultsPage.create(startCol, ImmutableList.of(), false);
                         }
+                        RowColumnRangeExtractor extractor = new RowColumnRangeExtractor();
+                        extractor.extractResults(ImmutableList.of(row), results, startTs);
+                        RowColumnRangeExtractor.RowColumnRangeResult decoded = extractor.getRowColumnRangeResult();
+                        Map<Cell, Value> ret = decoded.getResults().get(row);
+
                         ColumnOrSuperColumn lastColumn = values.get(values.size() - 1);
                         byte[] lastCol = CassandraKeyValueServices.decomposeName(lastColumn.getColumn()).getLhSide();
                         // Same idea as the getRows case to handle seeing only newer entries of a column

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -287,10 +288,18 @@ public abstract class AbstractKeyValueServiceTest {
                 ImmutableList.of(row1),
                 BatchColumnRangeSelection.create(null, null, 3),
                 TEST_TIMESTAMP + 1).get(row1);
-        List<byte[]> columns = Streams.stream(iterator)
+        List<ByteBuffer> columns = Streams.stream(iterator)
                 .map(entry -> entry.getKey().getColumnName())
+                .map(ByteBuffer::wrap)
                 .collect(Collectors.toList());
-        assertEquals(ImmutableList.of(column0, column1, column2, column3, column4, column5, column6), columns);
+        assertEquals(ImmutableList.of(
+                ByteBuffer.wrap(column0),
+                ByteBuffer.wrap(column1),
+                ByteBuffer.wrap(column2),
+                ByteBuffer.wrap(column3),
+                ByteBuffer.wrap(column4),
+                ByteBuffer.wrap(column5),
+                ByteBuffer.wrap(column6)), columns);
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -58,7 +58,14 @@ develop
            and on serializable tables, transactions that paradoxically conflict with themselves.
            Now, they are guaranteed to be returned in order, which removes this issue.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3174>`__)
-    
+
+    *    - |fixed|
+         - The Cassandra key value service is now guaranteed to return getRowsColumnRange results in the correct order.
+           Previously while paging over row dynamic columns, the first batchHint results are ordered lexicographically,
+           whilst the remainder are hashmap ordered in chunks of batchHint. In practice, when paging this can lead to
+           entirely incorrect, duplicate results being returned. Now, they are returned in order.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3184>`__)
+ 
 =======
 v0.84.0
 =======


### PR DESCRIPTION
**Goals (and why)**: Contract of KeyValueService (and real life code) dictates that cells be handed back ordered lexicographically. In practice, whilst this is true for the first page, subsequent are handed back in HashMap order.

**Implementation Description (bullets)**:

Change the method that returns the second-and-beyond-page to use the RowColumnRangeExtractor not the RowExtractor.

**Concerns (what feedback would you like?)**:

I'd like this merged and released ASAP, since internally we have stuff blocking on this.

**Where should we start reviewing?**:

If you want background context, the single host version of the getRowsColumnRange method is sensible place to start.

Gist is that the algorithm is:

Do a batch call to get all the columns, limit foo. See if the last column returned indicates to us that there are no more, and if so, that's it. Otherwise, create a lazy batching iterator that will read the second page and beyond.

The codepaths for getting the first page and getting the second page are sadly different, but I've unified them a little bit here.

**Priority (whenever / two weeks / yesterday)**:

Yesterday

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3185)
<!-- Reviewable:end -->
