### PR TITLE
Feature/async delete on rollback

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -124,7 +124,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    long lockAcquireTimeoutMs,
                                    ExecutorService getRangesExecutor,
                                    int defaultGetRangesConcurrency,
-                                   MultiTableSweepQueueWriter sweepQueue) {
+                                   MultiTableSweepQueueWriter sweepQueue,
+                                   ExecutorService deleteExecutor) {
         super(keyValueService,
               timelockService,
               transactionService,
@@ -143,7 +144,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               lockAcquireTimeoutMs,
               getRangesExecutor,
               defaultGetRangesConcurrency,
-              sweepQueue);
+              sweepQueue,
+              deleteExecutor);
     }
 
     @Override
@@ -637,7 +639,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                                 RangeRequests.getNextStartRow(false, rangeEnd),
                                 range.getBatchHint());
                     }
-                    rangesToRows.computeIfAbsent(range, ignored -> Lists.newArrayList()).add(row);                    
+                    rangesToRows.computeIfAbsent(range, ignored -> Lists.newArrayList()).add(row);
                 }
             }
             for (Entry<BatchColumnRangeSelection, List<byte[]>> e : rangesToRows.entrySet()) {
@@ -727,7 +729,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 lockAcquireTimeoutMs,
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                MultiTableSweepQueueWriter.NO_OP) {
+                MultiTableSweepQueueWriter.NO_OP,
+                deleteExecutor) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -333,7 +334,9 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 concurrentGetRangesThreadPoolSize,
                 defaultGetRangesConcurrency,
                 timestampCacheSize,
-                sweepQueueWriter);
+                sweepQueueWriter,
+                Executors.newSingleThreadExecutor()
+        );
     }
 
     @Override
@@ -360,7 +363,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 lockAcquireTimeoutMs.get(),
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                sweepQueueWriter);
+                sweepQueueWriter,
+                deleteExecutor);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.transaction.impl;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -319,6 +320,43 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             MultiTableSweepQueueWriter sweepQueueWriter) {
+        this(
+                keyValueService,
+                timelockService,
+                lockService,
+                transactionService,
+                constraintModeSupplier,
+                conflictDetectionManager,
+                sweepStrategyManager,
+                cleaner,
+                timestampTracker,
+                timestampCacheSize,
+                allowHiddenTableAccess,
+                lockAcquireTimeoutMs,
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency,
+                sweepQueueWriter,
+                Executors.newSingleThreadExecutor()
+        );
+    }
+
+    @VisibleForTesting
+    SerializableTransactionManager(KeyValueService keyValueService,
+            TimelockService timelockService,
+            LockService lockService,
+            TransactionService transactionService,
+            Supplier<AtlasDbConstraintCheckingMode> constraintModeSupplier,
+            ConflictDetectionManager conflictDetectionManager,
+            SweepStrategyManager sweepStrategyManager,
+            Cleaner cleaner,
+            TimestampTracker timestampTracker,
+            Supplier<Long> timestampCacheSize,
+            boolean allowHiddenTableAccess,
+            Supplier<Long> lockAcquireTimeoutMs,
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency,
+            MultiTableSweepQueueWriter sweepQueueWriter,
+            ExecutorService deleteExecutor) {
         super(
                 keyValueService,
                 timelockService,
@@ -335,7 +373,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 defaultGetRangesConcurrency,
                 timestampCacheSize,
                 sweepQueueWriter,
-                Executors.newSingleThreadExecutor()
+                deleteExecutor
         );
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -71,6 +71,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.Sets;
@@ -1703,12 +1704,30 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             }
         }
 
-        // TODO deleteExecutor.submit(deletions)
-        log.debug("For table: {} we are *NOT* deleting values of an uncommitted transaction: {}."
-                        + "These values will eventually be cleaned up by sweep.",
-                LoggingArgs.tableRef(tableRef),
-                UnsafeArg.of("keysToDelete", keysToDelete));
+        deleteExecutor.submit(() -> deleteCells(tableRef, keysToDelete));
         return true;
