### PR TITLE
request counts retries per host

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -70,12 +70,13 @@ class CassandraRequestExceptionHandler {
 
         req.triedOnHost(hostTried);
         int numberOfAttempts = req.getNumberOfAttempts();
+        int numberOfAttemptsOnHost = req.getNumberOfAttemptsOnHost(hostTried);
 
         if (numberOfAttempts >= maxTriesTotal.get()) {
             logAndThrowException(numberOfAttempts, ex);
         }
 
-        if (shouldBlacklist(ex, numberOfAttempts)) {
+        if (shouldBlacklist(ex, numberOfAttemptsOnHost)) {
             blacklist.add(hostTried);
         }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -153,6 +153,7 @@ class CassandraRequestExceptionHandler {
         try {
             Thread.sleep(backOffPeriod);
         } catch (InterruptedException i) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(i);
         }
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -257,9 +257,8 @@ public class CassandraClientPoolTest {
                     stubbing.thenReturn("Response");
                 }
             } catch (Exception ex) {
-                Throwables.throwIfUnchecked(ex);
+                throw new RuntimeException(ex);
             }
-
             cassandraClientPool.getCurrentPools().put(address, container);
         }
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -35,9 +36,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.cassandra.thrift.InvalidRequestException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.stubbing.OngoingStubbing;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Throwables;
@@ -195,6 +198,70 @@ public class CassandraClientPoolTest {
 
         runNoopWithRetryOnHost(HOST_2, cassandraClientPool);
         assertThat(blacklist.contains(HOST_1), is(false));
+    }
+
+    @Test
+    public void attemptsShouldBeCountedPerHost() {
+        CassandraClientPoolImpl cassandraClientPool =
+                CassandraClientPoolImpl.createImplForTest(
+                        MetricsManagers.of(metricRegistry, new DefaultTaggedMetricRegistry()),
+                        config,
+                        CassandraClientPoolImpl.StartupChecks.DO_NOT_RUN,
+                        blacklist);
+
+        host(HOST_1).throwsException(new SocketTimeoutException())
+                .throwsException(new InvalidRequestException())
+                .continuesToThrow()
+                .inPool(cassandraClientPool);
+
+        host(HOST_2).throwsException(new SocketTimeoutException())
+                .inPool(cassandraClientPool);
+
+        runNoopWithRetryOnHost(HOST_1, cassandraClientPool);
+        assertThat(blacklist.contains(HOST_2), is(false));
+    }
+
+    private HostBuilder host(InetSocketAddress address) {
+        return new HostBuilder(address);
+    }
+
+    class HostBuilder {
+        private InetSocketAddress address;
+        private List<Exception> exceptions = new LinkedList<>();
+        private boolean returnsValue = true;
+
+        HostBuilder(InetSocketAddress address) {
+            this.address = address;
+        }
+
+        HostBuilder throwsException(Exception ex) {
+            exceptions.add(ex);
+            return this;
+        }
+
+        HostBuilder continuesToThrow() {
+            returnsValue = false;
+            return this;
+        }
+
+        void inPool(CassandraClientPool cassandraClientPool) {
+            CassandraClientPoolingContainer container = mock(CassandraClientPoolingContainer.class);
+            when(container.getHost()).thenReturn(address);
+            try {
+                OngoingStubbing<Object> stubbing = when(container.runWithPooledResource(
+                        Mockito.<FunctionCheckedException<CassandraClient, Object, Exception>>any()));
+                for (Exception ex : exceptions) {
+                    stubbing = stubbing.thenThrow(ex);
+                }
+                if (returnsValue) {
+                    stubbing.thenReturn("Response");
+                }
+            } catch (Exception ex) {
+                Throwables.throwIfUnchecked(ex);
+            }
+
+            cassandraClientPool.getCurrentPools().put(address, container);
+        }
     }
 
     private void verifyNumberOfAttemptsOnHost(InetSocketAddress host,

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/RetryableCassandraRequestTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/RetryableCassandraRequestTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.palantir.common.base.FunctionCheckedException;
+
+public class RetryableCassandraRequestTest {
+    private static final int DEFAULT_PORT = 5000;
+    private static final String HOSTNAME_1 = "1.0.0.0";
+    private static final String HOSTNAME_2 = "2.0.0.0";
+    private static final InetSocketAddress HOST_1 = new InetSocketAddress(HOSTNAME_1, DEFAULT_PORT);
+    private static final InetSocketAddress HOST_2 = new InetSocketAddress(HOSTNAME_2, DEFAULT_PORT);
+
+    private RetryableCassandraRequest<Void, RuntimeException> request;
+
+    @Before
+    public void setup() {
+        request = new RetryableCassandraRequest<>(
+                HOST_1,
+                noOp()
+        );
+    }
+
+    @Test
+    public void totalNumberOfRetriesShouldBeZeroInitially() {
+        assertNumberOfTotalAttempts(0);
+    }
+
+    @Test
+    public void numberOfRetriesOnHostShouldBeZeroInitially() {
+        assertNumberOfAttemptsOnHost(0, HOST_1);
+        assertNumberOfAttemptsOnHost(0, HOST_2);
+    }
+
+    @Test
+    public void shouldIncrementRetries() {
+        request.triedOnHost(HOST_1);
+        assertNumberOfTotalAttempts(1);
+        assertNumberOfAttemptsOnHost(1, HOST_1);
+
+        request.triedOnHost(HOST_1);
+        assertNumberOfTotalAttempts(2);
+        assertNumberOfAttemptsOnHost(2, HOST_1);
+    }
+
+    @Test
+    public void shouldSeparateRetriesOnDifferentHosts() {
+        request.triedOnHost(HOST_1);
+        assertNumberOfTotalAttempts(1);
+        assertNumberOfAttemptsOnHost(1, HOST_1);
+        assertNumberOfAttemptsOnHost(0, HOST_2);
+
+        request.triedOnHost(HOST_2);
+        assertNumberOfTotalAttempts(2);
+        assertNumberOfAttemptsOnHost(1, HOST_1);
+        assertNumberOfAttemptsOnHost(1, HOST_2);
+    }
+
+    private void assertNumberOfTotalAttempts(int expected) {
+        assertThat(request.getNumberOfAttempts(), is(expected));
+    }
+
+    private void assertNumberOfAttemptsOnHost(int expected, InetSocketAddress host) {
+        assertThat(request.getNumberOfAttemptsOnHost(host), is(expected));
+    }
+
+    private FunctionCheckedException<CassandraClient, Void, RuntimeException> noOp() {
+        return new FunctionCheckedException<CassandraClient, Void, RuntimeException>() {
+            @Override
+            public Void apply(CassandraClient input) throws RuntimeException {
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return "no-op";
+            }
+        };
+    }
+}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -75,6 +75,10 @@ develop
            Previously, if these tools needed to delete a value that a failed transaction had written, the delete executor was never closed, thereby preventing an orderly JVM shutdown.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3328>`__)
 
+    *    - |fixed|
+         - Fixed a bug in C* retry logic where number of retries over all the hosts were used as number of retries on a single host, which may cause unexpected blacklisting behaviour.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3323>`__)
+
 =======
 v0.93.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
Fix https://github.com/palantir/atlasdb/issues/3289

**Implementation Description (bullets)**:
Request object now keeps a map of hosts to retries, rather then keeping an integer of retries for all hosts.

**Concerns (what feedback would you like?)**:
Retries are still recorded per request. That may cause issues if we change the retry strategy such that an exception that should cause blacklist also causes to retry on another host. For example, say we have hosts A and B, where A throws an exception E that causes to retry on another host, and say implementation of `shouldBlacklist` is something like:
`shouldBlacklist(ex, numRetriesOnSameHost) { return ex instanceof E && numRetriesOnSameHost > 3 }`
In that case, every request that is first retried on A will be redirected to B, and numRetriesOnSameHost will never exceed 3. As a result we won't be blacklisting A. Solution would be counting retries in a global object rather than counting them per request.

This is not a problem currently as there isn't any exception that is both causing blacklisting and retrying on another host. We may want to address this later though. (I have actually implemented that also, but wanted to change the code incrementally) 

**Where should we start reviewing?**:
Starting from the test probably.

**Priority (whenever / two weeks / yesterday)**:
This week
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3323)
<!-- Reviewable:end -->
