### PR TITLE
[TS] Part 20: Thorough Sweep Deletes Sentinels

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -385,6 +385,17 @@ public interface KeyValueService extends AutoCloseable {
             Map<Cell, Long> maxTimestampExclusiveByCell);
 
     /**
+     * For each cell, deletes all timestamps prior to the associated maximum timestamp, including garbage collection
+     * sentinels. Depending on the implementation, this may result in a range tombstone in the underlying KVS.
+     */
+    @POST
+    @Path("delete-all-timestamps-including-sentinels")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Idempotent
+    void deleteAllTimestampsIncludingSentinels(@QueryParam("tableRef") TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell);
+
+    /**
      * Truncate a table in the key-value store.
      * <p>
      * This is preferred to dropping and re-adding a table, as live schema changes can

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -389,10 +389,10 @@ public interface KeyValueService extends AutoCloseable {
      * sentinels. Depending on the implementation, this may result in a range tombstone in the underlying KVS.
      */
     @POST
-    @Path("delete-all-timestamps-including-sentinels")
+    @Path("delete-all-timestamps-and-sentinels")
     @Consumes(MediaType.APPLICATION_JSON)
     @Idempotent
-    void deleteAllTimestampsIncludingSentinels(@QueryParam("tableRef") TableReference tableRef,
+    void deleteAllTimestampsAndSentinels(@QueryParam("tableRef") TableReference tableRef,
             Map<Cell, Long> maxTimestampExclusiveByCell);
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
@@ -31,4 +31,13 @@ public final class Mutations {
         return new Mutation().setDeletion(deletion);
     }
 
+    public static Mutation rangeTombstoneIncludingSentinelForColumn(byte[] columnName, long maxTimestampExclusive) {
+        Deletion deletion = new Deletion()
+                .setTimestamp(maxTimestampExclusive)
+                .setPredicate(SlicePredicates
+                        .rangeTombstoneIncludingSentinelForColumn(columnName, maxTimestampExclusive));
+
+        return new Mutation().setDeletion(deletion);
+    }
+
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/SlicePredicates.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/SlicePredicates.java
@@ -43,6 +43,15 @@ public final class SlicePredicates {
                 Limit.NO_LIMIT);
     }
 
+    public static SlicePredicate rangeTombstoneIncludingSentinelForColumn(byte[] columnName,
+            long maxTimestampExclusive) {
+        return create(
+                Range.of(
+                        Range.startOfColumn(columnName, maxTimestampExclusive),
+                        Range.endOfColumnIncludingSentinels(columnName)),
+                Limit.NO_LIMIT);
+    }
+
     public static SlicePredicate create(Range range, Limit limit) {
         SliceRange slice = new SliceRange(
                 range.start(),

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -219,13 +219,12 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell) {
+    public void deleteAllTimestampsAndSentinels(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
         deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell, true);
     }
 
     public static void deleteAllTimestampsDefaultImpl(KeyValueService kvs, TableReference tableRef,
-            Map<Cell, Long> maxTimestampByCell, boolean includingSentinel) {
+            Map<Cell, Long> maxTimestampByCell, boolean deleteSentinel) {
         if (maxTimestampByCell.isEmpty()) {
             return;
         }
@@ -239,7 +238,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
             long maxTimestampForCell = maxTimestampByCell.get(entry.getKey());
 
             long timestamp = entry.getValue();
-            return timestamp < maxTimestampForCell && (includingSentinel || timestamp != Value.INVALID_VALUE_TIMESTAMP);
+            return timestamp < maxTimestampForCell && (deleteSentinel || timestamp != Value.INVALID_VALUE_TIMESTAMP);
         });
 
         kvs.delete(tableRef, timestampsByCellExcludingSentinels);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueService.java
