### PR TITLE
Moved CancelableServerCall annotation to commons-annotations

### DIFF
--- a/commons-annotations/src/main/java/com/palantir/annotations/remoting/CancelableServerCall.java
+++ b/commons-annotations/src/main/java/com/palantir/annotations/remoting/CancelableServerCall.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 
 /**
  * Marks a server call cancelable - the server call can now throw interrupted exceptions on the client,
- * and interrupting on the client will propagate to the server
+ * and interrupting on the client will propagate to the server.
  *
  * @author kbrainard
  */

--- a/commons-annotations/src/main/java/com/palantir/annotations/remoting/CancelableServerCall.java
+++ b/commons-annotations/src/main/java/com/palantir/annotations/remoting/CancelableServerCall.java
@@ -27,5 +27,5 @@ import java.lang.annotation.RetentionPolicy;
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CancelableServerCall {
-    //marker interface used in spring
+    //marker interface
 }


### PR DESCRIPTION
from atlasdb-commons

**Goals (and why)**:

It's an annotation. Annotations go in commons-annotations.
Not a break because atlasdb-commons depends on commons-annotations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3311)
<!-- Reviewable:end -->
