### PR TITLE
[TS] Write to sweep queue at start timestamp

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueUtils.java
@@ -36,8 +36,7 @@ public final class SweepQueueUtils {
     public static final int MAX_CELLS_DEDICATED = 100_000;
     public static final int SWEEP_BATCH_SIZE = MAX_CELLS_DEDICATED;
     public static final int BATCH_SIZE_KVS = 1000;
-    public static final long READ_TS = 1L;
-    public static final long WRITE_TS = 0L;
+    public static final long READ_TS = Long.MAX_VALUE;
     public static final long INITIAL_TIMESTAMP = -1L;
     public static final ColumnRangeSelection ALL_COLUMNS = allPossibleColumns();
     public static final int MINIMUM_WRITE_INDEX = -TargetedSweepMetadata.MAX_DEDICATED_ROWS;
@@ -72,7 +71,6 @@ public final class SweepQueueUtils {
 
     public static WriteInfo toWriteInfo(TableReference tableRef, Map.Entry<Cell, byte[]> write, long timestamp) {
         Cell cell = write.getKey();
-        // todo(gmaretic): verify this is indeed how a tombstone is encoded
         boolean isTombstone = Arrays.equals(write.getValue(), PtBytes.EMPTY_BYTE_ARRAY);
         return WriteInfo.of(WriteReference.of(tableRef, cell, isTombstone), timestamp);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -67,13 +67,19 @@ public class SweepableCells extends KvsSweepQueueWriter {
     }
 
     @Override
+    Map<Cell, byte[]> populateReferences(PartitionInfo partitionInfo, List<WriteInfo> writes) {
+        boolean dedicate = writes.size() > SweepQueueUtils.MAX_CELLS_GENERIC;
+        if (dedicate) {
+            return addReferenceToDedicatedRows(partitionInfo, writes);
+        } else {
+            return ImmutableMap.of();
+        }
+    }
+
+    @Override
     Map<Cell, byte[]> populateCells(PartitionInfo partitionInfo, List<WriteInfo> writes) {
         Map<Cell, byte[]> cells = new HashMap<>();
         boolean dedicate = writes.size() > SweepQueueUtils.MAX_CELLS_GENERIC;
-
-        if (dedicate) {
-            cells.putAll(addReferenceToDedicatedRows(partitionInfo, writes));
-        }
 
         long index = 0;
         for (WriteInfo write : writes) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
@@ -42,6 +42,11 @@ public class SweepableTimestamps extends KvsSweepQueueWriter {
     }
 
     @Override
+    Map<Cell, byte[]> populateReferences(PartitionInfo partitionInfo, List<WriteInfo> writes) {
+        return ImmutableMap.of();
+    }
+
+    @Override
     Map<Cell, byte[]> populateCells(PartitionInfo info, List<WriteInfo> writes) {
         SweepableTimestampsTable.SweepableTimestampsRow row = computeRow(info);
         SweepableTimestampsTable.SweepableTimestampsColumn col = computeColumn(info);

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,11 @@ develop
          - Change
 
     *    - |fixed|
+         - Writes to the targeted sweep queue are now done using the start timestamp of the transaction that makes the call.
+           Previously, the writes were done at timestamp 0, which was interfering with Cassandra compactions.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3342>`__)
+
+    *    - |fixed|
          - The sweep CLI will no longer perform in-process compactions after sweeping a table.
            For DbKvs, this operation is handled by the background compaction thread; Cassandra performs its own compactions.
            Note that the sweep CLI itself has been deprecated in favour of using the sweep priority override configuration, possibly in conjunction with the thread count (:ref:`Docs<sweep_tunable_parameters>`).


### PR DESCRIPTION
**Goals (and why)**:
Do not write to sweepable cells and sweepable timestamps at timestamp 0, use the transaction's start timestamp instead. Also, use multiPut, and ensure references are written first.

**Concerns (what feedback would you like?)**:
Is always reading at `Long.MAX_VALUE` reasonable?

@j-baker @ashrayjain for SA
