### PR TITLE
Default PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @tboam @sandorw


### PR DESCRIPTION
https://help.github.com/articles/about-codeowners/

Sandor and I will be assigned to each new PR by default, we can then either review it or assign to someone else.

**Goals (and why)**: Ensure every PR is assigned promptly and looked at by someone.

**Implementation Description (bullets)**: Add a CODEOWNERS file which specifies that Sandor and I will be reviewers on every PR by default.  We can then assign to team members as appropriate.

**Concerns (what feedback would you like?)**: Should be fine.  We can create a test PR once this merges to check the workflow.  Worst case scenario is that PRs can't be merged unless one of us approves it, but I've checked and believe this isn't the configured behaviour.

**Where should we start reviewing?**: One line change

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3355)
<!-- Reviewable:end -->
