### PR TITLE
C* Request Exception Handler: Log number of tries, not the Supplier

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -119,13 +119,13 @@ class CassandraRequestExceptionHandler {
         if (numberOfAttempts > 1) {
             log.info("Error occurred talking to cassandra. Attempt {} of {}. Exception message was: {} : {}",
                     SafeArg.of("numTries", numberOfAttempts),
-                    SafeArg.of("maxTotalTries", maxTriesTotal),
+                    SafeArg.of("maxTotalTries", maxTriesTotal.get()),
                     SafeArg.of("exceptionClass", ex.getClass().getTypeName()),
                     UnsafeArg.of("exceptionMessage", ex.getMessage()));
         } else {
             log.info("Error occurred talking to cassandra. Attempt {} of {}.",
                     SafeArg.of("numTries", numberOfAttempts),
-                    SafeArg.of("maxTotalTries", maxTriesTotal),
+                    SafeArg.of("maxTotalTries", maxTriesTotal.get()),
                     ex);
         }
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -68,6 +68,12 @@ develop
          - Added logging for leadership election code.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3275>`__)
 
+    *    - |fixed|
+         - Cassandra retry messages now log bounds on attempts correctly.
+           Previously, they would log the supplier of these bounds (instead of the actual bounds, which users are more likely to be interested in).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/nnnn>`__)
+
+
 =======
 v0.91.0
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -71,7 +71,7 @@ develop
     *    - |fixed|
          - Cassandra retry messages now log bounds on attempts correctly.
            Previously, they would log the supplier of these bounds (instead of the actual bounds, which users are more likely to be interested in).
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/nnnn>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3291>`__)
 
 
 =======


### PR DESCRIPTION
**Goals (and why)**:
- Fixes #3294.
- Fix bug where we log a supplier rather than the value it returns.

**Implementation Description (bullets)**:
- Call get on the supplier

**Concerns (what feedback would you like?)**:
- Technically this retrieves the value AFTER the decision to make an attempt is made, meaning you can get weirdness like `attempt 10 of 2`.

**Where should we start reviewing?**: CassandraRequestExceptionHandler.java

**Priority (whenever / two weeks / yesterday)**: today

@SerialVelocity for SA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3291)
<!-- Reviewable:end -->
