### PR TITLE
[TS] Do not report metrics when no data on last swept timestamp

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
@@ -64,15 +64,15 @@ public final class SweepMetricsAssert extends AbstractAssert<SweepMetricsAssert,
         objects.assertEqual(info, getGaugeConservative(AtlasDbMetricNames.ABORTED_WRITES_DELETED).getValue(), value);
     }
 
-    public void hasSweepTimestampConservativeEqualTo(long value) {
+    public void hasSweepTimestampConservativeEqualTo(Long value) {
         objects.assertEqual(info, getGaugeConservative(AtlasDbMetricNames.SWEEP_TS).getValue(), value);
     }
 
-    public void hasLastSweptTimestampConservativeEqualTo(long value) {
+    public void hasLastSweptTimestampConservativeEqualTo(Long value) {
         objects.assertEqual(info, getGaugeConservative(AtlasDbMetricNames.LAST_SWEPT_TS).getValue(), value);
     }
 
-    public void hasMillisSinceLastSweptConservativeEqualTo(long value) {
+    public void hasMillisSinceLastSweptConservativeEqualTo(Long value) {
         objects.assertEqual(info, getGaugeConservative(AtlasDbMetricNames.LAG_MILLIS).getValue(), value);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetricsTest.java
@@ -51,6 +51,17 @@ public class TargetedSweepMetricsTest {
     }
 
     @Test
+    public void initialMetricsAreNormalized() {
+        assertThat(metricsManager).hasEnqueuedWritesConservativeEqualTo(0);
+        assertThat(metricsManager).hasEntriesReadConservativeEqualTo(0);
+        assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(0);
+        assertThat(metricsManager).hasAbortedWritesDeletedConservativeEquals(0);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(null);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(null);
+        assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(null);
+    }
+
+    @Test
     public void canUpdateConservativeMetrics() {
         metrics.updateEnqueuedWrites(CONS_ZERO, 10);
         metrics.updateEntriesRead(CONS_ZERO, 21);
@@ -64,8 +75,8 @@ public class TargetedSweepMetricsTest {
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(21);
         assertThat(metricsManager).hasTombstonesPutConservativeEqualTo(1);
         assertThat(metricsManager).hasAbortedWritesDeletedConservativeEquals(2);
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(7);
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(4);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(7L);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(4L);
 
         puncherStore.put(3, 2);
         puncherStore.put(4, 15);
@@ -135,13 +146,13 @@ public class TargetedSweepMetricsTest {
     @Test
     public void sweepTimestampGetsLastValueOverShards() {
         metrics.updateSweepTimestamp(CONS_ZERO, 1);
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(1);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(1L);
 
         metrics.updateSweepTimestamp(CONS_ONE, 5);
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(5);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(5L);
 
         metrics.updateSweepTimestamp(CONS_ZERO, 3);
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(3);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(3L);
     }
 
     @Test
@@ -151,7 +162,7 @@ public class TargetedSweepMetricsTest {
         metrics.updateProgressForShard(CONS_TWO, 1000);
         waitForProgressToRecompute();
 
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(1);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(1L);
 
         puncherStore.put(0, 5);
         puncherStore.put(2, 500);
@@ -200,13 +211,13 @@ public class TargetedSweepMetricsTest {
     public void lastSweptGoesDownIfNewInformationBecomesAvailable() {
         metrics.updateProgressForShard(CONS_ZERO, 9);
         waitForProgressToRecompute();
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(9);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(9L);
         puncherStore.put(9, 9);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(clockTime - 9);
 
         metrics.updateProgressForShard(CONS_ONE, 2);
         waitForProgressToRecompute();
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(2);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(2L);
         puncherStore.put(2, 2);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(clockTime - 2);
     }
@@ -221,7 +232,7 @@ public class TargetedSweepMetricsTest {
         metrics.updateProgressForShard(CONS_ONE, 15);
         waitForProgressToRecompute();
 
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(10);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(10L);
         puncherStore.put(1, 1);
         puncherStore.put(10, 7);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(clockTime - 7);
@@ -238,14 +249,14 @@ public class TargetedSweepMetricsTest {
         metrics.updateProgressForShard(CONS_TWO, 50);
         waitForProgressToRecompute();
 
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(10);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(10L);
         puncherStore.put(10, 10);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(clockTime - 10);
 
         metrics.updateProgressForShard(CONS_ONE, 40);
         waitForProgressToRecompute();
 
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(30);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(30L);
         puncherStore.put(30, 30);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(clockTime - 30);
     }
@@ -284,14 +295,14 @@ public class TargetedSweepMetricsTest {
     @Test
     public void sweepTimestampDoesNotClashAcrossStrategies() {
         metrics.updateSweepTimestamp(CONS_ZERO, 1);
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(1);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(1L);
 
         metrics.updateSweepTimestamp(THOR_ZERO, 5);
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(1);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(1L);
         assertThat(metricsManager).hasSweepTimestampThoroughEqualTo(5);
 
         metrics.updateSweepTimestamp(CONS_ZERO, 3);
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(3);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(3L);
         assertThat(metricsManager).hasSweepTimestampThoroughEqualTo(5);
     }
 
@@ -301,7 +312,7 @@ public class TargetedSweepMetricsTest {
         metrics.updateProgressForShard(THOR_ZERO, 50);
         waitForProgressToRecompute();
 
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(1);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(1L);
         assertThat(metricsManager).hasLastSweptTimestampThoroughEqualTo(50);
         puncherStore.put(1, 1);
         puncherStore.put(50, 50);
@@ -314,7 +325,7 @@ public class TargetedSweepMetricsTest {
         waitForProgressToRecompute();
 
         puncherStore.put(5, 5);
-        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(5);
+        assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(5L);
         assertThat(metricsManager).hasLastSweptTimestampThoroughEqualTo(5);
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(clockTime - 5);
         assertThat(metricsManager).hasMillisSinceLastSweptThoroughEqualTo(clockTime - 5);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -631,14 +631,14 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(0));
         sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(0));
 
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(17);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(17L);
         assertThat(metricsManager).hasSweepTimestampThoroughEqualTo(40);
 
         immutableTs = 5;
         sweepQueue.sweepNextBatch(ShardAndStrategy.conservative(0));
         sweepQueue.sweepNextBatch(ShardAndStrategy.thorough(0));
 
-        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(5);
+        assertThat(metricsManager).hasSweepTimestampConservativeEqualTo(5L);
         assertThat(metricsManager).hasSweepTimestampThoroughEqualTo(5);
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Before the first iteration of targeted sweep is run, the last swept timestamp metric used to report -1, which seemed like a reasonable default, but it would cause the millis since last swept to report the current time in millis.

**Implementation Description (bullets)**:
Instead, report null for last swept when we do not know, and then likewise report null for millis since last swept ts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3327)
<!-- Reviewable:end -->
