### PR TITLE
Less locking

### DIFF
--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -20,6 +20,7 @@ import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -48,7 +49,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
     public static TimeLockClient createDefault(TimelockService timelockService) {
         ScheduledExecutorService refreshExecutor = createSingleThreadScheduledExecutor("refresh");
         LockRefresher lockRefresher = new LockRefresher(refreshExecutor, timelockService, REFRESH_INTERVAL_MILLIS);
-        ScheduledExecutorService asyncUnlockExecutor = createSingleThreadScheduledExecutor("async-unlock");
+        ExecutorService asyncUnlockExecutor = createSingleThreadScheduledExecutor("async-unlock");
         AsyncTimeLockUnlocker asyncUnlocker = new AsyncTimeLockUnlocker(timelockService, asyncUnlockExecutor);
         return new TimeLockClient(timelockService, lockRefresher, asyncUnlocker);
     }


### PR DESCRIPTION
Locks are generally quite hard to reason about, hence all the javadoc in this class and code to deal with the concurrent ways of accessing the set.

This PR changes to use an ArrayBlockingQueue, which I believe to be a better primitive here; e.g. it makes clear that all elements will be seen eventually, and doesn't have e.g. the fairness issues we see before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3356)
<!-- Reviewable:end -->
