### PR TITLE
Kill DataTable.putUnlessExists()

### DIFF
--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
@@ -1635,18 +1635,6 @@ public final class AllValueTypesTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn0UnlessExists(AllValueTypesTestRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column0.of(value)));
-    }
-
-    public void putColumn0UnlessExists(Map<AllValueTypesTestRow, Long> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column0.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putColumn1(AllValueTypesTestRow row, Long value) {
         put(ImmutableMultimap.of(row, Column1.of(value)));
     }
@@ -1657,18 +1645,6 @@ public final class AllValueTypesTestTable implements
             toPut.put(e.getKey(), Column1.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putColumn1UnlessExists(AllValueTypesTestRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column1.of(value)));
-    }
-
-    public void putColumn1UnlessExists(Map<AllValueTypesTestRow, Long> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column1.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     public void putColumn2(AllValueTypesTestRow row, Long value) {
@@ -1683,18 +1659,6 @@ public final class AllValueTypesTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn2UnlessExists(AllValueTypesTestRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column2.of(value)));
-    }
-
-    public void putColumn2UnlessExists(Map<AllValueTypesTestRow, Long> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column2.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putColumn3(AllValueTypesTestRow row, Long value) {
         put(ImmutableMultimap.of(row, Column3.of(value)));
     }
@@ -1705,18 +1669,6 @@ public final class AllValueTypesTestTable implements
             toPut.put(e.getKey(), Column3.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putColumn3UnlessExists(AllValueTypesTestRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column3.of(value)));
-    }
-
-    public void putColumn3UnlessExists(Map<AllValueTypesTestRow, Long> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column3.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     public void putColumn4(AllValueTypesTestRow row, Sha256Hash value) {
@@ -1731,18 +1683,6 @@ public final class AllValueTypesTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn4UnlessExists(AllValueTypesTestRow row, Sha256Hash value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column4.of(value)));
-    }
-
-    public void putColumn4UnlessExists(Map<AllValueTypesTestRow, Sha256Hash> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, Sha256Hash> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column4.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putColumn5(AllValueTypesTestRow row, String value) {
         put(ImmutableMultimap.of(row, Column5.of(value)));
     }
@@ -1753,18 +1693,6 @@ public final class AllValueTypesTestTable implements
             toPut.put(e.getKey(), Column5.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putColumn5UnlessExists(AllValueTypesTestRow row, String value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column5.of(value)));
-    }
-
-    public void putColumn5UnlessExists(Map<AllValueTypesTestRow, String> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, String> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column5.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     public void putColumn6(AllValueTypesTestRow row, String value) {
@@ -1779,18 +1707,6 @@ public final class AllValueTypesTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn6UnlessExists(AllValueTypesTestRow row, String value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column6.of(value)));
-    }
-
-    public void putColumn6UnlessExists(Map<AllValueTypesTestRow, String> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, String> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column6.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putColumn7(AllValueTypesTestRow row, byte[] value) {
         put(ImmutableMultimap.of(row, Column7.of(value)));
     }
@@ -1801,18 +1717,6 @@ public final class AllValueTypesTestTable implements
             toPut.put(e.getKey(), Column7.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putColumn7UnlessExists(AllValueTypesTestRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column7.of(value)));
-    }
-
-    public void putColumn7UnlessExists(Map<AllValueTypesTestRow, byte[]> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column7.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     public void putColumn8(AllValueTypesTestRow row, byte[] value) {
@@ -1827,18 +1731,6 @@ public final class AllValueTypesTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn8UnlessExists(AllValueTypesTestRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column8.of(value)));
-    }
-
-    public void putColumn8UnlessExists(Map<AllValueTypesTestRow, byte[]> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column8.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putColumn9(AllValueTypesTestRow row, Long value) {
         put(ImmutableMultimap.of(row, Column9.of(value)));
     }
@@ -1849,18 +1741,6 @@ public final class AllValueTypesTestTable implements
             toPut.put(e.getKey(), Column9.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putColumn9UnlessExists(AllValueTypesTestRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column9.of(value)));
-    }
-
-    public void putColumn9UnlessExists(Map<AllValueTypesTestRow, Long> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column9.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     public void putColumn10(AllValueTypesTestRow row, UUID value) {
@@ -1875,18 +1755,6 @@ public final class AllValueTypesTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn10UnlessExists(AllValueTypesTestRow row, UUID value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column10.of(value)));
-    }
-
-    public void putColumn10UnlessExists(Map<AllValueTypesTestRow, UUID> map) {
-        Map<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AllValueTypesTestRow, UUID> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column10.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<AllValueTypesTestRow, ? extends AllValueTypesTestNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -1894,20 +1762,6 @@ public final class AllValueTypesTestTable implements
         for (AllValueTypesTestTrigger trigger : triggers) {
             trigger.putAllValueTypesTest(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<AllValueTypesTestRow, ? extends AllValueTypesTestNamedColumnValue<?>> rows) {
-        Multimap<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<AllValueTypesTestRow, AllValueTypesTestNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<AllValueTypesTestRow, ? extends AllValueTypesTestNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteColumn0(AllValueTypesTestRow row) {
@@ -2253,5 +2107,5 @@ public final class AllValueTypesTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "FKayZbE3gaKlW4+Xx6ZX1A==";
+    static String __CLASS_HASH = "7ICgYboWGmlASXKikUY+zQ==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
@@ -458,18 +458,6 @@ public final class HashComponentsTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumnUnlessExists(HashComponentsTestRow row, String value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column.of(value)));
-    }
-
-    public void putColumnUnlessExists(Map<HashComponentsTestRow, String> map) {
-        Map<HashComponentsTestRow, HashComponentsTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<HashComponentsTestRow, String> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<HashComponentsTestRow, ? extends HashComponentsTestNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -477,20 +465,6 @@ public final class HashComponentsTestTable implements
         for (HashComponentsTestTrigger trigger : triggers) {
             trigger.putHashComponentsTest(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<HashComponentsTestRow, ? extends HashComponentsTestNamedColumnValue<?>> rows) {
-        Multimap<HashComponentsTestRow, HashComponentsTestNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<HashComponentsTestRow, HashComponentsTestNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<HashComponentsTestRow, ? extends HashComponentsTestNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteColumn(HashComponentsTestRow row) {
@@ -775,5 +749,5 @@ public final class HashComponentsTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ZhLggIl3pmPr+p4Pgpmu1A==";
+    static String __CLASS_HASH = "D7jBjvqrJyVDhFQlvw9TRA==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
@@ -519,18 +519,6 @@ public final class SchemaApiTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn1UnlessExists(SchemaApiTestRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column1.of(value)));
-    }
-
-    public void putColumn1UnlessExists(Map<SchemaApiTestRow, Long> map) {
-        Map<SchemaApiTestRow, SchemaApiTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SchemaApiTestRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column1.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putColumn2(SchemaApiTestRow row, com.palantir.atlasdb.table.description.test.StringValue value) {
         put(ImmutableMultimap.of(row, Column2.of(value)));
     }
@@ -543,18 +531,6 @@ public final class SchemaApiTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn2UnlessExists(SchemaApiTestRow row, com.palantir.atlasdb.table.description.test.StringValue value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column2.of(value)));
-    }
-
-    public void putColumn2UnlessExists(Map<SchemaApiTestRow, com.palantir.atlasdb.table.description.test.StringValue> map) {
-        Map<SchemaApiTestRow, SchemaApiTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SchemaApiTestRow, com.palantir.atlasdb.table.description.test.StringValue> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column2.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<SchemaApiTestRow, ? extends SchemaApiTestNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -562,20 +538,6 @@ public final class SchemaApiTestTable implements
         for (SchemaApiTestTrigger trigger : triggers) {
             trigger.putSchemaApiTest(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<SchemaApiTestRow, ? extends SchemaApiTestNamedColumnValue<?>> rows) {
-        Multimap<SchemaApiTestRow, SchemaApiTestNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<SchemaApiTestRow, SchemaApiTestNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<SchemaApiTestRow, ? extends SchemaApiTestNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteColumn1(SchemaApiTestRow row) {
@@ -871,5 +833,5 @@ public final class SchemaApiTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "imjzrX/X4tDr/Y6I5HHi5A==";
+    static String __CLASS_HASH = "gJjGs7nehodvK83lsXBdyA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
@@ -415,18 +415,6 @@ public final class CompactMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putLastCompactTimeUnlessExists(CompactMetadataRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, LastCompactTime.of(value)));
-    }
-
-    public void putLastCompactTimeUnlessExists(Map<CompactMetadataRow, Long> map) {
-        Map<CompactMetadataRow, CompactMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<CompactMetadataRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), LastCompactTime.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<CompactMetadataRow, ? extends CompactMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -434,20 +422,6 @@ public final class CompactMetadataTable implements
         for (CompactMetadataTrigger trigger : triggers) {
             trigger.putCompactMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<CompactMetadataRow, ? extends CompactMetadataNamedColumnValue<?>> rows) {
-        Multimap<CompactMetadataRow, CompactMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<CompactMetadataRow, CompactMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<CompactMetadataRow, ? extends CompactMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteLastCompactTime(CompactMetadataRow row) {
@@ -683,5 +657,5 @@ public final class CompactMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "49LUGGRKSR/vJ9oAtYrAcA==";
+    static String __CLASS_HASH = "0WtSpbMMOvlM3AribPiPxQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -831,18 +831,6 @@ public final class SweepPriorityTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putWriteCountUnlessExists(SweepPriorityRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, WriteCount.of(value)));
-    }
-
-    public void putWriteCountUnlessExists(Map<SweepPriorityRow, Long> map) {
-        Map<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepPriorityRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), WriteCount.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putLastSweepTime(SweepPriorityRow row, Long value) {
         put(ImmutableMultimap.of(row, LastSweepTime.of(value)));
     }
@@ -853,18 +841,6 @@ public final class SweepPriorityTable implements
             toPut.put(e.getKey(), LastSweepTime.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putLastSweepTimeUnlessExists(SweepPriorityRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, LastSweepTime.of(value)));
-    }
-
-    public void putLastSweepTimeUnlessExists(Map<SweepPriorityRow, Long> map) {
-        Map<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepPriorityRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), LastSweepTime.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     public void putMinimumSweptTimestamp(SweepPriorityRow row, Long value) {
@@ -879,18 +855,6 @@ public final class SweepPriorityTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMinimumSweptTimestampUnlessExists(SweepPriorityRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, MinimumSweptTimestamp.of(value)));
-    }
-
-    public void putMinimumSweptTimestampUnlessExists(Map<SweepPriorityRow, Long> map) {
-        Map<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepPriorityRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), MinimumSweptTimestamp.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putCellsDeleted(SweepPriorityRow row, Long value) {
         put(ImmutableMultimap.of(row, CellsDeleted.of(value)));
     }
@@ -901,18 +865,6 @@ public final class SweepPriorityTable implements
             toPut.put(e.getKey(), CellsDeleted.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putCellsDeletedUnlessExists(SweepPriorityRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, CellsDeleted.of(value)));
-    }
-
-    public void putCellsDeletedUnlessExists(Map<SweepPriorityRow, Long> map) {
-        Map<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepPriorityRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), CellsDeleted.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     public void putCellsExamined(SweepPriorityRow row, Long value) {
@@ -927,18 +879,6 @@ public final class SweepPriorityTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putCellsExaminedUnlessExists(SweepPriorityRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, CellsExamined.of(value)));
-    }
-
-    public void putCellsExaminedUnlessExists(Map<SweepPriorityRow, Long> map) {
-        Map<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SweepPriorityRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), CellsExamined.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<SweepPriorityRow, ? extends SweepPriorityNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -946,20 +886,6 @@ public final class SweepPriorityTable implements
         for (SweepPriorityTrigger trigger : triggers) {
             trigger.putSweepPriority(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<SweepPriorityRow, ? extends SweepPriorityNamedColumnValue<?>> rows) {
-        Multimap<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<SweepPriorityRow, SweepPriorityNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<SweepPriorityRow, ? extends SweepPriorityNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteWriteCount(SweepPriorityRow row) {
@@ -1239,5 +1165,5 @@ public final class SweepPriorityTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1Jg6QChUupx53+JdkO4bzg==";
+    static String __CLASS_HASH = "TJJRvx5uQ/E1NQVzUnggYQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
@@ -464,7 +464,6 @@ public final class SweepShardProgressTable implements
 
     /** @deprecated Use separate read and write in a single transaction instead. */
     @Deprecated
-    @Override
     public void putUnlessExists(Multimap<SweepShardProgressRow, ? extends SweepShardProgressNamedColumnValue<?>> rows) {
         Multimap<SweepShardProgressRow, SweepShardProgressNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
         Multimap<SweepShardProgressRow, SweepShardProgressNamedColumnValue<?>> toPut = HashMultimap.create();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
@@ -541,21 +541,18 @@ public final class SweepableCellsTable implements
 
     /** @deprecated Use separate read and write in a single transaction instead. */
     @Deprecated
-    @Override
     public void putUnlessExists(SweepableCellsRow rowName, Iterable<SweepableCellsColumnValue> values) {
         putUnlessExists(ImmutableMultimap.<SweepableCellsRow, SweepableCellsColumnValue>builder().putAll(rowName, values).build());
     }
 
     /** @deprecated Use separate read and write in a single transaction instead. */
     @Deprecated
-    @Override
     public void putUnlessExists(SweepableCellsRow rowName, SweepableCellsColumnValue... values) {
         putUnlessExists(ImmutableMultimap.<SweepableCellsRow, SweepableCellsColumnValue>builder().putAll(rowName, values).build());
     }
 
     /** @deprecated Use separate read and write in a single transaction instead. */
     @Deprecated
-    @Override
     public void putUnlessExists(Multimap<SweepableCellsRow, ? extends SweepableCellsColumnValue> rows) {
         Multimap<SweepableCellsRow, SweepableCellsColumn> toGet = Multimaps.transformValues(rows, SweepableCellsColumnValue.getColumnNameFun());
         Multimap<SweepableCellsRow, SweepableCellsColumnValue> existing = get(toGet);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
@@ -538,21 +538,18 @@ public final class SweepableTimestampsTable implements
 
     /** @deprecated Use separate read and write in a single transaction instead. */
     @Deprecated
-    @Override
     public void putUnlessExists(SweepableTimestampsRow rowName, Iterable<SweepableTimestampsColumnValue> values) {
         putUnlessExists(ImmutableMultimap.<SweepableTimestampsRow, SweepableTimestampsColumnValue>builder().putAll(rowName, values).build());
     }
 
     /** @deprecated Use separate read and write in a single transaction instead. */
     @Deprecated
-    @Override
     public void putUnlessExists(SweepableTimestampsRow rowName, SweepableTimestampsColumnValue... values) {
         putUnlessExists(ImmutableMultimap.<SweepableTimestampsRow, SweepableTimestampsColumnValue>builder().putAll(rowName, values).build());
     }
 
     /** @deprecated Use separate read and write in a single transaction instead. */
     @Deprecated
-    @Override
     public void putUnlessExists(Multimap<SweepableTimestampsRow, ? extends SweepableTimestampsColumnValue> rows) {
         Multimap<SweepableTimestampsRow, SweepableTimestampsColumn> toGet = Multimaps.transformValues(rows, SweepableTimestampsColumnValue.getColumnNameFun());
         Multimap<SweepableTimestampsRow, SweepableTimestampsColumnValue> existing = get(toGet);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbDynamicMutablePersistentTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbDynamicMutablePersistentTable.java
@@ -25,7 +25,5 @@ public interface AtlasDbDynamicMutablePersistentTable<ROW, COLUMN, COLUMN_VALUE,
             AtlasDbMutablePersistentTable<ROW, COLUMN_VALUE, ROW_RESULT> {
     void put(ROW row, Iterable<COLUMN_VALUE> values);
     void put(ROW row, COLUMN_VALUE... values);
-    void putUnlessExists(ROW row, Iterable<COLUMN_VALUE> values);
-    void putUnlessExists(ROW row, COLUMN_VALUE... values);
     void touch(Multimap<ROW, COLUMN> cellsToTouch);
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbMutablePersistentTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/api/AtlasDbMutablePersistentTable.java
@@ -23,5 +23,4 @@ import com.google.common.collect.Multimap;
 public interface AtlasDbMutablePersistentTable<ROW, COLUMN_VALUE, ROW_RESULT> extends
             AtlasDbImmutableTable<ROW, COLUMN_VALUE, ROW_RESULT> {
     void put(Multimap<ROW, ? extends COLUMN_VALUE> rows);
-    void putUnlessExists(Multimap<ROW, ? extends COLUMN_VALUE> rows);
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/TableRenderer.java
@@ -301,8 +301,6 @@ public class TableRenderer {
             }
             renderNamedPut();
             line();
-            renderNamedPutUnlessExists();
-            line();
             for (NamedColumnDescription col : table.getColumns().getNamedColumns()) {
                 renderNamedDeleteColumn(col);
                 line();
@@ -341,8 +339,6 @@ public class TableRenderer {
             renderDynamicDelete();
             line();
             renderDynamicPut();
-            line();
-            renderDynamicPutUnlessExists();
             line();
             renderDynamicTouch();
             line();
@@ -484,20 +480,6 @@ public class TableRenderer {
                 line("for (", Trigger, " trigger : triggers) {"); {
                     line("trigger.put", tableName, "(values);");
                 } line("}");
-            } line("}");
-            line();
-            line("/** @deprecated Use separate read and write in a single transaction instead. */");
-            line("@Deprecated");
-            line("@Override");
-            line("public void putUnlessExists(", Row, " rowName, Iterable<", ColumnValue, "> values) {"); {
-                line("putUnlessExists(ImmutableMultimap.<", Row, ", ", ColumnValue, ">builder().putAll(rowName, values).build());");
-            } line("}");
-            line();
-            line("/** @deprecated Use separate read and write in a single transaction instead. */");
-            line("@Deprecated");
-            line("@Override");
-            line("public void putUnlessExists(", Row, " rowName, ", ColumnValue, "... values) {"); {
-                line("putUnlessExists(ImmutableMultimap.<", Row, ", ", ColumnValue, ">builder().putAll(rowName, values).build());");
             } line("}");
         }
 
@@ -666,18 +648,6 @@ public class TableRenderer {
                 } line("}");
                 line("put(Multimaps.forMap(toPut));");
             } line("}");
-            line();
-            line("public void put", ColumnRenderers.VarName(col), "UnlessExists(", Row, " row, ", Value, " value) {"); {
-                line("putUnlessExists(ImmutableMultimap.of(row, ", ColumnRenderers.VarName(col), ".of(value)));");
-            } line("}");
-            line();
-            line("public void put", ColumnRenderers.VarName(col), "UnlessExists(Map<", Row, ", ", Value, "> map) {"); {
-                line("Map<", Row, ", ", ColumnValue, "> toPut = Maps.newHashMapWithExpectedSize(map.size());");
-                line("for (Entry<", Row, ", ", Value, "> e : map.entrySet()) {"); {
-                    line("toPut.put(e.getKey(), ", ColumnRenderers.VarName(col), ".of(e.getValue()));");
-                } line("}");
-                line("putUnlessExists(Multimaps.forMap(toPut));");
-            } line("}");
         }
 
         private void renderNamedGetAffectedCells() {
@@ -723,39 +693,6 @@ public class TableRenderer {
                 line("for (", Trigger, " trigger : triggers) {"); {
                     line("trigger.put", tableName, "(rows);");
                 } line("}");
-            } line("}");
-        }
-
-        private void renderNamedPutUnlessExists() {
-            line("/** @deprecated Use separate read and write in a single transaction instead. */");
-            line("@Deprecated");
-            line("@Override");
-            line("public void putUnlessExists(Multimap<", Row, ", ? extends ", ColumnValue, "> rows) {"); {
-                line("Multimap<", Row, ", ", ColumnValue, "> existing = getRowsMultimap(rows.keySet());");
-                line("Multimap<", Row, ", ", ColumnValue, "> toPut = HashMultimap.create();");
-                line("for (Entry<", Row, ", ? extends ", ColumnValue, "> entry : rows.entries()) {"); {
-                    line("if (!existing.containsEntry(entry.getKey(), entry.getValue())) {"); {
-                        line("toPut.put(entry.getKey(), entry.getValue());");
-                    } line("}");
-                } line("}");
-                line("put(toPut);");
-            } line("}");
-        }
-
-        private void renderDynamicPutUnlessExists() {
-            line("/** @deprecated Use separate read and write in a single transaction instead. */");
-            line("@Deprecated");
-            line("@Override");
-            line("public void putUnlessExists(Multimap<", Row, ", ? extends ", ColumnValue, "> rows) {"); {
-                line("Multimap<", Row, ", ", Column, "> toGet = Multimaps.transformValues(rows, ", ColumnValue, ".getColumnNameFun());");
-                line("Multimap<", Row, ", ", ColumnValue, "> existing = get(toGet);");
-                line("Multimap<", Row, ", ", ColumnValue, "> toPut = HashMultimap.create();");
-                line("for (Entry<", Row, ", ? extends ", ColumnValue, "> entry : rows.entries()) {"); {
-                    line("if (!existing.containsEntry(entry.getKey(), entry.getValue())) {"); {
-                        line("toPut.put(entry.getKey(), entry.getValue());");
-                    } line("}");
-                } line("}");
-                line("put(toPut);");
             } line("}");
         }
 

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -489,35 +489,6 @@ public final class GenericRangeScanTestTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(GenericRangeScanTestRow rowName, Iterable<GenericRangeScanTestColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(GenericRangeScanTestRow rowName, GenericRangeScanTestColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<GenericRangeScanTestRow, GenericRangeScanTestColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<GenericRangeScanTestRow, ? extends GenericRangeScanTestColumnValue> rows) {
-        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> toGet = Multimaps.transformValues(rows, GenericRangeScanTestColumnValue.getColumnNameFun());
-        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> existing = get(toGet);
-        Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> toPut = HashMultimap.create();
-        for (Entry<GenericRangeScanTestRow, ? extends GenericRangeScanTestColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumn> values) {
         Multimap<GenericRangeScanTestRow, GenericRangeScanTestColumnValue> currentValues = get(values);
@@ -795,5 +766,5 @@ public final class GenericRangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "AY9xYqAK0/4MlWNEl2//dg==";
+    static String __CLASS_HASH = "nLl28oDHfbNzyKxXdgdZ7Q==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -415,18 +415,6 @@ public final class RangeScanTestTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putColumn1UnlessExists(RangeScanTestRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Column1.of(value)));
-    }
-
-    public void putColumn1UnlessExists(Map<RangeScanTestRow, Long> map) {
-        Map<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<RangeScanTestRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Column1.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<RangeScanTestRow, ? extends RangeScanTestNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -434,20 +422,6 @@ public final class RangeScanTestTable implements
         for (RangeScanTestTrigger trigger : triggers) {
             trigger.putRangeScanTest(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<RangeScanTestRow, ? extends RangeScanTestNamedColumnValue<?>> rows) {
-        Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<RangeScanTestRow, RangeScanTestNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<RangeScanTestRow, ? extends RangeScanTestNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteColumn1(RangeScanTestRow row) {
@@ -732,5 +706,5 @@ public final class RangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "4Ueuy0y856/ejfFWhWZDqQ==";
+    static String __CLASS_HASH = "L/EHvF7Ho3czZ/Z7Oae6xg==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
@@ -415,18 +415,6 @@ public final class LatestSnapshotTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putStreamIdUnlessExists(LatestSnapshotRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, StreamId.of(value)));
-    }
-
-    public void putStreamIdUnlessExists(Map<LatestSnapshotRow, Long> map) {
-        Map<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<LatestSnapshotRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), StreamId.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<LatestSnapshotRow, ? extends LatestSnapshotNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -434,20 +422,6 @@ public final class LatestSnapshotTable implements
         for (LatestSnapshotTrigger trigger : triggers) {
             trigger.putLatestSnapshot(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<LatestSnapshotRow, ? extends LatestSnapshotNamedColumnValue<?>> rows) {
-        Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<LatestSnapshotRow, LatestSnapshotNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<LatestSnapshotRow, ? extends LatestSnapshotNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteStreamId(LatestSnapshotRow row) {
@@ -683,5 +657,5 @@ public final class LatestSnapshotTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "HCvIueEecK9Xhwr3eqEnVQ==";
+    static String __CLASS_HASH = "W1wwimLI6PCSvWYMupoGKg==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
@@ -22,7 +23,6 @@ import javax.annotation.Generated;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -206,7 +206,7 @@ public final class NamespacedTodoTable implements
                 return false;
             }
             NamespacedTodoRow other = (NamespacedTodoRow) obj;
-            return Objects.equal(namespace, other.namespace);
+            return Objects.equals(namespace, other.namespace);
         }
 
         @SuppressWarnings("ArrayHashCode")
@@ -298,7 +298,7 @@ public final class NamespacedTodoTable implements
                 return false;
             }
             NamespacedTodoColumn other = (NamespacedTodoColumn) obj;
-            return Objects.equal(todoId, other.todoId);
+            return Objects.equals(todoId, other.todoId);
         }
 
         @SuppressWarnings("ArrayHashCode")
@@ -487,35 +487,6 @@ public final class NamespacedTodoTable implements
         for (NamespacedTodoTrigger trigger : triggers) {
             trigger.putNamespacedTodo(values);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(NamespacedTodoRow rowName, Iterable<NamespacedTodoColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<NamespacedTodoRow, NamespacedTodoColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(NamespacedTodoRow rowName, NamespacedTodoColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<NamespacedTodoRow, NamespacedTodoColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<NamespacedTodoRow, ? extends NamespacedTodoColumnValue> rows) {
-        Multimap<NamespacedTodoRow, NamespacedTodoColumn> toGet = Multimaps.transformValues(rows, NamespacedTodoColumnValue.getColumnNameFun());
-        Multimap<NamespacedTodoRow, NamespacedTodoColumnValue> existing = get(toGet);
-        Multimap<NamespacedTodoRow, NamespacedTodoColumnValue> toPut = HashMultimap.create();
-        for (Entry<NamespacedTodoRow, ? extends NamespacedTodoColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     @Override
@@ -742,5 +713,5 @@ public final class NamespacedTodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/r7gWeqwhi+4p3TyxG70ag==";
+    static String __CLASS_HASH = "OUopFBahCh4GfAJWIg453g==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
@@ -489,35 +489,6 @@ public final class SnapshotsStreamHashAidxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(SnapshotsStreamHashAidxRow rowName, Iterable<SnapshotsStreamHashAidxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(SnapshotsStreamHashAidxRow rowName, SnapshotsStreamHashAidxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<SnapshotsStreamHashAidxRow, ? extends SnapshotsStreamHashAidxColumnValue> rows) {
-        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, SnapshotsStreamHashAidxColumnValue.getColumnNameFun());
-        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> existing = get(toGet);
-        Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> toPut = HashMultimap.create();
-        for (Entry<SnapshotsStreamHashAidxRow, ? extends SnapshotsStreamHashAidxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumn> values) {
         Multimap<SnapshotsStreamHashAidxRow, SnapshotsStreamHashAidxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class SnapshotsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Rr89YNzlBm2CiK/6z02A1A==";
+    static String __CLASS_HASH = "oS3B0uQRP5UTheSmeHU/1Q==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
@@ -489,35 +489,6 @@ public final class SnapshotsStreamIdxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(SnapshotsStreamIdxRow rowName, Iterable<SnapshotsStreamIdxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(SnapshotsStreamIdxRow rowName, SnapshotsStreamIdxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<SnapshotsStreamIdxRow, ? extends SnapshotsStreamIdxColumnValue> rows) {
-        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumn> toGet = Multimaps.transformValues(rows, SnapshotsStreamIdxColumnValue.getColumnNameFun());
-        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> existing = get(toGet);
-        Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> toPut = HashMultimap.create();
-        for (Entry<SnapshotsStreamIdxRow, ? extends SnapshotsStreamIdxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumn> values) {
         Multimap<SnapshotsStreamIdxRow, SnapshotsStreamIdxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class SnapshotsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "dTHc3aLGJVhEPyOdcva0PA==";
+    static String __CLASS_HASH = "trH+p2NDZdfn9AnxphcvkA==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
@@ -439,18 +439,6 @@ public final class SnapshotsStreamMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(SnapshotsStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<SnapshotsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SnapshotsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -458,20 +446,6 @@ public final class SnapshotsStreamMetadataTable implements
         for (SnapshotsStreamMetadataTrigger trigger : triggers) {
             trigger.putSnapshotsStreamMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataNamedColumnValue<?>> rows) {
-        Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<SnapshotsStreamMetadataRow, SnapshotsStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<SnapshotsStreamMetadataRow, ? extends SnapshotsStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(SnapshotsStreamMetadataRow row) {
@@ -707,5 +681,5 @@ public final class SnapshotsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "hvWVuHH/IrtQNLF+hv4oNQ==";
+    static String __CLASS_HASH = "1zvuS46tqORldVBQiL1/uw==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
@@ -427,18 +427,6 @@ public final class SnapshotsStreamValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(SnapshotsStreamValueRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<SnapshotsStreamValueRow, byte[]> map) {
-        Map<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<SnapshotsStreamValueRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<SnapshotsStreamValueRow, ? extends SnapshotsStreamValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -446,20 +434,6 @@ public final class SnapshotsStreamValueTable implements
         for (SnapshotsStreamValueTrigger trigger : triggers) {
             trigger.putSnapshotsStreamValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<SnapshotsStreamValueRow, ? extends SnapshotsStreamValueNamedColumnValue<?>> rows) {
-        Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<SnapshotsStreamValueRow, SnapshotsStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<SnapshotsStreamValueRow, ? extends SnapshotsStreamValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(SnapshotsStreamValueRow row) {
@@ -695,5 +669,5 @@ public final class SnapshotsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "IyCIfgbpIWFg+j1HB+px5A==";
+    static String __CLASS_HASH = "w2Kv2zKptBlrmL07xKxTRg==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
@@ -415,18 +415,6 @@ public final class TodoTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putTextUnlessExists(TodoRow row, String value) {
-        putUnlessExists(ImmutableMultimap.of(row, Text.of(value)));
-    }
-
-    public void putTextUnlessExists(Map<TodoRow, String> map) {
-        Map<TodoRow, TodoNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<TodoRow, String> e : map.entrySet()) {
-            toPut.put(e.getKey(), Text.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<TodoRow, ? extends TodoNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -434,20 +422,6 @@ public final class TodoTable implements
         for (TodoTrigger trigger : triggers) {
             trigger.putTodo(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<TodoRow, ? extends TodoNamedColumnValue<?>> rows) {
-        Multimap<TodoRow, TodoNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<TodoRow, TodoNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<TodoRow, ? extends TodoNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteText(TodoRow row) {
@@ -683,5 +657,5 @@ public final class TodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "y7QrcAPHltjY8JFPQEedVw==";
+    static String __CLASS_HASH = "WZNsYRJNFU3f5r1AQ65yrw==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
@@ -415,18 +415,6 @@ public final class AuditedDataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putDataUnlessExists(AuditedDataRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Data.of(value)));
-    }
-
-    public void putDataUnlessExists(Map<AuditedDataRow, byte[]> map) {
-        Map<AuditedDataRow, AuditedDataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<AuditedDataRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Data.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<AuditedDataRow, ? extends AuditedDataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -434,20 +422,6 @@ public final class AuditedDataTable implements
         for (AuditedDataTrigger trigger : triggers) {
             trigger.putAuditedData(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<AuditedDataRow, ? extends AuditedDataNamedColumnValue<?>> rows) {
-        Multimap<AuditedDataRow, AuditedDataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<AuditedDataRow, AuditedDataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<AuditedDataRow, ? extends AuditedDataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteData(AuditedDataRow row) {
@@ -683,5 +657,5 @@ public final class AuditedDataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "eNIK44rR7EaLDmiV0nOb7Q==";
+    static String __CLASS_HASH = "q9Ur/tVv9Zy8v6wnnmNG6A==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
@@ -489,35 +489,6 @@ public final class DataStreamHashAidxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(DataStreamHashAidxRow rowName, Iterable<DataStreamHashAidxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<DataStreamHashAidxRow, DataStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(DataStreamHashAidxRow rowName, DataStreamHashAidxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<DataStreamHashAidxRow, DataStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<DataStreamHashAidxRow, ? extends DataStreamHashAidxColumnValue> rows) {
-        Multimap<DataStreamHashAidxRow, DataStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, DataStreamHashAidxColumnValue.getColumnNameFun());
-        Multimap<DataStreamHashAidxRow, DataStreamHashAidxColumnValue> existing = get(toGet);
-        Multimap<DataStreamHashAidxRow, DataStreamHashAidxColumnValue> toPut = HashMultimap.create();
-        for (Entry<DataStreamHashAidxRow, ? extends DataStreamHashAidxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<DataStreamHashAidxRow, DataStreamHashAidxColumn> values) {
         Multimap<DataStreamHashAidxRow, DataStreamHashAidxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class DataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "qlMGE04avGWoWcqnMpEujQ==";
+    static String __CLASS_HASH = "DgL76OhsjjfzDcgwbtKo5A==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
@@ -503,35 +503,6 @@ public final class DataStreamIdxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(DataStreamIdxRow rowName, Iterable<DataStreamIdxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<DataStreamIdxRow, DataStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(DataStreamIdxRow rowName, DataStreamIdxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<DataStreamIdxRow, DataStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<DataStreamIdxRow, ? extends DataStreamIdxColumnValue> rows) {
-        Multimap<DataStreamIdxRow, DataStreamIdxColumn> toGet = Multimaps.transformValues(rows, DataStreamIdxColumnValue.getColumnNameFun());
-        Multimap<DataStreamIdxRow, DataStreamIdxColumnValue> existing = get(toGet);
-        Multimap<DataStreamIdxRow, DataStreamIdxColumnValue> toPut = HashMultimap.create();
-        for (Entry<DataStreamIdxRow, ? extends DataStreamIdxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<DataStreamIdxRow, DataStreamIdxColumn> values) {
         Multimap<DataStreamIdxRow, DataStreamIdxColumnValue> currentValues = get(values);
@@ -756,5 +727,5 @@ public final class DataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "qP8z0k6dELrJ1//noaJ68w==";
+    static String __CLASS_HASH = "akfc3RwqwCN9ne8saSTh2A==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
@@ -453,18 +453,6 @@ public final class DataStreamMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(DataStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<DataStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<DataStreamMetadataRow, DataStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<DataStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<DataStreamMetadataRow, ? extends DataStreamMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -472,20 +460,6 @@ public final class DataStreamMetadataTable implements
         for (DataStreamMetadataTrigger trigger : triggers) {
             trigger.putDataStreamMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<DataStreamMetadataRow, ? extends DataStreamMetadataNamedColumnValue<?>> rows) {
-        Multimap<DataStreamMetadataRow, DataStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<DataStreamMetadataRow, DataStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<DataStreamMetadataRow, ? extends DataStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(DataStreamMetadataRow row) {
@@ -721,5 +695,5 @@ public final class DataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "uLIsDYFW39YaApnj0nLGZw==";
+    static String __CLASS_HASH = "R8htd1SMhNPTnF3yuJ+Htg==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
@@ -442,18 +442,6 @@ public final class DataStreamValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(DataStreamValueRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<DataStreamValueRow, byte[]> map) {
-        Map<DataStreamValueRow, DataStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<DataStreamValueRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<DataStreamValueRow, ? extends DataStreamValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -461,20 +449,6 @@ public final class DataStreamValueTable implements
         for (DataStreamValueTrigger trigger : triggers) {
             trigger.putDataStreamValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<DataStreamValueRow, ? extends DataStreamValueNamedColumnValue<?>> rows) {
-        Multimap<DataStreamValueRow, DataStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<DataStreamValueRow, DataStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<DataStreamValueRow, ? extends DataStreamValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(DataStreamValueRow row) {
@@ -710,5 +684,5 @@ public final class DataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JynJH7emC6QCUKeaXoxK0A==";
+    static String __CLASS_HASH = "mDGfypIqrVWc1GEkvuAc2g==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
@@ -489,35 +489,6 @@ public final class HotspottyDataStreamHashAidxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(HotspottyDataStreamHashAidxRow rowName, Iterable<HotspottyDataStreamHashAidxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<HotspottyDataStreamHashAidxRow, HotspottyDataStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(HotspottyDataStreamHashAidxRow rowName, HotspottyDataStreamHashAidxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<HotspottyDataStreamHashAidxRow, HotspottyDataStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<HotspottyDataStreamHashAidxRow, ? extends HotspottyDataStreamHashAidxColumnValue> rows) {
-        Multimap<HotspottyDataStreamHashAidxRow, HotspottyDataStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, HotspottyDataStreamHashAidxColumnValue.getColumnNameFun());
-        Multimap<HotspottyDataStreamHashAidxRow, HotspottyDataStreamHashAidxColumnValue> existing = get(toGet);
-        Multimap<HotspottyDataStreamHashAidxRow, HotspottyDataStreamHashAidxColumnValue> toPut = HashMultimap.create();
-        for (Entry<HotspottyDataStreamHashAidxRow, ? extends HotspottyDataStreamHashAidxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<HotspottyDataStreamHashAidxRow, HotspottyDataStreamHashAidxColumn> values) {
         Multimap<HotspottyDataStreamHashAidxRow, HotspottyDataStreamHashAidxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class HotspottyDataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "h3NNoQda1GH4gZI4Dk5i4w==";
+    static String __CLASS_HASH = "Lh4UEEm2Yer4BJTWKfCP4Q==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
@@ -489,35 +489,6 @@ public final class HotspottyDataStreamIdxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(HotspottyDataStreamIdxRow rowName, Iterable<HotspottyDataStreamIdxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<HotspottyDataStreamIdxRow, HotspottyDataStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(HotspottyDataStreamIdxRow rowName, HotspottyDataStreamIdxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<HotspottyDataStreamIdxRow, HotspottyDataStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<HotspottyDataStreamIdxRow, ? extends HotspottyDataStreamIdxColumnValue> rows) {
-        Multimap<HotspottyDataStreamIdxRow, HotspottyDataStreamIdxColumn> toGet = Multimaps.transformValues(rows, HotspottyDataStreamIdxColumnValue.getColumnNameFun());
-        Multimap<HotspottyDataStreamIdxRow, HotspottyDataStreamIdxColumnValue> existing = get(toGet);
-        Multimap<HotspottyDataStreamIdxRow, HotspottyDataStreamIdxColumnValue> toPut = HashMultimap.create();
-        for (Entry<HotspottyDataStreamIdxRow, ? extends HotspottyDataStreamIdxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<HotspottyDataStreamIdxRow, HotspottyDataStreamIdxColumn> values) {
         Multimap<HotspottyDataStreamIdxRow, HotspottyDataStreamIdxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class HotspottyDataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "9RHp/+CSmiwzyo2808GTWg==";
+    static String __CLASS_HASH = "G2byjrwUZEphtaXrSUazqA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
@@ -439,18 +439,6 @@ public final class HotspottyDataStreamMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(HotspottyDataStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<HotspottyDataStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<HotspottyDataStreamMetadataRow, HotspottyDataStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<HotspottyDataStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<HotspottyDataStreamMetadataRow, ? extends HotspottyDataStreamMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -458,20 +446,6 @@ public final class HotspottyDataStreamMetadataTable implements
         for (HotspottyDataStreamMetadataTrigger trigger : triggers) {
             trigger.putHotspottyDataStreamMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<HotspottyDataStreamMetadataRow, ? extends HotspottyDataStreamMetadataNamedColumnValue<?>> rows) {
-        Multimap<HotspottyDataStreamMetadataRow, HotspottyDataStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<HotspottyDataStreamMetadataRow, HotspottyDataStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<HotspottyDataStreamMetadataRow, ? extends HotspottyDataStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(HotspottyDataStreamMetadataRow row) {
@@ -707,5 +681,5 @@ public final class HotspottyDataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "RcUexC0TnGCNaypiMzlCaA==";
+    static String __CLASS_HASH = "oe90c1XfQ57B56r5/IE91g==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
@@ -427,18 +427,6 @@ public final class HotspottyDataStreamValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(HotspottyDataStreamValueRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<HotspottyDataStreamValueRow, byte[]> map) {
-        Map<HotspottyDataStreamValueRow, HotspottyDataStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<HotspottyDataStreamValueRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<HotspottyDataStreamValueRow, ? extends HotspottyDataStreamValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -446,20 +434,6 @@ public final class HotspottyDataStreamValueTable implements
         for (HotspottyDataStreamValueTrigger trigger : triggers) {
             trigger.putHotspottyDataStreamValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<HotspottyDataStreamValueRow, ? extends HotspottyDataStreamValueNamedColumnValue<?>> rows) {
-        Multimap<HotspottyDataStreamValueRow, HotspottyDataStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<HotspottyDataStreamValueRow, HotspottyDataStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<HotspottyDataStreamValueRow, ? extends HotspottyDataStreamValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(HotspottyDataStreamValueRow row) {
@@ -695,5 +669,5 @@ public final class HotspottyDataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "zoMUkwPXsAQo2wBiBiyF7A==";
+    static String __CLASS_HASH = "SbxZ2fy8SdPXh+5D339tnQ==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/cas/generated/CheckAndSetTable.java
@@ -415,18 +415,6 @@ public final class CheckAndSetTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(CheckAndSetRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<CheckAndSetRow, Long> map) {
-        Map<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<CheckAndSetRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<CheckAndSetRow, ? extends CheckAndSetNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -434,20 +422,6 @@ public final class CheckAndSetTable implements
         for (CheckAndSetTrigger trigger : triggers) {
             trigger.putCheckAndSet(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<CheckAndSetRow, ? extends CheckAndSetNamedColumnValue<?>> rows) {
-        Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<CheckAndSetRow, CheckAndSetNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<CheckAndSetRow, ? extends CheckAndSetNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(CheckAndSetRow row) {
@@ -683,5 +657,5 @@ public final class CheckAndSetTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "woRNI9VtMe2tFg8WOowU2Q==";
+    static String __CLASS_HASH = "QWc6X5pvzfCCbu6ttAaF3A==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
@@ -432,7 +432,6 @@ public final class KeyValueTable implements
         }
     }
 
-    @Override
     public void putUnlessExists(Multimap<KeyValueRow, ? extends KeyValueNamedColumnValue<?>> rows) {
         Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
         Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> toPut = HashMultimap.create();

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
@@ -484,17 +484,14 @@ public final class ValueStreamHashAidxTable implements
         }
     }
 
-    @Override
     public void putUnlessExists(ValueStreamHashAidxRow rowName, Iterable<ValueStreamHashAidxColumnValue> values) {
         putUnlessExists(ImmutableMultimap.<ValueStreamHashAidxRow, ValueStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
     }
 
-    @Override
     public void putUnlessExists(ValueStreamHashAidxRow rowName, ValueStreamHashAidxColumnValue... values) {
         putUnlessExists(ImmutableMultimap.<ValueStreamHashAidxRow, ValueStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
     }
 
-    @Override
     public void putUnlessExists(Multimap<ValueStreamHashAidxRow, ? extends ValueStreamHashAidxColumnValue> rows) {
         Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, ValueStreamHashAidxColumnValue.getColumnNameFun());
         Multimap<ValueStreamHashAidxRow, ValueStreamHashAidxColumnValue> existing = get(toGet);

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
@@ -485,17 +485,14 @@ public final class ValueStreamIdxTable implements
         }
     }
 
-    @Override
     public void putUnlessExists(ValueStreamIdxRow rowName, Iterable<ValueStreamIdxColumnValue> values) {
         putUnlessExists(ImmutableMultimap.<ValueStreamIdxRow, ValueStreamIdxColumnValue>builder().putAll(rowName, values).build());
     }
 
-    @Override
     public void putUnlessExists(ValueStreamIdxRow rowName, ValueStreamIdxColumnValue... values) {
         putUnlessExists(ImmutableMultimap.<ValueStreamIdxRow, ValueStreamIdxColumnValue>builder().putAll(rowName, values).build());
     }
 
-    @Override
     public void putUnlessExists(Multimap<ValueStreamIdxRow, ? extends ValueStreamIdxColumnValue> rows) {
         Multimap<ValueStreamIdxRow, ValueStreamIdxColumn> toGet = Multimaps.transformValues(rows, ValueStreamIdxColumnValue.getColumnNameFun());
         Multimap<ValueStreamIdxRow, ValueStreamIdxColumnValue> existing = get(toGet);

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
@@ -456,7 +456,6 @@ public final class ValueStreamMetadataTable implements
         }
     }
 
-    @Override
     public void putUnlessExists(Multimap<ValueStreamMetadataRow, ? extends ValueStreamMetadataNamedColumnValue<?>> rows) {
         Multimap<ValueStreamMetadataRow, ValueStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
         Multimap<ValueStreamMetadataRow, ValueStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
@@ -444,7 +444,6 @@ public final class ValueStreamValueTable implements
         }
     }
 
-    @Override
     public void putUnlessExists(Multimap<ValueStreamValueRow, ? extends ValueStreamValueNamedColumnValue<?>> rows) {
         Multimap<ValueStreamValueRow, ValueStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
         Multimap<ValueStreamValueRow, ValueStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -415,18 +415,6 @@ public final class DataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(DataRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<DataRow, Long> map) {
-        Map<DataRow, DataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<DataRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<DataRow, ? extends DataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -502,20 +490,6 @@ public final class DataTable implements
         for (DataTrigger trigger : triggers) {
             trigger.putData(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<DataRow, ? extends DataNamedColumnValue<?>> rows) {
-        Multimap<DataRow, DataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<DataRow, DataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<DataRow, ? extends DataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(DataRow row) {
@@ -1290,35 +1264,6 @@ public final class DataTable implements
             }
         }
 
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Index1IdxRow rowName, Iterable<Index1IdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<Index1IdxRow, Index1IdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Index1IdxRow rowName, Index1IdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<Index1IdxRow, Index1IdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<Index1IdxRow, ? extends Index1IdxColumnValue> rows) {
-            Multimap<Index1IdxRow, Index1IdxColumn> toGet = Multimaps.transformValues(rows, Index1IdxColumnValue.getColumnNameFun());
-            Multimap<Index1IdxRow, Index1IdxColumnValue> existing = get(toGet);
-            Multimap<Index1IdxRow, Index1IdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<Index1IdxRow, ? extends Index1IdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
-        }
-
         @Override
         public void touch(Multimap<Index1IdxRow, Index1IdxColumn> values) {
             Multimap<Index1IdxRow, Index1IdxColumnValue> currentValues = get(values);
@@ -1964,35 +1909,6 @@ public final class DataTable implements
             }
         }
 
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Index2IdxRow rowName, Iterable<Index2IdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<Index2IdxRow, Index2IdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Index2IdxRow rowName, Index2IdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<Index2IdxRow, Index2IdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<Index2IdxRow, ? extends Index2IdxColumnValue> rows) {
-            Multimap<Index2IdxRow, Index2IdxColumn> toGet = Multimaps.transformValues(rows, Index2IdxColumnValue.getColumnNameFun());
-            Multimap<Index2IdxRow, Index2IdxColumnValue> existing = get(toGet);
-            Multimap<Index2IdxRow, Index2IdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<Index2IdxRow, ? extends Index2IdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
-        }
-
         @Override
         public void touch(Multimap<Index2IdxRow, Index2IdxColumn> values) {
             Multimap<Index2IdxRow, Index2IdxColumnValue> currentValues = get(values);
@@ -2614,35 +2530,6 @@ public final class DataTable implements
             for (Index3IdxTrigger trigger : triggers) {
                 trigger.putIndex3Idx(values);
             }
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Index3IdxRow rowName, Iterable<Index3IdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<Index3IdxRow, Index3IdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Index3IdxRow rowName, Index3IdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<Index3IdxRow, Index3IdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<Index3IdxRow, ? extends Index3IdxColumnValue> rows) {
-            Multimap<Index3IdxRow, Index3IdxColumn> toGet = Multimaps.transformValues(rows, Index3IdxColumnValue.getColumnNameFun());
-            Multimap<Index3IdxRow, Index3IdxColumnValue> existing = get(toGet);
-            Multimap<Index3IdxRow, Index3IdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<Index3IdxRow, ? extends Index3IdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
         }
 
         @Override
@@ -3290,35 +3177,6 @@ public final class DataTable implements
             }
         }
 
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Index4IdxRow rowName, Iterable<Index4IdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<Index4IdxRow, Index4IdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Index4IdxRow rowName, Index4IdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<Index4IdxRow, Index4IdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<Index4IdxRow, ? extends Index4IdxColumnValue> rows) {
-            Multimap<Index4IdxRow, Index4IdxColumn> toGet = Multimaps.transformValues(rows, Index4IdxColumnValue.getColumnNameFun());
-            Multimap<Index4IdxRow, Index4IdxColumnValue> existing = get(toGet);
-            Multimap<Index4IdxRow, Index4IdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<Index4IdxRow, ? extends Index4IdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
-        }
-
         @Override
         public void touch(Multimap<Index4IdxRow, Index4IdxColumn> values) {
             Multimap<Index4IdxRow, Index4IdxColumnValue> currentValues = get(values);
@@ -3598,5 +3456,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "am52K64Gej3IAHTMaJ2/kQ==";
+    static String __CLASS_HASH = "xnOm0QZPMtAT9yZToV1YiQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -519,18 +519,6 @@ public final class TwoColumnsTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putFooUnlessExists(TwoColumnsRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Foo.of(value)));
-    }
-
-    public void putFooUnlessExists(Map<TwoColumnsRow, Long> map) {
-        Map<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<TwoColumnsRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Foo.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putBar(TwoColumnsRow row, Long value) {
         put(ImmutableMultimap.of(row, Bar.of(value)));
     }
@@ -541,18 +529,6 @@ public final class TwoColumnsTable implements
             toPut.put(e.getKey(), Bar.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putBarUnlessExists(TwoColumnsRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, Bar.of(value)));
-    }
-
-    public void putBarUnlessExists(Map<TwoColumnsRow, Long> map) {
-        Map<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<TwoColumnsRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), Bar.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     @Override
@@ -596,20 +572,6 @@ public final class TwoColumnsTable implements
         for (TwoColumnsTrigger trigger : triggers) {
             trigger.putTwoColumns(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<TwoColumnsRow, ? extends TwoColumnsNamedColumnValue<?>> rows) {
-        Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<TwoColumnsRow, TwoColumnsNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<TwoColumnsRow, ? extends TwoColumnsNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteFoo(TwoColumnsRow row) {
@@ -1320,35 +1282,6 @@ public final class TwoColumnsTable implements
             }
         }
 
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(FooToIdCondIdxRow rowName, Iterable<FooToIdCondIdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<FooToIdCondIdxRow, FooToIdCondIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(FooToIdCondIdxRow rowName, FooToIdCondIdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<FooToIdCondIdxRow, FooToIdCondIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<FooToIdCondIdxRow, ? extends FooToIdCondIdxColumnValue> rows) {
-            Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumn> toGet = Multimaps.transformValues(rows, FooToIdCondIdxColumnValue.getColumnNameFun());
-            Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumnValue> existing = get(toGet);
-            Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<FooToIdCondIdxRow, ? extends FooToIdCondIdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
-        }
-
         @Override
         public void touch(Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumn> values) {
             Multimap<FooToIdCondIdxRow, FooToIdCondIdxColumnValue> currentValues = get(values);
@@ -1967,35 +1900,6 @@ public final class TwoColumnsTable implements
             }
         }
 
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(FooToIdIdxRow rowName, Iterable<FooToIdIdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<FooToIdIdxRow, FooToIdIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(FooToIdIdxRow rowName, FooToIdIdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<FooToIdIdxRow, FooToIdIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<FooToIdIdxRow, ? extends FooToIdIdxColumnValue> rows) {
-            Multimap<FooToIdIdxRow, FooToIdIdxColumn> toGet = Multimaps.transformValues(rows, FooToIdIdxColumnValue.getColumnNameFun());
-            Multimap<FooToIdIdxRow, FooToIdIdxColumnValue> existing = get(toGet);
-            Multimap<FooToIdIdxRow, FooToIdIdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<FooToIdIdxRow, ? extends FooToIdIdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
-        }
-
         @Override
         public void touch(Multimap<FooToIdIdxRow, FooToIdIdxColumn> values) {
             Multimap<FooToIdIdxRow, FooToIdIdxColumnValue> currentValues = get(values);
@@ -2222,5 +2126,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UMjhKkoloz/KxD02p3ykSA==";
+    static String __CLASS_HASH = "JnmKvbbyrrxBYn7NjaLlMQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
@@ -415,18 +415,6 @@ public final class KeyValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putStreamIdUnlessExists(KeyValueRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, StreamId.of(value)));
-    }
-
-    public void putStreamIdUnlessExists(Map<KeyValueRow, Long> map) {
-        Map<KeyValueRow, KeyValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<KeyValueRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), StreamId.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<KeyValueRow, ? extends KeyValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -434,20 +422,6 @@ public final class KeyValueTable implements
         for (KeyValueTrigger trigger : triggers) {
             trigger.putKeyValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<KeyValueRow, ? extends KeyValueNamedColumnValue<?>> rows) {
-        Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<KeyValueRow, KeyValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<KeyValueRow, ? extends KeyValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteStreamId(KeyValueRow row) {
@@ -683,5 +657,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "q9oMibrXLUXP3R7y6PNrjA==";
+    static String __CLASS_HASH = "yq2eXKtO//M5nxFkoep7Tw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -489,35 +489,6 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestMaxMemStreamHashAidxRow rowName, Iterable<StreamTestMaxMemStreamHashAidxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestMaxMemStreamHashAidxRow rowName, StreamTestMaxMemStreamHashAidxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestMaxMemStreamHashAidxRow, ? extends StreamTestMaxMemStreamHashAidxColumnValue> rows) {
-        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, StreamTestMaxMemStreamHashAidxColumnValue.getColumnNameFun());
-        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> existing = get(toGet);
-        Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> toPut = HashMultimap.create();
-        for (Entry<StreamTestMaxMemStreamHashAidxRow, ? extends StreamTestMaxMemStreamHashAidxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumn> values) {
         Multimap<StreamTestMaxMemStreamHashAidxRow, StreamTestMaxMemStreamHashAidxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "tP8ZBm3sXOwkmUliRmO3Gg==";
+    static String __CLASS_HASH = "E8Zf6PtirrT7zsEz8//DWA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -489,35 +489,6 @@ public final class StreamTestMaxMemStreamIdxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestMaxMemStreamIdxRow rowName, Iterable<StreamTestMaxMemStreamIdxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestMaxMemStreamIdxRow rowName, StreamTestMaxMemStreamIdxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestMaxMemStreamIdxRow, ? extends StreamTestMaxMemStreamIdxColumnValue> rows) {
-        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> toGet = Multimaps.transformValues(rows, StreamTestMaxMemStreamIdxColumnValue.getColumnNameFun());
-        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> existing = get(toGet);
-        Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> toPut = HashMultimap.create();
-        for (Entry<StreamTestMaxMemStreamIdxRow, ? extends StreamTestMaxMemStreamIdxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumn> values) {
         Multimap<StreamTestMaxMemStreamIdxRow, StreamTestMaxMemStreamIdxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "22X00eE6SU9TOGniFwrq1Q==";
+    static String __CLASS_HASH = "KcJ0j6ecliQFnp5AXn9sPg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -439,18 +439,6 @@ public final class StreamTestMaxMemStreamMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(StreamTestMaxMemStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<StreamTestMaxMemStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<StreamTestMaxMemStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -458,20 +446,6 @@ public final class StreamTestMaxMemStreamMetadataTable implements
         for (StreamTestMaxMemStreamMetadataTrigger trigger : triggers) {
             trigger.putStreamTestMaxMemStreamMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>> rows) {
-        Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<StreamTestMaxMemStreamMetadataRow, StreamTestMaxMemStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<StreamTestMaxMemStreamMetadataRow, ? extends StreamTestMaxMemStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(StreamTestMaxMemStreamMetadataRow row) {
@@ -707,5 +681,5 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "RLXK4My5qNx6pbuEaK2nSg==";
+    static String __CLASS_HASH = "LUALHqjCsPPOiV+ASF250g==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -427,18 +427,6 @@ public final class StreamTestMaxMemStreamValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(StreamTestMaxMemStreamValueRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<StreamTestMaxMemStreamValueRow, byte[]> map) {
-        Map<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<StreamTestMaxMemStreamValueRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -446,20 +434,6 @@ public final class StreamTestMaxMemStreamValueTable implements
         for (StreamTestMaxMemStreamValueTrigger trigger : triggers) {
             trigger.putStreamTestMaxMemStreamValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueNamedColumnValue<?>> rows) {
-        Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<StreamTestMaxMemStreamValueRow, StreamTestMaxMemStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<StreamTestMaxMemStreamValueRow, ? extends StreamTestMaxMemStreamValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(StreamTestMaxMemStreamValueRow row) {
@@ -695,5 +669,5 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "UTI5cnZKoXNOJAh59tWLxA==";
+    static String __CLASS_HASH = "xlZF1W8D8pUOTe2VGEmOMg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
@@ -489,35 +489,6 @@ public final class StreamTestStreamHashAidxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestStreamHashAidxRow rowName, Iterable<StreamTestStreamHashAidxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestStreamHashAidxRow rowName, StreamTestStreamHashAidxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestStreamHashAidxRow, ? extends StreamTestStreamHashAidxColumnValue> rows) {
-        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, StreamTestStreamHashAidxColumnValue.getColumnNameFun());
-        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> existing = get(toGet);
-        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> toPut = HashMultimap.create();
-        for (Entry<StreamTestStreamHashAidxRow, ? extends StreamTestStreamHashAidxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> values) {
         Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ewJNW3nh7SbSlMCq9ik6vw==";
+    static String __CLASS_HASH = "9FT31wDEhFmVUaK07cQXhQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
@@ -489,35 +489,6 @@ public final class StreamTestStreamIdxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestStreamIdxRow rowName, Iterable<StreamTestStreamIdxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestStreamIdxRow rowName, StreamTestStreamIdxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestStreamIdxRow, ? extends StreamTestStreamIdxColumnValue> rows) {
-        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumn> toGet = Multimaps.transformValues(rows, StreamTestStreamIdxColumnValue.getColumnNameFun());
-        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> existing = get(toGet);
-        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> toPut = HashMultimap.create();
-        for (Entry<StreamTestStreamIdxRow, ? extends StreamTestStreamIdxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumn> values) {
         Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class StreamTestStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "32hJIPc5EBfytboK8tWg/Q==";
+    static String __CLASS_HASH = "lgn8+RrwnRD+ORztxbl9ww==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -439,18 +439,6 @@ public final class StreamTestStreamMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(StreamTestStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<StreamTestStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<StreamTestStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<StreamTestStreamMetadataRow, ? extends StreamTestStreamMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -458,20 +446,6 @@ public final class StreamTestStreamMetadataTable implements
         for (StreamTestStreamMetadataTrigger trigger : triggers) {
             trigger.putStreamTestStreamMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestStreamMetadataRow, ? extends StreamTestStreamMetadataNamedColumnValue<?>> rows) {
-        Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<StreamTestStreamMetadataRow, ? extends StreamTestStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(StreamTestStreamMetadataRow row) {
@@ -707,5 +681,5 @@ public final class StreamTestStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "TQ9D6HM7l88UD9uCzEHIpQ==";
+    static String __CLASS_HASH = "qha2HckQObFa2UMd3U5jvg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -427,18 +427,6 @@ public final class StreamTestStreamValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(StreamTestStreamValueRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<StreamTestStreamValueRow, byte[]> map) {
-        Map<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<StreamTestStreamValueRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<StreamTestStreamValueRow, ? extends StreamTestStreamValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -446,20 +434,6 @@ public final class StreamTestStreamValueTable implements
         for (StreamTestStreamValueTrigger trigger : triggers) {
             trigger.putStreamTestStreamValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestStreamValueRow, ? extends StreamTestStreamValueNamedColumnValue<?>> rows) {
-        Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<StreamTestStreamValueRow, ? extends StreamTestStreamValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(StreamTestStreamValueRow row) {
@@ -695,5 +669,5 @@ public final class StreamTestStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Buf58KKaXzWPx3pSTTPuRg==";
+    static String __CLASS_HASH = "Ij5stLmnPhWfrTCFkq5FAA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
@@ -489,35 +489,6 @@ public final class StreamTestWithHashStreamHashAidxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestWithHashStreamHashAidxRow rowName, Iterable<StreamTestWithHashStreamHashAidxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestWithHashStreamHashAidxRow rowName, StreamTestWithHashStreamHashAidxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestWithHashStreamHashAidxRow, ? extends StreamTestWithHashStreamHashAidxColumnValue> rows) {
-        Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, StreamTestWithHashStreamHashAidxColumnValue.getColumnNameFun());
-        Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> existing = get(toGet);
-        Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> toPut = HashMultimap.create();
-        for (Entry<StreamTestWithHashStreamHashAidxRow, ? extends StreamTestWithHashStreamHashAidxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumn> values) {
         Multimap<StreamTestWithHashStreamHashAidxRow, StreamTestWithHashStreamHashAidxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "jaNFalFAA4FoN2Pf3mz65Q==";
+    static String __CLASS_HASH = "WAs1Cyso9MG+qRz7sxvbNw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
@@ -503,35 +503,6 @@ public final class StreamTestWithHashStreamIdxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestWithHashStreamIdxRow rowName, Iterable<StreamTestWithHashStreamIdxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(StreamTestWithHashStreamIdxRow rowName, StreamTestWithHashStreamIdxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestWithHashStreamIdxRow, ? extends StreamTestWithHashStreamIdxColumnValue> rows) {
-        Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumn> toGet = Multimaps.transformValues(rows, StreamTestWithHashStreamIdxColumnValue.getColumnNameFun());
-        Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue> existing = get(toGet);
-        Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue> toPut = HashMultimap.create();
-        for (Entry<StreamTestWithHashStreamIdxRow, ? extends StreamTestWithHashStreamIdxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumn> values) {
         Multimap<StreamTestWithHashStreamIdxRow, StreamTestWithHashStreamIdxColumnValue> currentValues = get(values);
@@ -756,5 +727,5 @@ public final class StreamTestWithHashStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "As9jJKkEeB+qIWnhTtQ1vA==";
+    static String __CLASS_HASH = "+6r8zM0UTE4/vU55y0KptA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -453,18 +453,6 @@ public final class StreamTestWithHashStreamMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(StreamTestWithHashStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<StreamTestWithHashStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<StreamTestWithHashStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<StreamTestWithHashStreamMetadataRow, ? extends StreamTestWithHashStreamMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -472,20 +460,6 @@ public final class StreamTestWithHashStreamMetadataTable implements
         for (StreamTestWithHashStreamMetadataTrigger trigger : triggers) {
             trigger.putStreamTestWithHashStreamMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestWithHashStreamMetadataRow, ? extends StreamTestWithHashStreamMetadataNamedColumnValue<?>> rows) {
-        Multimap<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<StreamTestWithHashStreamMetadataRow, StreamTestWithHashStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<StreamTestWithHashStreamMetadataRow, ? extends StreamTestWithHashStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(StreamTestWithHashStreamMetadataRow row) {
@@ -721,5 +695,5 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "AN4vlEpT234mM7TK4eA27Q==";
+    static String __CLASS_HASH = "pVGawJaETifebtYT3F/T4Q==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
@@ -441,18 +441,6 @@ public final class StreamTestWithHashStreamValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(StreamTestWithHashStreamValueRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<StreamTestWithHashStreamValueRow, byte[]> map) {
-        Map<StreamTestWithHashStreamValueRow, StreamTestWithHashStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<StreamTestWithHashStreamValueRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<StreamTestWithHashStreamValueRow, ? extends StreamTestWithHashStreamValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -460,20 +448,6 @@ public final class StreamTestWithHashStreamValueTable implements
         for (StreamTestWithHashStreamValueTrigger trigger : triggers) {
             trigger.putStreamTestWithHashStreamValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<StreamTestWithHashStreamValueRow, ? extends StreamTestWithHashStreamValueNamedColumnValue<?>> rows) {
-        Multimap<StreamTestWithHashStreamValueRow, StreamTestWithHashStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<StreamTestWithHashStreamValueRow, StreamTestWithHashStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<StreamTestWithHashStreamValueRow, ? extends StreamTestWithHashStreamValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(StreamTestWithHashStreamValueRow row) {
@@ -709,5 +683,5 @@ public final class StreamTestWithHashStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "H9s9oYltnwIo26sFEYi7KA==";
+    static String __CLASS_HASH = "DuQnupgMKPT4lnevj8xrww==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
@@ -489,35 +489,6 @@ public final class TestHashComponentsStreamHashAidxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(TestHashComponentsStreamHashAidxRow rowName, Iterable<TestHashComponentsStreamHashAidxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<TestHashComponentsStreamHashAidxRow, TestHashComponentsStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(TestHashComponentsStreamHashAidxRow rowName, TestHashComponentsStreamHashAidxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<TestHashComponentsStreamHashAidxRow, TestHashComponentsStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<TestHashComponentsStreamHashAidxRow, ? extends TestHashComponentsStreamHashAidxColumnValue> rows) {
-        Multimap<TestHashComponentsStreamHashAidxRow, TestHashComponentsStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, TestHashComponentsStreamHashAidxColumnValue.getColumnNameFun());
-        Multimap<TestHashComponentsStreamHashAidxRow, TestHashComponentsStreamHashAidxColumnValue> existing = get(toGet);
-        Multimap<TestHashComponentsStreamHashAidxRow, TestHashComponentsStreamHashAidxColumnValue> toPut = HashMultimap.create();
-        for (Entry<TestHashComponentsStreamHashAidxRow, ? extends TestHashComponentsStreamHashAidxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<TestHashComponentsStreamHashAidxRow, TestHashComponentsStreamHashAidxColumn> values) {
         Multimap<TestHashComponentsStreamHashAidxRow, TestHashComponentsStreamHashAidxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class TestHashComponentsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "z7A9cMbt+PFD5iMoH0auow==";
+    static String __CLASS_HASH = "sFCttfGO7EQofqlyqvWtlA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
@@ -503,35 +503,6 @@ public final class TestHashComponentsStreamIdxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(TestHashComponentsStreamIdxRow rowName, Iterable<TestHashComponentsStreamIdxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(TestHashComponentsStreamIdxRow rowName, TestHashComponentsStreamIdxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<TestHashComponentsStreamIdxRow, ? extends TestHashComponentsStreamIdxColumnValue> rows) {
-        Multimap<TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxColumn> toGet = Multimaps.transformValues(rows, TestHashComponentsStreamIdxColumnValue.getColumnNameFun());
-        Multimap<TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxColumnValue> existing = get(toGet);
-        Multimap<TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxColumnValue> toPut = HashMultimap.create();
-        for (Entry<TestHashComponentsStreamIdxRow, ? extends TestHashComponentsStreamIdxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxColumn> values) {
         Multimap<TestHashComponentsStreamIdxRow, TestHashComponentsStreamIdxColumnValue> currentValues = get(values);
@@ -756,5 +727,5 @@ public final class TestHashComponentsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Dg8v1ZBoHiqc15DcOAAtDA==";
+    static String __CLASS_HASH = "WUJhPLtOVMnnlz7XwW6M/w==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
@@ -453,18 +453,6 @@ public final class TestHashComponentsStreamMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(TestHashComponentsStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<TestHashComponentsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<TestHashComponentsStreamMetadataRow, TestHashComponentsStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<TestHashComponentsStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<TestHashComponentsStreamMetadataRow, ? extends TestHashComponentsStreamMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -472,20 +460,6 @@ public final class TestHashComponentsStreamMetadataTable implements
         for (TestHashComponentsStreamMetadataTrigger trigger : triggers) {
             trigger.putTestHashComponentsStreamMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<TestHashComponentsStreamMetadataRow, ? extends TestHashComponentsStreamMetadataNamedColumnValue<?>> rows) {
-        Multimap<TestHashComponentsStreamMetadataRow, TestHashComponentsStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<TestHashComponentsStreamMetadataRow, TestHashComponentsStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<TestHashComponentsStreamMetadataRow, ? extends TestHashComponentsStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(TestHashComponentsStreamMetadataRow row) {
@@ -721,5 +695,5 @@ public final class TestHashComponentsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "GXUtEtLv8l+PuL/sVgu91Q==";
+    static String __CLASS_HASH = "Kab3YlNRdYChKU+cEiku0w==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
@@ -442,18 +442,6 @@ public final class TestHashComponentsStreamValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(TestHashComponentsStreamValueRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<TestHashComponentsStreamValueRow, byte[]> map) {
-        Map<TestHashComponentsStreamValueRow, TestHashComponentsStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<TestHashComponentsStreamValueRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<TestHashComponentsStreamValueRow, ? extends TestHashComponentsStreamValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -461,20 +449,6 @@ public final class TestHashComponentsStreamValueTable implements
         for (TestHashComponentsStreamValueTrigger trigger : triggers) {
             trigger.putTestHashComponentsStreamValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<TestHashComponentsStreamValueRow, ? extends TestHashComponentsStreamValueNamedColumnValue<?>> rows) {
-        Multimap<TestHashComponentsStreamValueRow, TestHashComponentsStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<TestHashComponentsStreamValueRow, TestHashComponentsStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<TestHashComponentsStreamValueRow, ? extends TestHashComponentsStreamValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(TestHashComponentsStreamValueRow row) {
@@ -710,5 +684,5 @@ public final class TestHashComponentsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ozE5yG/vf3RLtkMDzEboYg==";
+    static String __CLASS_HASH = "WDrtA9lkyrgZzQza82MpIQ==";
 }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,6 +53,7 @@ develop
     *    - |devbreak|
          - The ``putUnlessExists`` API has been removed from AtlasDB tables, as it was misleading (it only did the put if the given row, column and value triple were already present, as opposed to the more intuitive condition of the row and column value pair being present).
            Please replace any uses of ``putUnlessExists`` with a get, check and put - these will still be transactional because of the AtlasDB transaction protocol.
+           Note that this is not the same as the KVS ``putUnlessExists`` API, which is still used by the transaction protocol.
            This API has already been deprecated for 11 months.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3340>`__)
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,11 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |devbreak|
+         - The ``putUnlessExists`` API has been removed from AtlasDB tables, as it was misleading (it only did the put if the given row, column and value triple were already present, as opposed to the more intuitive condition of the row and column value pair being present).
+           Please replace any uses of ``putUnlessExists`` with a get, check and put - these will still be transactional because of the AtlasDB transaction protocol.
+           This API has already been deprecated for 11 months.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3340>`__)
 
 =======
 v0.94.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -52,9 +52,9 @@ develop
 
     *    - |devbreak|
          - The ``putUnlessExists`` API has been removed from AtlasDB tables, as it was misleading (it only did the put if the given row, column and value triple were already present, as opposed to the more intuitive condition of the row and column value pair being present).
-           Please replace any uses of ``putUnlessExists`` with a get, check and put - these will still be transactional because of the AtlasDB transaction protocol.
+           Please replace any uses of the table-level ``putUnlessExists`` with a get, check and put if appropriate - these will still be transactional because of the AtlasDB transaction protocol.
            Note that this is not the same as the KVS ``putUnlessExists`` API, which is still used by the transaction protocol.
-           This API has already been deprecated for 11 months.
+           This API has already been deprecated for 10 months (since August 2017).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3340>`__)
 
 =======

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -489,35 +489,6 @@ public final class UserPhotosStreamHashAidxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(UserPhotosStreamHashAidxRow rowName, Iterable<UserPhotosStreamHashAidxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(UserPhotosStreamHashAidxRow rowName, UserPhotosStreamHashAidxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<UserPhotosStreamHashAidxRow, ? extends UserPhotosStreamHashAidxColumnValue> rows) {
-        Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumn> toGet = Multimaps.transformValues(rows, UserPhotosStreamHashAidxColumnValue.getColumnNameFun());
-        Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> existing = get(toGet);
-        Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> toPut = HashMultimap.create();
-        for (Entry<UserPhotosStreamHashAidxRow, ? extends UserPhotosStreamHashAidxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumn> values) {
         Multimap<UserPhotosStreamHashAidxRow, UserPhotosStreamHashAidxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "P2PrSZzgCPFMMBDLCxaDOQ==";
+    static String __CLASS_HASH = "02INLh3XG7XrmmPfLsx4KQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -489,35 +489,6 @@ public final class UserPhotosStreamIdxTable implements
         }
     }
 
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(UserPhotosStreamIdxRow rowName, Iterable<UserPhotosStreamIdxColumnValue> values) {
-        putUnlessExists(ImmutableMultimap.<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(UserPhotosStreamIdxRow rowName, UserPhotosStreamIdxColumnValue... values) {
-        putUnlessExists(ImmutableMultimap.<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue>builder().putAll(rowName, values).build());
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<UserPhotosStreamIdxRow, ? extends UserPhotosStreamIdxColumnValue> rows) {
-        Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumn> toGet = Multimaps.transformValues(rows, UserPhotosStreamIdxColumnValue.getColumnNameFun());
-        Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> existing = get(toGet);
-        Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> toPut = HashMultimap.create();
-        for (Entry<UserPhotosStreamIdxRow, ? extends UserPhotosStreamIdxColumnValue> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
-    }
-
     @Override
     public void touch(Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumn> values) {
         Multimap<UserPhotosStreamIdxRow, UserPhotosStreamIdxColumnValue> currentValues = get(values);
@@ -742,5 +713,5 @@ public final class UserPhotosStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ukLlDl5FsdnHPvAjx9GFdw==";
+    static String __CLASS_HASH = "3b/K8DhV3hQOpybiav1PxA==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -439,18 +439,6 @@ public final class UserPhotosStreamMetadataTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(UserPhotosStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
-        Map<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<UserPhotosStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<UserPhotosStreamMetadataRow, ? extends UserPhotosStreamMetadataNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -458,20 +446,6 @@ public final class UserPhotosStreamMetadataTable implements
         for (UserPhotosStreamMetadataTrigger trigger : triggers) {
             trigger.putUserPhotosStreamMetadata(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<UserPhotosStreamMetadataRow, ? extends UserPhotosStreamMetadataNamedColumnValue<?>> rows) {
-        Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<UserPhotosStreamMetadataRow, UserPhotosStreamMetadataNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<UserPhotosStreamMetadataRow, ? extends UserPhotosStreamMetadataNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(UserPhotosStreamMetadataRow row) {
@@ -707,5 +681,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "62A+3fFUiSoaSRtntFmVRQ==";
+    static String __CLASS_HASH = "dzgGQC/ADP1dlAWGQYQKXg==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -427,18 +427,6 @@ public final class UserPhotosStreamValueTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putValueUnlessExists(UserPhotosStreamValueRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Value.of(value)));
-    }
-
-    public void putValueUnlessExists(Map<UserPhotosStreamValueRow, byte[]> map) {
-        Map<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<UserPhotosStreamValueRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Value.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<UserPhotosStreamValueRow, ? extends UserPhotosStreamValueNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -446,20 +434,6 @@ public final class UserPhotosStreamValueTable implements
         for (UserPhotosStreamValueTrigger trigger : triggers) {
             trigger.putUserPhotosStreamValue(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<UserPhotosStreamValueRow, ? extends UserPhotosStreamValueNamedColumnValue<?>> rows) {
-        Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<UserPhotosStreamValueRow, UserPhotosStreamValueNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<UserPhotosStreamValueRow, ? extends UserPhotosStreamValueNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteValue(UserPhotosStreamValueRow row) {
@@ -695,5 +669,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "DBa2YYRX16IjNuuzq15viA==";
+    static String __CLASS_HASH = "dhfdRzb+jI2Hx8yK47x24Q==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -744,18 +744,6 @@ public final class UserProfileTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putMetadataUnlessExists(UserProfileRow row, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile value) {
-        putUnlessExists(ImmutableMultimap.of(row, Metadata.of(value)));
-    }
-
-    public void putMetadataUnlessExists(Map<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> map) {
-        Map<UserProfileRow, UserProfileNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<UserProfileRow, com.palantir.example.profile.protos.generated.ProfilePersistence.UserProfile> e : map.entrySet()) {
-            toPut.put(e.getKey(), Metadata.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putCreate(UserProfileRow row, com.palantir.example.profile.schema.CreationData value) {
         put(ImmutableMultimap.of(row, Create.of(value)));
     }
@@ -766,18 +754,6 @@ public final class UserProfileTable implements
             toPut.put(e.getKey(), Create.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putCreateUnlessExists(UserProfileRow row, com.palantir.example.profile.schema.CreationData value) {
-        putUnlessExists(ImmutableMultimap.of(row, Create.of(value)));
-    }
-
-    public void putCreateUnlessExists(Map<UserProfileRow, com.palantir.example.profile.schema.CreationData> map) {
-        Map<UserProfileRow, UserProfileNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<UserProfileRow, com.palantir.example.profile.schema.CreationData> e : map.entrySet()) {
-            toPut.put(e.getKey(), Create.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     public void putJson(UserProfileRow row, com.fasterxml.jackson.databind.JsonNode value) {
@@ -792,18 +768,6 @@ public final class UserProfileTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putJsonUnlessExists(UserProfileRow row, com.fasterxml.jackson.databind.JsonNode value) {
-        putUnlessExists(ImmutableMultimap.of(row, Json.of(value)));
-    }
-
-    public void putJsonUnlessExists(Map<UserProfileRow, com.fasterxml.jackson.databind.JsonNode> map) {
-        Map<UserProfileRow, UserProfileNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<UserProfileRow, com.fasterxml.jackson.databind.JsonNode> e : map.entrySet()) {
-            toPut.put(e.getKey(), Json.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     public void putPhotoStreamId(UserProfileRow row, Long value) {
         put(ImmutableMultimap.of(row, PhotoStreamId.of(value)));
     }
@@ -814,18 +778,6 @@ public final class UserProfileTable implements
             toPut.put(e.getKey(), PhotoStreamId.of(e.getValue()));
         }
         put(Multimaps.forMap(toPut));
-    }
-
-    public void putPhotoStreamIdUnlessExists(UserProfileRow row, Long value) {
-        putUnlessExists(ImmutableMultimap.of(row, PhotoStreamId.of(value)));
-    }
-
-    public void putPhotoStreamIdUnlessExists(Map<UserProfileRow, Long> map) {
-        Map<UserProfileRow, UserProfileNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<UserProfileRow, Long> e : map.entrySet()) {
-            toPut.put(e.getKey(), PhotoStreamId.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
     }
 
     @Override
@@ -885,20 +837,6 @@ public final class UserProfileTable implements
         for (UserProfileTrigger trigger : triggers) {
             trigger.putUserProfile(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<UserProfileRow, ? extends UserProfileNamedColumnValue<?>> rows) {
-        Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<UserProfileRow, UserProfileNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<UserProfileRow, ? extends UserProfileNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteMetadata(UserProfileRow row) {
@@ -1669,35 +1607,6 @@ public final class UserProfileTable implements
             }
         }
 
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(CookiesIdxRow rowName, Iterable<CookiesIdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<CookiesIdxRow, CookiesIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(CookiesIdxRow rowName, CookiesIdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<CookiesIdxRow, CookiesIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<CookiesIdxRow, ? extends CookiesIdxColumnValue> rows) {
-            Multimap<CookiesIdxRow, CookiesIdxColumn> toGet = Multimaps.transformValues(rows, CookiesIdxColumnValue.getColumnNameFun());
-            Multimap<CookiesIdxRow, CookiesIdxColumnValue> existing = get(toGet);
-            Multimap<CookiesIdxRow, CookiesIdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<CookiesIdxRow, ? extends CookiesIdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
-        }
-
         @Override
         public void touch(Multimap<CookiesIdxRow, CookiesIdxColumn> values) {
             Multimap<CookiesIdxRow, CookiesIdxColumnValue> currentValues = get(values);
@@ -2353,35 +2262,6 @@ public final class UserProfileTable implements
             for (CreatedIdxTrigger trigger : triggers) {
                 trigger.putCreatedIdx(values);
             }
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(CreatedIdxRow rowName, Iterable<CreatedIdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<CreatedIdxRow, CreatedIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(CreatedIdxRow rowName, CreatedIdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<CreatedIdxRow, CreatedIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<CreatedIdxRow, ? extends CreatedIdxColumnValue> rows) {
-            Multimap<CreatedIdxRow, CreatedIdxColumn> toGet = Multimaps.transformValues(rows, CreatedIdxColumnValue.getColumnNameFun());
-            Multimap<CreatedIdxRow, CreatedIdxColumnValue> existing = get(toGet);
-            Multimap<CreatedIdxRow, CreatedIdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<CreatedIdxRow, ? extends CreatedIdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
         }
 
         @Override
@@ -3041,35 +2921,6 @@ public final class UserProfileTable implements
             }
         }
 
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(UserBirthdaysIdxRow rowName, Iterable<UserBirthdaysIdxColumnValue> values) {
-            putUnlessExists(ImmutableMultimap.<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(UserBirthdaysIdxRow rowName, UserBirthdaysIdxColumnValue... values) {
-            putUnlessExists(ImmutableMultimap.<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue>builder().putAll(rowName, values).build());
-        }
-
-        /** @deprecated Use separate read and write in a single transaction instead. */
-        @Deprecated
-        @Override
-        public void putUnlessExists(Multimap<UserBirthdaysIdxRow, ? extends UserBirthdaysIdxColumnValue> rows) {
-            Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> toGet = Multimaps.transformValues(rows, UserBirthdaysIdxColumnValue.getColumnNameFun());
-            Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> existing = get(toGet);
-            Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> toPut = HashMultimap.create();
-            for (Entry<UserBirthdaysIdxRow, ? extends UserBirthdaysIdxColumnValue> entry : rows.entries()) {
-                if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                    toPut.put(entry.getKey(), entry.getValue());
-                }
-            }
-            put(toPut);
-        }
-
         @Override
         public void touch(Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumn> values) {
             Multimap<UserBirthdaysIdxRow, UserBirthdaysIdxColumnValue> currentValues = get(values);
@@ -3349,5 +3200,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "WNNRujDdISZR1guCBdOk3g==";
+    static String __CLASS_HASH = "i1/fSbC65yELf1GNvIGF5Q==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BenchmarksTableFactory.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BenchmarksTableFactory.java
@@ -1,33 +1,36 @@
 package com.palantir.atlasdb.timelock.benchmarks.schema.generated;
 
-import java.util.List;
-
-import javax.annotation.Generated;
-
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.table.generation.Triggers;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import java.lang.Override;
+import java.util.List;
+import javax.annotation.Generated;
 
 @Generated("com.palantir.atlasdb.table.description.render.TableFactoryRenderer")
 public final class BenchmarksTableFactory {
-    private final static Namespace defaultNamespace = Namespace.create("benchmarks", Namespace.UNCHECKED_NAME);
+    private static final Namespace defaultNamespace = Namespace.create("benchmarks", Namespace.UNCHECKED_NAME);
+
     private final List<Function<? super Transaction, SharedTriggers>> sharedTriggers;
+
     private final Namespace namespace;
 
-    public static BenchmarksTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
+    private BenchmarksTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+            Namespace namespace) {
+        this.sharedTriggers = sharedTriggers;
+        this.namespace = namespace;
+    }
+
+    public static BenchmarksTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers,
+            Namespace namespace) {
         return new BenchmarksTableFactory(sharedTriggers, namespace);
     }
 
     public static BenchmarksTableFactory of(List<Function<? super Transaction, SharedTriggers>> sharedTriggers) {
         return new BenchmarksTableFactory(sharedTriggers, defaultNamespace);
-    }
-
-    private BenchmarksTableFactory(List<Function<? super Transaction, SharedTriggers>> sharedTriggers, Namespace namespace) {
-        this.sharedTriggers = sharedTriggers;
-        this.namespace = namespace;
     }
 
     public static BenchmarksTableFactory of(Namespace namespace) {
@@ -42,11 +45,13 @@ public final class BenchmarksTableFactory {
         return BlobsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public BlobsSerializableTable getBlobsSerializableTable(Transaction t, BlobsSerializableTable.BlobsSerializableTrigger... triggers) {
+    public BlobsSerializableTable getBlobsSerializableTable(Transaction t,
+            BlobsSerializableTable.BlobsSerializableTrigger... triggers) {
         return BlobsSerializableTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public KvDynamicColumnsTable getKvDynamicColumnsTable(Transaction t, KvDynamicColumnsTable.KvDynamicColumnsTrigger... triggers) {
+    public KvDynamicColumnsTable getKvDynamicColumnsTable(Transaction t,
+            KvDynamicColumnsTable.KvDynamicColumnsTrigger... triggers) {
         return KvDynamicColumnsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
@@ -54,17 +59,12 @@ public final class BenchmarksTableFactory {
         return KvRowsTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public MetadataTable getMetadataTable(Transaction t, MetadataTable.MetadataTrigger... triggers) {
+    public MetadataTable getMetadataTable(Transaction t,
+            MetadataTable.MetadataTrigger... triggers) {
         return MetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
-    public interface SharedTriggers extends
-            BlobsTable.BlobsTrigger,
-            BlobsSerializableTable.BlobsSerializableTrigger,
-            KvDynamicColumnsTable.KvDynamicColumnsTrigger,
-            KvRowsTable.KvRowsTrigger,
-            MetadataTable.MetadataTrigger {
-        /* empty */
+    public interface SharedTriggers extends BlobsTable.BlobsTrigger, BlobsSerializableTable.BlobsSerializableTrigger, KvDynamicColumnsTable.KvDynamicColumnsTrigger, KvRowsTable.KvRowsTrigger, MetadataTable.MetadataTrigger {
     }
 
     public abstract static class NullSharedTriggers implements SharedTriggers {

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
@@ -8,9 +8,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -21,7 +23,6 @@ import javax.annotation.Generated;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -414,18 +415,6 @@ public final class BlobsSerializableTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putDataUnlessExists(BlobsSerializableRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Data.of(value)));
-    }
-
-    public void putDataUnlessExists(Map<BlobsSerializableRow, byte[]> map) {
-        Map<BlobsSerializableRow, BlobsSerializableNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<BlobsSerializableRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Data.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<BlobsSerializableRow, ? extends BlobsSerializableNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -433,20 +422,6 @@ public final class BlobsSerializableTable implements
         for (BlobsSerializableTrigger trigger : triggers) {
             trigger.putBlobsSerializable(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<BlobsSerializableRow, ? extends BlobsSerializableNamedColumnValue<?>> rows) {
-        Multimap<BlobsSerializableRow, BlobsSerializableNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<BlobsSerializableRow, BlobsSerializableNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<BlobsSerializableRow, ? extends BlobsSerializableNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteData(BlobsSerializableRow row) {
@@ -606,11 +581,8 @@ public final class BlobsSerializableTable implements
      * {@link Arrays}
      * {@link AssertUtils}
      * {@link AtlasDbConstraintCheckingMode}
-     * {@link AtlasDbDynamicMutableExpiringTable}
      * {@link AtlasDbDynamicMutablePersistentTable}
-     * {@link AtlasDbMutableExpiringTable}
      * {@link AtlasDbMutablePersistentTable}
-     * {@link AtlasDbNamedExpiringSet}
      * {@link AtlasDbNamedMutableTable}
      * {@link AtlasDbNamedPersistentSet}
      * {@link BatchColumnRangeSelection}
@@ -681,8 +653,9 @@ public final class BlobsSerializableTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "yLyE7LWp3HCpLg4wfAKk+w==";
+    static String __CLASS_HASH = "SdgUSR8Y7V+fu2C7iUMTDg==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
@@ -8,9 +8,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -21,7 +23,6 @@ import javax.annotation.Generated;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -414,18 +415,6 @@ public final class BlobsTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putDataUnlessExists(BlobsRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Data.of(value)));
-    }
-
-    public void putDataUnlessExists(Map<BlobsRow, byte[]> map) {
-        Map<BlobsRow, BlobsNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<BlobsRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Data.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<BlobsRow, ? extends BlobsNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -433,20 +422,6 @@ public final class BlobsTable implements
         for (BlobsTrigger trigger : triggers) {
             trigger.putBlobs(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<BlobsRow, ? extends BlobsNamedColumnValue<?>> rows) {
-        Multimap<BlobsRow, BlobsNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<BlobsRow, BlobsNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<BlobsRow, ? extends BlobsNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteData(BlobsRow row) {
@@ -606,11 +581,8 @@ public final class BlobsTable implements
      * {@link Arrays}
      * {@link AssertUtils}
      * {@link AtlasDbConstraintCheckingMode}
-     * {@link AtlasDbDynamicMutableExpiringTable}
      * {@link AtlasDbDynamicMutablePersistentTable}
-     * {@link AtlasDbMutableExpiringTable}
      * {@link AtlasDbMutablePersistentTable}
-     * {@link AtlasDbNamedExpiringSet}
      * {@link AtlasDbNamedMutableTable}
      * {@link AtlasDbNamedPersistentSet}
      * {@link BatchColumnRangeSelection}
@@ -681,8 +653,9 @@ public final class BlobsTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "tG3SDjMN1T6Qg84GKbWJ+Q==";
+    static String __CLASS_HASH = "Qvg9woe62nJkKkNxn/bXHg==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
@@ -8,9 +8,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -21,7 +23,6 @@ import javax.annotation.Generated;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
@@ -135,24 +136,24 @@ public final class KvRowsTable implements
     /**
      * <pre>
      * KvRowsRow {
-     *   {@literal Long firstComponentHash};
+     *   {@literal Long hashOfRowComponents};
      *   {@literal String bucket};
      *   {@literal Long key};
      * }
      * </pre>
      */
     public static final class KvRowsRow implements Persistable, Comparable<KvRowsRow> {
-        private final long firstComponentHash;
+        private final long hashOfRowComponents;
         private final String bucket;
         private final long key;
 
         public static KvRowsRow of(String bucket, long key) {
-            long firstComponentHash = Hashing.murmur3_128().hashBytes(ValueType.VAR_STRING.convertFromJava(bucket)).asLong();
-            return new KvRowsRow(firstComponentHash, bucket, key);
+            long hashOfRowComponents = computeHashFirstComponents(bucket);
+            return new KvRowsRow(hashOfRowComponents, bucket, key);
         }
 
-        private KvRowsRow(long firstComponentHash, String bucket, long key) {
-            this.firstComponentHash = firstComponentHash;
+        private KvRowsRow(long hashOfRowComponents, String bucket, long key) {
+            this.hashOfRowComponents = hashOfRowComponents;
             this.bucket = bucket;
             this.key = key;
         }
@@ -185,60 +186,65 @@ public final class KvRowsTable implements
 
         @Override
         public byte[] persistToBytes() {
-            byte[] firstComponentHashBytes = PtBytes.toBytes(Long.MIN_VALUE ^ firstComponentHash);
+            byte[] hashOfRowComponentsBytes = PtBytes.toBytes(Long.MIN_VALUE ^ hashOfRowComponents);
             byte[] bucketBytes = EncodingUtils.encodeVarString(bucket);
             byte[] keyBytes = PtBytes.toBytes(Long.MIN_VALUE ^ key);
-            return EncodingUtils.add(firstComponentHashBytes, bucketBytes, keyBytes);
+            return EncodingUtils.add(hashOfRowComponentsBytes, bucketBytes, keyBytes);
         }
 
         public static final Hydrator<KvRowsRow> BYTES_HYDRATOR = new Hydrator<KvRowsRow>() {
             @Override
             public KvRowsRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long firstComponentHash = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
                 String bucket = EncodingUtils.decodeVarString(__input, __index);
                 __index += EncodingUtils.sizeOfVarString(bucket);
                 Long key = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                return new KvRowsRow(firstComponentHash, bucket, key);
+                return new KvRowsRow(hashOfRowComponents, bucket, key);
             }
         };
 
-        public static RangeRequest.Builder createPrefixRangeUnsorted(String bucket) {
-            long firstComponentHash = Hashing.murmur3_128().hashBytes(ValueType.VAR_STRING.convertFromJava(bucket)).asLong();
-            byte[] firstComponentHashBytes = PtBytes.toBytes(Long.MIN_VALUE ^ firstComponentHash);
+        public static long computeHashFirstComponents(String bucket) {
             byte[] bucketBytes = EncodingUtils.encodeVarString(bucket);
-            return RangeRequest.builder().prefixRange(EncodingUtils.add(firstComponentHashBytes, bucketBytes));
+            return Hashing.murmur3_128().hashBytes(EncodingUtils.add(bucketBytes)).asLong();
+        }
+
+        public static RangeRequest.Builder createPrefixRangeUnsorted(String bucket) {
+            long hashOfRowComponents = computeHashFirstComponents(bucket);
+            byte[] hashOfRowComponentsBytes = PtBytes.toBytes(Long.MIN_VALUE ^ hashOfRowComponents);
+            byte[] bucketBytes = EncodingUtils.encodeVarString(bucket);
+            return RangeRequest.builder().prefixRange(EncodingUtils.add(hashOfRowComponentsBytes, bucketBytes));
         }
 
         public static Prefix prefixUnsorted(String bucket) {
-            long firstComponentHash = Hashing.murmur3_128().hashBytes(ValueType.VAR_STRING.convertFromJava(bucket)).asLong();
-            byte[] firstComponentHashBytes = PtBytes.toBytes(Long.MIN_VALUE ^ firstComponentHash);
+            long hashOfRowComponents = computeHashFirstComponents(bucket);
+            byte[] hashOfRowComponentsBytes = PtBytes.toBytes(Long.MIN_VALUE ^ hashOfRowComponents);
             byte[] bucketBytes = EncodingUtils.encodeVarString(bucket);
-            return new Prefix(EncodingUtils.add(firstComponentHashBytes, bucketBytes));
+            return new Prefix(EncodingUtils.add(hashOfRowComponentsBytes, bucketBytes));
         }
 
         public static RangeRequest.Builder createPrefixRange(String bucket, long key) {
-            long firstComponentHash = Hashing.murmur3_128().hashBytes(ValueType.VAR_STRING.convertFromJava(bucket)).asLong();
-            byte[] firstComponentHashBytes = PtBytes.toBytes(Long.MIN_VALUE ^ firstComponentHash);
+            long hashOfRowComponents = computeHashFirstComponents(bucket);
+            byte[] hashOfRowComponentsBytes = PtBytes.toBytes(Long.MIN_VALUE ^ hashOfRowComponents);
             byte[] bucketBytes = EncodingUtils.encodeVarString(bucket);
             byte[] keyBytes = PtBytes.toBytes(Long.MIN_VALUE ^ key);
-            return RangeRequest.builder().prefixRange(EncodingUtils.add(firstComponentHashBytes, bucketBytes, keyBytes));
+            return RangeRequest.builder().prefixRange(EncodingUtils.add(hashOfRowComponentsBytes, bucketBytes, keyBytes));
         }
 
         public static Prefix prefix(String bucket, long key) {
-            long firstComponentHash = Hashing.murmur3_128().hashBytes(ValueType.VAR_STRING.convertFromJava(bucket)).asLong();
-            byte[] firstComponentHashBytes = PtBytes.toBytes(Long.MIN_VALUE ^ firstComponentHash);
+            long hashOfRowComponents = computeHashFirstComponents(bucket);
+            byte[] hashOfRowComponentsBytes = PtBytes.toBytes(Long.MIN_VALUE ^ hashOfRowComponents);
             byte[] bucketBytes = EncodingUtils.encodeVarString(bucket);
             byte[] keyBytes = PtBytes.toBytes(Long.MIN_VALUE ^ key);
-            return new Prefix(EncodingUtils.add(firstComponentHashBytes, bucketBytes, keyBytes));
+            return new Prefix(EncodingUtils.add(hashOfRowComponentsBytes, bucketBytes, keyBytes));
         }
 
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(getClass().getSimpleName())
-                .add("firstComponentHash", firstComponentHash)
+                .add("hashOfRowComponents", hashOfRowComponents)
                 .add("bucket", bucket)
                 .add("key", key)
                 .toString();
@@ -256,19 +262,19 @@ public final class KvRowsTable implements
                 return false;
             }
             KvRowsRow other = (KvRowsRow) obj;
-            return Objects.equal(firstComponentHash, other.firstComponentHash) && Objects.equal(bucket, other.bucket) && Objects.equal(key, other.key);
+            return Objects.equals(hashOfRowComponents, other.hashOfRowComponents) && Objects.equals(bucket, other.bucket) && Objects.equals(key, other.key);
         }
 
         @SuppressWarnings("ArrayHashCode")
         @Override
         public int hashCode() {
-            return Arrays.deepHashCode(new Object[]{ firstComponentHash, bucket, key });
+            return Arrays.deepHashCode(new Object[]{ hashOfRowComponents, bucket, key });
         }
 
         @Override
         public int compareTo(KvRowsRow o) {
             return ComparisonChain.start()
-                .compare(this.firstComponentHash, o.firstComponentHash)
+                .compare(this.hashOfRowComponents, o.hashOfRowComponents)
                 .compare(this.bucket, o.bucket)
                 .compare(this.key, o.key)
                 .result();
@@ -465,18 +471,6 @@ public final class KvRowsTable implements
         put(Multimaps.forMap(toPut));
     }
 
-    public void putDataUnlessExists(KvRowsRow row, byte[] value) {
-        putUnlessExists(ImmutableMultimap.of(row, Data.of(value)));
-    }
-
-    public void putDataUnlessExists(Map<KvRowsRow, byte[]> map) {
-        Map<KvRowsRow, KvRowsNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
-        for (Entry<KvRowsRow, byte[]> e : map.entrySet()) {
-            toPut.put(e.getKey(), Data.of(e.getValue()));
-        }
-        putUnlessExists(Multimaps.forMap(toPut));
-    }
-
     @Override
     public void put(Multimap<KvRowsRow, ? extends KvRowsNamedColumnValue<?>> rows) {
         t.useTable(tableRef, this);
@@ -484,20 +478,6 @@ public final class KvRowsTable implements
         for (KvRowsTrigger trigger : triggers) {
             trigger.putKvRows(rows);
         }
-    }
-
-    /** @deprecated Use separate read and write in a single transaction instead. */
-    @Deprecated
-    @Override
-    public void putUnlessExists(Multimap<KvRowsRow, ? extends KvRowsNamedColumnValue<?>> rows) {
-        Multimap<KvRowsRow, KvRowsNamedColumnValue<?>> existing = getRowsMultimap(rows.keySet());
-        Multimap<KvRowsRow, KvRowsNamedColumnValue<?>> toPut = HashMultimap.create();
-        for (Entry<KvRowsRow, ? extends KvRowsNamedColumnValue<?>> entry : rows.entries()) {
-            if (!existing.containsEntry(entry.getKey(), entry.getValue())) {
-                toPut.put(entry.getKey(), entry.getValue());
-            }
-        }
-        put(toPut);
     }
 
     public void deleteData(KvRowsRow row) {
@@ -658,6 +638,12 @@ public final class KvRowsTable implements
                 (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, KvRowsRowResult::of)));
     }
 
+    public <T> Stream<T> getRanges(Iterable<RangeRequest> ranges,
+                                   BiFunction<RangeRequest, BatchingVisitable<KvRowsRowResult>, T> visitableProcessor) {
+        return t.getRanges(tableRef, ranges,
+                (rangeRequest, visitable) -> visitableProcessor.apply(rangeRequest, BatchingVisitables.transform(visitable, KvRowsRowResult::of)));
+    }
+
     public Stream<BatchingVisitable<KvRowsRowResult>> getRangesLazy(Iterable<RangeRequest> ranges) {
         Stream<BatchingVisitable<RowResult<byte[]>>> rangeResults = t.getRangesLazy(tableRef, ranges);
         return rangeResults.map(visitable -> BatchingVisitables.transform(visitable, KvRowsRowResult::of));
@@ -700,11 +686,8 @@ public final class KvRowsTable implements
      * {@link Arrays}
      * {@link AssertUtils}
      * {@link AtlasDbConstraintCheckingMode}
-     * {@link AtlasDbDynamicMutableExpiringTable}
      * {@link AtlasDbDynamicMutablePersistentTable}
-     * {@link AtlasDbMutableExpiringTable}
      * {@link AtlasDbMutablePersistentTable}
-     * {@link AtlasDbNamedExpiringSet}
      * {@link AtlasDbNamedMutableTable}
      * {@link AtlasDbNamedPersistentSet}
      * {@link BatchColumnRangeSelection}
@@ -775,8 +758,9 @@ public final class KvRowsTable implements
      * {@link TimeUnit}
      * {@link Transaction}
      * {@link TypedRowResult}
+     * {@link UUID}
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "8IM1VFFyEfQZuXiplEiPdg==";
+    static String __CLASS_HASH = "m8yeo8CW8a+4SZzBshzfRA==";
 }


### PR DESCRIPTION
**Goals (and why)**: Fix #2047 and #2539 

**Implementation Description (bullets)**:
- Remove the API from the table renderer
- Remove the API from all generated code tables in AtlasDB, by regenerating all schemas

**Concerns (what feedback would you like?)**:
- I noticed that regenerateSchemas in AtlasDB doesn't actually regenerate all the schemas. I didn't fix this here as it would require a bit of gradle digging.
- This is obviously a dev break, but it's been deprecated for 10 months so there's nothing holding me back here.
- I checked the docs and I think all references to `putUnlessExists` there refer to the KVS API, not the table-level API, but could be worth a sanity check.

**Where should we start reviewing?**: `TableRenderer`

**Priority (whenever / two weeks / yesterday)**: this week

@tpetracca for SA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3340)
<!-- Reviewable:end -->
