### PR TITLE
[TS] Part 19: Hash Metadata to avoid hotspotting

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
@@ -47,7 +47,7 @@ public enum TargetedSweepSchema implements AtlasSchema {
             javaTableName("SweepableCells");
             allSafeForLoggingByDefault();
             rowName();
-                hashFirstRowComponent();
+                hashFirstNRowComponents(2);
                 rowComponent("timestamp_partition", ValueType.VAR_LONG);
                 rowComponent("metadata", ValueType.BLOB);
             dynamicColumns();


### PR DESCRIPTION
**Goals (and why)**:
- Avoid hotspotting when writing to dedicated rows (currently everything on the same shard goes to the same node during a `FINE_PARTITION_TS` time-block)

**Implementation Description (bullets)**:
- Change `SweepableCells` to hash the first two row components
- Change `deleteDedicatedRows` to perform deletions on a per-row basis as opposed to across a row range (see first point under Concerns for details)

**Concerns (what feedback would you like?)**:
- The main tradeoff here is that multiple dedicated rows in a single transaction were previously deleted as a single `RangeRequest` in a single call to `deleteRange`, but now we have to delete them one row at a time (because hashing metadata means they'll no longer be contiguous). Given these deletes take place on a background thread and the current impl of `deleteRange` basically will make multiple delete calls to Cassandra anyway (we don't do something very clever) I think this is fine.
- Is the performance cost of hashing the metadata significant? I'd guess not.
- Are the tests too specific?

**Where should we start reviewing?**: `TargetedSweepSchema`, but the real meat is in `SweepableCells` which has the fiddly change in range deletions.

**Priority (whenever / two weeks / yesterday)**: ideally by EOD tomorrow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3204)
<!-- Reviewable:end -->
