### PR TITLE
FFT - getRowColumnRange Merge, Part 2: SortedMap -> List + Sort

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2084,7 +2084,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             // uninstantiable
         }
 
-        public static <T> PostFilteringPopulator mapBasedPopulator(
+        static <T> PostFilteringPopulator mapBasedPopulator(
                 SnapshotTransaction tx,
                 Map<Cell, T> outputMap,
                 Function<Value, T> valueTransformer) {
@@ -2137,7 +2137,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             };
         }
 
-        public static <T> PostFilteringPopulator listBasedPopulator(
+        static <T> PostFilteringPopulator listBasedPopulator(
                 SnapshotTransaction tx,
                 List<Map.Entry<Cell, T>> outputList,
                 Function<Value, T> valueTransformer) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -422,6 +422,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 keyValueService, tableRef, row, columnRangeSelection, getStartTimestamp());
         BatchSizeIncreasingIterator<Map.Entry<Cell, Value>> batchIterator = new BatchSizeIncreasingIterator<>(
                 batchProvider, columnRangeSelection.getBatchHint(), ClosableIterators.wrap(rawIterator));
+
         Iterator<Iterator<Map.Entry<Cell, byte[]>>> postFilteredBatches =
                 new AbstractIterator<Iterator<Map.Entry<Cell, byte[]>>>() {
             @Override
@@ -436,10 +437,17 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 if (raw.isEmpty()) {
                     return endOfData();
                 }
-                SortedMap<Cell, byte[]> post = new TreeMap<>();
-                getWithPostFiltering(tableRef, raw, post, Value.GET_VALUE);
-                batchIterator.markNumResultsNotDeleted(post.keySet().size());
-                return post.entrySet().iterator();
+                List<Map.Entry<Cell, byte[]>> postFiltered = new ArrayList<>();
+                getWithPostFiltering(
+                        tableRef,
+                        raw,
+                        PostFilteringPopulators.listBasedPopulator(
+                                SnapshotTransaction.this,
+                                postFiltered,
+                                Value.GET_VALUE));
+                postFiltered.sort(Comparator.comparing(Entry::getKey));
+                batchIterator.markNumResultsNotDeleted(postFiltered.size());
+                return postFiltered.iterator();
             }
         };
         return Iterators.concat(postFilteredBatches);
@@ -515,7 +523,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     private SortedMap<byte[], RowResult<byte[]>> filterRowResults(TableReference tableRef,
                                                                   Map<Cell, Value> rawResults,
                                                                   Map<Cell, byte[]> result) {
-        getWithPostFiltering(tableRef, rawResults, result, Value.GET_VALUE);
+        getWithPostFiltering(
+                tableRef, rawResults, PostFilteringPopulators.mapBasedPopulator(this, result, Value.GET_VALUE));
         Map<Cell, byte[]> filterDeletedValues = Maps.filterValues(result, Predicates.not(Value.IS_EMPTY));
         return RowResults.viewOfSortedMap(Cells.breakCellsUpByRow(filterDeletedValues));
     }
@@ -596,7 +605,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         Map<Cell, byte[]> result = Maps.newHashMap();
         Map<Cell, Long> toRead = Cells.constantValueMap(cells, getStartTimestamp());
         Map<Cell, Value> rawResults = keyValueService.get(tableRef, toRead);
-        getWithPostFiltering(tableRef, rawResults, result, Value.GET_VALUE);
+        getWithPostFiltering(
+                tableRef, rawResults, PostFilteringPopulators.mapBasedPopulator(this, result, Value.GET_VALUE));
         return result;
     }
 
@@ -1000,7 +1010,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         }
 
         SortedMap<Cell, T> postFilter = Maps.newTreeMap();
-        getWithPostFiltering(tableRef, rawResults, postFilter, transformer);
+        getWithPostFiltering(
+                tableRef,
+                rawResults,
+                PostFilteringPopulators.mapBasedPopulator(this, postFilter, transformer));
         return postFilter;
     }
 
@@ -1012,12 +1025,34 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return estimatedSize;
     }
 
