### PR TITLE
log before removing from blacklist

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -392,6 +392,8 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
 
             try {
                 V response = runWithPooledResourceRecordingMetrics(hostPool, req.getFunction());
+                log.info("Added host {} back into the pool after receiving a successful response",
+                        SafeArg.of("host", CassandraLogHelper.host(hostPool.getHost())));
                 blacklist.remove(hostPool.getHost()); // successful request -> can un-blacklist
                 return response;
             } catch (Exception ex) {
@@ -426,6 +428,8 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
             FunctionCheckedException<CassandraClient, V, K> fn) throws K {
         CassandraClientPoolingContainer hostPool = cassandra.getPools().get(specifiedHost);
         V response = runWithPooledResourceRecordingMetrics(hostPool, fn);
+        log.info("Added host {} back into the pool after receiving a successful response",
+                SafeArg.of("host", CassandraLogHelper.host(specifiedHost)));
         blacklist.remove(specifiedHost);
         return response;
     }


### PR DESCRIPTION
**Goals (and why)**:
Currently we have two ways of un-blacklisting a host. One of them is running a background thread that healthcheck blacklisted hosts periodically and adds them back into pool if healthy (we are logging messages for this one). 
Second one is adding the host back into pool if we receive a successful response. It would be easier to debug some issues if we had logging for this one also.

**Priority (whenever / two weeks / yesterday)**:
This week
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3286)
<!-- Reviewable:end -->