@@ -215,11 +215,17 @@ public abstract class AbstractKeyValueService implements KeyValueService {
     @Override
     public void deleteAllTimestamps(TableReference tableRef,
             Map<Cell, Long> maxTimestampExclusiveByCell) {
-        deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell);
+        deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell, false);
+    }
+
+    @Override
+    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell) {
+        deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell, true);
     }
 
     public static void deleteAllTimestampsDefaultImpl(KeyValueService kvs, TableReference tableRef,
-            Map<Cell, Long> maxTimestampByCell) {
+            Map<Cell, Long> maxTimestampByCell, boolean includingSentinel) {
         if (maxTimestampByCell.isEmpty()) {
             return;
         }
@@ -233,7 +239,7 @@ public abstract class AbstractKeyValueService implements KeyValueService {
             long maxTimestampForCell = maxTimestampByCell.get(entry.getKey());
 
             long timestamp = entry.getValue();
-            return timestamp < maxTimestampForCell && timestamp != Value.INVALID_VALUE_TIMESTAMP;
+            return timestamp < maxTimestampForCell && (includingSentinel || timestamp != Value.INVALID_VALUE_TIMESTAMP);
         });
 
         kvs.delete(tableRef, timestampsByCellExcludingSentinels);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -137,6 +137,13 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell) {
+        delegate1.deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+        delegate2.deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+    }
+
+    @Override
     public void truncateTable(TableReference tableRef) {
         delegate1.truncateTable(tableRef);
         delegate2.truncateTable(tableRef);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -137,10 +137,9 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell) {
-        delegate1.deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
-        delegate2.deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+    public void deleteAllTimestampsAndSentinels(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        delegate1.deleteAllTimestampsAndSentinels(tableRef, maxTimestampExclusiveByCell);
+        delegate2.deleteAllTimestampsAndSentinels(tableRef, maxTimestampExclusiveByCell);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
@@ -81,6 +81,12 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     }
 
     @Override
+    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell) {
+        delegate().deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+    }
+
+    @Override
     public Multimap<Cell, Long> getAllTimestamps(TableReference tableRef, Set<Cell> keys, long timestamp) {
         return delegate().getAllTimestamps(tableRef, keys, timestamp);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ForwardingKeyValueService.java
@@ -81,9 +81,8 @@ public abstract class ForwardingKeyValueService extends ForwardingObject impleme
     }
 
     @Override
