### PR TITLE
Recover from race on Oracle startup

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleErrorConstants.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleErrorConstants.java
@@ -20,6 +20,7 @@ public final class OracleErrorConstants {
         //utility class
     }
 
+    public static final String ORACLE_CONSTRAINT_VIOLATION_ERROR = "ORA-00001";
     public static final String ORACLE_ALREADY_EXISTS_ERROR = "ORA-00955";
     public static final String ORACLE_NOT_EXISTS_ERROR = "ORA-00942";
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java
@@ -57,7 +57,7 @@ public class InDbTimestampBoundStore implements TimestampBoundStore {
     private Long currentLimit = null;
 
     /**
-     * Use only if you have already initialized the timestamo table. This exists for legacy support.
+     * Use only if you have already initialized the timestamp table. This exists for legacy support.
      */
     public InDbTimestampBoundStore(ConnectionManager connManager, TableReference timestampTable) {
         this(connManager, timestampTable, EMPTY_TABLE_PREFIX);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -61,7 +61,7 @@ develop
 
            Note that targeted sweep is considered a beta feature as it is not fully functional yet.
            Consult with the AtlasDB team if you wish to use targeted sweep in addition to, or instead of, standard sweep.
-                      
+
     *    - |improved|
          - When writing to Cassandra, the internal write timestamp for writes of sweep sentinels, range tombstones and deletes to regular tables are now approximately fresh timestamps from the timestamp service, as opposed to being an arbitrary hardcoded value or related to the transaction's start timestamp.
            This should improve Cassandra's ability to purge droppable tombstones at compaction time, particularly in tables that see heavy volumes of overwrites and sweeping.
@@ -93,6 +93,11 @@ develop
          - Some users of AtlasDB rely on being able to abort transactions which are in progress. Until the last release of AtlasDB, this worked successfully, however this was only the case because before
            an assert could throw an AssertionError, an NPE was thrown by different code. Now, the assertion error is not thrown.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3254>`__)
+
+    *    - |fixed|
+         - Fixed an issue where starting an HA Oracle-backed client may fail due to constraint violation.
+           The issue occurred when multiple nodes attempted to insert the same metadata.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3269>`__)
 
     *    - |changed| |metrics|
          - Sweep metrics have been reworked based on their observed usefulness in the field.


### PR DESCRIPTION
**Goals (and why)**: Fix an issue that was causing Oracle tests to time out, so that we can reliably catch future Oracle-flavoured DbKvs issues.

When starting up a new multi-node Oracle cluster, the nodes race to create tables and insert metadata. Most of the DB calls are wrapped with catch blocks to ignore the specific errors, but the metadata insert was failing with "constraint violation" if another thread manages to insert metadata ahead of us.

The closeables logic in #2964 was causing the connection pool to be closed, but the `ConnectionManagerAwareDbKvs` object was apparently reused without attempting to reset the connection pool, causing startup to once again fail.

I fixed the error that was causing the connection pool to be closed in the first place, but we'll still try to reuse the connection pool if other errors get thrown. I think it would be high lift to fix this properly (easier hacks are possible but may lead to other issues), and if this unflakes the tests, then there are surely higher priority things to work on.

**Implementation Description (bullets)**:
- Ignore constraint violation on metadata inserter

**Concerns (what feedback would you like?)**: Is it reasonable to punt fixing the "reuse closed pool" issue? 

**Where should we start reviewing?**: OracleDdlTable

**Priority (whenever / two weeks / yesterday)**: today, to verify that this unflakes DbKvs Oracle tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3269)
<!-- Reviewable:end -->
