### PR TITLE
Deletes for a single row are now Cassandra tombstones per row not per cell

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraMutationTimestampProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraMutationTimestampProvider.java
@@ -42,6 +42,11 @@ public interface CassandraMutationTimestampProvider {
     long getSweepSentinelWriteTimestamp();
 
     /**
+     * Returns the Cassandra timestamp at which whole row deletes should be performed.
+     */
+    long getRemoveTimestamp();
+
+    /**
      * Returns an operator, which determines the Cassandra timestamp to write a delete at, given the Atlas timestamp
      * at which the deletion occurred.
      * The operator is intended to be use for a single batch deletion, and must not be re-used outside of the

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraMutationTimestampProviders.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraMutationTimestampProviders.java
@@ -38,6 +38,11 @@ public final class CassandraMutationTimestampProviders {
             }
 
             @Override
+            public long getRemoveTimestamp() {
+                throw new UnsupportedOperationException("Can't be implemented");
+            }
+
+            @Override
             public LongUnaryOperator getDeletionTimestampOperatorForBatchDelete() {
                 return deletionTimestamp -> deletionTimestamp + 1;
             }
@@ -54,6 +59,11 @@ public final class CassandraMutationTimestampProviders {
         return new CassandraMutationTimestampProvider() {
             @Override
             public long getSweepSentinelWriteTimestamp() {
+                return longSupplier.getAsLong();
+            }
+
+            @Override
+            public long getRemoveTimestamp() {
                 return longSupplier.getAsLong();
             }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClient.java
@@ -93,6 +93,13 @@ public interface CassandraClient {
             throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException,
             org.apache.thrift.TException;
 
+    void remove(String kvsMethodName,
+            TableReference tableRef,
+            byte[] row,
+            long timestamp,
+            ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, org.apache.thrift.TException;
+
     TProtocol getOutputProtocol();
 
     TProtocol getInputProtocol();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientImpl.java
@@ -131,6 +131,20 @@ public class CassandraClientImpl implements CassandraClient {
     }
 
     @Override
+    public void remove(String kvsMethodName, TableReference tableRef,
+            byte[] row, long timestamp, ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        String internalTableName = AbstractKeyValueService.internalTableName(tableRef);
+        ColumnPath columnPath = new ColumnPath();
+        columnPath.setColumn_family(internalTableName);
+        executeHandlingExceptions(() -> client.remove(
+                ByteBuffer.wrap(row),
+                columnPath,
+                timestamp,
+                consistency_level));
+    }
+
+    @Override
     public TProtocol getOutputProtocol() {
         return executeMethodWithoutException(() -> client.getOutputProtocol());
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClient.java
@@ -113,6 +113,26 @@ public class ProfilingCassandraClient implements AutoDelegate_CassandraClient {
     }
 
     @Override
+    public void remove(String kvsMethodName, TableReference tableRef, byte[] row, long timestamp,
+            ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        long startTime = System.currentTimeMillis();
+        KvsProfilingLogger.maybeLog(
+                (KvsProfilingLogger.CallableCheckedException<Void, TException>)
+                        () -> {
+                             client.remove(kvsMethodName, tableRef, row, timestamp, consistency_level);
+                             return null;
+                        },
+                (logger, timer) -> logger.log("CassandraClient.remove({}, {}, {}, {}) at time {}, on kvs.{} took {} ms",
+                        LoggingArgs.tableRef(tableRef),
+                        SafeArg.of("timestamp", timestamp),
+                        SafeArg.of("consistency", consistency_level.toString()),
+                        LoggingArgs.startTimeMillis(startTime),
+                        SafeArg.of("kvsMethodName", kvsMethodName),
+                        LoggingArgs.durationMillis(timer)));
+    }
+
+    @Override
     public void batch_mutate(String kvsMethodName,
             Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
             ConsistencyLevel consistency_level)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -93,6 +93,16 @@ public class TracingCassandraClient implements AutoDelegate_CassandraClient {
     }
 
     @Override
+    public void remove(String kvsMethodName, TableReference tableRef, byte[] row, long timestamp,
+            ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        try (CloseableTrace trace = startLocalTrace(
+                "client.remove(consistency {}) on kvs.{}", consistency_level, kvsMethodName)) {
+            client.remove(kvsMethodName, tableRef, row, timestamp, consistency_level);
+        }
+    }
+
+    @Override
     public void batch_mutate(String kvsMethodName,
             Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
             ConsistencyLevel consistency_level)

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/QosCassandraClient.java
@@ -87,6 +87,18 @@ public class QosCassandraClient implements AutoDelegate_CassandraClient {
     }
 
     @Override
+    public void remove(String kvsMethodName, TableReference tableRef, byte[] row, long timestamp,
+            ConsistencyLevel consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        qosClient.executeWrite(
+                () -> {
+                    client.remove(kvsMethodName, tableRef, row, timestamp, consistency_level);
+                    return null;
+                    },
+                ThriftQueryWeighers.remove(row));
+    }
+
+    @Override
     public void batch_mutate(String kvsMethodName, Map<ByteBuffer, Map<String, List<Mutation>>> mutation_map,
             ConsistencyLevel consistency_level)
             throws InvalidRequestException, UnavailableException, TimedOutException, TException {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/qos/ThriftQueryWeighers.java
@@ -92,6 +92,10 @@ public final class ThriftQueryWeighers {
         return writeWeigher(numRows, () -> ThriftObjectSizeUtils.getApproximateSizeOfMutationMap(mutationMap));
     }
 
+    static QosClient.QueryWeigher<Void> remove(byte[] row) {
+        return writeWeigher(1, () -> (long) row.length);
+    }
+
     private static <T> QosClient.QueryWeigher<T> readWeigherWithZeroEstimate(Function<T, Long> bytesRead,
             Function<T, Integer> numRows,
             int numberOfQueriedRows) {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/AbstractKeyValueServiceTest.java
@@ -1064,6 +1064,13 @@ public abstract class AbstractKeyValueServiceTest {
     }
 
     @Test
+    public void testDeleteRangeSingleRow() {
+        // should delete row0 only
+        setupTestRowsZeroOneAndTwoAndDeleteFrom(row0, RangeRequests.nextLexicographicName(row0));
+        checkThatTableIsNowOnly(row1, row2);
+    }
+
+    @Test
     public void testDeleteRangeStartRowInclusivity() {
         // should delete row0 and row1
         setupTestRowsZeroOneAndTwoAndDeleteFrom(row0, PtBytes.toBytes("row1b"));

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,10 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Cassandra deleteRows now avoids reading any information in the case that we delete the whole row.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3312>`__)
+
     *    -
          -
 


### PR DESCRIPTION
Re: targeted sweep

I had been informed that we'd be deleting the whole row in one go, but
as I saw the number of cells read increase, I realised I'd seen no
evidence for this actually happening :P upon investigating, I realised
that it does not.

This PR makes the 'deleteRows' kvs method drop a tombstone for the whole
row if we're trying to delete a whole row. This avoids reading the whole row
in one go (which could be reading 100k cells).

It also trivially extends to DBKVS, but I haven't implemented it there
because the whole method isn't implemented there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3312)
<!-- Reviewable:end -->
