### PR TITLE
Do not suppress printing of errors in benchmark test run

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/MinimalReportFormatForTest.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/MinimalReportFormatForTest.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.runner.format.OutputFormat;
 
 public final class MinimalReportFormatForTest implements OutputFormat {
     private static final PrintStream out = System.out;
+    private static final PrintStream err = System.err;
 
     private static final MinimalReportFormatForTest INSTANCE = new MinimalReportFormatForTest();
 
@@ -79,7 +80,9 @@ public final class MinimalReportFormatForTest implements OutputFormat {
 
     @Override
     public void println(String str) {
-
+        if (str.contains("Error") || str.contains("Exception")) {
+            err.println(str);
+        }
     }
 
     @Override

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/MinimalReportFormatForTest.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/MinimalReportFormatForTest.java
@@ -29,7 +29,6 @@ import org.openjdk.jmh.runner.format.OutputFormat;
 
 public final class MinimalReportFormatForTest implements OutputFormat {
     private static final PrintStream out = System.out;
-    private static final PrintStream err = System.err;
 
     private static final MinimalReportFormatForTest INSTANCE = new MinimalReportFormatForTest();
 
@@ -80,9 +79,7 @@ public final class MinimalReportFormatForTest implements OutputFormat {
 
     @Override
     public void println(String str) {
-        if (str.contains("Error") || str.contains("Exception")) {
-            err.println(str);
-        }
+
     }
 
     @Override

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/cli/AtlasDbPerfCli.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/cli/AtlasDbPerfCli.java
@@ -29,7 +29,6 @@ import javax.inject.Inject;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.RunResult;
-import org.openjdk.jmh.runner.BenchmarkException;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/cli/AtlasDbPerfCli.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/cli/AtlasDbPerfCli.java
@@ -29,12 +29,15 @@ import javax.inject.Inject;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.BenchmarkException;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.reflections.Reflections;
 import org.reflections.scanners.MethodAnnotationsScanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.palantir.atlasdb.performance.BenchmarkParam;
 import com.palantir.atlasdb.performance.MinimalReportFormatForTest;
@@ -60,6 +63,8 @@ import io.airlift.airline.SingleCommand;
 
 @Command(name = "atlasdb-perf", description = "The AtlasDB performance benchmark CLI.")
 public class AtlasDbPerfCli {
+    private static final Logger log = LoggerFactory.getLogger(AtlasDbPerfCli.class);
+
     @Inject
     private HelpOption helpOption;
 
@@ -160,7 +165,12 @@ public class AtlasDbPerfCli {
     private static void runCliInTestMode(ChainedOptionsBuilder optBuilder) throws RunnerException {
         optBuilder.warmupIterations(0)
                 .mode(Mode.SingleShotTime);
-        new Runner(optBuilder.build(), MinimalReportFormatForTest.get()).run();
+        try {
+            new Runner(optBuilder.build(), MinimalReportFormatForTest.get()).run();
+        } catch (RunnerException e) {
+            log.error("Error running benchmark test run.", e);
+            throw e;
+        }
     }
 
     private static DatabasesContainer startupDatabase(Set<String> backends) {


### PR DESCRIPTION
**Goals (and why)**:
Benchmark tests have caught legit problems a number of times now, but it's nontrivial to figure out what the underlying issue is because we suppress JMH output and gradle does not know why the task failed. 

**Implementation Description (bullets)**:
Log the exception at error if JMH throws.

**Concerns (what feedback would you like?)**:
None really

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3223)
<!-- Reviewable:end -->