-    private <T> void getWithPostFiltering(TableReference tableRef,
+    private void getWithPostFiltering(TableReference tableRef,
                                           Map<Cell, Value> rawResults,
-                                          @Output Map<Cell, T> results,
-                                          Function<Value, T> transformer) {
+                                          PostFilteringPopulator populator) {
+        countBytesAndLogIfLarge(tableRef, rawResults);
+        // TODO(hsaraogi): add table names as a tag
+        getMeter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_READ).mark(rawResults.size());
+
+        if (AtlasDbConstants.hiddenTables.contains(tableRef)) {
+            Preconditions.checkState(allowHiddenTableAccess, "hidden tables cannot be read in this transaction");
+            // hidden tables are used outside of the transaction protocol, and in general have invalid timestamps,
+            // so do not apply post-filtering as post-filtering would rollback (actually delete) the data incorrectly
+            // this case is hit when reading a hidden table from console
+            populator.passthroughResults(rawResults);
+            return;
+        }
+
+        Map<Cell, Value> remainingResultsToPostfilter = rawResults;
+        while (!remainingResultsToPostfilter.isEmpty()) {
+            remainingResultsToPostfilter = getWithPostFilteringInternal(
+                    tableRef, remainingResultsToPostfilter, populator);
+        }
+
+        getMeter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_RETURNED).mark(populator.size());
+    }
+
+    private void countBytesAndLogIfLarge(TableReference tableRef, Map<Cell, Value> rawResults) {
         long bytes = 0;
-        for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
+        for (Entry<Cell, Value> e : rawResults.entrySet()) {
             bytes += e.getValue().getContents().length + Cells.getApproxSizeOfCell(e.getKey());
         }
         if (bytes > TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES && log.isWarnEnabled()) {
@@ -1033,85 +1068,20 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             }
             getHistogram(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_TOO_MANY_BYTES_READ).update(bytes);
         }
-        // TODO(hsaraogi): add table names as a tag
-        getMeter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_READ).mark(rawResults.size());
-
-        if (AtlasDbConstants.hiddenTables.contains(tableRef)) {
-            Preconditions.checkState(allowHiddenTableAccess, "hidden tables cannot be read in this transaction");
-            // hidden tables are used outside of the transaction protocol, and in general have invalid timestamps,
-            // so do not apply post-filtering as post-filtering would rollback (actually delete) the data incorrectly
-            // this case is hit when reading a hidden table from console
-            for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
-                results.put(e.getKey(), transformer.apply(e.getValue()));
-            }
-            return;
-        }
-
-        Map<Cell, Value> remainingResultsToPostfilter = rawResults;
-        while (!remainingResultsToPostfilter.isEmpty()) {
-            remainingResultsToPostfilter = getWithPostFilteringInternal(
-                    tableRef, remainingResultsToPostfilter, results, transformer);
-        }
-
-        getMeter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_RETURNED).mark(results.size());
     }
 
     /**
      * This will return all the keys that still need to be postFiltered.  It will output properly
      * postFiltered keys to the results output param.
      */
