### PR TITLE
Actually rate limit detailed profile logging

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
-import java.util.function.BooleanSupplier;
 
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -74,6 +73,7 @@ import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
+import com.palantir.atlasdb.transaction.impl.logging.CommitProfileProcessor;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.annotation.Idempotent;
@@ -129,7 +129,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    int defaultGetRangesConcurrency,
                                    MultiTableSweepQueueWriter sweepQueue,
                                    ExecutorService deleteExecutor,
-                                   BooleanSupplier shouldProfile) {
+                                   CommitProfileProcessor commitProfileProcessor) {
         super(metricsManager,
               keyValueService,
               timelockService,
@@ -151,7 +151,7 @@ public class SerializableTransaction extends SnapshotTransaction {
               defaultGetRangesConcurrency,
               sweepQueue,
               deleteExecutor,
-              shouldProfile);
+              commitProfileProcessor);
     }
 
     @Override
@@ -710,7 +710,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
                 deleteExecutor,
-                shouldProfile) {
+                commitProfileProcessor) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
+import java.util.function.BooleanSupplier;
 
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -127,7 +128,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                                    ExecutorService getRangesExecutor,
                                    int defaultGetRangesConcurrency,
                                    MultiTableSweepQueueWriter sweepQueue,
-                                   ExecutorService deleteExecutor) {
+                                   ExecutorService deleteExecutor,
+                                   BooleanSupplier shouldProfile) {
         super(metricsManager,
               keyValueService,
               timelockService,
@@ -148,7 +150,8 @@ public class SerializableTransaction extends SnapshotTransaction {
               getRangesExecutor,
               defaultGetRangesConcurrency,
               sweepQueue,
-              deleteExecutor);
+              deleteExecutor,
+              shouldProfile);
     }
 
     @Override
@@ -706,7 +709,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
-                deleteExecutor) {
+                deleteExecutor,
+                shouldProfile) {
             @Override
             protected Map<Long, Long> getCommitTimestamps(TableReference tableRef,
                                                           Iterable<Long> startTimestamps,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -320,7 +320,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 sweepQueueWriter,
-                deleteExecutor);
+                deleteExecutor,
+                profilingRateLimiter);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -321,7 +321,7 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 defaultGetRangesConcurrency,
                 sweepQueueWriter,
                 deleteExecutor,
-                profilingRateLimiter);
+                commitProfileProcessor);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -98,7 +98,8 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
-                IGNORING_EXECUTOR);
+                IGNORING_EXECUTOR,
+                () -> false);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ShouldNotDeleteAndRollbackTransaction.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.logging.CommitProfileProcessor;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 
@@ -99,7 +100,7 @@ public class ShouldNotDeleteAndRollbackTransaction extends SnapshotTransaction {
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
                 IGNORING_EXECUTOR,
-                () -> false);
+                CommitProfileProcessor.createNonLogging(metricsManager));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -117,7 +118,6 @@ import com.palantir.atlasdb.transaction.impl.logging.ImmutableChainingLogConsume
 import com.palantir.atlasdb.transaction.impl.logging.ImmutableTransactionCommitProfile;
 import com.palantir.atlasdb.transaction.impl.logging.LogConsumerProcessor;
 import com.palantir.atlasdb.transaction.impl.logging.PredicateBackedLogConsumerProcessor;
-import com.palantir.atlasdb.transaction.impl.logging.RateLimitedBooleanSupplier;
 import com.palantir.atlasdb.transaction.impl.logging.TransactionCommitProfile;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -222,8 +222,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     protected volatile boolean hasReads;
 
     private final Timer.Context transactionTimerContext;
