### PR TITLE
retry on different host if cassandra load is high in default strategy

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -254,8 +254,15 @@ class CassandraRequestExceptionHandler {
 
         @Override
         public boolean shouldRetryOnDifferentHost(Exception ex, int maxTriesSameHost, int numberOfAttempts) {
-            return isFastFailoverException(ex) || isIndicativeOfCassandraLoad(ex)
-                    || numberOfAttempts >= maxTriesSameHost;
+            if (isFastFailoverException(ex) || isIndicativeOfCassandraLoad(ex)) {
+                log.info(EXCEPTION_CAUSED_RETRY_ON_DIFFERENT_HOST_MSG,
+                        SafeArg.of("exceptionClass", ex.getClass().getTypeName()));
+                return true;
+            } else if (numberOfAttempts >= maxTriesSameHost) {
+                log.info(MAX_RETRY_EXCEEDED_RETRY_ON_DIFFERENT_HOST_MSG);
+                return true;
+            }
+            return false;
         }
     }
 
@@ -275,8 +282,20 @@ class CassandraRequestExceptionHandler {
 
         @Override
         public boolean shouldRetryOnDifferentHost(Exception ex, int maxTriesSameHost, int numberOfAttempts) {
-            return isFastFailoverException(ex) || isIndicativeOfCassandraLoad(ex)
-                    || numberOfAttempts >= maxTriesSameHost;
+            if (isFastFailoverException(ex) || isIndicativeOfCassandraLoad(ex)) {
+                log.info(EXCEPTION_CAUSED_RETRY_ON_DIFFERENT_HOST_MSG,
+                        SafeArg.of("exceptionClass", ex.getClass().getTypeName()));
+                return true;
+            } else if (numberOfAttempts >= maxTriesSameHost) {
+                log.info(MAX_RETRY_EXCEEDED_RETRY_ON_DIFFERENT_HOST_MSG);
+                return true;
+            }
+            return false;
         }
     }
+
+    private static final String EXCEPTION_CAUSED_RETRY_ON_DIFFERENT_HOST_MSG =
+            "Request will be retried on a different host because current host has thrown the exception: {}";
+    private static final String MAX_RETRY_EXCEEDED_RETRY_ON_DIFFERENT_HOST_MSG =
+            "Request will be retried on a different host as maximum retries on same host is exceeded.";
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -254,7 +254,8 @@ class CassandraRequestExceptionHandler {
 
         @Override
         public boolean shouldRetryOnDifferentHost(Exception ex, int maxTriesSameHost, int numberOfAttempts) {
-            return isFastFailoverException(ex) || numberOfAttempts >= maxTriesSameHost;
+            return isFastFailoverException(ex) || isIndicativeOfCassandraLoad(ex)
+                    || numberOfAttempts >= maxTriesSameHost;
         }
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
@@ -154,9 +154,9 @@ public class CassandraRequestExceptionHandlerTest {
     }
 
     @Test
-    public void cassandraLoadExceptionRetriesOnSameHostDefault() {
+    public void cassandraLoadExceptionRetriesOnDifferentHostWithoutRetryingDefault() {
         for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
-            assertFalse(handlerDefault.shouldRetryOnDifferentHost(ex, 0, handlerDefault.getStrategy()));
+            assertTrue(handlerDefault.shouldRetryOnDifferentHost(ex, 0, handlerDefault.getStrategy()));
         }
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -88,6 +88,9 @@ develop
            Previously, they would log the supplier of these bounds (instead of the actual bounds, which users are more likely to be interested in).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3291>`__)
 
+    *    - |changed|
+         - Default Cassandra exception handler logic is changed. Previously, requests were retried on the same host if failed with an exception indicating Cassandra load; now those will be retried on a random different host.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3288>`__)
 
 =======
 v0.91.0


### PR DESCRIPTION
**Goals (and why)**:
Internal ticket pds-69886 indicates that default retry strategy gets stuck in retrying on the same node while that C* node is coming back to life. I don't see a reason not to try on a different host if we have high load (either on cassandra cluster as a whole or on a single node).

**Concerns (what feedback would you like?)**:
Conservative strategy retries on a different host if exception is indicative of C* load already. Is there a reason why we used a different logic for default strategy?

**Priority (whenever / two weeks / yesterday)**:
This week
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3288)
<!-- Reviewable:end -->
