### PR TITLE
Fix thread leak in Dagger module (fixes benchmark/CLI/console JVM shutdown)

### DIFF
--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/AtlasDbServices.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/AtlasDbServices.java
@@ -56,6 +56,6 @@ public abstract class AtlasDbServices implements AutoCloseable {
 
     @Override
     public void close() {
-        getKeyValueService().close();
+        getTransactionManager().close();
     }
 }

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -37,6 +37,7 @@ import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.v2.TimelockService;
 
@@ -108,7 +109,8 @@ public class TransactionManagerModule {
                 config.atlasDbConfig().keyValueService().concurrentGetRangesThreadPoolSize(),
                 config.atlasDbConfig().keyValueService().defaultGetRangesConcurrency(),
                 MultiTableSweepQueueWriter.NO_OP,
-                Executors.newSingleThreadExecutor());
+                Executors.newSingleThreadExecutor(
+                        new NamedThreadFactory(TransactionManagerModule.class + "-delete-executor", true)));
     }
 
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -60,6 +60,11 @@ develop
            This should reduce request volumes on TimeLock Server.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3303>`__)
 
+    *    - |fixed|
+         - AtlasDB Benchmarks, CLIs and Console now shutdown properly under certain read patterns.
+           Previously, if these tools needed to delete a value that a failed transaction had written, the delete executor was never closed, thereby preventing an orderly JVM shutdown.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3328>`__)
+
 =======
 v0.93.0
 =======


### PR DESCRIPTION
**Goals (and why)**: Fix #3317 

**Implementation Description (bullets)**:
- Create a thread-factory that makes the delete executor a named daemon thread
- Close the _transaction manager_ as opposed to just the _key-value-service_ when closing a Dagger `AtlasDbServices`
- Sadly this does *not* fix the thread-leaks @gsheasby identified on several support tickets mentioned in #3317

**Concerns (what feedback would you like?)**:
- Is closing the TM altogether safe (as opposed to leaving an open TM sitting atop a closed KVS)?

**Where should we start reviewing?**: `TransactionManagerModule`

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3328)
<!-- Reviewable:end -->
