### PR TITLE
Make Callbacks Easier to Use

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/CallbackInitializable.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/CallbackInitializable.java
@@ -44,7 +44,7 @@ public interface CallbackInitializable<R> {
 
     /**
      * Returns a Callback that will retry initialization on failure, unless the cleanup task also throws, in which case
-     * the cause is not caught.
+     * the exception thrown by the cleanup task is propagated.
      */
     default Callback<R> retryUnlessCleanupThrowsCallback() {
         return LambdaCallback.retrying(this::initialize, this::onInitializationFailureCleanup);

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/CallbackInitializable.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/CallbackInitializable.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.async.initializer;
+
+/**
+ * An interface simplifying the creation of initialization Callbacks. If a class C requires a resource R to initialize
+ * some of its components, but R may not be ready yet at the time of C's creation, C should implement this interface
+ * and pass the desired Callback to R. When R is ready, it can then call {@link Callback#runWithRetry(R)} to initialize
+ * C.
+ */
+public interface CallbackInitializable<R> {
+    void initialize(R resource);
+
+    /**
+     * If {@link #initialize(R)} failing can result in a state where cleanup is necessary, override this method.
+     *
+     * @param resource the resource used in initialization.
+     * @param initFailure the Throwable causing the failure in initialization.
+     */
+    default void onInitializationFailureCleanup(R resource, Throwable initFailure) {
+    }
+
+    /**
+     * Returns a Callback that runs initialize only once. On initialization failure, executes the specified cleanup and
+     * then wraps and throws the cause.
+     */
+    default Callback<R> singleAttemptCallback() {
+        return LambdaCallback.singleAttempt(this::initialize, this::onInitializationFailureCleanup);
+    }
+
+    /**
+     * Returns a Callback that will retry initialization on failure, unless the cleanup task also throws, in which case
+     * the cause is not caught.
+     */
+    default Callback<R> retryUnlessCleanupThrowsCallback() {
+        return LambdaCallback.retrying(this::initialize, this::onInitializationFailureCleanup);
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/LambdaCallback.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/LambdaCallback.java
@@ -16,21 +16,67 @@
 
 package com.palantir.async.initializer;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public final class LambdaCallback<R> extends Callback<R> {
-    private final Consumer<R> consumer;
+import com.palantir.common.base.Throwables;
 
-    private LambdaCallback(Consumer<R> consumer) {
-        this.consumer = consumer;
+/**
+ * Convenience class for creating callbacks using lambda expressions.
+ */
+public final class LambdaCallback<R> extends Callback<R> {
+    private static final BiConsumer<Object, Throwable> FAIL = (ignore, throwable) -> {
+        throw Throwables.rewrapAndThrowUncheckedException(throwable);
+    };
+
+    private final Consumer<R> initialize;
+    private final BiConsumer<R, Throwable> onInitializationFailure;
+
+    private LambdaCallback(Consumer<R> initialize, BiConsumer<R, Throwable> onInitializationFailure) {
+        this.initialize = initialize;
+        this.onInitializationFailure = onInitializationFailure;
     }
 
-    public static <R> Callback<R> of(Consumer<R> consumer) {
-        return new LambdaCallback<>(consumer);
+    /**
+     * Creates a callback that will attempt to initialize once. If initialize throws, onInitFailureCleanup is called
+     * before wrapping and throwing a RuntimeException.
+     * @param initialize initialization method.
+     * @param onInitFailureCleanup cleanup to be done in case initialization throws. If this method also throws, it will
+     * bubble up to the caller.
+     * @return the desired Callback object.
+     */
+    public static <R> Callback<R> singleAttempt(Consumer<R> initialize, BiConsumer<R, Throwable> onInitFailureCleanup) {
+        return new LambdaCallback<>(initialize, onInitFailureCleanup.andThen(FAIL));
+    }
+
+    /**
+     * Creates a callback that will retry initialization until cleanup also throws. If initialize throws,
+     * onInitFailureCleanup is called before calling initialize again.
+     * @param initialize initialization method.
+     * @param onInitFailureCleanup cleanup to be done in case initialization throws. If this method also throws, no more
+     * retries will be attampted and it will bubble up to the caller.
+     * @return the desired Callback object.
+     */
+    public static <R> Callback<R> retrying(Consumer<R> initialize, BiConsumer<R, Throwable> onInitFailureCleanup) {
+        return new LambdaCallback<>(initialize, onInitFailureCleanup);
+    }
+
+    /**
+     * Simple version of {@link #singleAttempt(Consumer, BiConsumer)} when no cleanup is necessary on failure.
+     * @param initialize initialization method.
+     * @return the desired Callback object.
+     */
+    public static <R> Callback<R> of(Consumer<R> initialize) {
+        return singleAttempt(initialize, (no, cleanup) -> { });
     }
 
     @Override
     public void init(R resource) {
-        consumer.accept(resource);
+        initialize.accept(resource);
+    }
+
+    @Override
+    public void cleanup(R resource, Throwable initFailure) {
+        onInitializationFailure.accept(resource, initFailure);
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/LambdaCallback.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/LambdaCallback.java
@@ -42,7 +42,7 @@ public final class LambdaCallback<R> extends Callback<R> {
      * before wrapping and throwing a RuntimeException.
      * @param initialize initialization method.
      * @param onInitFailureCleanup cleanup to be done in case initialization throws. If this method also throws, it will
-     * bubble up to the caller.
+     * propagate up to the caller.
      * @return the desired Callback object.
      */
     public static <R> Callback<R> singleAttempt(Consumer<R> initialize, BiConsumer<R, Throwable> onInitFailureCleanup) {
@@ -54,7 +54,7 @@ public final class LambdaCallback<R> extends Callback<R> {
      * onInitFailureCleanup is called before calling initialize again.
      * @param initialize initialization method.
      * @param onInitFailureCleanup cleanup to be done in case initialization throws. If this method also throws, no more
-     * retries will be attampted and it will bubble up to the caller.
+     * retries will be attempted and it will propagate up to the caller.
      * @return the desired Callback object.
      */
     public static <R> Callback<R> retrying(Consumer<R> initialize, BiConsumer<R, Throwable> onInitFailureCleanup) {

--- a/atlasdb-commons/src/test/java/com/palantir/async/initializer/LambdaCallbackTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/async/initializer/LambdaCallbackTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.async.initializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.immutables.value.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LambdaCallbackTest {
+    private static final RuntimeException INIT_FAIL = new RuntimeException("Failed during initialization.");
+    private static final RuntimeException CLEANUP_FAIL = new RuntimeException("Failed during cleanup.");
+    private ModifiableInitsAndCleanups initsAndCleanups;
+    private Callback<ModifiableInitsAndCleanups> callback;
+
+    @Before
+    public void setup() {
+        initsAndCleanups = InitsAndCleanups.createInitialized();
+    }
+
+    @Test
+    public void singleAttemptCallbackCallsInitializeOnceAndSkipsCleanupOnSuccess() {
+        callback = LambdaCallback.singleAttempt(this::markInit, this::markCleanup);
+
+        callback.runWithRetry(initsAndCleanups);
+        assertThat(initsAndCleanups.inits()).isEqualTo(1);
+        assertThat(initsAndCleanups.cleanups()).isEqualTo(0);
+    }
+
+    @Test
+    public void singleAttemptCallbackCallsInitializeAndCleanuoOnceThenRethrowsOnInitFailure() {
+        callback = LambdaCallback.singleAttempt(this::markInitAndFail, this::markCleanup);
+
+        assertThatThrownBy(() -> callback.runWithRetry(initsAndCleanups)).isEqualToComparingFieldByField(INIT_FAIL);
+        assertThat(initsAndCleanups.inits()).isEqualTo(1);
+        assertThat(initsAndCleanups.cleanups()).isEqualTo(1);
+    }
+
+    @Test
+    public void singleAttemptCallbackThrowsCleanupExceptionOnCleanupFailure() {
+        callback = LambdaCallback.singleAttempt(this::markInitAndFail, this::markCleanupAndFail);
+
+        assertThatThrownBy(() -> callback.runWithRetry(initsAndCleanups)).isEqualToComparingFieldByField(CLEANUP_FAIL);
+    }
+
+    @Test
+    public void retryingCallbackCallsInitializeOnceAndSkipsCleanupOnSuccess() {
+        callback = LambdaCallback.retrying(this::markInit, this::markCleanup);
+
+        callback.runWithRetry(initsAndCleanups);
+        assertThat(initsAndCleanups.inits()).isEqualTo(1);
+        assertThat(initsAndCleanups.cleanups()).isEqualTo(0);
+    }
+
+    @Test
+    public void retryingCallbackCallsInitializeAndCleanupUntilSuccess() {
+        callback = LambdaCallback.retrying(this::markInitThenFailIfFewerThatTenInits, this::markCleanup);
+
+        callback.runWithRetry(initsAndCleanups);
+        assertThat(initsAndCleanups.inits()).isEqualTo(10);
+        assertThat(initsAndCleanups.cleanups()).isEqualTo(9);
+    }
+
+    @Test
+    public void retryingCallbackStopsRetryingWhenCleanupThrows() {
+        callback = LambdaCallback.retrying(this::markInitAndFail, this::markCleanupThenFailIfMoreThatTenInits);
+
+        assertThatThrownBy(() -> callback.runWithRetry(initsAndCleanups)).isEqualToComparingFieldByField(CLEANUP_FAIL);
+        assertThat(initsAndCleanups.inits()).isEqualTo(11);
+        assertThat(initsAndCleanups.cleanups()).isEqualTo(11);
+    }
+
+    private void markInit(ModifiableInitsAndCleanups initsAndCleanups) {
+        initsAndCleanups.setInits(initsAndCleanups.inits() + 1);
+    }
+
+    private void markInitAndFail(ModifiableInitsAndCleanups initsAndCleanups) {
+        markInit(initsAndCleanups);
+        throw INIT_FAIL;
+    }
+
+    private void markInitThenFailIfFewerThatTenInits(ModifiableInitsAndCleanups initsAndCleanups) {
+        markInit(initsAndCleanups);
+        if (initsAndCleanups.inits() < 10) {
+            throw INIT_FAIL;
+        }
+    }
+
+    private void markCleanup(ModifiableInitsAndCleanups initsAndCleanups, Throwable ignore) {
+        initsAndCleanups.setCleanups(initsAndCleanups.cleanups() + 1);
+    }
+
+    private void markCleanupAndFail(ModifiableInitsAndCleanups initsAndCleanups, Throwable ignore) {
+        markCleanup(initsAndCleanups, ignore);
+        throw CLEANUP_FAIL;
+    }
+
+    private void markCleanupThenFailIfMoreThatTenInits(ModifiableInitsAndCleanups initsAndCleanups, Throwable ignore) {
+        markCleanup(initsAndCleanups, ignore);
+        if (initsAndCleanups.inits() > 10) {
+            throw CLEANUP_FAIL;
+        }
+    }
+
+    @Value.Modifiable
+    interface InitsAndCleanups {
+        int inits();
+        int cleanups();
+
+        static ModifiableInitsAndCleanups createInitialized() {
+            return ModifiableInitsAndCleanups.create()
+                    .setInits(0)
+                    .setCleanups(0);
+        }
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/async/initializer/LambdaCallbackTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/async/initializer/LambdaCallbackTest.java
@@ -44,7 +44,7 @@ public class LambdaCallbackTest {
     }
 
     @Test
-    public void singleAttemptCallbackCallsInitializeAndCleanuoOnceThenRethrowsOnInitFailure() {
+    public void singleAttemptCallbackCallsInitializeAndCleanupOnceThenRethrowsOnInitFailure() {
         callback = LambdaCallback.singleAttempt(this::markInitAndFail, this::markCleanup);
 
         assertThatThrownBy(() -> callback.runWithRetry(initsAndCleanups)).isEqualToComparingFieldByField(INIT_FAIL);

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -42,7 +42,6 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.palantir.async.initializer.AsyncInitializer;
 import com.palantir.async.initializer.Callback;
-import com.palantir.async.initializer.LambdaCallback;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
@@ -347,9 +346,9 @@ public abstract class TransactionManagers {
                         JavaSuppliers.compose(AtlasDbRuntimeConfig::targetedSweep, runtimeConfigSupplier)),
                 closeables);
 
-        Callback<TransactionManager> callbacks = new Callback.CallChain(ImmutableList.of(
+        Callback<TransactionManager> callbacks = new Callback.CallChain<>(ImmutableList.of(
                 timelockConsistencyCheckCallback(config, runtimeConfigSupplier.get(), lockAndTimestampServices),
-                LambdaCallback.of(targetedSweep::callbackInit),
+                targetedSweep.singleAttemptCallback(),
                 asyncInitializationCallback()));
 
         TransactionManager transactionManager = initializeCloseable(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/MultiTableSweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/MultiTableSweepQueueWriter.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.palantir.async.initializer.CallbackInitializable;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
@@ -27,7 +28,7 @@ import com.palantir.atlasdb.transaction.api.TransactionManager;
 /**
  * Adds {@link WriteInfo}s to a global queue to be swept.
  */
-public interface MultiTableSweepQueueWriter extends AutoCloseable {
+public interface MultiTableSweepQueueWriter extends AutoCloseable, CallbackInitializable<TransactionManager> {
     MultiTableSweepQueueWriter NO_OP = ignored -> { };
 
     default void enqueue(Map<TableReference, ? extends Map<Cell, byte[]>> writes, long timestamp) {
@@ -48,7 +49,8 @@ public interface MultiTableSweepQueueWriter extends AutoCloseable {
      *
      * @param txManager the transaction manager performing the callback
      */
-    default void callbackInit(TransactionManager txManager) {
+    @Override
+    default void initialize(TransactionManager txManager) {
         // noop
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -125,7 +125,7 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter {
     }
 
     @Override
-    public void callbackInit(TransactionManager txManager) {
+    public void initialize(TransactionManager txManager) {
         initialize(SpecialTimestampsSupplier.create(txManager),
                 txManager.getTimelockService(),
                 txManager.getKeyValueService(),

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -81,7 +81,7 @@ public final class SweepTestUtils {
                 () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
                 writer);
         setupTables(kvs);
-        writer.callbackInit(txManager);
+        writer.initialize(txManager);
         return txManager;
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 () -> AtlasDbConstants.DEFAULT_TIMESTAMP_CACHE_SIZE,
                 sweepQueue);
-        sweepQueue.callbackInit(txManager);
+        sweepQueue.initialize(txManager);
         return txManager;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -126,7 +126,7 @@ public class AtlasDbTestCase {
                 sweepQueue,
                 MoreExecutors.newDirectExecutorService());
 
-        sweepQueue.callbackInit(serializableTxManager);
+        sweepQueue.initialize(serializableTxManager);
         txManager = new CachingTestTransactionManager(serializableTxManager);
     }
 

--- a/docs/source/miscellaneous/asynchronous-initialization.rst
+++ b/docs/source/miscellaneous/asynchronous-initialization.rst
@@ -14,6 +14,7 @@ If ``initializeAsync`` is set to false, the callback will be run synchronously (
 If ``initializeAsync`` is set to true, the callback will also be run asynchronously:
 
 1. Once all the resources for the transaction manager have become ready, **but before the transaction manager becomes initialized**, the registered callback will be run asynchronously.
+   Note that calls to the transaction manager from the callback at this time bypass the initialization checks.
 2. If the callback fails and should not be retried, the transaction manager will be closed.
 3. If the callback is successful, the transaction manager then becomes initialized.
 

--- a/docs/source/miscellaneous/asynchronous-initialization.rst
+++ b/docs/source/miscellaneous/asynchronous-initialization.rst
@@ -1,0 +1,31 @@
+===========================
+Asynchronous Initialization
+===========================
+
+If the ``initializeAsync`` parameter of the AtlasDB configuration is set to true, AtlasDB will be able to start even when some of
+the necessary resources are not ready yet. The main use of this feature is to avoid race conditions when starting multiple
+services simultaneously and allow AtlasDB to start even if, e.g., the KVS is still starting up.
+
+To simplify initialization of objects depending on a transaction manager that may be asynchronously initialized,
+``TransactionManagers`` has an ``asyncInitializationCallback()`` parameter allowing users to specify a custom callback
+that should be executed when ready.
+
+If ``initializeAsync`` is set to false, the callback will be run synchronously (blocking until it is done) as the last step in creating the transaction manager.
+If ``initializeAsync`` is set to true, the callback will also be run asynchronously:
+
+1. Once all the resources for the transaction manager have become ready, **but before the transaction manager becomes initialized**, the registered callback will be run asynchronously.
+2. If the callback fails and should not be retried, the transaction manager will be closed.
+3. If the callback is successful, the transaction manager then becomes initialized.
+
+Using Callbacks
+---------------
+
+For an example of using callbacks, refer to ``TargetedSweeper``. The simplest way of using this functionality is to
+implement the ``CallbackInitializable`` interface. The ``initialize`` method should initialize all the
+resources that require an initialized transaction manager, and the ``onInitializationFailureCleanup`` should specify any
+cleanup to be done in case of failure, if necessary. The callback that should be passed to the `TransactionManagers`
+builder is then given by the interface:
+
+1. If initialization should not be retried on failure use ``singleAttemptCallback()``.
+2. If initialization should be retried on failure use ``retryUnlessCleanupThrowsCallback()``.
+3. If initialization should be conditionally retried on failure also use ``retryUnlessCleanupThrowsCallback()``, but the ``onInitializationFailureCleanup`` method should throw when the condition is not satisfied.

--- a/docs/source/miscellaneous/index.rst
+++ b/docs/source/miscellaneous/index.rst
@@ -6,6 +6,7 @@ Miscellaneous
    :maxdepth: 1
    :titlesonly:
 
+   asynchronous-initialization
    contributing
    doc/adr/index
    kvs-status-check

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,6 +51,10 @@ develop
          - Change
 
     *    - |improved|
+         - Added the ``CallbackInitializable`` interface to simplify asynchronous initialization of resources using transaction manager callbacks.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3360>`__)
+
+    *    - |improved|
          - The atlas console metadata query now returns more table metadata, such as sweep strategy and conflict handler information.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3161>`__)
 


### PR DESCRIPTION
**Goals (and why)**:
Make it easier to use Callbacks: make it useful, and prevent wrong usage. Address https://github.com/palantir/atlasdb/issues/3353

**Implementation Description (bullets)**:
Added a bunch of docs, and added an interface that should make it simpler to create your callback.

**Concerns (what feedback would you like?)**:
Is this actually simpler now? Do we need a better example -- I could have `ConsistencyCheckRunner` implement `CallbackInitializable` instead of being a `Callback`, but not sure it makes sense to do so just to have another example in the codebase.

**Where should we start reviewing?**:
`CallbackInitializable.java`

**Priority (whenever / two weeks / yesterday)**:
Not super urgent

@pkoenig10 for SA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3360)
<!-- Reviewable:end -->
