### PR TITLE
Refactor SweepableCellFilter + bugfix for free

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsCache.java
@@ -42,7 +42,7 @@ public final class CommitTsCache {
 
     /**
      * Loads the commit timestamps for a batch of timestamps. Potentially reduces the number of kvs accesses since it
-     * only does a single lookup for all the non-cached start timestamps.
+     * does batched lookups for non-cached start timestamps.
      */
     public Map<Long, Long> loadBatch(Collection<Long> timestamps) {
         try {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/SweepableCellFilter.java
@@ -60,7 +60,6 @@ public class SweepableCellFilter {
     }
 
     private Optional<CellToSweep> getCellToSweep(CandidateCellForSweeping candidate, Map<Long, Long> startToCommitTs) {
-        Preconditions.checkArgument(candidate.sortedTimestamps().size() > 0);
         List<Long> timestampsToSweep = new ArrayList<>();
         List<Long> uncommittedTimestamps = new ArrayList<>();
         boolean maxStartTsIsCommittedBeforeTs = false;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsCacheTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/CommitTsCacheTest.java
@@ -36,7 +36,6 @@ import java.util.stream.LongStream;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
@@ -81,6 +81,7 @@ public class SweepableCellFilterParametrizedTest {
     }
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() {
             Map<Long, Long> startTsToCommitTs = new HashMap<>();
             COMMITTED_BEFORE.forEach(startTs -> startTsToCommitTs.put(startTs, startTs));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
@@ -131,7 +131,6 @@ public class SweepableCellFilterParametrizedTest {
 
         assertThat(timestamps).hasSameElementsAs(expectedAll);
         assertThat(timestamps.stream().filter(expectedCommitted::contains)).isSorted();
-        System.out.println(timestamps);
     }
 
     private CellToSweep getCellsToSweepFor() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -45,19 +46,21 @@ import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 
 @RunWith(Parameterized.class)
-public class SweepableCellsParameterizedTest {
+public class SweepableCellFilterParametrizedTest {
+    private static final Set<Boolean> BOOLEANS = ImmutableSet.of(true, false);
+
     private static final Cell SINGLE_CELL = Cell.create(
             "cellRow".getBytes(StandardCharsets.UTF_8),
             "cellCol".getBytes(StandardCharsets.UTF_8));
-
-    private final TransactionService mockTransactionService = mock(TransactionService.class);
-    private final CommitTsCache commitTsCache = CommitTsCache.create(mockTransactionService);
-    private static final List<Long> COMMITTED_BEFORE = ImmutableList.of(10L, 20L, 30L);
+    private static final List<Long> COMMITTED_BEFORE = ImmutableList.of(10L, 20L, 30L, 40L);
     private static final List<Long> COMMITTED_AFTER = ImmutableList.of(13L, 23L, 33L);
     private static final List<Long> ABORTED_TS = ImmutableList.of(16L, 26L, 36L);
     private static final long SWEEP_TS = 50L;
     private static final long LAST_TS = SWEEP_TS - 5;
-    private static final Set<Boolean> BOOLEANS = ImmutableSet.of(true, false);
+
+    private final TransactionService mockTransactionService = mock(TransactionService.class);
+    private final CommitTsCache commitTsCache = CommitTsCache.create(mockTransactionService);
+    private List<CandidateCellForSweeping> candidate;
 
     @Parameterized.Parameter
     public boolean lastIsTombstone;
@@ -70,9 +73,26 @@ public class SweepableCellsParameterizedTest {
 
     @Parameterized.Parameters(name = "{0}, {1}, {2}")
     public static Collection<Object[]> parameters() {
-        return Sets.<Object>cartesianProduct(BOOLEANS, ImmutableSet.copyOf(Committed.values()), ImmutableSet.copyOf(Sweeper.values()))
-                .stream().map(List::toArray)
+        return Sets.<Object>cartesianProduct(BOOLEANS,
+                ImmutableSet.copyOf(Committed.values()),
+                ImmutableSet.copyOf(Sweeper.values())).stream()
+                .map(List::toArray)
                 .collect(Collectors.toList());
+    }
+
+    @Before
+    public void setup() {
+            Map<Long, Long> startTsToCommitTs = new HashMap<>();
+            COMMITTED_BEFORE.forEach(startTs -> startTsToCommitTs.put(startTs, startTs));
+            COMMITTED_AFTER.forEach(startTs -> startTsToCommitTs.put(startTs, startTs + SWEEP_TS));
+            ABORTED_TS.forEach(startTs -> startTsToCommitTs.put(startTs, TransactionConstants.FAILED_COMMIT_TS));
+            startTsToCommitTs.put(LAST_TS, status.commitTs);
+            when(mockTransactionService.get(anyCollection())).thenReturn(startTsToCommitTs);
+            candidate = ImmutableList.of(ImmutableCandidateCellForSweeping.builder()
+                    .cell(SINGLE_CELL)
+                    .sortedTimestamps(ImmutableList.sortedCopyOf(startTsToCommitTs.keySet()))
+                    .isLatestValueEmpty(lastIsTombstone)
+                    .build());
     }
 
     /**
@@ -80,18 +100,22 @@ public class SweepableCellsParameterizedTest {
      * timestamp was a tombstone; whether that last write was committed before, after sweep ts, or was aborted; and
      * sweep strategy.
      *
-     * Writes that were aborted should always appear, sorted, and as an implementation detail, at the end of the list.
+     * Writes that were aborted should always appear.
      * Writes that were committed after should never appear.
-     * Writes that were committed before should appear, sorted, and as an implementation detail at the beginning of the
-     * list; however, the greatest such write should appear if and only if it is greater than any aborted, it is a
-     * tombstone, and sweep is thorough.
+     * Writes that were committed before should appear, in sorted order. However, the greatest such write should appear
+     * (if and) only if it is a tombstone (we only have this information for the greatest overall write), and sweep is
+     * thorough.
      */
     @Test
-    public void proba() {
+    public void sweepableCellFilterTest() {
         List<Long> timestamps = getCellsToSweepFor().sortedTimestamps();
 
-        assertThat(timestamps).containsAll(ABORTED_TS);
         assertThat(timestamps).doesNotContainAnyElementsOf(COMMITTED_AFTER);
+
+        List<Long> expectedAll = new ArrayList<>(ABORTED_TS);
+        if (status == Committed.ABORTED) {
+            expectedAll.add(LAST_TS);
+        }
 
         List<Long> expectedCommitted;
         if (status == Committed.BEFORE) {
@@ -103,34 +127,18 @@ public class SweepableCellsParameterizedTest {
             expectedCommitted = new ArrayList<>(COMMITTED_BEFORE.subList(0, COMMITTED_BEFORE.size() - 1));
         }
 
-        assertThat(timestamps).containsAll(expectedCommitted);
-        assertThat(timestamps.stream().filter(expectedCommitted::contains)).isSorted();
+        expectedAll.addAll(expectedCommitted);
 
-        assertThat(timestamps.contains(LAST_TS)).isEqualTo(status == Committed.ABORTED
-                || (lastIsTombstone && status == Committed.BEFORE && sweeper == Sweeper.THOROUGH));
+        assertThat(timestamps).hasSameElementsAs(expectedAll);
+        assertThat(timestamps.stream().filter(expectedCommitted::contains)).isSorted();
+        System.out.println(timestamps);
     }
 
     private CellToSweep getCellsToSweepFor() {
-        List<CandidateCellForSweeping> candidate = setup();
         SweepableCellFilter filter = new SweepableCellFilter(commitTsCache, sweeper, SWEEP_TS);
         List<CellToSweep> cells = filter.getCellsToSweep(candidate).cells();
         assertThat(cells.size()).isEqualTo(1);
         return Iterables.getOnlyElement(cells);
-    }
-
-    private List<CandidateCellForSweeping> setup() {
-        Map<Long, Long> startTsToCommitTs = new HashMap<>();
-        COMMITTED_BEFORE.forEach(startTs -> startTsToCommitTs.put(startTs, startTs));
-        COMMITTED_AFTER.forEach(startTs -> startTsToCommitTs.put(startTs, startTs + SWEEP_TS));
-        ABORTED_TS.forEach(startTs -> startTsToCommitTs.put(startTs, TransactionConstants.FAILED_COMMIT_TS));
-        startTsToCommitTs.put(LAST_TS, status.commitTs);
-        when(mockTransactionService.get(anyCollection())).thenReturn(startTsToCommitTs);
-        return ImmutableList.of(
-                ImmutableCandidateCellForSweeping.builder()
-                        .cell(SINGLE_CELL)
-                        .sortedTimestamps(ImmutableList.sortedCopyOf(startTsToCommitTs.keySet()))
-                        .isLatestValueEmpty(lastIsTombstone)
-                        .build());
     }
 
     private enum Committed {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellsParameterizedTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellsParameterizedTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweeping;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+
+@RunWith(Parameterized.class)
+public class SweepableCellsParameterizedTest {
+    private static final Cell SINGLE_CELL = Cell.create(
+            "cellRow".getBytes(StandardCharsets.UTF_8),
+            "cellCol".getBytes(StandardCharsets.UTF_8));
+
+    private final TransactionService mockTransactionService = mock(TransactionService.class);
+    private final CommitTsCache commitTsCache = CommitTsCache.create(mockTransactionService);
+    private static final List<Long> COMMITTED_BEFORE = ImmutableList.of(10L, 20L, 30L);
+    private static final List<Long> COMMITTED_AFTER = ImmutableList.of(13L, 23L, 33L);
+    private static final List<Long> ABORTED_TS = ImmutableList.of(16L, 26L, 36L);
+    private static final long SWEEP_TS = 50L;
+    private static final long LAST_TS = SWEEP_TS - 5;
+    private static final Set<Boolean> BOOLEANS = ImmutableSet.of(true, false);
+
+    @Parameterized.Parameter
+    public boolean lastIsTombstone;
+
+    @Parameterized.Parameter(value = 1)
+    public Committed status;
+
+    @Parameterized.Parameter(value = 2)
+    public Sweeper sweeper;
+
+    @Parameterized.Parameters(name = "{0}, {1}, {2}")
+    public static Collection<Object[]> parameters() {
+        return Sets.<Object>cartesianProduct(BOOLEANS, ImmutableSet.copyOf(Committed.values()), ImmutableSet.copyOf(Sweeper.values()))
+                .stream().map(List::toArray)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * The following tests are testing all combinations of whether the last write with start timestamp before the sweep
+     * timestamp was a tombstone; whether that last write was committed before, after sweep ts, or was aborted; and
+     * sweep strategy.
+     *
+     * Writes that were aborted should always appear, sorted, and as an implementation detail, at the end of the list.
+     * Writes that were committed after should never appear.
+     * Writes that were committed before should appear, sorted, and as an implementation detail at the beginning of the
+     * list; however, the greatest such write should appear if and only if it is greater than any aborted, it is a
+     * tombstone, and sweep is thorough.
+     */
+    @Test
+    public void proba() {
+        List<Long> timestamps = getCellsToSweepFor().sortedTimestamps();
+
+        assertThat(timestamps).containsAll(ABORTED_TS);
+        assertThat(timestamps).doesNotContainAnyElementsOf(COMMITTED_AFTER);
+
+        List<Long> expectedCommitted;
+        if (status == Committed.BEFORE) {
+            expectedCommitted = new ArrayList<>(COMMITTED_BEFORE);
+            if (lastIsTombstone && sweeper == Sweeper.THOROUGH) {
+                expectedCommitted.add(LAST_TS);
+            }
+        } else {
+            expectedCommitted = new ArrayList<>(COMMITTED_BEFORE.subList(0, COMMITTED_BEFORE.size() - 1));
+        }
+
+        assertThat(timestamps).containsAll(expectedCommitted);
+        assertThat(timestamps.stream().filter(expectedCommitted::contains)).isSorted();
+
+        assertThat(timestamps.contains(LAST_TS)).isEqualTo(status == Committed.ABORTED
+                || (lastIsTombstone && status == Committed.BEFORE && sweeper == Sweeper.THOROUGH));
+    }
+
+    private CellToSweep getCellsToSweepFor() {
+        List<CandidateCellForSweeping> candidate = setup();
+        SweepableCellFilter filter = new SweepableCellFilter(commitTsCache, sweeper, SWEEP_TS);
+        List<CellToSweep> cells = filter.getCellsToSweep(candidate).cells();
+        assertThat(cells.size()).isEqualTo(1);
+        return Iterables.getOnlyElement(cells);
+    }
+
+    private List<CandidateCellForSweeping> setup() {
+        Map<Long, Long> startTsToCommitTs = new HashMap<>();
+        COMMITTED_BEFORE.forEach(startTs -> startTsToCommitTs.put(startTs, startTs));
+        COMMITTED_AFTER.forEach(startTs -> startTsToCommitTs.put(startTs, startTs + SWEEP_TS));
+        ABORTED_TS.forEach(startTs -> startTsToCommitTs.put(startTs, TransactionConstants.FAILED_COMMIT_TS));
+        startTsToCommitTs.put(LAST_TS, status.commitTs);
+        when(mockTransactionService.get(anyCollection())).thenReturn(startTsToCommitTs);
+        return ImmutableList.of(
+                ImmutableCandidateCellForSweeping.builder()
+                        .cell(SINGLE_CELL)
+                        .sortedTimestamps(ImmutableList.sortedCopyOf(startTsToCommitTs.keySet()))
+                        .isLatestValueEmpty(lastIsTombstone)
+                        .build());
+    }
+
+    private enum Committed {
+        BEFORE(SWEEP_TS - 1), AFTER(SWEEP_TS + 1), ABORTED(TransactionConstants.FAILED_COMMIT_TS);
+
+        private long commitTs;
+
+        Committed(long commitTs) {
+            this.commitTs = commitTs;
+        }
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
Refactored SweepableCellFilter which was really hard to parse. Wanted to make sure that nothing breaks, so added better tests, which caught a bug in the original implementation:
startTs 10 -> commitTs 20
startTs 30 -> commitTs 40 (tombstone)
thorough sweep, sweepTs 35 => should not sweep anything, but instead sweeps the first entry. (failing test case (true, AFTER, THOROUGH))

**Implementation Description (bullets)**:
The refactor is more or less trivial

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3259)
<!-- Reviewable:end -->
