### PR TITLE
Better batching with timelock

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1783,7 +1783,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
             InetSocketAddress host,
             Map<Cell, Long> maxTimestampExclusiveByCell,
             boolean deleteSentinels,
-            long rangeTombstoneCassandraTimestamp) {
+            long rangeTombstoneCassandraTs) {
         if (maxTimestampExclusiveByCell.isEmpty()) {
             return;
         }
@@ -1793,7 +1793,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
                 @Override
                 public Void apply(CassandraClient client) throws Exception {
-                    insertRangeTombstones(client, maxTimestampExclusiveByCell, tableRef, deleteSentinels);
+                    insertRangeTombstones(client, maxTimestampExclusiveByCell, tableRef,
+                            deleteSentinels, rangeTombstoneCassandraTs);
                     return null;
                 }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -1764,6 +1764,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
         Map<InetSocketAddress, Map<Cell, Long>> keysByHost = HostPartitioner.partitionMapByHost(
                 clientPool, maxTimestampExclusiveByCell.entrySet());
 
+        // this is required by the interface of the CassandraMutationTimestampProvider, although it exists for tests
         long maxTimestampForAllCells = maxTimestampExclusiveByCell.values().stream().mapToLong(x -> x).max().getAsLong();
         long rangeTombstoneCassandraTimestamp =
                 mutationTimestampProvider.getRangeTombstoneTimestamp(maxTimestampForAllCells);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,8 +51,9 @@ develop
          - Change
 
     *    - |fixed|
-         - We now only call timelock once per range tombstone we leave, rather than once per cell.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3303>`__)
+         - With targeted sweep, We now only call timelock once per set of range tombstones we leave,
+           rather than once per cell.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3305>`__)
 
     *    - |fixed|
          - We now consider only one row at a time when getting rows from the KVS with sweepable cells.

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,10 @@ develop
          - Change
 
     *    - |fixed|
+         - We now only call timelock once per range tombstone we leave, rather than once per cell.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3303>`__)
+
+    *    - |fixed|
          - We now consider only one row at a time when getting rows from the KVS with sweepable cells.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3302>`__)
 


### PR DESCRIPTION
Internally we were seeing that atm it takes about 2.5 seconds to delete
1k things. This is almost surely exclusively due to the overhead of
calling timelock once per cell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3305)
<!-- Reviewable:end -->
