### PR TITLE
log only if host is really removed from blacklist

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -70,6 +70,10 @@ develop
            Please contact the AtlasDB team if you deploy AtlasDB with scyllaDb (this was never supported).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3313>`__)
 
+    *    - |fixed| |logs|
+         - Fixed a bug where Cassandra client pool was erroneously logging host removal from blacklist.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3314>`__)
+
 =======
 v0.92.2
 =======


### PR DESCRIPTION
**Goals (and why)**:
Fix the bug where we are logging bunch of "added back host.." logs, as we didn't check if we really removed the host from blacklist.

**Implementation Description (bullets)**:
Check if host is blacklisted first.

**Priority (whenever / two weeks / yesterday)**:
This week
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3314)
<!-- Reviewable:end -->