-    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell) {
-        delegate().deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+    public void deleteAllTimestampsAndSentinels(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        delegate().deleteAllTimestampsAndSentinels(tableRef, maxTimestampExclusiveByCell);
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -185,10 +185,9 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell) {
-        maybeLog(() -> delegate.deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell),
-                logTimeAndTable("deleteAllTimestampsIncludingSentinels", tableRef));
+    public void deleteAllTimestampsAndSentinels(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        maybeLog(() -> delegate.deleteAllTimestampsAndSentinels(tableRef, maxTimestampExclusiveByCell),
+                logTimeAndTable("deleteAllTimestampsAndSentinels", tableRef));
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -185,6 +185,13 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell) {
+        maybeLog(() -> delegate.deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell),
+                logTimeAndTable("deleteAllTimestampsIncludingSentinels", tableRef));
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         maybeLog(() -> delegate.dropTable(tableRef),
                 logTimeAndTable("dropTable", tableRef));

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -174,6 +174,16 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
+    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell) {
+        //noinspection unused - try-with-resources closes trace
+        try (CloseableTrace trace = startLocalTrace("deleteAllTimestampsIncludingSentinels({})",
+                LoggingArgs.safeTableOrPlaceholder(tableRef))) {
+            delegate().deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+        }
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTrace trace = startLocalTrace("dropTable({})",

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -174,12 +174,11 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
-    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell) {
+    public void deleteAllTimestampsAndSentinels(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
         //noinspection unused - try-with-resources closes trace
-        try (CloseableTrace trace = startLocalTrace("deleteAllTimestampsIncludingSentinels({})",
+        try (CloseableTrace trace = startLocalTrace("deleteAllTimestampsAndSentinels({})",
                 LoggingArgs.safeTableOrPlaceholder(tableRef))) {
-            delegate().deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+            delegate().deleteAllTimestampsAndSentinels(tableRef, maxTimestampExclusiveByCell);
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -124,6 +124,17 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
+    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell) {
+        try {
+            delegate().deleteAllTimestampsIncludingSentinels(tableMapper.getMappedTableName(tableRef),
+                    maxTimestampExclusiveByCell);
+        } catch (TableMappingNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         dropTables(ImmutableSet.of(tableRef));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -124,11 +124,9 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
     }
 
     @Override
-    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell) {
+    public void deleteAllTimestampsAndSentinels(TableReference tableRef, Map<Cell, Long> maxTsExclusiveByCell) {
         try {
-            delegate().deleteAllTimestampsIncludingSentinels(tableMapper.getMappedTableName(tableRef),
-                    maxTimestampExclusiveByCell);
+            delegate().deleteAllTimestampsAndSentinels(tableMapper.getMappedTableName(tableRef), maxTsExclusiveByCell);
         } catch (TableMappingNotFoundException e) {
             throw new IllegalArgumentException(e);
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -140,9 +140,8 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell) {
-        getDelegate(tableRef).deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+    public void deleteAllTimestampsAndSentinels(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
+        getDelegate(tableRef).deleteAllTimestampsAndSentinels(tableRef, maxTimestampExclusiveByCell);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableSplittingKeyValueService.java
@@ -140,6 +140,12 @@ public final class TableSplittingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell) {
+        getDelegate(tableRef).deleteAllTimestampsIncludingSentinels(tableRef, maxTimestampExclusiveByCell);
+    }
+
+    @Override
     public void dropTable(TableReference tableRef) {
         getDelegate(tableRef).dropTable(tableRef);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -48,7 +48,7 @@ public class SweepQueueDeleter {
                 kvs.addGarbageCollectionSentinelValues(entry.getKey(), entry.getValue().keySet());
                 kvs.deleteAllTimestamps(entry.getKey(), entry.getValue());
             } else {
-                kvs.deleteAllTimestampsIncludingSentinels(entry.getKey(), entry.getValue());
+                kvs.deleteAllTimestampsAndSentinels(entry.getKey(), entry.getValue());
             }
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueDeleter.java
@@ -46,8 +46,10 @@ public class SweepQueueDeleter {
         for (Map.Entry<TableReference, Map<Cell, Long>> entry: maxTimestampByCell.entrySet()) {
             if (sweeper.shouldAddSentinels()) {
                 kvs.addGarbageCollectionSentinelValues(entry.getKey(), entry.getValue().keySet());
+                kvs.deleteAllTimestamps(entry.getKey(), entry.getValue());
+            } else {
+                kvs.deleteAllTimestampsIncludingSentinels(entry.getKey(), entry.getValue());
             }
-            kvs.deleteAllTimestamps(entry.getKey(), entry.getValue());
         }
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -137,6 +137,15 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     }
 
     @Test
+    public void thoroughSweepDeletesExistingSentinel() {
+        spiedKvs.addGarbageCollectionSentinelValues(TABLE_THOR, ImmutableList.of(DEFAULT_CELL));
+        assertReadAtTimestampReturnsSentinel(TABLE_THOR, 0L);
+        enqueueWrite(TABLE_THOR, 10L);
+        sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(THOR_SHARD));
+        assertReadAtTimestampReturnsNothing(TABLE_THOR, 0L);
+    }
+
+    @Test
     public void conservativeSweepDeletesLowerValue() {
         enqueueWrite(TABLE_CONS, LOW_TS);
         enqueueWrite(TABLE_CONS, LOW_TS2);
@@ -161,7 +170,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     }
 
     @Test
-    public void sweepDeletesAllButLatestWithSingleDeleteAllTimestamps() {
+    public void conservativeSweepDeletesAllButLatestWithSingleDeleteAllTimestamps() {
         long lastWriteTs = TS_FINE_GRANULARITY - 1;
         for (long i = 0; i <= lastWriteTs; i++) {
             enqueueWrite(TABLE_CONS, i);
@@ -170,6 +179,18 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertReadAtTimestampReturnsSentinel(TABLE_CONS, lastWriteTs);
         assertTestValueEnqueuedAtGivenTimestampStillPresent(TABLE_CONS, lastWriteTs);
         verify(spiedKvs, times(1)).deleteAllTimestamps(any(TableReference.class), anyMap());
+    }
+
+    @Test
+    public void thoroughSweepDeletesAllButLatestWithSingleDeleteAllTimestampsIncludingSentinels() {
+        long lastWriteTs = TS_FINE_GRANULARITY - 1;
+        for (long i = 0; i <= lastWriteTs; i++) {
+            enqueueWrite(TABLE_THOR, i);
+        }
+        sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(THOR_SHARD));
+        assertReadAtTimestampReturnsNothing(TABLE_THOR, lastWriteTs);
+        assertTestValueEnqueuedAtGivenTimestampStillPresent(TABLE_THOR, lastWriteTs);
+        verify(spiedKvs, times(1)).deleteAllTimestampsIncludingSentinels(any(TableReference.class), anyMap());
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -190,7 +190,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(THOR_SHARD));
         assertReadAtTimestampReturnsNothing(TABLE_THOR, lastWriteTs);
         assertTestValueEnqueuedAtGivenTimestampStillPresent(TABLE_THOR, lastWriteTs);
-        verify(spiedKvs, times(1)).deleteAllTimestampsIncludingSentinels(any(TableReference.class), anyMap());
+        verify(spiedKvs, times(1)).deleteAllTimestampsAndSentinels(any(TableReference.class), anyMap());
     }
 
     @Test

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -695,8 +695,7 @@ public class JdbcKeyValueService implements KeyValueService {
     }
 
     @Override
-    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
-            Map<Cell, Long> maxTimestampExclusiveByCell) {
+    public void deleteAllTimestampsAndSentinels(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
         AbstractKeyValueService.deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell, true);
     }
 

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -691,7 +691,13 @@ public class JdbcKeyValueService implements KeyValueService {
 
     @Override
     public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
-        AbstractKeyValueService.deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell);
+        AbstractKeyValueService.deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell, false);
+    }
+
+    @Override
+    public void deleteAllTimestampsIncludingSentinels(TableReference tableRef,
+            Map<Cell, Long> maxTimestampExclusiveByCell) {
+        AbstractKeyValueService.deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell, true);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.keyvalue.impl;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
@@ -1123,7 +1122,7 @@ public abstract class AbstractKeyValueServiceTest {
 
     @Test
     public void deleteTimestampRangesIncludingSentinelsIgnoresEmptyMap() {
-        keyValueService.deleteAllTimestampsIncludingSentinels(TEST_TABLE, ImmutableMap.of());
+        keyValueService.deleteAllTimestampsAndSentinels(TEST_TABLE, ImmutableMap.of());
     }
 
     @Test
@@ -1137,7 +1136,7 @@ public abstract class AbstractKeyValueServiceTest {
         keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value01), ts2);
         keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value10), latestTs);
 
-        keyValueService.deleteAllTimestampsIncludingSentinels(TEST_TABLE, ImmutableMap.of(row0col0, latestTs));
+        keyValueService.deleteAllTimestampsAndSentinels(TEST_TABLE, ImmutableMap.of(row0col0, latestTs));
 
         assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col0), Long.MAX_VALUE).asMap().get(
                 row0col0), contains(latestTs));
