### PR TITLE
randomize backoff period for conservative strategy

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -56,6 +56,27 @@ class CassandraRequestExceptionHandler {
         this.blacklist = blacklist;
     }
 
+    public static void main(String[] args) {
+        long[] vals = new long[10];
+        long[] min = new long[10];
+        long[] max = new long[10];
+        for (int i = 0; i < 10; i++) {
+            min[i] = Long.MAX_VALUE;
+        }
+        for (int j = 0; j < 1000; j++) {
+            for (int i = 1; i < 10; i++) {
+                long currVal = Conservative.INSTANCE.getBackoffPeriod(i);
+                vals[i] = vals[i] + currVal;
+                min[i] = Math.min(currVal, min[i]);
+                max[i] = Math.max(currVal, max[i]);
+            }
+        }
+
+        for (int i = 1; i < 10; i++) {
+            System.out.println("Trial:" + i + ", avr:" + vals[i]/1000 + ", min:" + min[i] + ", max:" + max[i]);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     <K extends Exception> void handleExceptionFromRequest(
             RetryableCassandraRequest<?, K> req,
@@ -269,7 +290,10 @@ class CassandraRequestExceptionHandler {
 
     private static class Conservative implements RequestExceptionHandlerStrategy {
         private static final RequestExceptionHandlerStrategy INSTANCE = new Conservative();
-        private static final long MAX_EXPECTED_BACKOFF = Duration.ofSeconds(30).toMillis();
+        private static final long MAX_BACKOFF = Duration.ofSeconds(30).toMillis();
+        private static final double UNCERTAINTY = 0.5;
+
+        private static final long MAX_EXPECTED_BACKOFF = (long) (MAX_BACKOFF / (UNCERTAINTY + 1));
 
         @Override
         public boolean shouldBackoff(Exception ex) {
@@ -278,8 +302,8 @@ class CassandraRequestExceptionHandler {
 
         @Override
         public long getBackoffPeriod(int numberOfAttempts) {
-            double randomCoeff = ThreadLocalRandom.current().nextDouble() + 0.5;
-            return (long) (Math.min(500 * Math.pow(2, numberOfAttempts), MAX_EXPECTED_BACKOFF) * randomCoeff);
+            double randomizationCoeff = ThreadLocalRandom.current().nextDouble() * UNCERTAINTY + 1 - UNCERTAINTY;
+            return (long) (Math.min(500 * Math.pow(2, numberOfAttempts), MAX_EXPECTED_BACKOFF) * randomizationCoeff);
         }
 
         @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -269,7 +269,7 @@ class CassandraRequestExceptionHandler {
 
     private static class Conservative implements RequestExceptionHandlerStrategy {
         private static final RequestExceptionHandlerStrategy INSTANCE = new Conservative();
-        private static final long MAX_BACKOFF = Duration.ofSeconds(30).toMillis();
+        private static final long MAX_EXPECTED_BACKOFF = Duration.ofSeconds(30).toMillis();
 
         @Override
         public boolean shouldBackoff(Exception ex) {
@@ -278,7 +278,8 @@ class CassandraRequestExceptionHandler {
 
         @Override
         public long getBackoffPeriod(int numberOfAttempts) {
-            return Math.min(500 * (long) Math.pow(2, numberOfAttempts), MAX_BACKOFF);
+            double randomCoeff = ThreadLocalRandom.current().nextDouble() + 0.5;
+            return (long)(Math.min(500 * Math.pow(2, numberOfAttempts), MAX_EXPECTED_BACKOFF) * randomCoeff);
         }
 
         @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -279,7 +279,7 @@ class CassandraRequestExceptionHandler {
         @Override
         public long getBackoffPeriod(int numberOfAttempts) {
             double randomCoeff = ThreadLocalRandom.current().nextDouble() + 0.5;
-            return (long)(Math.min(500 * Math.pow(2, numberOfAttempts), MAX_EXPECTED_BACKOFF) * randomCoeff);
+            return (long) (Math.min(500 * Math.pow(2, numberOfAttempts), MAX_EXPECTED_BACKOFF) * randomCoeff);
         }
 
         @Override

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -56,27 +56,6 @@ class CassandraRequestExceptionHandler {
         this.blacklist = blacklist;
     }
 
-    public static void main(String[] args) {
-        long[] vals = new long[10];
-        long[] min = new long[10];
-        long[] max = new long[10];
-        for (int i = 0; i < 10; i++) {
-            min[i] = Long.MAX_VALUE;
-        }
-        for (int j = 0; j < 1000; j++) {
-            for (int i = 1; i < 10; i++) {
-                long currVal = Conservative.INSTANCE.getBackoffPeriod(i);
-                vals[i] = vals[i] + currVal;
-                min[i] = Math.min(currVal, min[i]);
-                max[i] = Math.max(currVal, max[i]);
-            }
-        }
-
-        for (int i = 1; i < 10; i++) {
-            System.out.println("Trial:" + i + ", avr:" + vals[i]/1000 + ", min:" + min[i] + ", max:" + max[i]);
-        }
-    }
-
     @SuppressWarnings("unchecked")
     <K extends Exception> void handleExceptionFromRequest(
             RetryableCassandraRequest<?, K> req,
@@ -302,8 +281,8 @@ class CassandraRequestExceptionHandler {
 
         @Override
         public long getBackoffPeriod(int numberOfAttempts) {
-            double randomizationCoeff = ThreadLocalRandom.current().nextDouble() * UNCERTAINTY + 1 - UNCERTAINTY;
-            return (long) (Math.min(500 * Math.pow(2, numberOfAttempts), MAX_EXPECTED_BACKOFF) * randomizationCoeff);
+            double randomCoeff = ThreadLocalRandom.current().nextDouble(1 - UNCERTAINTY, 1 + UNCERTAINTY);
+            return (long) (Math.min(500 * Math.pow(2, numberOfAttempts), MAX_EXPECTED_BACKOFF) * randomCoeff);
         }
 
         @Override


### PR DESCRIPTION
**Goals (and why)**:
Randomize the back off period for conservative strategy. I wanted to randomize it without changing expected value. Behavior is somewhat similar to http-remoting now.

| numRetries | conservative_expected(ms) | randomized_expected(ms) | randomized_min(ms) | randomized_max(ms)
|------------|------------------------|------------------------|-----------------|------------------|
|1 |1000 |1000 |500 |1500 |
|2 |2000 |2000 |1000 |3000 |
|3 |4000 |4000 |2000 |6000 |
|4 |8000 |8000 |4000 |12000 |
|5 |16000 |16000 |8000 | 24000 |
|6 |30000 |30000 |15000 |45000 |

**Implementation Description (bullets)**:
Multiplying the value with a double coeff changing between 0.5 and 1.5.

**Where should we start reviewing?**:
`CassandraRequestExceptionHandler`

**Priority (whenever / two weeks / yesterday)**:
This week?
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3346)
<!-- Reviewable:end -->
