### PR TITLE
Log maxTriesTotal properly.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -119,13 +119,13 @@ class CassandraRequestExceptionHandler {
         if (numberOfAttempts > 1) {
             log.info("Error occurred talking to cassandra. Attempt {} of {}. Exception message was: {} : {}",
                     SafeArg.of("numTries", numberOfAttempts),
-                    SafeArg.of("maxTotalTries", maxTriesTotal),
+                    SafeArg.of("maxTotalTries", maxTriesTotal.get()),
                     SafeArg.of("exceptionClass", ex.getClass().getTypeName()),
                     UnsafeArg.of("exceptionMessage", ex.getMessage()));
         } else {
             log.info("Error occurred talking to cassandra. Attempt {} of {}.",
                     SafeArg.of("numTries", numberOfAttempts),
-                    SafeArg.of("maxTotalTries", maxTriesTotal),
+                    SafeArg.of("maxTotalTries", maxTriesTotal.get()),
                     ex);
         }
     }


### PR DESCRIPTION
SafeArg was using the Supplier instead of the Supplier's value. #3294

**Goals (and why)**:

Fix internal logging tool.

**Implementation Description (bullets)**:

Convert SafeArg from Supplier to Supplier's value.

**Concerns (what feedback would you like?)**:

Unclear if SafeArg is supposed to handle Supplier's properly.

**Where should we start reviewing?**:

It's a tiny change. It'll be self-obvious.

**Priority (whenever / two weeks / yesterday)**:

Breaks debugging information so I'd appreciate a higher priority.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3295)
<!-- Reviewable:end -->