-    private <T> Map<Cell, Value> getWithPostFilteringInternal(TableReference tableRef,
+    private Map<Cell, Value> getWithPostFilteringInternal(TableReference tableRef,
             Map<Cell, Value> rawResults,
-            @Output Map<Cell, T> results,
-            Function<Value, T> transformer) {
+            PostFilteringPopulator populator) {
         Set<Long> startTimestampsForValues = getStartTimestampsForValues(rawResults.values());
         Map<Long, Long> commitTimestamps = getCommitTimestamps(tableRef, startTimestampsForValues, true);
         Map<Cell, Long> keysToReload = Maps.newHashMapWithExpectedSize(0);
         Map<Cell, Long> keysToDelete = Maps.newHashMapWithExpectedSize(0);
-        for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
-            Cell key = e.getKey();
-            Value value = e.getValue();
-
-            if (value.getTimestamp() == Value.INVALID_VALUE_TIMESTAMP) {
-                getMeter(AtlasDbMetricNames.CellFilterMetrics.INVALID_START_TS).mark();
-                // This means that this transaction started too long ago. When we do garbage collection,
-                // we clean up old values, and this transaction started at a timestamp before the garbage collection.
-                switch (getReadSentinelBehavior()) {
-                    case IGNORE:
-                        break;
-                    case THROW_EXCEPTION:
-                        throw new TransactionFailedRetriableException("Tried to read a value that has been deleted. "
-                                + " This can be caused by hard delete transactions using the type "
-                                + TransactionType.AGGRESSIVE_HARD_DELETE
-                                + ". It can also be caused by transactions taking too long, or"
-                                + " its locks expired. Retrying it should work.");
-                    default:
-                        throw new IllegalStateException("Invalid read sentinel behavior " + getReadSentinelBehavior());
-                }
-            } else {
-                Long theirCommitTimestamp = commitTimestamps.get(value.getTimestamp());
-                if (theirCommitTimestamp == null || theirCommitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
-                    keysToReload.put(key, value.getTimestamp());
-                    if (shouldDeleteAndRollback()) {
-                        // This is from a failed transaction so we can roll it back and then reload it.
-                        keysToDelete.put(key, value.getTimestamp());
-                        getMeter(AtlasDbMetricNames.CellFilterMetrics.INVALID_COMMIT_TS).mark();
-                    }
-                } else if (theirCommitTimestamp > getStartTimestamp()) {
-                    // The value's commit timestamp is after our start timestamp.
-                    // This means the value is from a transaction which committed
-                    // after our transaction began. We need to try reading at an
-                    // earlier timestamp.
-                    keysToReload.put(key, value.getTimestamp());
-                    getMeter(AtlasDbMetricNames.CellFilterMetrics.COMMIT_TS_GREATER_THAN_TRANSACTION_TS).mark();
-                } else {
-                    // The value has a commit timestamp less than our start timestamp, and is visible and valid.
-                    if (value.getContents().length != 0) {
-                        results.put(key, transformer.apply(value));
-                    }
-                }
-            }
-        }
+        populator.postfilterResults(rawResults, commitTimestamps, keysToReload, keysToDelete);
 
         if (!keysToDelete.isEmpty()) {
             // if we can't roll back the failed transactions, we should just try again
@@ -1126,6 +1096,39 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             return nextRawResults;
         } else {
             return ImmutableMap.of();
+        }
+    }
+
+    private void markKeyForDeletionAndReloading(@Output Map<Cell, Long> keysToReload,
+            @Output Map<Cell, Long> keysToDelete, Cell key, Value value) {
+        keysToReload.put(key, value.getTimestamp());
+        if (shouldDeleteAndRollback()) {
+            // This is from a failed transaction so we can roll it back and then reload it.
+            keysToDelete.put(key, value.getTimestamp());
+            getMeter(AtlasDbMetricNames.CellFilterMetrics.INVALID_COMMIT_TS).mark();
+        }
+    }
+
+    private void markKeyForReloading(@Output Map<Cell, Long> keysToReload, Cell key, Value value) {
+        keysToReload.put(key, value.getTimestamp());
+        getMeter(AtlasDbMetricNames.CellFilterMetrics.COMMIT_TS_GREATER_THAN_TRANSACTION_TS).mark();
+    }
+
+    private void handleReadSentinelsInPostfilter() {
+        getMeter(AtlasDbMetricNames.CellFilterMetrics.INVALID_START_TS).mark();
+        // This means that this transaction started too long ago. When we do garbage collection,
+        // we clean up old values, and this transaction started at a timestamp before the garbage collection.
+        switch (getReadSentinelBehavior()) {
+            case IGNORE:
+                break;
+            case THROW_EXCEPTION:
+                throw new TransactionFailedRetriableException("Tried to read a value that has been deleted. "
+                        + " This can be caused by hard delete transactions using the type "
+                        + TransactionType.AGGRESSIVE_HARD_DELETE
+                        + ". It can also be caused by transactions taking too long, or"
+                        + " its locks expired. Retrying it should work.");
+            default:
+                throw new IllegalStateException("Invalid read sentinel behavior " + getReadSentinelBehavior());
         }
     }
 
