### PR TITLE
People should use TimeLock, not reverse migrate

### DIFF
--- a/docs/source/services/timelock_service/reverse-migration.rst
+++ b/docs/source/services/timelock_service/reverse-migration.rst
@@ -3,10 +3,10 @@
 Reverse Migration
 =================
 
-.. warn::
+.. warning::
 
    Many Atlas clients switched to using TimeLock by default many versions after it was reasonable to use Atlas with TimeLock.
-   If you are on this page because you were directed to it by an error stating "This can happen if you attempt to run AtlasDB without a timelock block after having previously migrated to the TimeLock server", then please add :ref:`configure your service<timelock-client-configuration>` to use TimeLock rather than attempting a reverse migration.
+   If you are on this page because you were directed to it by an error stating "This can happen if you attempt to run AtlasDB without a timelock block after having previously migrated to the TimeLock server", then please :ref:`configure your service<timelock-client-configuration>` to use TimeLock rather than attempting a reverse migration.
 
 .. danger::
 

--- a/docs/source/services/timelock_service/reverse-migration.rst
+++ b/docs/source/services/timelock_service/reverse-migration.rst
@@ -3,6 +3,11 @@
 Reverse Migration
 =================
 
+.. warn::
+
+   Many Atlas clients switched to using TimeLock by default many versions after it was reasonable to use Atlas with TimeLock.
+   If you are on this page because you were directed to it by an error stating "This can happen if you attempt to run AtlasDB without a timelock block after having previously migrated to the TimeLock server", then please add :ref:`configure your service<timelock-client-configuration>` to use TimeLock rather than attempting a reverse migration.
+
 .. danger::
 
    Improperly executing reverse migration from external timestamp and lock services can result in


### PR DESCRIPTION
**Goals (and why)**: Prevent unnecessary support issues, and give people the correct advice. People hitting the "IllegalArgumentException trying to convert the stored value to a long" issue are directed to the reverse migration docs page, when they should be told to add TimeLock to their configuration. We can't change the error message, but we can catch people when they get to this page.

**Implementation Description (bullets)**: Added a warn block to this docs page

**Concerns (what feedback would you like?)**: Is the wording OK here? Note that if they saw this error, then they must be on a recent enough version of TimeLock that we were fairly comfortable with people using it.

**Where should we start reviewing?**: One docs file

**Priority (whenever / two weeks / yesterday)**: this week, so I don't get paged next week :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3290)
<!-- Reviewable:end -->
