### PR TITLE
fix test flake

### DIFF
--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -211,7 +211,6 @@ public class CassandraClientPoolTest {
 
         host(HOST_1).throwsException(new SocketTimeoutException())
                 .throwsException(new InvalidRequestException())
-                .continuesToThrow()
                 .inPool(cassandraClientPool);
 
         host(HOST_2).throwsException(new SocketTimeoutException())


### PR DESCRIPTION
**Goals (and why)**:
Fix test flake caused by `CassandraClientPoolTest.attemptsShouldBeCountedPerHost`

**Implementation Description (bullets)**:
Original test was introduced with an intention to ensure we are counting attempts per host. Test was working such that:
1.host_1 first throws `SocketTimeoutException`, which causes a backoff but not retry on another host. 
2.Request is retried on host_1 again, this time host_1 throws `InvalidRequestException` which causes retry on another host (host_2 is the only option in this case). 
3.Request is tried on host_2; but host_2 throws `SocketTimeoutException`. Which normally shouldn't tried on another host, but RequestHandler is not working as expected (another bug needs to be fixed, but will be addressed in a separate pr).
4.Request is randomly retried on either host_1 or host_2. If it picks host_1 3 times in a row, then test throws an `InvalidRequestException` and exits.

To fix the test flake, host_1 now doesn't continue throwing, as a result test should pass in either case; but it still tests the correct behavior (host_2 shouldn't be blacklisted)

**Priority (whenever / two weeks / yesterday)**:
Today would be nice, as it is causing test flakes
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3334)
<!-- Reviewable:end -->