@@ -1171,7 +1170,7 @@ public abstract class AbstractKeyValueServiceTest {
         keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col1, value01), ts2Col1);
         keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col1, value10), latestTsCol1);
 
-        keyValueService.deleteAllTimestampsIncludingSentinels(TEST_TABLE, ImmutableMap.of(
+        keyValueService.deleteAllTimestampsAndSentinels(TEST_TABLE, ImmutableMap.of(
                 row0col0, latestTsCol0,
                 row0col1, latestTsCol1,
                 row1col0, latestTsCol0));
@@ -1199,7 +1198,7 @@ public abstract class AbstractKeyValueServiceTest {
         keyValueService.addGarbageCollectionSentinelValues(TEST_TABLE, ImmutableSet.of(row0col0));
         keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value10), latestTs);
 
-        keyValueService.deleteAllTimestampsIncludingSentinels(TEST_TABLE, ImmutableMap.of(row0col0, latestTs));
+        keyValueService.deleteAllTimestampsAndSentinels(TEST_TABLE, ImmutableMap.of(row0col0, latestTs));
 
         assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col0), Long.MAX_VALUE).asMap()
                 .get(row0col0), contains(latestTs));

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.impl;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
@@ -1118,6 +1119,90 @@ public abstract class AbstractKeyValueServiceTest {
                 .get(row0col0), contains(Value.INVALID_VALUE_TIMESTAMP, latestTs));
         assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row0col0, Value.INVALID_VALUE_TIMESTAMP + 1L))
                         .get(row0col0), equalTo(Value.create(new byte[0], Value.INVALID_VALUE_TIMESTAMP)));
