### PR TITLE
[TS] Part 20 (alternative): delete sentinels

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/Mutations.java
@@ -31,4 +31,12 @@ public final class Mutations {
         return new Mutation().setDeletion(deletion);
     }
 
+    public static Mutation rangeTombstoneIncludingSentinelForColumn(byte[] columnName, long maxTimestampExclusive) {
+        Deletion deletion = new Deletion()
+                .setTimestamp(maxTimestampExclusive)
+                .setPredicate(
+                        SlicePredicates.rangeTombstoneIncludingSentinelForColumn(columnName, maxTimestampExclusive));
+
+        return new Mutation().setDeletion(deletion);
+    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/SlicePredicates.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/SlicePredicates.java
@@ -43,6 +43,15 @@ public final class SlicePredicates {
                 Limit.NO_LIMIT);
     }
 
+    public static SlicePredicate rangeTombstoneIncludingSentinelForColumn(byte[] columnName,
+            long maxTimestampExclusive) {
+        return create(
+                Range.of(
+                        Range.startOfColumn(columnName, maxTimestampExclusive),
+                        Range.endOfColumnIncludingSentinels(columnName)),
+                Limit.NO_LIMIT);
+    }
+
     public static SlicePredicate create(Range range, Limit limit) {
         SliceRange slice = new SliceRange(
                 range.start(),

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -182,7 +182,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     }
 
     @Test
-    public void thoroughSweepDeletesAllButLatestWithSingleDeleteAllTimestampsIncludingSentinels() {
+    public void thoroughSweepDeletesAllButLatestWithSingleDeleteAllTimestamps() {
         long lastWriteTs = TS_FINE_GRANULARITY - 1;
         for (long i = 0; i <= lastWriteTs; i++) {
             enqueueWrite(TABLE_THOR, i);
@@ -190,7 +190,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(THOR_SHARD));
         assertReadAtTimestampReturnsNothing(TABLE_THOR, lastWriteTs);
         assertTestValueEnqueuedAtGivenTimestampStillPresent(TABLE_THOR, lastWriteTs);
-//        verify(spiedKvs, times(1)).deleteAllTimestampsAndSentinels(any(TableReference.class), anyMap());
+        verify(spiedKvs, times(1)).deleteAllTimestamps(any(TableReference.class), anyMap());
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -137,6 +137,15 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     }
 
     @Test
+    public void thoroughSweepDeletesExistingSentinel() {
+        spiedKvs.addGarbageCollectionSentinelValues(TABLE_THOR, ImmutableList.of(DEFAULT_CELL));
+        assertReadAtTimestampReturnsSentinel(TABLE_THOR, 0L);
+        enqueueWrite(TABLE_THOR, 10L);
+        sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(THOR_SHARD));
+        assertReadAtTimestampReturnsNothing(TABLE_THOR, 0L);
+    }
+
+    @Test
     public void conservativeSweepDeletesLowerValue() {
         enqueueWrite(TABLE_CONS, LOW_TS);
         enqueueWrite(TABLE_CONS, LOW_TS2);
@@ -161,7 +170,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     }
 
     @Test
-    public void sweepDeletesAllButLatestWithSingleDeleteAllTimestamps() {
+    public void conservativeSweepDeletesAllButLatestWithSingleDeleteAllTimestamps() {
         long lastWriteTs = TS_FINE_GRANULARITY - 1;
         for (long i = 0; i <= lastWriteTs; i++) {
             enqueueWrite(TABLE_CONS, i);
@@ -170,6 +179,18 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertReadAtTimestampReturnsSentinel(TABLE_CONS, lastWriteTs);
         assertTestValueEnqueuedAtGivenTimestampStillPresent(TABLE_CONS, lastWriteTs);
         verify(spiedKvs, times(1)).deleteAllTimestamps(any(TableReference.class), anyMap());
+    }
+
+    @Test
+    public void thoroughSweepDeletesAllButLatestWithSingleDeleteAllTimestampsIncludingSentinels() {
+        long lastWriteTs = TS_FINE_GRANULARITY - 1;
+        for (long i = 0; i <= lastWriteTs; i++) {
+            enqueueWrite(TABLE_THOR, i);
+        }
+        sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(THOR_SHARD));
+        assertReadAtTimestampReturnsNothing(TABLE_THOR, lastWriteTs);
+        assertTestValueEnqueuedAtGivenTimestampStillPresent(TABLE_THOR, lastWriteTs);
+//        verify(spiedKvs, times(1)).deleteAllTimestampsAndSentinels(any(TableReference.class), anyMap());
     }
 
     @Test

--- a/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
+++ b/atlasdb-jdbc/src/main/java/com/palantir/atlasdb/keyvalue/jdbc/JdbcKeyValueService.java
@@ -691,7 +691,7 @@ public class JdbcKeyValueService implements KeyValueService {
 
     @Override
     public void deleteAllTimestamps(TableReference tableRef, Map<Cell, Long> maxTimestampExclusiveByCell) {
-        AbstractKeyValueService.deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell);
+        AbstractKeyValueService.deleteAllTimestampsDefaultImpl(this, tableRef, maxTimestampExclusiveByCell, false);
     }
 
     @Override


### PR DESCRIPTION
**Goals (and why)**: Rewrite of #3209, but without an extra KVS method

**Implementation Description (bullets)**:
- Fetch sweep strategy from kvs metadata
- Copy various helpers and test methods from the original PR

**Concerns (what feedback would you like?)**: There doesn't seem to be Targeted Sweep tests that cover C* KVS - or I didn't look very hard for them. Should we add an integration test as well as a unit test? Or should we add other integration tests to cover the modified C*KVS code?

**Where should we start reviewing?**: C*KVSImpl

**Priority (whenever / two weeks / yesterday)**: now :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3211)
<!-- Reviewable:end -->
