### PR TITLE
Call async initialization callback after initialization

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -149,8 +149,8 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
 
         private void runCallback() {
             try {
-                callback.runWithRetry(txManager);
                 checkAndSetStatus(ImmutableSet.of(State.INITIALIZING), State.READY);
+                callback.runWithRetry(txManager);
             } catch (Throwable e) {
                 log.error("Callback failed and was not able to perform its cleanup task. "
                         + "Closing the TransactionManager.", e);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -178,31 +178,23 @@ public class SerializableTransactionManagerTest {
     }
 
     @Test
-    public void callbackBlocksInitializationUntilDone() {
+    public void callbackRunsAfterInitialization() {
         everythingInitialized();
         ClusterAvailabilityStatusBlockingCallback blockingCallback = new ClusterAvailabilityStatusBlockingCallback();
         manager = getManagerWithCallback(true, blockingCallback);
 
         Awaitility.waitAtMost(2L, TimeUnit.SECONDS).until(() -> blockingCallback.wasInvoked());
-        assertFalse(manager.isInitialized());
-
-        blockingCallback.stopBlocking();
-        Awaitility.waitAtMost(2L, TimeUnit.SECONDS).until(() -> manager.isInitialized());
+        assertTrue(manager.isInitialized());
     }
 
     @Test
-    public void callbackCanCallTmMethodsEvenThoughTmStillThrows() {
+    public void callbackCanCallTmMethods() {
         everythingInitialized();
         ClusterAvailabilityStatusBlockingCallback blockingCallback = new ClusterAvailabilityStatusBlockingCallback();
         manager = getManagerWithCallback(true, blockingCallback);
 
         Awaitility.waitAtMost(2L, TimeUnit.SECONDS).until(() -> blockingCallback.wasInvoked());
         verify(mockKvs, atLeast(1)).getClusterAvailabilityStatus();
-        Assertions.assertThatThrownBy(() -> manager.getKeyValueServiceStatus())
-                .isInstanceOf(NotInitializedException.class);
-
-        blockingCallback.stopBlocking();
-        Awaitility.waitAtMost(2L, TimeUnit.SECONDS).until(() -> manager.isInitialized());
         manager.getKeyValueServiceStatus();
     }
 


### PR DESCRIPTION
**Goals (and why)**:
Update the initialization status before running the async initialization callback. Clients need a way to perform initialization tasks once the transaction manager is initialized. Unfortunately in the current implementation, clients may not be able to call transaction manager methods and thus don't have a hook for post-initialization tasks.

**Concerns (what feedback would you like?)**:
@gmaretic What was the motivation for implementing it in the other order in #3011 (it appears deliberate)?

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3345)
<!-- Reviewable:end -->
