### PR TITLE
The static cached executors in BasicSQL are configurable

### DIFF
--- a/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
+++ b/commons-db/src/main/java/com/palantir/nexus/db/sql/BasicSQL.java
@@ -54,8 +54,7 @@ import org.joda.time.format.DateTimeFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.palantir.common.base.Throwables;
-import com.palantir.common.concurrent.NamedThreadFactory;
-import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.common.concurrent.CachedExecutors;
 import com.palantir.common.concurrent.ThreadNamingCallable;
 import com.palantir.db.oracle.JdbcHandler;
 import com.palantir.db.oracle.JdbcHandler.BlobHandler;
@@ -359,10 +358,10 @@ public abstract class BasicSQL {
     private static final String selectThreadName = "SQL select statement"; //$NON-NLS-1$
     private static final String executeThreadName = "SQL execute statement"; //$NON-NLS-1$
     private static final int KEEP_SQL_THREAD_ALIVE_TIMEOUT = 3000; //3 seconds
-    private static ExecutorService service = PTExecutors.newCachedThreadPool(
-            new NamedThreadFactory(selectThreadName, true), KEEP_SQL_THREAD_ALIVE_TIMEOUT);
-    static ExecutorService executeService = PTExecutors.newCachedThreadPool(
-            new NamedThreadFactory(executeThreadName, true), KEEP_SQL_THREAD_ALIVE_TIMEOUT);
+    private static ExecutorService service = CachedExecutors.getCachedExecutorService(
+            selectThreadName, KEEP_SQL_THREAD_ALIVE_TIMEOUT);
+    static ExecutorService executeService = CachedExecutors.getCachedExecutorService(
+            executeThreadName, KEEP_SQL_THREAD_ALIVE_TIMEOUT);
 
     protected static enum AutoClose {
         TRUE, FALSE;

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/CachedExecutorServiceFactory.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/CachedExecutorServiceFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.concurrent;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Configurable factory for cached executor instances.
+ * Consumers of this library may wish to provide additional configuration
+ * around default executor instances.
+ */
+public interface CachedExecutorServiceFactory {
+
+    /**
+     * Gets an unbounded {@link ExecutorService} with daemon threads using the provided thread name prefix and timeout.
+     */
+    ExecutorService getCachedExecutorService(String threadNamePrefix, int threadIdleTimeoutMillis);
+
+    /**
+     * Gets an unbounded {@link ExecutorService} with daemon threads using the provided thread name prefix.
+     * Creates an executor using the default idle timeout.
+     */
+    ExecutorService getCachedExecutorService(String threadNamePrefix);
+
+    /**
+     * Get the priority of this factory. The factory service with the highest priority will be used.
+     *
+     * @return Priority of this factory
+     */
+    int getPriority();
+}

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/CachedExecutors.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/CachedExecutors.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.concurrent;
+
+import java.util.ServiceLoader;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Suppliers;
+
+public final class CachedExecutors {
+    private static final Logger log = LoggerFactory.getLogger(CachedExecutors.class);
+
+    private static final Supplier<CachedExecutorServiceFactory> executorFactory = Suppliers.memoize(() -> {
+        int maxPriority = Integer.MIN_VALUE;
+        CachedExecutorServiceFactory highestPriority = null;
+
+        try {
+            for (CachedExecutorServiceFactory factory : ServiceLoader.load(CachedExecutorServiceFactory.class)) {
+                int priority = factory.getPriority();
+                if (priority > maxPriority) {
+                    maxPriority = priority;
+                    highestPriority = factory;
+                }
+            }
+        } catch (Throwable t) {
+            log.error("Failed to search for CachedExecutorServiceFactory instances", t);
+        }
+        if (highestPriority == null) {
+            highestPriority = new PTExecutorsCachedExecutorServiceFactory();
+        }
+        log.debug("Using CachedExecutorServiceFactory implementation {} with priority {}",
+                highestPriority, maxPriority);
+        return highestPriority;
+    });
+
+    public static ExecutorService getCachedExecutorService(String threadNamePrefix, int threadIdleTimeoutMillis) {
+        return executorFactory.get().getCachedExecutorService(threadNamePrefix, threadIdleTimeoutMillis);
+    }
+
+    public static ExecutorService getCachedExecutorService(String threadNamePrefix) {
+        return executorFactory.get().getCachedExecutorService(threadNamePrefix);
+    }
+
+    private CachedExecutors() {
+        // Utility
+    }
+
+}

--- a/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutorsCachedExecutorServiceFactory.java
+++ b/commons-executors/src/main/java/com/palantir/common/concurrent/PTExecutorsCachedExecutorServiceFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.concurrent;
+
+import java.util.concurrent.ExecutorService;
+
+public class PTExecutorsCachedExecutorServiceFactory implements CachedExecutorServiceFactory {
+
+    @Override
+    public ExecutorService getCachedExecutorService(String threadNamePrefix, int threadIdleTimeoutMillis) {
+        return PTExecutors.newCachedThreadPool(
+                new NamedThreadFactory(threadNamePrefix, true),
+                threadIdleTimeoutMillis);
+    }
+
+    @Override
+    public ExecutorService getCachedExecutorService(String threadNamePrefix) {
+        return PTExecutors.newCachedThreadPool(new NamedThreadFactory(threadNamePrefix, true));
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+}

--- a/commons-executors/src/main/resources/META-INF/services/com.palantir.common.concurrent.CachedExecutorServiceFactory
+++ b/commons-executors/src/main/resources/META-INF/services/com.palantir.common.concurrent.CachedExecutorServiceFactory
@@ -1,0 +1,16 @@
+##
+# Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+#
+# Licensed under the BSD-3 License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.palantir.common.concurrent.PTExecutorsCachedExecutorServiceFactory

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -131,6 +131,11 @@ develop
 
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3244>`__)
 
+    *    - |improved|
+         - Added ``CachedExecutorServiceFactory``, the default implementation of which may be overridden in order
+           to configure thread pooling more reasonably for downstream applications.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3272>`__)
+
 =======
 v0.89.0
 =======


### PR DESCRIPTION
A configured executor may be supplied rater than the default
implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3272)
<!-- Reviewable:end -->
