### PR TITLE
C* Timestamps, Part 3: ETE Test

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -332,6 +332,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             CassandraMutationTimestampProvider mutationTimestampProvider) {
         super(AbstractKeyValueService.createFixedThreadPool("Atlas Cassandra KVS",
                 config.poolSize() * config.servers().size()));
+//        mutationTimestampProvider = CassandraMutationTimestampProviders.legacyModeForTestsOnly();
         this.log = log;
         this.config = config;
         this.clientPool = clientPool;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -332,7 +332,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             CassandraMutationTimestampProvider mutationTimestampProvider) {
         super(AbstractKeyValueService.createFixedThreadPool("Atlas Cassandra KVS",
                 config.poolSize() * config.servers().size()));
-//        mutationTimestampProvider = CassandraMutationTimestampProviders.legacyModeForTestsOnly();
         this.log = log;
         this.config = config;
         this.clientPool = clientPool;

--- a/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.yml
+++ b/atlasdb-ete-tests/docker/conf/atlasdb-ete.no-leader.cassandra.yml
@@ -27,3 +27,9 @@ atlasdb:
     autoRefreshNodes: false
   targetedSweep:
     enableSweepQueueWrites: true
+
+atlasDbRuntime:
+  sweep:
+    enabled: false
+  targetedSweep:
+    enabled: true

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraNoLeaderTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraNoLeaderTestSuite.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.containers.CassandraEnvironment;
 @Suite.SuiteClasses({
         TodoEteTest.class,
         ServiceExposureEteTest.class,
+        CassandraTimestampsEteTest.class,
         })
 public class CassandraNoLeaderTestSuite extends EteSetup {
     private static final List<String> CLIENTS = ImmutableList.of("ete1");

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimeLockTestSuite.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimeLockTestSuite.java
@@ -28,7 +28,8 @@ import com.palantir.atlasdb.containers.CassandraEnvironment;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         TodoEteTest.class,
-        TargetedSweepEteTest.class
+        TargetedSweepEteTest.class,
+        CassandraTimestampsEteTest.class
         })
 public class CassandraTimeLockTestSuite extends EteSetup {
     private static final List<String> CLIENTS = ImmutableList.of("ete1");

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimestampsEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/CassandraTimestampsEteTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.ete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.ete.cassandra.util.CassandraCommands;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.todo.ImmutableTodo;
+import com.palantir.atlasdb.todo.Todo;
+import com.palantir.atlasdb.todo.TodoResource;
+import com.palantir.atlasdb.todo.generated.TodoTable;
+
+public class CassandraTimestampsEteTest {
+    private static final Todo TODO = ImmutableTodo.of("todo");
+    private static final Todo TODO_2 = ImmutableTodo.of("todo_two");
+    public static final String CASSANDRA_CONTAINER_NAME = "cassandra";
+    public static final long ID = 1L;
+
+    private TodoResource todoClient = EteSetup.createClientToSingleNode(TodoResource.class);
+
+    @Before
+    public void setup() {
+        todoClient.truncate();
+    }
+
+    @After
+    public void cleanup() {
+        todoClient.truncate();
+    }
+
+    @Test
+    public void tombstonesInOneSSTableAreCurrent() throws IOException, InterruptedException {
+        long firstWriteTimestamp = todoClient.addTodoWithIdAndReturnTimestamp(ID, TODO);
+        todoClient.addTodoWithIdAndReturnTimestamp(ID, TODO_2);
+
+        // Wait for targeted sweep to sweep the old value
+        Awaitility.waitAtMost(30, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+                .until(() -> todoClient.doesNotExistBeforeTimestamp(ID, firstWriteTimestamp));
+
+        CassandraCommands.nodetoolFlush(CASSANDRA_CONTAINER_NAME);
+
+        List<String> ssTables = CassandraCommands.nodetoolGetSSTables(
+                CASSANDRA_CONTAINER_NAME,
+                "atlasete",
+                TableReference.create(Namespace.DEFAULT_NAMESPACE, TodoTable.getRawTableName()),
+                ValueType.FIXED_LONG.convertFromJava(ID));
+        String sstableMetadata = CassandraCommands.ssTableMetadata(
+                CASSANDRA_CONTAINER_NAME, Iterables.getOnlyElement(ssTables));
+
+        assertMinimumTimestampIsAtLeast(sstableMetadata, firstWriteTimestamp);
+        assertDroppableTombstoneRatioPositive(sstableMetadata);
+    }
+
+    private void assertMinimumTimestampIsAtLeast(String sstableMetadata, long expectedMinimum) {
+        Pattern pattern = Pattern.compile("Minimum timestamp: ([0-9]*)");
+        Matcher timestampMatcher = pattern.matcher(sstableMetadata);
+        assertThat(timestampMatcher.find()).isTrue();
+        assertThat(Long.parseLong(timestampMatcher.group(1))).isGreaterThanOrEqualTo(expectedMinimum);
+    }
+
+    private void assertDroppableTombstoneRatioPositive(String sstableMetadata) {
+        Pattern pattern = Pattern.compile("Estimated droppable tombstones: ([0-9]*\\.[0-9]*)");
+        Matcher droppableTombstoneRatioMatcher = pattern.matcher(sstableMetadata);
+        assertThat(droppableTombstoneRatioMatcher.find()).isTrue();
+        assertThat(Double.parseDouble(droppableTombstoneRatioMatcher.group(1))).isGreaterThan(0);
+    }
+}

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -141,11 +141,14 @@ public abstract class EteSetup {
 
     static void execCliCommand(String command) throws IOException, InterruptedException {
         for (String client : availableClients) {
-            docker.exec(
-                    DockerComposeExecOption.options("-T"),
-                    client,
-                    DockerComposeExecArgument.arguments("bash", "-c", command));
+            execCliCommand(client, command);
         }
+    }
+
+    public static String execCliCommand(String client, String command) throws IOException, InterruptedException {
+        return docker.exec(DockerComposeExecOption.noOptions(),
+                client,
+                DockerComposeExecArgument.arguments("bash", "-c", command));
     }
 
     static <T> T createClientToSingleNode(Class<T> clazz) {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/EteSetup.java
@@ -139,16 +139,19 @@ public abstract class EteSetup {
                 DockerComposeRunArgument.arguments("bash", "-c", command));
     }
 
-    static void execCliCommand(String command) throws IOException, InterruptedException {
+    static void execCliCommandNoTty(String command) throws IOException, InterruptedException {
         for (String client : availableClients) {
-            execCliCommand(client, command);
+            execCliCommand(DockerComposeExecOption.options("-T"), client, command);
         }
     }
 
     public static String execCliCommand(String client, String command) throws IOException, InterruptedException {
-        return docker.exec(DockerComposeExecOption.noOptions(),
-                client,
-                DockerComposeExecArgument.arguments("bash", "-c", command));
+        return execCliCommand(DockerComposeExecOption.noOptions(), client, command);
+    }
+
+    private static String execCliCommand(DockerComposeExecOption execOption, String client, String command)
+            throws IOException, InterruptedException {
+        return docker.exec(execOption, client, DockerComposeExecArgument.arguments("bash", "-c", command));
     }
 
     static <T> T createClientToSingleNode(Class<T> clazz) {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceUtils.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/StartupIndependenceUtils.java
@@ -43,7 +43,7 @@ public final class StartupIndependenceUtils {
     }
 
     public static void randomizeNamespace() throws IOException, InterruptedException {
-        EteSetup.execCliCommand("sed -i 's/namespace: .*/namespace: " + UUID.randomUUID().toString().replace("-", "_")
+        EteSetup.execCliCommandNoTty("sed -i 's/namespace: .*/namespace: " + UUID.randomUUID().toString().replace("-", "_")
                 + "/' var/conf/atlasdb-ete.yml");
     }
 
@@ -98,12 +98,12 @@ public final class StartupIndependenceUtils {
     }
 
     private static void stopAtlasServerAndAssertSuccess() throws IOException, InterruptedException {
-        EteSetup.execCliCommand("service/bin/init.sh stop");
+        EteSetup.execCliCommandNoTty("service/bin/init.sh stop");
         assertSatisfiedWithin(120, () -> !serverRunning());
     }
 
     private static void startAtlasServerAndAssertSuccess() throws IOException, InterruptedException {
-        EteSetup.execCliCommand("service/bin/init.sh start");
+        EteSetup.execCliCommandNoTty("service/bin/init.sh start");
         assertSatisfiedWithin(240, StartupIndependenceUtils::serverRunning);
     }
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/cassandra/util/CassandraCommands.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/cassandra/util/CassandraCommands.java
@@ -24,20 +24,24 @@ import java.util.stream.Collectors;
 import com.google.common.io.BaseEncoding;
 import com.palantir.atlasdb.ete.EteSetup;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 
 public class CassandraCommands {
     public static void nodetoolFlush(String containerName) throws IOException, InterruptedException {
         EteSetup.execCliCommand(containerName, "nodetool flush");
     }
 
+    public static void nodetoolCompact(String containerName) throws IOException, InterruptedException {
+        EteSetup.execCliCommand(containerName, "nodetool compact");
+    }
+
     public static List<String> nodetoolGetSSTables(String containerName,
             String keyspace,
             TableReference tableRef,
             byte[] rowKey) throws IOException, InterruptedException {
-        String query = String.format("nodetool getsstables %s %s__%s %s",
+        String query = String.format("nodetool getsstables %s %s %s",
                 keyspace,
-                tableRef.getNamespace().getName(),
-                tableRef.getTablename(),
+                CassandraKeyValueServiceImpl.internalTableName(tableRef),
                 BaseEncoding.base16().lowerCase().encode(rowKey));
         String output = EteSetup.execCliCommand(containerName, query);
 

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/cassandra/util/CassandraCommands.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/cassandra/util/CassandraCommands.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.ete.cassandra.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.io.BaseEncoding;
+import com.palantir.atlasdb.ete.EteSetup;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+public class CassandraCommands {
+    public static void nodetoolFlush(String containerName) throws IOException, InterruptedException {
+        EteSetup.execCliCommand(containerName, "nodetool flush");
+    }
+
+    public static List<String> nodetoolGetSSTables(String containerName,
+            String keyspace,
+            TableReference tableRef,
+            byte[] rowKey) throws IOException, InterruptedException {
+        String query = String.format("nodetool getsstables %s %s__%s %s",
+                keyspace,
+                tableRef.getNamespace().getName(),
+                tableRef.getTablename(),
+                BaseEncoding.base16().lowerCase().encode(rowKey));
+        String output = EteSetup.execCliCommand(containerName, query);
+
+        String[] outputSplitIntoLines = output.split("\n");
+        return Arrays.stream(outputSplitIntoLines)
+                .skip(1) // first line is Picked up _JAVA_OPTIONS...
+                .collect(Collectors.toList());
+    }
+
+    public static String ssTableMetadata(String containerName, String path) throws IOException, InterruptedException {
+        return EteSetup.execCliCommand(containerName, "sstablemetadata " + path);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Have an ete test that checks that SSTables are written in a sane way

**Implementation Description (bullets)**:
- The test writes a value, overwrites it, and then forces the old version of the value to be swept.
It then checks the relevant SSTable, ensuring that it has a minimum timestamp that is recent (greater than the write timestamp of the first value) and that it has droppable tombstones.
- The test is run as part of a Cassandra+TimeLock test, and also on Cassandra+Embedded.

**Concerns (what feedback would you like?)**:
- Are the expectations of this test too strong?
- Tests that Atlas starts properly and behaves in a sane way already happen on the other paths, so it should be fine to just test the two paths I did.
- I kind of abused awaitility - is this _too_ gross?

**Where should we start reviewing?**: CassandraTimestampsEteTest

**Priority (whenever / two weeks / yesterday)**: this week or so

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3266)
<!-- Reviewable:end -->