+    }
+
+    @Test
+    public void deleteTimestampRangesIncludingSentinelsIgnoresEmptyMap() {
+        keyValueService.deleteAllTimestampsIncludingSentinels(TEST_TABLE, ImmutableMap.of());
+    }
+
+    @Test
+    public void deleteTimestampRangesIncludingSentinelsDeletesForSingleColumn() {
+        Cell row0col0 = Cell.create(row0, column0);
+        long ts1 = 5L;
+        long ts2 = 10L;
+        long latestTs = 15L;
+
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value00), ts1);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value01), ts2);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value10), latestTs);
+
+        keyValueService.deleteAllTimestampsIncludingSentinels(TEST_TABLE, ImmutableMap.of(row0col0, latestTs));
+
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col0), Long.MAX_VALUE).asMap().get(
+                row0col0), contains(latestTs));
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row0col0, Long.MAX_VALUE)).get(row0col0),
+                equalTo(Value.create(value10, latestTs)));
+    }
+
+    @Test
+    public void deleteTimestampRangesIncludingSentinelsDeletesMultipleColumnsAcrossMultipleRows() {
+        Cell row0col0 = Cell.create(row0, column0);
+        Cell row0col1 = Cell.create(row0, column1);
+        Cell row1col0 = Cell.create(row1, column0);
+
+        long ts1Col0 = 5L;
+        long ts2Col0 = 10L;
+        long latestTsCol0 = 15L;
+
+        long ts1Col1 = 2L;
+        long ts2Col1 = 3L;
+        long latestTsCol1 = 4L;
+
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value00), ts1Col0);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value01), ts2Col0);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value10), latestTsCol0);
+
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row1col0, value00), ts1Col0);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row1col0, value01), ts2Col0);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row1col0, value10), latestTsCol0);
+
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col1, value00), ts1Col1);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col1, value01), ts2Col1);
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col1, value10), latestTsCol1);
+
+        keyValueService.deleteAllTimestampsIncludingSentinels(TEST_TABLE, ImmutableMap.of(
+                row0col0, latestTsCol0,
+                row0col1, latestTsCol1,
+                row1col0, latestTsCol0));
+
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col0), Long.MAX_VALUE).asMap().get(
+                row0col0), contains(latestTsCol0));
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col1), Long.MAX_VALUE).asMap().get(
+                row0col1), contains(latestTsCol1));
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row1col0), Long.MAX_VALUE).asMap().get(
+                row1col0), contains(latestTsCol0));
+
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row0col0, Long.MAX_VALUE)).get(row0col0),
+                equalTo(Value.create(value10, latestTsCol0)));
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row0col1, Long.MAX_VALUE)).get(row0col1),
+                equalTo(Value.create(value10, latestTsCol1)));
+        assertThat(keyValueService.get(TEST_TABLE, ImmutableMap.of(row1col0, Long.MAX_VALUE)).get(row1col0),
+                equalTo(Value.create(value10, latestTsCol0)));
+    }
+
+    @Test
+    public void deleteTimestampRangesIncludingSentinelsDeletesSentinels() {
+        Cell row0col0 = Cell.create(row0, column0);
+        long latestTs = 15L;
+
+        keyValueService.addGarbageCollectionSentinelValues(TEST_TABLE, ImmutableSet.of(row0col0));
+        keyValueService.put(TEST_TABLE, ImmutableMap.of(row0col0, value10), latestTs);
+
+        keyValueService.deleteAllTimestampsIncludingSentinels(TEST_TABLE, ImmutableMap.of(row0col0, latestTs));
+
+        assertThat(keyValueService.getAllTimestamps(TEST_TABLE, ImmutableSet.of(row0col0), Long.MAX_VALUE).asMap()
+                .get(row0col0), contains(latestTs));
     }
 
     private void setupTestRowsZeroOneAndTwoAndDeleteFrom(byte[] start, byte[] end) {


### PR DESCRIPTION
**Goals (and why)**:
Have thorough sweep include sentinels in the ranged tombstone.

**Implementation Description (bullets)**:
Added a kvs method that adds the appropriate ranged tombstones.

**Concerns (what feedback would you like?)**:
Is it worth bloating the API?

**Where should we start reviewing?**:
Anywhere, really

**Priority (whenever / two weeks / yesterday)**:
Now :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3209)
<!-- Reviewable:end -->