@@ -2055,6 +2058,134 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 .addProcessors(PredicateBackedLogConsumerProcessor.create(
                         log::info, RateLimitedBooleanSupplier.create(5.0)))
                 .build();
+    }
+
+    private interface PostFilteringPopulator {
+        void passthroughResults(Map<Cell, Value> rawResults);
+        void postfilterResults(
+                Map<Cell, Value> rawResults,
+                Map<Long, Long> commitTimestamps,
+                @Output Map<Cell, Long> keysToReload,
+                @Output Map<Cell, Long> keysToDelete);
+        int size();
+    }
+
+    /**
+     * A {@link PostFilteringPopulator} populates results from post-filtering.
+     *
+     * The classes obviously look obscenely duplicated especially when a simple {@link java.util.function.BiConsumer}
+     * would address the need to have different ways of writing to a {@link Map} or a simple {@link List}.
+     *
+     * However, this is an extremely hot code-path, and we have found the overhead of a function call on a per-cell
+     * basis can be significant in benchmarks.
+     */
+    private static final class PostFilteringPopulators {
+        private PostFilteringPopulators() {
+            // uninstantiable
+        }
+
+        public static <T> PostFilteringPopulator mapBasedPopulator(
+                SnapshotTransaction tx,
+                Map<Cell, T> outputMap,
+                Function<Value, T> valueTransformer) {
+            return new PostFilteringPopulator() {
+                @Override
+                public void passthroughResults(Map<Cell, Value> rawResults) {
+                    for (Map.Entry<Cell, Value> entry : rawResults.entrySet()) {
+                        outputMap.put(entry.getKey(), valueTransformer.apply(entry.getValue()));
+                    }
+                }
+
+                @Override
+                public void postfilterResults(
+                        Map<Cell, Value> rawResults,
+                        Map<Long, Long> commitTimestamps,
+                        @Output Map<Cell, Long> keysToReload,
+                        @Output Map<Cell, Long> keysToDelete) {
+                    for (Entry<Cell, Value> e : rawResults.entrySet()) {
+                        Cell key = e.getKey();
+                        Value value = e.getValue();
+
+                        if (value.getTimestamp() == Value.INVALID_VALUE_TIMESTAMP) {
+                            tx.handleReadSentinelsInPostfilter();
+                        } else {
+                            Long theirCommitTimestamp = commitTimestamps.get(value.getTimestamp());
+
+                            if (theirCommitTimestamp == null
+                                    || theirCommitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
+                                tx.markKeyForDeletionAndReloading(keysToReload, keysToDelete, key, value);
+                            } else if (theirCommitTimestamp > tx.getStartTimestamp()) {
+                                // The value's commit timestamp is after our start timestamp. This means the value is
+                                // from a transaction which committed after our transaction began. We need to try
+                                // reading at an earlier timestamp.
+                                tx.markKeyForReloading(keysToReload, key, value);
+                            } else {
+                                // The value has a commit timestamp less than our start timestamp, and is visible and
+                                // valid.
+                                if (value.getContents().length != 0) {
+                                    outputMap.put(key, valueTransformer.apply(value));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                @Override
+                public int size() {
+                    return outputMap.size();
+                }
+            };
+        }
+
+        public static <T> PostFilteringPopulator listBasedPopulator(
+                SnapshotTransaction tx,
+                List<Map.Entry<Cell, T>> outputList,
+                Function<Value, T> valueTransformer) {
+            return new PostFilteringPopulator() {
+                @Override
+                public void passthroughResults(Map<Cell, Value> rawResults) {
+                    for (Map.Entry<Cell, Value> entry : rawResults.entrySet()) {
+                        outputList.add(Maps.immutableEntry(entry.getKey(), valueTransformer.apply(entry.getValue())));
+                    }
+                }
+
+                @Override
+                public void postfilterResults(Map<Cell, Value> rawResults, Map<Long, Long> commitTimestamps,
+                        @Output Map<Cell, Long> keysToReload, @Output Map<Cell, Long> keysToDelete) {
+                    for (Entry<Cell, Value> e : rawResults.entrySet()) {
+                        Cell key = e.getKey();
+                        Value value = e.getValue();
+
+                        if (value.getTimestamp() == Value.INVALID_VALUE_TIMESTAMP) {
+                            tx.handleReadSentinelsInPostfilter();
+                        } else {
+                            Long theirCommitTimestamp = commitTimestamps.get(value.getTimestamp());
+
+                            if (theirCommitTimestamp == null
+                                    || theirCommitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
+                                tx.markKeyForDeletionAndReloading(keysToReload, keysToDelete, key, value);
+                            } else if (theirCommitTimestamp > tx.getStartTimestamp()) {
+                                // The value's commit timestamp is after our start timestamp. This means the value is
+                                // from a transaction which committed after our transaction began. We need to try
+                                // reading at an earlier timestamp.
+                                tx.markKeyForReloading(keysToReload, key, value);
+                            } else {
+                                // The value has a commit timestamp less than our start timestamp, and is visible and
+                                // valid.
+                                if (value.getContents().length != 0) {
+                                    outputList.add(Maps.immutableEntry(key, valueTransformer.apply(value)));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                @Override
+                public int size() {
+                    return outputList.size();
+                }
+            };
+        }
     }
 }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -26,7 +26,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -328,7 +327,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         // We don't need to do work postFiltering if we have a write locally.
         rawResults.keySet().removeAll(result.keySet());
 
-        SortedMap<byte[], RowResult<byte[]>> results = filterRowResults(tableRef, rawResults, result);
+        SortedMap<byte[], RowResult<byte[]>> results = filterRowResults(tableRef, rawResults, ImmutableMap.builder());
         long getRowsMillis = TimeUnit.NANOSECONDS.toMillis(timer.stop());
         if (perfLogger.isDebugEnabled()) {
             perfLogger.debug("getRows({}, {} rows) found {} rows, took {} ms",
@@ -436,10 +435,11 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 if (raw.isEmpty()) {
                     return endOfData();
                 }
-                SortedMap<Cell, byte[]> post = new TreeMap<>();
+                ImmutableSortedMap.Builder<Cell, byte[]> post = ImmutableSortedMap.naturalOrder();
                 getWithPostFiltering(tableRef, raw, post, Value.GET_VALUE);
-                batchIterator.markNumResultsNotDeleted(post.keySet().size());
-                return post.entrySet().iterator();
+                SortedMap<Cell, byte[]> postFiltered = post.build();
+                batchIterator.markNumResultsNotDeleted(postFiltered.size());
+                return postFiltered.entrySet().iterator();
             }
         };
         return Iterators.concat(postFilteredBatches);
@@ -509,14 +509,14 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 getStartTimestamp()));
 
         validateExternalAndCommitLocksIfNecessary(tableRef, getStartTimestamp());
-        return filterRowResults(tableRef, rawResults, Maps.newHashMap());
+        return filterRowResults(tableRef, rawResults, ImmutableMap.builderWithExpectedSize(rawResults.size()));
     }
 
     private SortedMap<byte[], RowResult<byte[]>> filterRowResults(TableReference tableRef,
                                                                   Map<Cell, Value> rawResults,
-                                                                  Map<Cell, byte[]> result) {
+                                                                  ImmutableMap.Builder<Cell, byte[]> result) {
         getWithPostFiltering(tableRef, rawResults, result, Value.GET_VALUE);
-        Map<Cell, byte[]> filterDeletedValues = Maps.filterValues(result, Predicates.not(Value.IS_EMPTY));
+        Map<Cell, byte[]> filterDeletedValues = Maps.filterValues(result.build(), Predicates.not(Value.IS_EMPTY));
         return RowResults.viewOfSortedMap(Cells.breakCellsUpByRow(filterDeletedValues));
     }
 
@@ -593,11 +593,11 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
      * this will be included here and needs to be filtered out.
      */
     private Map<Cell, byte[]> getFromKeyValueService(TableReference tableRef, Set<Cell> cells) {
-        Map<Cell, byte[]> result = Maps.newHashMap();
+        ImmutableMap.Builder<Cell, byte[]> result = ImmutableMap.builderWithExpectedSize(cells.size());
         Map<Cell, Long> toRead = Cells.constantValueMap(cells, getStartTimestamp());
         Map<Cell, Value> rawResults = keyValueService.get(tableRef, toRead);
         getWithPostFiltering(tableRef, rawResults, result, Value.GET_VALUE);
-        return result;
+        return result.build();
     }
 
     private static byte[] getNextStartRowName(
@@ -999,9 +999,9 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             }
         }
 
-        SortedMap<Cell, T> postFilter = Maps.newTreeMap();
+        ImmutableSortedMap.Builder<Cell, T> postFilter = ImmutableSortedMap.naturalOrder();
         getWithPostFiltering(tableRef, rawResults, postFilter, transformer);
-        return postFilter;
+        return postFilter.build();
     }
 
     private int estimateSize(List<RowResult<Value>> rangeRows) {
@@ -1014,7 +1014,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
 
     private <T> void getWithPostFiltering(TableReference tableRef,
                                           Map<Cell, Value> rawResults,
-                                          @Output Map<Cell, T> results,
+                                          @Output ImmutableMap.Builder<Cell, T> results,
                                           Function<Value, T> transformer) {
         long bytes = 0;
         for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
@@ -1052,8 +1052,6 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             remainingResultsToPostfilter = getWithPostFilteringInternal(
                     tableRef, remainingResultsToPostfilter, results, transformer);
         }
-
-        getMeter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_RETURNED).mark(results.size());
     }
 
     /**
@@ -1062,12 +1060,14 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
      */
     private <T> Map<Cell, Value> getWithPostFilteringInternal(TableReference tableRef,
             Map<Cell, Value> rawResults,
-            @Output Map<Cell, T> results,
+            @Output ImmutableMap.Builder<Cell, T> results,
             Function<Value, T> transformer) {
         Set<Long> startTimestampsForValues = getStartTimestampsForValues(rawResults.values());
         Map<Long, Long> commitTimestamps = getCommitTimestamps(tableRef, startTimestampsForValues, true);
         Map<Cell, Long> keysToReload = Maps.newHashMapWithExpectedSize(0);
         Map<Cell, Long> keysToDelete = Maps.newHashMapWithExpectedSize(0);
+
+        int found = 0;
         for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
             Cell key = e.getKey();
             Value value = e.getValue();
@@ -1107,11 +1107,14 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                 } else {
                     // The value has a commit timestamp less than our start timestamp, and is visible and valid.
                     if (value.getContents().length != 0) {
+                        found++;
                         results.put(key, transformer.apply(value));
                     }
                 }
             }
         }
+
+        getMeter(AtlasDbMetricNames.SNAPSHOT_TRANSACTION_CELLS_RETURNED).mark(found);
 
         if (!keysToDelete.isEmpty()) {
             // if we can't roll back the failed transactions, we should just try again

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,11 +51,16 @@ develop
          - Change
 
     *    - |improved|
-         - Snapshot transaction ``getRowsColumnRange`` performance has been improved by using a ``List`` and sorting it at the end.
+         - Snapshot transaction ``getRowsColumnRange`` performance has been improved by using an ``ImmutableSortedMap.Builder`` and constructing the map at the end.
            We previously used a ``SortedSet`` which would incur overhead in rebalancing the underlying red-black tree as the data was already mostly sorted.
-           We have seen a 10 percent speedup for reading all columns from a wide row (50,000 columns).
-           We have also seen an 8 percent speedup for reading 50,000 columns from a wide row, where a random 2 percent of these rows are from uncommitted transactions.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/NNNN>`__)
+           We have seen a 7 percent speedup for reading all columns from a wide row (50,000 columns).
+           We have also seen a 6 percent speedup for reading 50,000 columns from a wide row, where a random 2 percent of these rows are from uncommitted transactions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3319>`__)
+
+    *    - |devbreak|
+         - Snapshot transactions now return immutable maps when calling ``getRows`` and ``getRowsColumnRange``.
+           These used to return mutable maps - please make a copy of the map if you need it to be mutable.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3319>`__)
 
 =======
 v0.93.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,12 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |improved|
+         - Snapshot transaction ``getRowsColumnRange`` performance has been improved by using a ``List`` and sorting it at the end.
+           We previously used a ``SortedSet`` which would incur overhead in rebalancing the underlying red-black tree as the data was already mostly sorted.
+           We have seen a 10 percent speedup for reading all columns from a wide row (50,000 columns).
+           We have also seen an 8 percent speedup for reading 50,000 columns from a wide row, where a random 2 percent of these rows are from uncommitted transactions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/NNNN>`__)
 
 =======
 v0.93.0


