### PR TITLE
Add detail when sweep logs that it's UNABLE_TO_ACQUIRE_LOCKS

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -150,8 +150,7 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
 
                 SweepOutcome outcome = checkConfigAndRunSweep(locks);
 
-                log.info("Sweep iteration finished with outcome: {}", SafeArg.of("sweepOutcome", outcome));
-
+                logOutcome(outcome);
                 updateBatchSize(outcome);
                 updateMetrics(outcome);
 
@@ -173,6 +172,17 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
                     + "asynchronous initialization, these tables are being initialized asynchronously. Background "
                     + "sweeper will start once the initialization is complete.");
             sleepForMillis(getBackoffTimeWhenSweepHasNotRun());
+        }
+    }
+
+    private void logOutcome(SweepOutcome outcome) {
+        if (outcome.equals(SweepOutcome.UNABLE_TO_ACQUIRE_LOCKS)) {
+            log.info("Sweep iteration finished with outcome: {}. This means that sweep is running elsewhere. "
+                            + "If all nodes in an HA setup report this outcome, "
+                            + "then another cluster may be connecting to the same Cassandra keyspace.",
+                    SafeArg.of("sweepOutcome", outcome));
+        } else {
+            log.info("Sweep iteration finished with outcome: {}", SafeArg.of("sweepOutcome", outcome));
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweeperImpl.java
@@ -178,7 +178,9 @@ public final class BackgroundSweeperImpl implements BackgroundSweeper, AutoClose
     private void logOutcome(SweepOutcome outcome) {
         if (outcome.equals(SweepOutcome.UNABLE_TO_ACQUIRE_LOCKS)) {
             log.info("Sweep iteration finished with outcome: {}. This means that sweep is running elsewhere. "
-                            + "If all nodes in an HA setup report this outcome, "
+                            + "If the lock was in fact leaked, then it should expire within one hour, after which "
+                            + "time one node should be able to grab the lock. "
+                            + "If all nodes in an HA setup report this outcome for more than an hour, "
                             + "then another cluster may be connecting to the same Cassandra keyspace.",
                     SafeArg.of("sweepOutcome", outcome));
         } else {


### PR DESCRIPTION
This commonly happens when running in an HA setup.
We have a log.debug line when we set this outcome, but I didn't upgrade that one to info because two separate log lines at info for this situation would be overkill.

[no release notes]

**Goals (and why)**: Avoid confusion (see PDS-69959 and PDS-69969) when sweep apparently can not acquire locks.

**Implementation Description (bullets)**:
- Update log message
- Extract method following the One Thing Rule, as adjacent code already does

**Concerns (what feedback would you like?)**: Is this _too_ wordy?

**Where should we start reviewing?**: One file

**Priority (whenever / two weeks / yesterday)**: today? PR is shorter than the description 😆 