+    }
+
+    private void deleteCells(TableReference tableRef, Map<Cell, Long> keysToDelete) {
+        try {
+            log.debug("For table: {} we are deleting values of an uncommitted transaction: {}",
+                    LoggingArgs.tableRef(tableRef),
+                    UnsafeArg.of("keysToDelete", keysToDelete));
+            keyValueService.delete(tableRef, Multimaps.forMap(keysToDelete));
+        } catch (RuntimeException e) {
+            final String msg = "This isn't a bug but it should be infrequent if all nodes of your KV service are"
+                    + " running. Delete has stronger consistency semantics than read/write and must talk to all nodes"
+                    + " instead of just talking to a quorum of nodes. "
+                    + "Failed to delete keys for table: {} from an uncommitted transaction; "
+                    + " sweep should eventually clean this when it processes this table.";
+            if (log.isDebugEnabled()) {
+                log.warn(msg + " The keys that failed to be deleted during rollback were {}",
+                        LoggingArgs.tableRef(tableRef),
+                        UnsafeArg.of("keysToDelete", keysToDelete));
+            } else {
+                log.warn(msg, LoggingArgs.tableRef(tableRef), e);
+            }
+        }
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -65,6 +65,7 @@ import com.palantir.timestamp.TimestampService;
     final boolean allowHiddenTableAccess;
     protected final Supplier<Long> lockAcquireTimeoutMs;
     final ExecutorService getRangesExecutor;
+    final ExecutorService deleteExecutor;
     final TimestampTracker timestampTracker;
     final int defaultGetRangesConcurrency;
     final MultiTableSweepQueueWriter sweepQueueWriter;
@@ -87,7 +88,8 @@ import com.palantir.timestamp.TimestampService;
             int concurrentGetRangesThreadPoolSize,
             int defaultGetRangesConcurrency,
             Supplier<Long> timestampCacheSize,
-            MultiTableSweepQueueWriter sweepQueueWriter) {
+            MultiTableSweepQueueWriter sweepQueueWriter,
+            ExecutorService deleteExecutor) {
         super(timestampCacheSize);
 
         this.keyValueService = keyValueService;
@@ -106,6 +108,7 @@ import com.palantir.timestamp.TimestampService;
         this.timestampTracker = timestampTracker;
         this.defaultGetRangesConcurrency = defaultGetRangesConcurrency;
         this.sweepQueueWriter = sweepQueueWriter;
+        this.deleteExecutor = deleteExecutor;
     }
 
     @Override
@@ -187,7 +190,8 @@ import com.palantir.timestamp.TimestampService;
                 lockAcquireTimeoutMs.get(),
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                sweepQueueWriter);
+                sweepQueueWriter,
+                deleteExecutor);
     }
 
     @Override