### PR DESCRIPTION
**Goals (and why)**:
- Improve the performance of the post-filtering stage of `getRowsColumnRange`. During this process, we accumulate multiple lists of entries that are known to be in sorted order as we try to read the newest version, then the next newest if that hasn't committed, etc. We need to merge them to produce a final, fully sorted list.

**Implementation Description (bullets)**:
**UPDATE Opted to go for @j-baker's `ImmutableSortedMap` solution as it's cleaner and gets us 75-80% of the performance gain without hurting readability of SnapshotTransaction.**
- ~Replace the use of a `TreeSet` with a plain `ArrayList` and sorting at the end. It makes sense that `TreeSet` is slow as it reads a mostly sorted list of elements and has to rebalance its internal structure a lot.~
- ~Create a `PostFilteringPopulator` which processes elements. Crucially, the method calls are only invoked *once* on. There is a much easier implementation with a `BiConsumer<Cell, Value>`, but benchmarks found that function calls when done on a per-cell basis can actually add a nontrivial overhead - in JMH benchmarks this was deemed to be about 2 and 4 percent respectively when dealing with reads with 100 and 50,000 columns.~
- Alternative solutions benchmarked were performing an N-way merge (linear time, but more complex and not clearly better in tests, using a BiConsumer to process output using a sorted list, and using an ImmutableSortedMap's builder which waits to the end to sort. All units were in microseconds. Tables read had one row with Size columns; a randomly selected %Aborted of these were aborted. I used the in-memory KVS to remove uncertainty from Docker/Cassandra performance overheads (this is also why the perf improvements in the release notes are only ~10 percent, not the ~40 percent this could suggest)

| Size  | %Aborted |   TreeSet   |  List+Sort  | N-way Merge | BiConsumer | Imm.SortMap
|-------|----------|-------------|-------------|-------------|-----------------|----|
|   100 |        0 | 94 ± 8      | 79 ± 6      | 78 ± 6      | 81 ± 5          | 80 ± 5 |
|   100 |        2 | 96 ± 6      | 86 ± 6      | 87 ± 6      | 87 ± 5          | 86 ± 5 |
|   100 |       20 | 95 ± 6      | 88 ± 6      | 87 ± 7      | 87 ± 6          | 88 ± 6 |
| 50000 |        0 | 34325 ± 115 | 18936 ± 68  | 19050 ± 75  | 19501 ± 84      | 20666 ± 82      |
| 50000 |        2 | 37316 ± 143 | 24858 ± 100 | 24837 ± 108 | 25477 ± 101     | 26855 ± 127      |
| 50000 |       20 | 37751 ± 171 | 24988 ± 100 | 24581 ± 101 | 25473 ± 102     | 27001 ± 286      |

**Concerns (what feedback would you like?)**:
- ~The inner classes in SnapshotTransaction feature egregious and reprehensible duplication, though I can't really think of a better way to do it offhand. Note earlier comments on benchmarking as this is a very hot code-path.~
- This isn't the fastest solution, is this the right tradeoff?
- I didn't add tests as this PR should not change behaviour. The critical test is `SnapshotTransactionTest#getRowsColumnRangesReturnsInOrderInCaseOfAbortedTxns` which I've confirmed fails if you remove the list-sort line.

**How can we see a perf improvement?**:
By JMH benchmarks (to come in Part 2), and general improvements in `runTaskWithRetry` for heavy users of dynamic column queries.
Unfortunately we don't quite have metrics for the performance of `getRowColumnRange` yet.

**Where should we start reviewing?**: `SnapshotTransaction.java`

**Priority (whenever / two weeks / yesterday)**: this week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3319)
<!-- Reviewable:end -->
