### PR TITLE
Don't run in-process compaction from sweep CLI.

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -27,7 +26,6 @@ import javax.annotation.Nullable;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Functions;
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.BaseEncoding;
@@ -213,14 +211,6 @@ public class SweepCommand extends SingleBackendCommand {
                     LoggingArgs.tableRef(tableToSweep),
                     SafeArg.of("cellTs pairs examined", finalAccumulatedResults.getCellTsPairsExamined()),
                     SafeArg.of("cellTs pairs deleted", finalAccumulatedResults.getStaleValuesDeleted()));
-
-            if (!dryRun && finalAccumulatedResults.getStaleValuesDeleted() > 0) {
-                Stopwatch watch = Stopwatch.createStarted();
-                services.getKeyValueService().compactInternally(tableToSweep);
-                printer.info("Finished performing compactInternally on {} in {} ms.",
-                        LoggingArgs.tableRef(tableToSweep),
-                        SafeArg.of("time taken", watch.elapsed(TimeUnit.MILLISECONDS)));
-            }
         }
         return 0;
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,11 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - The sweep CLI will no longer perform in-process compactions after sweeping a table.
+           For DbKvs, this operation is handled by the background compaction thread; Cassandra performs its own compactions.
+           Note that the sweep CLI itself has been deprecated in favour of using the sweep priority override configuration, possibly in conjunction with the thread count (:ref:`Docs<sweep_tunable_parameters>`).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3338>`__)
 
 =======
 v0.94.0


### PR DESCRIPTION
Where useful, this operation should be handled by the background compactor instead.

**Do not merge** without internal product approval.

**Goals (and why)**:
- Manage compaction 
- Fix an error that occurred in internal product testing

**Implementation Description (bullets)**:
- Delete an if block

**Concerns (what feedback would you like?)**: 
1. Should we keep this CLI around at all?
2. Does this break any internal product workflow? @mswintermeyer 
3. Just the minor existential concern that happens when you change some code functionality and don't break any unit tests 😞 

**Where should we start reviewing?**: SweepCommand.java

**Priority (whenever / two weeks / yesterday)**: ASAP, the error blocks rollout of the background compactor to places that need it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3338)
<!-- Reviewable:end -->
