### PR TITLE
Don't greedily delete data from aborted txns

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1696,26 +1696,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             }
         }
 
-        try {
-            log.debug("For table: {} we are deleting values of an uncommitted transaction: {}",
-                    LoggingArgs.tableRef(tableRef),
-                    UnsafeArg.of("keysToDelete", keysToDelete));
-            keyValueService.delete(tableRef, Multimaps.forMap(keysToDelete));
-        } catch (RuntimeException e) {
-            final String msg = "This isn't a bug but it should be infrequent if all nodes of your KV service are"
-                    + " running. Delete has stronger consistency semantics than read/write and must talk to all nodes"
-                    + " instead of just talking to a quorum of nodes. "
-                    + "Failed to delete keys for table: {} from an uncommitted transaction; "
-                    + " sweep should eventually clean this when it processes this table.";
-            if (log.isDebugEnabled()) {
-                log.warn(msg + " The keys that failed to be deleted during rollback were {}",
-                        LoggingArgs.tableRef(tableRef),
-                        UnsafeArg.of("keysToDelete", keysToDelete));
-            } else {
-                log.warn(msg, LoggingArgs.tableRef(tableRef), e);
-            }
-        }
-
+        log.debug("For table: {} we are *NOT* deleting values of an uncommitted transaction: {}."
+                        + "These values will eventually be cleaned up by sweep.",
+                LoggingArgs.tableRef(tableRef),
+                UnsafeArg.of("keysToDelete", keysToDelete));
         return true;
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -71,7 +71,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.Sets;

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,11 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - ``SnapshotTransaction`` will no longer attempt to delete values for transactions that get rolled back.
+           The deletes were (necessarily) run at consistency ``ALL``, meaning that if aborted data was present, read
+           transactions had significantly impaired performance if a database node was down.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3199>`__)
 
 =======
 v0.86.0


### PR DESCRIPTION
This caused reads and writes to become extremely slow (but still
eventually pass) when a database node is offline.

Potential fixes:
- Add the rolled-back data to the sweep queue
- Delete the rolled-back data asynchronously

**Goals (and why)**: Make AtlasDB (performantly) HA (P-HA) Again.
Reads and writes were previously not P-HA when aborted transaction data existed. This caused a P0 with the internal Megatron product.

**Implementation Description (bullets)**:
- Remove the try block where we were attempting to delete the data
- Note that we already (correctly) abort the transaction earlier in that same method, so no other change was necessary

**Concerns (what feedback would you like?)**: Why didn't this change break any tests? We should also track adding this cleanup step back in future, but possibly not until Targeted Sweep is a thing

**Where should we start reviewing?**: One java file

**Priority (whenever / two weeks / yesterday)**: Yesterday. In fact, like last year, because that's when we started promising to be HA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3199)
<!-- Reviewable:end -->
