### PR TITLE
FFT - getRowColumnRange Merge, Part 1: JMH Benchmarks

### DIFF
--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/DatabasesContainer.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/DatabasesContainer.java
@@ -31,7 +31,7 @@ public final class DatabasesContainer implements AutoCloseable {
                 DockerizedDatabase db = DockerizedDatabase.start(backend);
                 Awaitility.await()
                         .atMost(Duration.FIVE_MINUTES)
-                        .pollInterval(Duration.ONE_MINUTE)
+                        .pollInterval(Duration.FIVE_SECONDS)
                         .until(() -> backend.canConnect(db.getUri().getAddress()));
                 dbs.add(db);
             }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetRowsColumnRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetRowsColumnRangeBenchmarks.java
@@ -46,50 +46,50 @@ public class TransactionGetRowsColumnRangeBenchmarks {
     @Threads(1)
     @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
     @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
-    public Object getAllColumnsSingleBigRow(VeryWideRowTable table, Blackhole blackhole) {
-        return getAllRowsAndAssert(table, blackhole,
+    public void getAllColumnsSingleBigRow(VeryWideRowTable table, Blackhole blackhole) {
+        getAllRowsAndAssert(table, blackhole,
                 count -> Preconditions.checkState(count == table.getNumCols(),
                         "Should be %s columns, but was: %s", table.getNumCols(), count));
     }
 
     @Benchmark
     @Threads(1)
-    @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
-    public Object getAllColumnsModeratelyWideRow(
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 20, timeUnit = TimeUnit.SECONDS)
+    public void getAllColumnsModeratelyWideRow(
             ModeratelyWideRowTable table,
             Blackhole blackhole) {
-        return getAllRowsAndAssert(table, blackhole,
+        getAllRowsAndAssert(table, blackhole,
                 count -> Preconditions.checkState(count == table.getNumCols(),
                         "Should be %s columns, but was: %s", table.getNumCols(), count));
     }
 
     @Benchmark
     @Threads(1)
-    @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
-    public Object getAllColumnsModeratelyWideRowWithSomeUncommitted(
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 20, timeUnit = TimeUnit.SECONDS)
+    public void getAllColumnsModeratelyWideRowWithSomeUncommitted(
             CleanModeratelyWideRowTable table,
             Blackhole blackhole) {
-        return getAllRowsAndAssert(table, blackhole,
+        getAllRowsAndAssert(table, blackhole,
                 count -> Preconditions.checkState(count == table.getNumReadableCols(),
                         "Should be %s columns, but was: %s", table.getNumReadableCols(), count));
     }
 
     @Benchmark
     @Threads(1)
-    @Warmup(time = 16, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 160, timeUnit = TimeUnit.SECONDS)
-    public Object getAllColumnsModeratelyWideRowWithManyUncommitted(
+    @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 20, timeUnit = TimeUnit.SECONDS)
+    public void getAllColumnsModeratelyWideRowWithManyUncommitted(
             DirtyModeratelyWideRowTable table,
             Blackhole blackhole) {
-        return getAllRowsAndAssert(table, blackhole,
+        getAllRowsAndAssert(table, blackhole,
                 count -> Preconditions.checkState(count == table.getNumReadableCols(),
                         "Should be %s columns, but was: %s", table.getNumReadableCols(), count));
     }
 
-    private Object getAllRowsAndAssert(WideRowTable table, Blackhole blackhole, Consumer<Integer> assertion) {
-        return table.getTransactionManager().runTaskThrowOnConflict(txn -> {
+    private void getAllRowsAndAssert(WideRowTable table, Blackhole blackhole, Consumer<Integer> assertion) {
+        int rowsRead = table.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Iterator<Map.Entry<Cell, byte[]>> iter = txn.getRowsColumnRange(
                     table.getTableRef(),
                     Collections.singleton(Tables.ROW_BYTES.array()),
@@ -102,5 +102,6 @@ public class TransactionGetRowsColumnRangeBenchmarks {
             }
             return count;
         });
+        assertion.accept(rowsRead);
     }
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetRowsColumnRangeBenchmarks.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/TransactionGetRowsColumnRangeBenchmarks.java
@@ -55,7 +55,7 @@ public class TransactionGetRowsColumnRangeBenchmarks {
     @Benchmark
     @Threads(1)
     @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 20, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public void getAllColumnsModeratelyWideRow(
             ModeratelyWideRowTable table,
             Blackhole blackhole) {
@@ -67,7 +67,7 @@ public class TransactionGetRowsColumnRangeBenchmarks {
     @Benchmark
     @Threads(1)
     @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 20, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public void getAllColumnsModeratelyWideRowWithSomeUncommitted(
             CleanModeratelyWideRowTable table,
             Blackhole blackhole) {
@@ -79,7 +79,7 @@ public class TransactionGetRowsColumnRangeBenchmarks {
     @Benchmark
     @Threads(1)
     @Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
-    @Measurement(time = 20, timeUnit = TimeUnit.SECONDS)
+    @Measurement(time = 15, timeUnit = TimeUnit.SECONDS)
     public void getAllColumnsModeratelyWideRowWithManyUncommitted(
             DirtyModeratelyWideRowTable table,
             Blackhole blackhole) {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/CleanModeratelyWideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/CleanModeratelyWideRowTable.java
@@ -39,7 +39,7 @@ public class CleanModeratelyWideRowTable extends WideRowTableWithAbortedValues {
     }
 
     @Override
-    public int getNumUncommittedValues() {
+    public int getNumUncommittedValuesPerCell() {
         return 1;
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/CleanModeratelyWideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/CleanModeratelyWideRowTable.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.performance.benchmarks.table;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+@State(Scope.Benchmark)
+public class CleanModeratelyWideRowTable extends WideRowTableWithAbortedValues {
+    @Override
+    public int getNumColsCommitted() {
+        return 49_000;
+    }
+
+    @Override
+    public int getNumColsCommittedAndNewerUncommitted() {
+        return 500;
+    }
+
+    @Override
+    public int getNumColsUncommitted() {
+        return 500;
+    }
+
+    @Override
+    public int getNumUncommittedValues() {
+        return 1;
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return false;
+    }
+
+    @Override
+    public TableReference getTableRef() {
+        return Tables.TABLE_REF;
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/DirtyModeratelyWideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/DirtyModeratelyWideRowTable.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.performance.benchmarks.table;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+
+@State(Scope.Benchmark)
+public class DirtyModeratelyWideRowTable extends WideRowTableWithAbortedValues {
+    @Override
+    public int getNumColsCommitted() {
+        return 40_000;
+    }
+
+    @Override
+    public int getNumColsCommittedAndNewerUncommitted() {
+        return 5_000;
+    }
+
+    @Override
+    public int getNumColsUncommitted() {
+        return 5_000;
+    }
+
+    @Override
+    public int getNumUncommittedValues() {
+        return 1;
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return false;
+    }
+
+    @Override
+    public TableReference getTableRef() {
+        return Tables.TABLE_REF;
+    }
+}

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/DirtyModeratelyWideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/DirtyModeratelyWideRowTable.java
@@ -39,7 +39,7 @@ public class DirtyModeratelyWideRowTable extends WideRowTableWithAbortedValues {
     }
 
     @Override
-    public int getNumUncommittedValues() {
+    public int getNumUncommittedValuesPerCell() {
         return 1;
     }
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTable.java
@@ -38,13 +38,13 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
  * State class for creating a single Atlas table with one wide row.
  */
 public abstract class WideRowTable {
-    private AtlasDbServicesConnector connector;
-    private AtlasDbServices services;
+    protected AtlasDbServicesConnector connector;
+    protected AtlasDbServices services;
 
-    private TableReference tableRef;
+    protected TableReference tableRef;
 
-    private Map<Cell, Long> allCellsAtMaxTimestamp;
-    private Map<Cell, Long> firstCellAtMaxTimestamp;
+    protected Map<Cell, Long> allCellsAtMaxTimestamp;
+    protected Map<Cell, Long> firstCellAtMaxTimestamp;
 
     public TransactionManager getTransactionManager() {
         return services.getTransactionManager();
@@ -98,7 +98,7 @@ public abstract class WideRowTable {
         connector.close();
     }
 
-    private void storeData() {
+    protected void storeData() {
         services.getTransactionManager().runTaskThrowOnConflict(txn -> {
             Map<Cell, byte[]> values = Maps.newHashMap();
             allCellsAtMaxTimestamp = Maps.newHashMap();

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTableWithAbortedValues.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTableWithAbortedValues.java
@@ -37,7 +37,7 @@ import com.palantir.util.crypto.Sha256Hash;
  * columns which have committed versions, but have newer uncommitted versions on top.
  */
 public abstract class WideRowTableWithAbortedValues extends WideRowTable {
-    public final byte[] DUMMY_VALUE = PtBytes.toBytes("dummy");
+    public static final byte[] DUMMY_VALUE = PtBytes.toBytes("dummy");
 
     public abstract int getNumColsCommitted();
     public abstract int getNumColsCommittedAndNewerUncommitted();

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTableWithAbortedValues.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTableWithAbortedValues.java
@@ -49,6 +49,10 @@ public abstract class WideRowTableWithAbortedValues extends WideRowTable {
         return getNumColsCommitted() + getNumColsCommittedAndNewerUncommitted() + getNumColsUncommitted();
     }
 
+    public int getNumReadableCols() {
+        return getNumColsCommitted() + getNumColsCommittedAndNewerUncommitted();
+    }
+
     public abstract boolean isPersistent();
 
     public Map<Cell, Long> getFirstCellAtMaxTimestampAsMap() {

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTableWithAbortedValues.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/benchmarks/table/WideRowTableWithAbortedValues.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.performance.benchmarks.table;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import com.google.common.primitives.Ints;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+
+/**
+ * State class for creating a single Atlas table with one wide row.
+ * Unlike {@link WideRowTable}, this table may have columns which were never successfully committed, as well as
+ * columns which have committed versions, but have newer uncommitted versions on top.
+ */
+public abstract class WideRowTableWithAbortedValues extends WideRowTable {
+    public abstract int getNumColsCommitted();
+    public abstract int getNumColsCommittedAndNewerUncommitted();
+    public abstract int getNumColsUncommitted();
+
+    public abstract int getNumUncommittedValues();
+
+    public int getNumCols() {
+        return getNumColsCommitted() + getNumColsCommittedAndNewerUncommitted() + getNumColsUncommitted();
+    }
+
+    public abstract boolean isPersistent();
+
+    @Override
+    protected void storeData() {
+        services.getTransactionManager().runTaskThrowOnConflict(txn -> {
+            Map<Cell, byte[]> values = Maps.newHashMap();
+            allCellsAtMaxTimestamp = Maps.newHashMap();
+            firstCellAtMaxTimestamp = Maps.newHashMap();
+            firstCellAtMaxTimestamp.put(cell(0), Long.MAX_VALUE);
+            for (int i = 0; i < getNumCols(); i++) {
+                Cell curCell = cell(i);
+                values.put(curCell, Ints.toByteArray(i));
+                allCellsAtMaxTimestamp.put(curCell, Long.MAX_VALUE);
+            }
+            txn.put(this.tableRef, values);
+            return null;
+        });
+    }
+
+    private Cell cell(int index) {
+        return Cell.create(Tables.ROW_BYTES.array(), ("col_" + index).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private enum CellType {
+        COMMITTED,
+        COMMITTED_AND_NEWER_UNCOMMITTED,
+        UNCOMMITTED
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Have benchmarks that cover the post-filtering stage of `getRowColumnRange`

**Implementation Description (bullets)**:
- Add a state table that is set up with one row, where some columns are uncommitted, and other columns are committed but have uncommitted values written on top of them. The table is parameterised in number of columns that are purely committed, committed with uncommitted values, and uncommitted.
- Add benchmarks that read all columns from tables with various mixtures of these parameters and check that the number of visible columns (purely committed + committed with uncommitted values) is correct.

**Concerns (what feedback would you like?)**:
- Is the scrambling of the rows that were uncommitted something reasonable to do?
- This adds a good eight minutes to the benchmarks. Is that okay?

**Where should we start reviewing?**: `WideRowTableWithAbortedValues.java`

**Priority (whenever / two weeks / yesterday)**: this week. Ideally before #3319

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3320)
<!-- Reviewable:end -->
