### PR TITLE
no longer blacklist connections due to a CAS error

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyAlreadyExistsException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyAlreadyExistsException.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import com.google.common.collect.ImmutableList;
 import com.palantir.common.exception.AtlasDbDependencyException;
 
-public class KeyAlreadyExistsException extends AtlasDbDependencyException {
+public class KeyAlreadyExistsException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     private final ImmutableList<Cell> existingKeys;

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyAlreadyExistsException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyAlreadyExistsException.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.keyvalue.api;
 import java.util.Collection;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.common.exception.AtlasDbDependencyException;
 
 public class KeyAlreadyExistsException extends RuntimeException {
     private static final long serialVersionUID = 1L;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1877,7 +1877,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                     }
                 }
                 clientPool.markWritesForTable(values, tableRef);
-                return null;
+                return Optional.empty();
             });
             failure.ifPresent(exception -> {
                 throw exception;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1902,7 +1902,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     @Override
     public void checkAndSet(final CheckAndSetRequest request) throws CheckAndSetException {
         try {
-            CASResult casResult = clientPool.runWithRetry(client -> executeCheckAndSet(client, request);
+            CASResult casResult = clientPool.runWithRetry(client -> executeCheckAndSet(client, request));
             if (!casResult.isSuccess()) {
                 List<byte[]> currentValues = casResult.current_values.stream()
                         .map(Column::getValue)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1882,6 +1882,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             failure.ifPresent(exception -> {
                 throw exception;
             });
+        } catch (KeyAlreadyExistsException e) {
+            throw e;
         } catch (Exception e) {
             throw QosAwareThrowables.unwrapAndThrowRateLimitExceededOrAtlasDbDependencyException(e);
         }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1412,7 +1412,7 @@ public abstract class AbstractKeyValueServiceTest {
         }
 
         assertThatThrownBy(() -> keyValueService.putUnlessExists(TEST_TABLE, ImmutableMap.of(TEST_CELL, value00)))
-                .isInstanceOf(AtlasDbDependencyException.class)
+                .isInstanceOf(KeyAlreadyExistsException.class)
                 .as("putUnlessExists must throw when overwriting the same cell!");
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1399,7 +1399,7 @@ public abstract class AbstractKeyValueServiceTest {
             keyValueService.putWithTimestamps(TEST_TABLE, ImmutableMultimap.of(
                     TEST_CELL, Value.create(value01, TEST_TIMESTAMP + 1)));
             // Legal
-        } catch (AtlasDbDependencyException e) {
+        } catch (KeyAlreadyExistsException e) {
             // Legal
         }
 
@@ -1407,7 +1407,7 @@ public abstract class AbstractKeyValueServiceTest {
         try {
             keyValueService.putUnlessExists(TEST_TABLE, ImmutableMap.of(TEST_CELL, value00));
             // Legal
-        } catch (AtlasDbDependencyException e) {
+        } catch (KeyAlreadyExistsException e) {
             // Legal
         }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -82,7 +82,6 @@ import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.collect.IterableView;
 import com.palantir.common.collect.MapEntries;
-import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.lock.impl.LegacyTimelockService;
 import com.palantir.util.Pair;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -58,6 +58,7 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
@@ -178,7 +179,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
         assertThatThrownBy(() ->
                 keyValueService.putUnlessExists(TransactionConstants.TRANSACTION_TABLE,
                         ImmutableMap.of(cell, "v2".getBytes())))
-                .isInstanceOf(AtlasDbDependencyException.class);
+                .isInstanceOf(KeyAlreadyExistsException.class);
     }
 
     @Test

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   java:
     version:
-      oraclejdk8
+      openjdk8
   environment:
     _JAVA_OPTIONS: "-Xmx512M -XX:+HeapDumpOnOutOfMemoryError -verbose:gc -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:-TraceClassUnloading -Xloggc:build-%t-%p.gc.log"
     TERM: dumb

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,12 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - We no longer treat CAS failure in Cassandra as a Cassandra level issue, meaning that we won't
+           blacklist connections due to a failed CAS.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3215>`__)
+
+
     *    - |devbreak| |new|
          - KVS method ``deleteAllTimestamps`` now also takes a boolean argument specifying if garbage deletion sentinels should also be deleted.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3212>`__)


### PR DESCRIPTION
**Goals (and why)**: We currently throw exceptions in the client pool on a check and set failure. This causes retries and blacklisting to be invoked, making those methods detrimental to overall performance and more importantly causing a lot of logspam.

**Implementation Description (bullets)**: Throw _outside_ the client pool.

**Concerns (what feedback would you like?)**: Not sure how to test this, given it's not observable behaviour at this level.

**Priority (whenever / two weeks / yesterday)**: Now?

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3215)
<!-- Reviewable:end -->
