### PR TITLE
[TimeLock] Fix Jepsen runtime error

### DIFF
--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -1,5 +1,5 @@
 (ns jepsen.atlasdb.lock
-  (:require [jepsen.atlasdb.timelock :as timelock]
+    (:require [jepsen.atlasdb.timelock :as timelock]
             [jepsen.checker :as checker]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
@@ -8,10 +8,11 @@
             [jepsen.os.debian :as debian]
             [jepsen.util :refer [timeout]]
             [knossos.history :as history])
-  (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
-  (:import com.palantir.atlasdb.http.JepsenLockClient)
-  (:import com.palantir.atlasdb.http.SynchronousLockClient)
-  (:import com.palantir.atlasdb.http.AsyncLockClient))
+    (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
+    (:import com.palantir.atlasdb.http.JepsenLockClient)
+    (:import com.palantir.atlasdb.http.SynchronousLockClient)
+    (:import com.palantir.atlasdb.http.AsyncLockClient)
+    (:import com.codahale.metrics.MetricRegistry))
 
 (def lock-names ["alpha" "bravo" "charlie" "delta"])
 
@@ -140,9 +141,9 @@
     :checker checker))
 
 (defn sync-lock-test
-  [nem]
-    (lock-test nem (fn [] (SynchronousLockClient/create '("n1" "n2" "n3" "n4" "n5")))))
+      [nem]
+      (lock-test nem (fn [] (SynchronousLockClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5")))))
 
 (defn async-lock-test
-  [nem]
-    (lock-test nem (fn [] (AsyncLockClient/create '("n1" "n2" "n3" "n4" "n5")))))
+      [nem]
+      (lock-test nem (fn [] (AsyncLockClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5")))))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -8,11 +8,11 @@
             [jepsen.os.debian :as debian]
             [jepsen.util :refer [timeout]]
             [knossos.history :as history])
+    (:import com.codahale.metrics.MetricRegistry)
     (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
     (:import com.palantir.atlasdb.http.JepsenLockClient)
     (:import com.palantir.atlasdb.http.SynchronousLockClient)
-    (:import com.palantir.atlasdb.http.AsyncLockClient)
-    (:import com.codahale.metrics.MetricRegistry))
+    (:import com.palantir.atlasdb.http.AsyncLockClient))
 
 (def lock-names ["alpha" "bravo" "charlie" "delta"])
 

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/lock.clj
@@ -1,5 +1,5 @@
 (ns jepsen.atlasdb.lock
-    (:require [jepsen.atlasdb.timelock :as timelock]
+  (:require [jepsen.atlasdb.timelock :as timelock]
             [jepsen.checker :as checker]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
@@ -8,11 +8,11 @@
             [jepsen.os.debian :as debian]
             [jepsen.util :refer [timeout]]
             [knossos.history :as history])
-    (:import com.codahale.metrics.MetricRegistry)
-    (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
-    (:import com.palantir.atlasdb.http.JepsenLockClient)
-    (:import com.palantir.atlasdb.http.SynchronousLockClient)
-    (:import com.palantir.atlasdb.http.AsyncLockClient))
+  (:import com.codahale.metrics.MetricRegistry)
+  (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
+  (:import com.palantir.atlasdb.http.JepsenLockClient)
+  (:import com.palantir.atlasdb.http.SynchronousLockClient)
+  (:import com.palantir.atlasdb.http.AsyncLockClient))
 
 (def lock-names ["alpha" "bravo" "charlie" "delta"])
 
@@ -141,9 +141,9 @@
     :checker checker))
 
 (defn sync-lock-test
-      [nem]
-      (lock-test nem (fn [] (SynchronousLockClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5")))))
+  [nem]
+    (lock-test nem (fn [] (SynchronousLockClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5")))))
 
 (defn async-lock-test
-      [nem]
-      (lock-test nem (fn [] (AsyncLockClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5")))))
+  [nem]
+    (lock-test nem (fn [] (AsyncLockClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5")))))

--- a/atlasdb-jepsen-tests/src/jepsen/atlasdb/timestamp.clj
+++ b/atlasdb-jepsen-tests/src/jepsen/atlasdb/timestamp.clj
@@ -9,8 +9,9 @@
             [jepsen.util :refer [timeout]]
             [knossos.history :as history])
   ;; We can import any Java objects, since Clojure runs on the JVM
-  (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers)
-  (:import com.palantir.atlasdb.http.TimestampClient))
+  (:import com.codahale.metrics.MetricRegistry)
+  (:import com.palantir.atlasdb.http.TimestampClient)
+  (:import com.palantir.atlasdb.jepsen.JepsenHistoryCheckers))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Defining the set of of operations that you can do with a client
@@ -30,7 +31,7 @@
     (setup!
       [this test node]
       "Factory that returns an object implementing client/Client"
-      (create-client (TimestampClient/create '("n1" "n2" "n3" "n4" "n5"))))
+      (create-client (TimestampClient/create (MetricRegistry.) '("n1" "n2" "n3" "n4" "n5"))))
 
     (invoke!
       [this test op]


### PR DESCRIPTION
**Goals (and why)**: Fix Jepsen runtime error that is making all tests fail

**Implementation Description (bullets)**:
- Pass the metric registry in to the timestamp/lock clients Jepsen uses

**Concerns (what feedback would you like?)**: nothing major

**Where should we start reviewing?**: timestamp.clj

**Priority (whenever / two weeks / yesterday)**: yesterday (should have been part of static metric registry PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3285)
<!-- Reviewable:end -->
