### PR TITLE
Feature/stop sweep priority writes

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -273,10 +273,8 @@ public abstract class TransactionManagers {
         Supplier<AtlasDbRuntimeConfig> runtimeConfigSupplier =
                 () -> runtimeConfigSupplier().get().orElse(defaultRuntime);
 
-        QosClient qosClient = initializeCloseable(
-                () -> getQosClient(metricsManager,
-                        JavaSuppliers.compose(AtlasDbRuntimeConfig::qos, runtimeConfigSupplier)),
-                closeables);
+        QosClient qosClient = initializeCloseable(() -> getQosClient(metricsManager,
+                        JavaSuppliers.compose(AtlasDbRuntimeConfig::qos, runtimeConfigSupplier)), closeables);
 
         FreshTimestampSupplierAdapter adapter = new FreshTimestampSupplierAdapter();
         ServiceDiscoveringAtlasSupplier atlasFactory = new ServiceDiscoveringAtlasSupplier(metricsManager,
@@ -318,14 +316,9 @@ public abstract class TransactionManagers {
         SchemaMetadataService schemaMetadataService = SchemaMetadataServiceImpl.create(keyValueService,
                 config.initializeAsync());
         TransactionManagersInitializer initializer = TransactionManagersInitializer.createInitialTables(
-                keyValueService,
-                schemas(),
-                schemaMetadataService,
-                config.initializeAsync());
+                keyValueService, schemas(), schemaMetadataService, config.initializeAsync());
         PersistentLockService persistentLockService = createAndRegisterPersistentLockService(
-                keyValueService,
-                registrar(),
-                config.initializeAsync());
+                keyValueService, registrar(), config.initializeAsync());
 
         TransactionService transactionService = AtlasDbMetrics.instrument(metricsManager.getRegistry(),
                 TransactionService.class, TransactionServices.createTransactionService(keyValueService));

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,6 +57,12 @@ develop
            This API has already been since August 2017 (11 months from time of writing).
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3340>`__)
 
+    *    - |improved|
+         - We will no longer continue to update ``sweep.priority`` if writes are persisted to the targeted sweep queue.
+           This means that assuming ``targetedSweep.enableSweepQueueWrites`` remains on, the background sweeper will eventually run out of things to sweep without further intervention.
+           At this point, the background sweeper will start reporting ``NOTHING_TO_SWEEP``, and the background sweeper may safely be disabled.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3349>`__)
+
     *    - |fixed|
          - The sweep CLI will no longer perform in-process compactions after sweeping a table.
            For DbKvs, this operation is handled by the background compaction thread; Cassandra performs its own compactions.


### PR DESCRIPTION
**Goals (and why)**: Fixes #3226. We want background sweep to eventually catch up, so we can retire it.

**Implementation Description (bullets)**: 
* Simply don't wrap the kvs in SweepStatsKVS if TargetedSweep.enableSweepQueueWrites is set (it's an install parameter, so won't change after TM.create)

**Concerns (what feedback would you like?)**: Is it really this simple?

**Where should we start reviewing?**: TransactionManagers

**Priority (whenever / two weeks / yesterday)**: before release?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3349)
<!-- Reviewable:end -->
