### PR TITLE
add subtype name 'cassandra' to runtime config

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
@@ -31,7 +31,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 @JsonSerialize(as = ImmutableCassandraKeyValueServiceRuntimeConfig.class)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = CassandraKeyValueServiceRuntimeConfig.class,
-                name = "CassandraKeyValueServiceRuntimeConfig"),
+                name = "CassandraKeyValueServiceRuntimeConfig"), //Deprecated, kept for backwards compatibility
         @JsonSubTypes.Type(value = CassandraKeyValueServiceRuntimeConfig.class,
                 name = CassandraKeyValueServiceRuntimeConfig.TYPE)})
 @Value.Immutable

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.cassandra;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.service.AutoService;
@@ -28,12 +29,20 @@ import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 @AutoService(KeyValueServiceRuntimeConfig.class)
 @JsonDeserialize(as = ImmutableCassandraKeyValueServiceRuntimeConfig.class)
 @JsonSerialize(as = ImmutableCassandraKeyValueServiceRuntimeConfig.class)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = CassandraKeyValueServiceRuntimeConfig.class,
+                name = "CassandraKeyValueServiceRuntimeConfig"),
+        @JsonSubTypes.Type(value = CassandraKeyValueServiceRuntimeConfig.class,
+                name = CassandraKeyValueServiceRuntimeConfig.TYPE)
+})
 @Value.Immutable
 public abstract class CassandraKeyValueServiceRuntimeConfig implements KeyValueServiceRuntimeConfig {
 
+    public static final String TYPE = "cassandra";
+
     @Override
     public String type() {
-        return "cassandra";
+        return TYPE;
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
@@ -33,8 +33,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
         @JsonSubTypes.Type(value = CassandraKeyValueServiceRuntimeConfig.class,
                 name = "CassandraKeyValueServiceRuntimeConfig"),
         @JsonSubTypes.Type(value = CassandraKeyValueServiceRuntimeConfig.class,
-                name = CassandraKeyValueServiceRuntimeConfig.TYPE)
-})
+                name = CassandraKeyValueServiceRuntimeConfig.TYPE)})
 @Value.Immutable
 public abstract class CassandraKeyValueServiceRuntimeConfig implements KeyValueServiceRuntimeConfig {
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
@@ -83,4 +83,28 @@ public class CassandraKeyValueServiceConfigsTest {
                 CONFIG_WITH_KEYSPACE, KEYSPACE_2);
         assertThat(newConfig.getKeyspaceOrThrow()).isEqualTo(KEYSPACE_2);
     }
+
+    @Test
+    public void canDeserializeRuntimeConfig() throws IOException {
+        CassandraKeyValueServiceRuntimeConfig expectedConfig = ImmutableCassandraKeyValueServiceRuntimeConfig.builder()
+                .numberOfRetriesOnSameHost(4)
+                .numberOfRetriesOnAllHosts(8)
+                .conservativeRequestExceptionHandler(true)
+                .build();
+
+        URL configUrl =
+                CassandraKeyValueServiceConfigsTest.class.getClassLoader().getResource("testRuntimeConfig.yml");
+
+        CassandraKeyValueServiceRuntimeConfig deserializedConfig = AtlasDbConfigs.OBJECT_MAPPER
+                .readValue(new File(configUrl.getPath()), CassandraKeyValueServiceRuntimeConfig.class);
+
+        assertThat(deserializedConfig).isEqualTo(expectedConfig);
+    }
+
+    @Test
+    public void canParseRuntimeDeprecatedConfigType() throws IOException {
+        CassandraKeyValueServiceRuntimeConfig config =
+                AtlasDbConfigs.OBJECT_MAPPER.readValue("type: CassandraKeyValueServiceRuntimeConfig",
+                        CassandraKeyValueServiceRuntimeConfig.class);
+    }
 }

--- a/atlasdb-cassandra/src/test/resources/testRuntimeConfig.yml
+++ b/atlasdb-cassandra/src/test/resources/testRuntimeConfig.yml
@@ -1,0 +1,4 @@
+  type: cassandra
+  numberOfRetriesOnSameHost: 4
+  numberOfRetriesOnAllHosts: 8
+  conservativeRequestExceptionHandler: true

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,9 +50,9 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
-
+    *    - |fixed| |deprecated|
+         - Atlas clients using Cassandra can specify type of kvs as `cassandra` rather then `CassandraKeyValueServiceRuntimeConfig` in runtime configuration. `CassandraKeyValueServiceRuntimeConfig` type is now deprecated.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3359>`__)
 =======
 v0.95.0
 =======


### PR DESCRIPTION
**Goals (and why)**:
Currently we need to specify `type` in KvsRuntimeConfig as `CassandraKeyValueServiceRuntimeConfig`; which is a bit ugly, and different then what we have for KvsConfig.

**Implementation Description (bullets)**:
Adding subtype name `cassandra` while keeping the old type name, for the sake of backwards compatibility.

**Where should we start reviewing?**:
`CassandraKeyValueServiceRuntimeConfig.java`

**Priority (whenever / two weeks / yesterday)**:
Whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3359)
<!-- Reviewable:end -->