@@ -214,7 +218,8 @@ import com.palantir.timestamp.TimestampService;
                 lockAcquireTimeoutMs.get(),
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                sweepQueueWriter);
+                sweepQueueWriter,
+                deleteExecutor);
         try {
             return runTaskThrowOnConflict(txn -> task.execute(txn, condition),
                     new ReadTransaction(transaction, sweepStrategyManager));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -45,6 +47,8 @@ public class SnapshotTransactionManagerTest {
     private final Cleaner cleaner = mock(Cleaner.class);
     private final KeyValueService keyValueService = mock(KeyValueService.class);
 
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
     private final SnapshotTransactionManager snapshotTransactionManager = new SnapshotTransactionManager(
             keyValueService,
             new LegacyTimelockService(new InMemoryTimestampService(), closeableLockService,
@@ -61,7 +65,8 @@ public class SnapshotTransactionManagerTest {
             TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
             TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
             () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
-            MultiTableSweepQueueWriter.NO_OP);
+            MultiTableSweepQueueWriter.NO_OP,
+            executorService);
 
     @Test
     public void isAlwaysInitialized() {
@@ -104,7 +109,8 @@ public class SnapshotTransactionManagerTest {
                 TransactionTestConstants.GET_RANGES_THREAD_POOL_SIZE,
                 TransactionTestConstants.DEFAULT_GET_RANGES_CONCURRENCY,
                 () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
-                MultiTableSweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP,
+                executorService);
         newTransactionManager.close(); // should not throw
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -112,7 +112,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_EXECUTOR,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                getSweepQueueWriterInitialized()) {
+                getSweepQueueWriterInitialized(),
+                AbstractTransactionTest.DELETE_EXECUTOR) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -103,7 +103,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     protected static final ExecutorService GET_RANGES_EXECUTOR =
             Executors.newFixedThreadPool(GET_RANGES_THREAD_POOL_SIZE);
 
-    protected static final ExecutorService DELETE_EXECUTOR = Executors.newSingleThreadExecutor();
+    public static final ExecutorService DELETE_EXECUTOR = Executors.newSingleThreadExecutor();
 
     protected Transaction startTransaction() {
         return new SnapshotTransaction(

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -103,6 +103,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     protected static final ExecutorService GET_RANGES_EXECUTOR =
             Executors.newFixedThreadPool(GET_RANGES_THREAD_POOL_SIZE);
 
+    protected static final ExecutorService DELETE_EXECUTOR = Executors.newSingleThreadExecutor();
+
     protected Transaction startTransaction() {
         return new SnapshotTransaction(
                 keyValueService,
@@ -120,7 +122,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 timestampCache,
                 GET_RANGES_EXECUTOR,
                 DEFAULT_GET_RANGES_CONCURRENCY,
-                MultiTableSweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP,
+                DELETE_EXECUTOR);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -123,7 +123,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 timestampValidationReadCache,
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
-                sweepQueueWriter);
+                sweepQueueWriter,
+                deleteExecutor);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.transaction.impl;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.AtlasDbConstants;
@@ -50,7 +51,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             TransactionService transactionService,
             ConflictDetectionManager conflictDetectionManager,
             SweepStrategyManager sweepStrategyManager,
-            MultiTableSweepQueueWriter sweepQueue) {
+            MultiTableSweepQueueWriter sweepQueue,
+            ExecutorService deleteExecutor) {
         super(
                 createAssertKeyValue(keyValueService, lockService),
                 new LegacyTimelockService(timestampService, lockService, lockClient),
@@ -66,7 +68,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                sweepQueue);
+                sweepQueue,
+                deleteExecutor);
     }
 
     @SuppressWarnings("Indentation") // Checkstyle complains about lambda in constructor.
@@ -91,7 +94,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 () -> AtlasDbConstants.DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS,
                 AbstractTransactionTest.GET_RANGES_THREAD_POOL_SIZE,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
-                MultiTableSweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP,
+                AbstractTransactionTest.DELETE_EXECUTOR);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -113,7 +113,8 @@ public abstract class TransactionTestSetup {
 
     protected TransactionManager getManager() {
         return new TestTransactionManagerImpl(keyValueService, timestampService, lockClient, lockService,
-                transactionService, conflictDetectionManager, sweepStrategyManager, MultiTableSweepQueueWriter.NO_OP);
+                transactionService, conflictDetectionManager, sweepStrategyManager, MultiTableSweepQueueWriter.NO_OP,
+                AbstractTransactionTest.DELETE_EXECUTOR);
     }
 
     protected void put(Transaction txn,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/TableMigratorTest.java
@@ -38,6 +38,7 @@ import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.description.TableDefinition;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
@@ -98,7 +99,8 @@ public class TableMigratorTest extends AtlasDbTestCase {
                 transactionService,
                 cdm2,
                 ssm2,
-                MultiTableSweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP,
+                AbstractTransactionTest.DELETE_EXECUTOR);
         kvs2.createTable(tableRef, definition.toTableMetadata().persistToBytes());
         kvs2.createTable(namespacedTableRef, definition.toTableMetadata().persistToBytes());
 
@@ -133,7 +135,8 @@ public class TableMigratorTest extends AtlasDbTestCase {
                 transactionService,
                 verifyCdm,
                 verifySsm,
-                MultiTableSweepQueueWriter.NO_OP);
+                MultiTableSweepQueueWriter.NO_OP,
+                AbstractTransactionTest.DELETE_EXECUTOR);
         final MutableLong count = new MutableLong();
         for (final TableReference name : Lists.newArrayList(tableRef, namespacedTableRef)) {
             verifyTxManager.runTaskReadOnly((TransactionTask<Void, RuntimeException>) txn -> {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -962,7 +962,6 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             return null;
         })).isSameAs(conditionFailure);
 
-        // read is rolling back
         List<Cell> cells = serializableTxManager.runTaskReadOnly(tx ->
                 BatchingVisitableView.of(tx.getRowsColumnRange(
                         TABLE,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -800,8 +800,6 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             tx.put(TABLE, ImmutableMap.of(TEST_CELL, PtBytes.toBytes("value")));
             return null;
         });
-
-        verify(keyValueService, times(0)).delete(any(), any());
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -277,7 +277,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         m.assertIsSatisfied();
     }
 
-    @Ignore("Until we know what we want to do with GC this will be ignored.")
+    @Ignore("Was ignored long ago, and now we need to fix the mocking logic.")
     // This tests that uncommitted values are deleted and cleaned up
     @SuppressWarnings("unchecked")
     @Test
@@ -291,7 +291,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         timestampService.getFreshTimestamp();
         final long startTs = timestampService.getFreshTimestamp();
         final long transactionTs = timestampService.getFreshTimestamp();
-        keyValueService.put(TABLE, ImmutableMap.of(cell, PtBytes.EMPTY_BYTE_ARRAY), startTs);
+        keyValueService.put(TABLE, ImmutableMap.of(cell, rowName), startTs);
 
         final Sequence seq = m.sequence("seq");
         m.checking(new Expectations() {{
@@ -326,7 +326,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 defaultGetRangesConcurrency,
                 sweepQueue,
                 deleteExecutor);
-        snapshot.put(TABLE, ImmutableMap.of(cell, PtBytes.EMPTY_BYTE_ARRAY));
+        snapshot.delete(TABLE, ImmutableSet.of(cell));
         snapshot.commit();
 
         m.assertIsSatisfied();

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -79,7 +79,7 @@ develop
               - ``lastSweptTimestamp``
 
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3202>`__)
-    
+
     *    - |improved| |logs|
          - Added logging of the values used to determine which table to sweep, provides more insight into why tables are being swept and others aren't.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/2829>`__)
@@ -89,6 +89,12 @@ develop
            This release fixes several issues with communication between Atlas servers and a QoS service, if configured (especially in HA configurations).
            Note that this change does not affect communication between timelock nodes, or between an Atlas client and timelock, as these do not currently use remoting.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3196>`__)
+
+    *    - |fixed|
+         - ``SnapshotTransaction`` now asynchronously deletes values for transactions that get rolled back.
+           This restores the behaviour from before the previous `fix <https://github.com/palantir/atlasdb/pull/3199>`__,
+           except that the parent transaction no longer waits for the delete to finish.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/32xx>`__)
 
     *    - |fixed|
          - ``SnapshotTransaction`` will no longer attempt to delete values for transactions that get rolled back.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,12 @@ develop
            never implemented correctly and never offered the serializable guarantee. The method now throws an ``UnsupportedOperationException`` in this case.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3200>`__)
 
+    *    - |improved|
+         - ``SnapshotTransaction`` now asynchronously deletes values for transactions that get rolled back.
+           This restores the behaviour from before the previous `fix <https://github.com/palantir/atlasdb/pull/3199>`__,
+           except that the parent transaction no longer waits for the delete to finish.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3219>`__)
+
     *    - |fixed|
          - Fixed an issue occurring during transaction commits, where a failure to putUnlessExists a commit timestamp caused an NPE, leading to a confusing error message.
            Previously, the method determining whether the transaction had committed successfully or been aborted would hit a code path that would always result in an NPE.
@@ -128,12 +134,6 @@ v0.87.0
 
     *    - Type
          - Change
-
-    *    - |fixed|
-         - ``SnapshotTransaction`` now asynchronously deletes values for transactions that get rolled back.
-           This restores the behaviour from before the previous `fix <https://github.com/palantir/atlasdb/pull/3199>`__,
-           except that the parent transaction no longer waits for the delete to finish.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/32xx>`__)
 
     *    - |fixed|
          - ``SnapshotTransaction`` will no longer attempt to delete values for transactions that get rolled back.


### PR DESCRIPTION
**Goals (and why)**: Fixes #3201. Restore deletes on transaction rollbacks after #3199,  but make them asynchronous.

**Implementation Description (bullets)**:
- Wire an `ExecutorService`, `deleteExecutor`, into SnapshotTransaction and friends.
- Submit a deletion task when we'd previously just greedily delete.

**Concerns (what feedback would you like?)**: It suits the test case to have a single-threaded executor, but do we want to allocate more threads in production code?
How do you feel about extra tests to show that things are still fast with a node down?

**Where should we start reviewing?**: SnapshotTransaction.java

**Priority (whenever / two weeks / yesterday)**: This week; P1 in weekly plan and needed by the autobumping internal product

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3219)
<!-- Reviewable:end -->
