### PR TITLE
PDS-69180 - CommitTsLoader is too aggressive when warming its cache

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.TreeMultimap;
 import com.google.common.primitives.UnsignedBytes;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -135,7 +136,7 @@ class CellLoader {
             cellsByCol.put(cell.getColumnName(), cell);
         }
         List<Callable<Void>> tasks = Lists.newArrayList();
-        int fetchBatchCount = config.fetchBatchCount();
+        int fetchBatchCount = AtlasDbConstants.TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT;
         for (Map.Entry<byte[], Collection<Cell>> entry : Multimaps.asMap(cellsByCol).entrySet()) {
             final byte[] col = entry.getKey();
             Collection<Cell> columnCells = entry.getValue();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java
@@ -140,8 +140,11 @@ class CellLoader {
             final byte[] col = entry.getKey();
             Collection<Cell> columnCells = entry.getValue();
             if (columnCells.size() > fetchBatchCount) {
-                log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to "
-                                + "multiget {} rows; this may indicate overly-large batching on a higher level.\n{}",
+                log.warn("Re-batching in getLoadWithTsTasksForSingleHost a call to {} for table {} that attempted to"
+                                + " multiget {} rows; this may indicate overly-large batching on a higher level."
+                                + " Note that batches are executed in parallel, which may cause load on both"
+                                + " your Atlas client as well as on Cassandra if the number of rows is exceptionally"
+                                + " high.\n{}",
                         SafeArg.of("host", CassandraLogHelper.host(host)),
                         LoggingArgs.tableRef(tableRef),
                         SafeArg.of("rows", columnCells.size()),

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -146,5 +146,7 @@ public final class AtlasDbConstants {
     public static final int CASSANDRA_TABLE_NAME_CHAR_LIMIT = 48;
     public static final int POSTGRES_TABLE_NAME_CHAR_LIMIT = 63;
 
+    public static final int TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT = 50_000;
+
     public static final String SCHEMA_V2_TABLE_NAME = "V2Table";
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
@@ -39,7 +40,8 @@ import gnu.trove.set.TLongSet;
 public final class CommitTsLoader {
     private static final Logger log = LoggerFactory.getLogger(CommitTsLoader.class);
 
-    private static final int TS_PER_BATCH = 5000;
+    @VisibleForTesting
+    static final int TS_PER_BATCH = 5000;
 
     private final TLongLongMap commitTsByStartTs;
     private final TransactionService transactionService;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
@@ -62,7 +62,7 @@ public final class CommitTsLoader {
             TransactionService transactionService,
             TLongSet startTssToWarmingCache,
             TLongLongMap cache) {
-        // Ideally TransactionService should work with primitive collections to avoid GC overhead..
+        // Ideally TransactionService should work with primitive collections to avoid GC overhead.
         for (List<Long> longList : Iterables.partition(TDecorators.wrap(startTssToWarmingCache), TS_PER_BATCH)) {
             cache.putAll(transactionService.get(longList));
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsLoader.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
@@ -39,9 +39,6 @@ import gnu.trove.set.TLongSet;
 
 public final class CommitTsLoader {
     private static final Logger log = LoggerFactory.getLogger(CommitTsLoader.class);
-
-    @VisibleForTesting
-    static final int TS_PER_BATCH = 5000;
 
     private final TLongLongMap commitTsByStartTs;
     private final TransactionService transactionService;
@@ -65,7 +62,8 @@ public final class CommitTsLoader {
             TLongSet startTssToWarmingCache,
             TLongLongMap cache) {
         // Ideally TransactionService should work with primitive collections to avoid GC overhead.
-        for (List<Long> longList : Iterables.partition(TDecorators.wrap(startTssToWarmingCache), TS_PER_BATCH)) {
+        for (List<Long> longList : Iterables.partition(TDecorators.wrap(startTssToWarmingCache),
+                AtlasDbConstants.TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT)) {
             cache.putAll(transactionService.get(longList));
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
@@ -48,7 +48,7 @@ public class SweepableCellFilter {
     public BatchOfCellsToSweep getCellsToSweep(List<CandidateCellForSweeping> candidates) {
         Preconditions.checkArgument(!candidates.isEmpty(),
                 "Got an empty collection of candidates. This is a programming error.");
-        CommitTsLoader commitTss = CommitTsLoader.create(transactionService, getAllTimestamps(candidates));
+        CommitTsLoader commitTss = createCommitTsLoader(candidates);
         ImmutableBatchOfCellsToSweep.Builder builder = ImmutableBatchOfCellsToSweep.builder();
         long numCellTsPairsExamined = 0;
         Cell lastCellExamined = null;
@@ -63,6 +63,10 @@ public class SweepableCellFilter {
             lastCellExamined = candidate.cell();
         }
         return builder.numCellTsPairsExamined(numCellTsPairsExamined).lastCellExamined(lastCellExamined).build();
+    }
+
+    private CommitTsLoader createCommitTsLoader(List<CandidateCellForSweeping> candidates) {
+        return CommitTsLoader.create(transactionService, getAllTimestamps(candidates));
     }
 
     // Decide if the candidate cell needs to be swept, and if so, for which timestamps.

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
@@ -30,6 +30,7 @@ import java.util.stream.LongStream;
 
 import org.junit.Test;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 
@@ -102,7 +103,7 @@ public class CommitTsLoaderTest {
 
         doAnswer((invocation) -> {
             Collection<Long> timestamps = ((Collection<Long>) invocation.getArguments()[0]);
-            if (timestamps.size() > CommitTsLoader.TS_PER_BATCH) {
+            if (timestamps.size() > AtlasDbConstants.TRANSACTION_TIMESTAMP_LOAD_BATCH_LIMIT) {
                 fail("Requested more timestamps in a batch than is reasonable!");
             }
             return timestamps.stream().collect(Collectors.toMap(n -> n, n -> n));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.sweep;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -103,7 +102,7 @@ public class CommitTsLoaderTest {
 
         doAnswer((invocation) -> {
             Collection<Long> timestamps = ((Collection<Long>) invocation.getArguments()[0]);
-            if (timestamps.size() > 5_000) {
+            if (timestamps.size() > CommitTsLoader.TS_PER_BATCH) {
                 fail("Requested more timestamps in a batch than is reasonable!");
             }
             return timestamps.stream().collect(Collectors.toMap(n -> n, n -> n));
@@ -114,7 +113,5 @@ public class CommitTsLoaderTest {
 
         CommitTsLoader loader = CommitTsLoader.create(mockTransactionService, initialTimestamps);
         assertThat(loader.load(valuesToInsert - 1)).isEqualTo(valuesToInsert - 1);
-
-        verify(mockTransactionService, atLeast(2)).get(any());
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -102,7 +102,7 @@ public class CommitTsLoaderTest {
         long valuesToInsert = 1_000_000;
 
         doAnswer((invocation) -> {
-            List<Long> timestamps = ((List<Long>) invocation.getArguments()[0]);
+            Collection<Long> timestamps = ((Collection<Long>) invocation.getArguments()[0]);
             if (timestamps.size() > 5_000) {
                 fail("Requested more timestamps in a batch than is reasonable!");
             }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsLoaderTest.java
@@ -16,18 +16,25 @@
 package com.palantir.atlasdb.sweep;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import org.junit.Test;
 
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 
+import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
 
 public class CommitTsLoaderTest {
@@ -87,5 +94,27 @@ public class CommitTsLoaderTest {
                 .when(mockTransactionService).get(VALID_START_TIMESTAMP);
 
         assertThat(loader.load(VALID_START_TIMESTAMP)).isEqualTo(ROLLBACK_TIMESTAMP);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void warmingCacheShouldNotPlaceUndueLoadOnTransactionService() throws Exception {
+        long valuesToInsert = 1_000_000;
+
+        doAnswer((invocation) -> {
+            List<Long> timestamps = ((List<Long>) invocation.getArguments()[0]);
+            if (timestamps.size() > 5_000) {
+                fail("Requested more timestamps in a batch than is reasonable!");
+            }
+            return timestamps.stream().collect(Collectors.toMap(n -> n, n -> n));
+        }).when(mockTransactionService).get(any());
+
+        TLongSet initialTimestamps = new TLongHashSet();
+        initialTimestamps.addAll(LongStream.range(0, valuesToInsert).boxed().collect(Collectors.toList()));
+
+        CommitTsLoader loader = CommitTsLoader.create(mockTransactionService, initialTimestamps);
+        assertThat(loader.load(valuesToInsert - 1)).isEqualTo(valuesToInsert - 1);
+
+        verify(mockTransactionService, atLeast(2)).get(any());
     }
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,12 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - When determining if large sets of candidate cells were part of committed transactions, Background and Targeted Sweep will now read smaller batches of timestamps from the transaction service in serial.
+           Previously, though these reads were re-partitioned into smaller batches, the batch requests were made in parallel which could monopolise Atlas client-side as well as KVS-side resources.
+           There may be a small performance regression here, though this change promotes better stability for the underlying key-value-service especially in the presence of wide rows.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3245>`__)
+
     *    - |new| |metrics|
          - Added a new tagged metric for targeted sweep showing approximate time in milliseconds since the last swept timestamp has been issued.
            This metric can be used to estimate how far targeted sweep is lagging behind the current moment in time.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -56,6 +56,12 @@ develop
            There may be a small performance regression here, though this change promotes better stability for the underlying key-value-service especially in the presence of wide rows.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3245>`__)
 
+    *    - |userbreak|
+         - The size of batches that are used when the ``CommitTsLoader`` loads timestamps is now set to be a non-configurable 50,000.
+           This used to be configured via the ``fetchBatchSize`` parameter; other workflows that use this parameter are unaffected.
+           If you have a use case for configuring this specifically, please contact the AtlasDB team.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3245>`__)
+
     *    - |new| |metrics|
          - Added a new tagged metric for targeted sweep showing approximate time in milliseconds since the last swept timestamp has been issued.
            This metric can be used to estimate how far targeted sweep is lagging behind the current moment in time.


### PR DESCRIPTION
**Goals (and why)**: 
- fix suspected root cause of internal ticket PDS-69180
- fix #2979 - see more details there

**Implementation Description (bullets)**:
- If Sweep is checking the status of a ton of candidates, split its reads into smaller batches of 5000, and warm the cache one batch at a time instead of all in parallel.

**Concerns (what feedback would you like?)**:
- should 5000 be configurable? Might be worth doing this, though I refrained owing to high priority and also because this is not a regression (existing is already a flat 5000)
- this obviously slows this phase of sweep down, but I think that's what we want to do!

**Where should we start reviewing?**: `CommitTsLoader.java`

**Priority (whenever / two weeks / yesterday)**: yesterday 🔥

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3245)
<!-- Reviewable:end -->
