### PR TITLE
[TS] Immediately stop reading from sweep queue if we know we should pause

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsCache.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/CommitTsCache.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.sweep;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import com.google.common.cache.CacheBuilder;
@@ -34,6 +35,10 @@ public final class CommitTsCache {
 
     public static CommitTsCache create(TransactionService transactionService) {
         return new CommitTsCache(transactionService, ONE_MILLION);
+    }
+
+    public Optional<Long> loadIfCached(long startTs) {
+        return Optional.ofNullable(cache.getIfPresent(startTs));
     }
 
     public long load(long startTs) {

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,10 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |improved|
+         - Targeted sweep now stops reading from the sweep queue immediately if it encounters an entry known to be committed after the sweep timestamp.
+           Previously, we would read an entire batch before checking commit timestamps so that lookups can be batched, but this is not necessary if the commit timestamp is cached from a previous iteration.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3325>`__)
 
 =======
 v0.93.0


### PR DESCRIPTION
**Goals (and why)**:
This should address https://github.com/palantir/atlasdb/issues/3322. We do not want to read an entire batch of entries if we know early on we will have to pause anyway.

**Implementation Description (bullets)**:
For each start timestamp check if we happen to have the commit timestamp cached (which we will if we have recently swept from the same node and had to pause here). If yes, and it is greater than the sweep timestamp, we know everything after will be filtered out anyway, so immediately stop reading.

**Concerns (what feedback would you like?)**:
Should there be a more detailed explanation in the code?

**Where should we start reviewing?**:
Small

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3325)
<!-- Reviewable:end -->
