### PR TITLE
Increased PTExecutors default thread timeout

### DIFF
--- a/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutors.java
@@ -60,7 +60,7 @@ public final class PTExecutors {
      * run into a number of issues (e.g., QA-44927) where thread pool mismanagement has lead to
      * OutOfMemoryExceptions.
      */
-    private static final int DEFAULT_THREAD_POOL_TIMEOUT_MILLIS = 100;
+    private static final int DEFAULT_THREAD_POOL_TIMEOUT_MILLIS = 5000;
 
     private static final RejectedExecutionHandler defaultHandler = new AbortPolicy();
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,8 +57,8 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3199>`__)
 
     *    - |improved|
-         - Increaesd PTExecutors default thread timeout from 100 milliseconds to 5 seconds to avoid recreating
-           threads unnecessarily.
+         - Increased PTExecutors default thread timeout from 100 milliseconds to 5 seconds to avoid recreating threads unnecessarily.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3208>`__)
 
 =======
 v0.86.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,10 @@ develop
            transactions had significantly impaired performance if a database node was down.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3199>`__)
 
+    *    - |improved|
+         - Increaesd PTExecutors default thread timeout from 100 milliseconds to 5 seconds to avoid recreating
+           threads unnecessarily.
+
 =======
 v0.86.0
 =======


### PR DESCRIPTION
Increased PTExecutors default thread timeout from 100 milliseconds
to 5 seconds to avoid recreating threads (and other resources
tied to threadlocal caches) unnecessarily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3208)
<!-- Reviewable:end -->
