### PR TITLE
less tablescans for grabbing CKVS tablemetadata

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -315,12 +315,19 @@ public final class CassandraKeyValueServices {
 
     static Cell getMetadataCell(TableReference tableRef) {
         // would have preferred an explicit charset, but thrift uses default internally
-        return Cell.create(tableReferenceToBytes(tableRef), "m".getBytes(StandardCharsets.UTF_8));
+        return Cell.create(lowerCaseTableReferenceToBytes(tableRef), "m".getBytes(StandardCharsets.UTF_8));
     }
 
     @SuppressWarnings("checkstyle:RegexpSinglelineJava")
-    private static byte[] tableReferenceToBytes(TableReference tableRef) {
-        return tableRef.getQualifiedName().getBytes(Charset.defaultCharset());
+    static Cell getOldMetadataCell(TableReference tableRef) {
+        return Cell.create(
+                tableRef.getQualifiedName().getBytes(Charset.defaultCharset()),
+                "m".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @SuppressWarnings("checkstyle:RegexpSinglelineJava")
+    private static byte[] lowerCaseTableReferenceToBytes(TableReference tableRef) {
+        return tableRef.getQualifiedName().toLowerCase().getBytes(Charset.defaultCharset());
     }
 
     @SuppressWarnings("checkstyle:RegexpSinglelineJava")

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |improved|
+         - Startup and schema change performance improved for Cassandra users with large numbers of tables.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3278>`__)
+
     *    -
          -
 


### PR DESCRIPTION
the diff view for internalPutMetadataForTables() sucks since its mostly a rewrite, you might want to look at the versions separately.

The drop table metadata cleanup case is also addressed by the new putMetadataForTables change, because a 'delete' of the table metadata is currently accomplished via  putMetadata(myTable, byte[0])

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3278)
<!-- Reviewable:end -->