-
-    private final CommitProfileProcessor profileProcessor = createDefaultCommitProfileProcessor();
+    protected final BooleanSupplier shouldProfile;
+    protected final CommitProfileProcessor profileProcessor;
 
     /**
      * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to
@@ -251,7 +251,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                                ExecutorService getRangesExecutor,
                                int defaultGetRangesConcurrency,
                                MultiTableSweepQueueWriter sweepQueue,
-                               ExecutorService deleteExecutor) {
+                               ExecutorService deleteExecutor,
+                               BooleanSupplier shouldProfile) {
         this.metricsManager = metricsManager;
         this.transactionTimerContext = getTimer("transactionMillis").time();
         this.keyValueService = keyValueService;
@@ -275,6 +276,8 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         this.sweepQueue = sweepQueue;
         this.deleteExecutor = deleteExecutor;
         this.hasReads = false;
+        this.shouldProfile = shouldProfile;
+        this.profileProcessor = createDefaultCommitProfileProcessor(shouldProfile);
     }
 
     @Override
@@ -2042,20 +2045,18 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return metricsManager.registerOrGetMeter(SnapshotTransaction.class, name);
     }
 
-    private CommitProfileProcessor createDefaultCommitProfileProcessor() {
-        return new CommitProfileProcessor(createDefaultPerfLogger(),
+    private CommitProfileProcessor createDefaultCommitProfileProcessor(BooleanSupplier shouldProfile) {
+        return new CommitProfileProcessor(createDefaultPerfLogger(shouldProfile),
                 () -> getTimer("nonPutOverhead"),
                 () -> getHistogram("nonPutOverheadMillionths"));
     }
 
-    private LogConsumerProcessor createDefaultPerfLogger() {
+    private LogConsumerProcessor createDefaultPerfLogger(BooleanSupplier shouldProfile) {
         return ImmutableChainingLogConsumerProcessor.builder()
                 .addProcessors(PredicateBackedLogConsumerProcessor.create(
                         perfLogger::debug, perfLogger::isDebugEnabled))
                 .addProcessors(PredicateBackedLogConsumerProcessor.create(
-                        log::info, RateLimitedBooleanSupplier.create(5.0)))
+                        log::info, shouldProfile))
                 .build();
     }
 }
-
-

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -277,7 +277,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         this.deleteExecutor = deleteExecutor;
         this.hasReads = false;
         this.shouldProfile = shouldProfile;
-        this.profileProcessor = createDefaultCommitProfileProcessor(shouldProfile);
+        this.profileProcessor = createDefaultCommitProfileProcessor();
     }
 
     @Override
@@ -2045,13 +2045,13 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return metricsManager.registerOrGetMeter(SnapshotTransaction.class, name);
     }
 
-    private CommitProfileProcessor createDefaultCommitProfileProcessor(BooleanSupplier shouldProfile) {
-        return new CommitProfileProcessor(createDefaultPerfLogger(shouldProfile),
+    private CommitProfileProcessor createDefaultCommitProfileProcessor() {
+        return new CommitProfileProcessor(createDefaultPerfLogger(),
                 () -> getTimer("nonPutOverhead"),
                 () -> getHistogram("nonPutOverheadMillionths"));
     }
 
-    private LogConsumerProcessor createDefaultPerfLogger(BooleanSupplier shouldProfile) {
+    private LogConsumerProcessor createDefaultPerfLogger() {
         return ImmutableChainingLogConsumerProcessor.builder()
                 .addProcessors(PredicateBackedLogConsumerProcessor.create(
                         perfLogger::debug, perfLogger::isDebugEnabled))

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/logging/CommitProfileProcessor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/logging/CommitProfileProcessor.java
@@ -40,7 +40,7 @@ public class CommitProfileProcessor {
     private final MetricsManager metricsManager;
     private final LogConsumerProcessor logSink;
 
-    public CommitProfileProcessor(
+    private CommitProfileProcessor(
             MetricsManager metricsManager,
             LogConsumerProcessor logSink) {
         this.metricsManager = metricsManager;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/logging/CommitProfileProcessor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/logging/CommitProfileProcessor.java
@@ -31,7 +31,7 @@ import com.palantir.atlasdb.transaction.impl.SnapshotTransaction;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.logsafe.SafeArg;
 
-public class CommitProfileProcessor {
+public final class CommitProfileProcessor {
     private static final Logger log = LoggerFactory.getLogger(CommitProfileProcessor.class);
     private static final Logger perfLogger = LoggerFactory.getLogger("dualschema.perf");
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/logging/LogConsumerProcessor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/logging/LogConsumerProcessor.java
@@ -19,5 +19,7 @@ package com.palantir.atlasdb.transaction.impl.logging;
 import java.util.function.Supplier;
 
 public interface LogConsumerProcessor {
+    LogConsumerProcessor NO_OP = unused -> {};
+
     void maybeLog(Supplier<LogTemplate> logTemplateSupplier);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/logging/LogConsumerProcessor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/logging/LogConsumerProcessor.java
@@ -19,7 +19,9 @@ package com.palantir.atlasdb.transaction.impl.logging;
 import java.util.function.Supplier;
 
 public interface LogConsumerProcessor {
-    LogConsumerProcessor NO_OP = unused -> {};
+    LogConsumerProcessor NO_OP = unused -> {
+        // no op
+    };
 
     void maybeLog(Supplier<LogTemplate> logTemplateSupplier);
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -177,8 +177,6 @@ public class SnapshotTransactionManagerTest {
                 UUID.randomUUID()), PreCommitConditions.NO_OP);
         SnapshotTransaction tx2 = snapshotTransactionManager.createTransaction(1, () -> 2L, LockToken.of(
                 UUID.randomUUID()), PreCommitConditions.NO_OP);
-        assertThat(tx1.shouldProfile).isSameAs(tx2.shouldProfile);
-        assertThat(tx1.shouldProfile.getAsBoolean()).isTrue();
-        assertThat(tx2.shouldProfile.getAsBoolean()).isFalse();
+        assertThat(tx1.commitProfileProcessor).isSameAs(tx2.commitProfileProcessor);
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -178,7 +178,7 @@ public class SnapshotTransactionManagerTest {
         SnapshotTransaction tx2 = snapshotTransactionManager.createTransaction(1, () -> 2L, LockToken.of(
                 UUID.randomUUID()), PreCommitConditions.NO_OP);
         assertThat(tx1.shouldProfile).isSameAs(tx2.shouldProfile);
-        tx1.shouldProfile.getAsBoolean();
+        assertThat(tx1.shouldProfile.getAsBoolean()).isTrue();
         assertThat(tx2.shouldProfile.getAsBoolean()).isFalse();
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -58,6 +58,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
+import com.palantir.atlasdb.transaction.impl.logging.CommitProfileProcessor;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
@@ -118,7 +119,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 getSweepQueueWriterInitialized(),
                 MoreExecutors.newDirectExecutorService(),
-                () -> false) {
+                CommitProfileProcessor.createNonLogging(metricsManager)) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -117,7 +117,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 AbstractTransactionTest.GET_RANGES_EXECUTOR,
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 getSweepQueueWriterInitialized(),
-                MoreExecutors.newDirectExecutorService()) {
+                MoreExecutors.newDirectExecutorService(),
+                () -> false) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, input -> input.clone());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -130,7 +130,8 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 GET_RANGES_EXECUTOR,
                 DEFAULT_GET_RANGES_CONCURRENCY,
                 MultiTableSweepQueueWriter.NO_OP,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService(),
+                () -> false);
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -78,6 +78,7 @@ import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionConflictException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.logging.CommitProfileProcessor;
 import com.palantir.common.base.AbortingVisitors;
 import com.palantir.common.base.BatchingVisitable;
 import com.palantir.common.base.BatchingVisitables;
@@ -131,7 +132,7 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
                 DEFAULT_GET_RANGES_CONCURRENCY,
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
-                () -> false);
+                CommitProfileProcessor.createNonLogging(metricsManager));
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.logging.CommitProfileProcessor;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.LockClient;
@@ -139,7 +140,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 defaultGetRangesConcurrency,
                 sweepQueueWriter,
                 deleteExecutor,
-                () -> false);
+                CommitProfileProcessor.createNonLogging(metricsManager));
     }
 
     @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -138,7 +138,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 sweepQueueWriter,
-                deleteExecutor);
+                deleteExecutor,
+                () -> false);
     }
 
     @Override

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -286,7 +286,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService(),
+                () -> false);
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
             fail();
@@ -352,7 +353,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService(),
+                () -> false);
         snapshot.delete(TABLE, ImmutableSet.of(cell));
         snapshot.commit();
 
@@ -1032,7 +1034,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService(),
+                () -> false);
 
         //simulate roll back at commit time
         transactionService.putUnlessExists(snapshot.getTimestamp(), TransactionConstants.FAILED_COMMIT_TS);
@@ -1074,7 +1077,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 sweepQueue,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService(),
+                () -> false);
 
         //forcing to try to commit a transaction that is already committed
         transactionService.putUnlessExists(transactionTs, TransactionConstants.FAILED_COMMIT_TS);
@@ -1117,7 +1121,8 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 getRangesExecutor,
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService(),
+                () -> false);
 
         when(timestampServiceSpy.getFreshTimestamp()).thenReturn(10000000L);
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -113,6 +113,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutException;
 import com.palantir.atlasdb.transaction.api.TransactionLockTimeoutNonRetriableException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.impl.logging.CommitProfileProcessor;
 import com.palantir.common.base.AbortingVisitor;
 import com.palantir.common.base.AbortingVisitors;
 import com.palantir.common.base.BatchingVisitable;
@@ -287,7 +288,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
-                () -> false);
+                CommitProfileProcessor.createNonLogging(metricsManager));
         try {
             snapshot.get(TABLE, ImmutableSet.of(cell));
             fail();
@@ -354,7 +355,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
-                () -> false);
+                CommitProfileProcessor.createNonLogging(metricsManager));
         snapshot.delete(TABLE, ImmutableSet.of(cell));
         snapshot.commit();
 
@@ -1035,7 +1036,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
-                () -> false);
+                CommitProfileProcessor.createNonLogging(metricsManager));
 
         //simulate roll back at commit time
         transactionService.putUnlessExists(snapshot.getTimestamp(), TransactionConstants.FAILED_COMMIT_TS);
@@ -1078,7 +1079,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 defaultGetRangesConcurrency,
                 sweepQueue,
                 MoreExecutors.newDirectExecutorService(),
-                () -> false);
+                CommitProfileProcessor.createNonLogging(metricsManager));
 
         //forcing to try to commit a transaction that is already committed
         transactionService.putUnlessExists(transactionTs, TransactionConstants.FAILED_COMMIT_TS);
@@ -1122,7 +1123,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 defaultGetRangesConcurrency,
                 MultiTableSweepQueueWriter.NO_OP,
                 MoreExecutors.newDirectExecutorService(),
-                () -> false);
+                CommitProfileProcessor.createNonLogging(metricsManager));
 
         when(timestampServiceSpy.getFreshTimestamp()).thenReturn(10000000L);
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,7 +63,7 @@ develop
     *    - |fixed|
          - Snapshot transactions now write detailed profiling logs of the form ``Committed {} bytes with locks...`` only once every 5 seconds per ``TransactionManager`` used.
            Previously, they were written on every transaction.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/33>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3326>`__)
 
 =======
 v0.93.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -61,7 +61,7 @@ develop
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3303>`__)
 
     *    - |fixed|
-         - Snapshot transactions now write detailed profiling logs of the form ``Committed {} bytes with locks...`` only once every 5 seconds.
+         - Snapshot transactions now write detailed profiling logs of the form ``Committed {} bytes with locks...`` only once every 5 seconds per ``TransactionManager`` used.
            Previously, they were written on every transaction.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/33>`__)
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,11 @@ develop
            This should reduce request volumes on TimeLock Server.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3303>`__)
 
+    *    - |fixed|
+         - Snapshot transactions now write detailed profiling logs of the form ``Committed {} bytes with locks...`` only once every 5 seconds.
+           Previously, they were written on every transaction.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/33>`__)
+
 =======
 v0.93.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
- The detailed profile logging was supposed to be written once every 5 seconds, but the rate-limiter was applied on a per-`SnapshotTransaction` level so it wasn't. This PR fixes that.

**Implementation Description (bullets)**:
- Have a single `RateLimitedBooleanSupplier` in the `SnapshotTransactionManager` that is passed to all transactions created by that TM.

**Concerns (what feedback would you like?)**:
- Does this actually work?
- This does not rate limit across TransactionManagers - is that a problem?

**Where should we start reviewing?**: `SnapshotTransactionManager` and the test associated with it, probably

**Priority (whenever / two weeks / yesterday)**: yesterday-ish. Probably doesn't break stacks, but generates excessive log volume and makes reading logs in internal tool without the relevant filter difficult.

@ashrayjain for SA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3326)
<!-- Reviewable:end -->
