### PR TITLE
[TS] Do not range scan punch table if timestamp is too far in the past

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
@@ -114,20 +114,20 @@ public final class KeyValueServicePuncherStore implements PuncherStore {
 
     @Override
     public Long get(Long timeMillis) {
+        return get(keyValueService, timeMillis);
+    }
+
+    public static Long get(KeyValueService kvs, Long timeMillis) {
         byte[] row = EncodingUtils.encodeUnsignedVarLong(timeMillis);
         EncodingUtils.flipAllBitsInPlace(row);
-        RangeRequest rangeRequest =
-                RangeRequest.builder().startRowInclusive(row).batchHint(1).build();
-        ClosableIterator<RowResult<Value>> result =
-                keyValueService.getRange(AtlasDbConstants.PUNCH_TABLE, rangeRequest, Long.MAX_VALUE);
-        try {
+        RangeRequest rangeRequest = RangeRequest.builder().startRowInclusive(row).batchHint(1).build();
+        try (ClosableIterator<RowResult<Value>> result = kvs.getRange(AtlasDbConstants.PUNCH_TABLE, rangeRequest,
+                Long.MAX_VALUE)) {
             if (result.hasNext()) {
                 return EncodingUtils.decodeUnsignedVarLong(result.next().getColumns().get(COLUMN).getContents());
             } else {
                 return Long.MIN_VALUE;
             }
-        } finally {
-            result.close();
         }
     }
 
@@ -136,18 +136,27 @@ public final class KeyValueServicePuncherStore implements PuncherStore {
         return getMillisForTimestamp(keyValueService, timestamp);
     }
 
+    /**
+     * Returns the real time in milliseconds corresponding to the given timestamp.
+     *
+     * Warning: If the given timestamp is low compared to currently given out timestamps, this call may range scan over
+     * the entire table. This table tends to grow quickly, so this call can be expensive. If you can bound how far in
+     * the past you want to look for, you should instead call
+     * {@link #getMillisForTimestampIfNotPunchedBefore(KeyValueService, long, long)}.
+     *
+     * @param kvs the KVS to query.
+     * @param timestamp timestamp to query for.
+     */
     public static long getMillisForTimestamp(KeyValueService kvs, long timestamp) {
         long timestampExclusive = timestamp + 1;
         // punch table is keyed by the real value we're trying to find so we have to do a whole table
         // scan, which is fine because this table should be really small
         byte[] startRow = EncodingUtils.encodeUnsignedVarLong(Long.MAX_VALUE);
         EncodingUtils.flipAllBitsInPlace(startRow);
-        RangeRequest rangeRequest =
-                RangeRequest.builder().startRowInclusive(startRow).batchHint(1).build();
-        ClosableIterator<RowResult<Value>> result =
-                kvs.getRange(AtlasDbConstants.PUNCH_TABLE, rangeRequest, timestampExclusive);
+        RangeRequest rangeRequest = RangeRequest.builder().startRowInclusive(startRow).batchHint(1).build();
 
-        try {
+        try (ClosableIterator<RowResult<Value>> result = kvs.getRange(AtlasDbConstants.PUNCH_TABLE, rangeRequest,
+                timestampExclusive)) {
             if (result.hasNext()) {
                 byte[] encodedMillis = result.next().getRowName();
                 EncodingUtils.flipAllBitsInPlace(encodedMillis);
@@ -155,9 +164,24 @@ public final class KeyValueServicePuncherStore implements PuncherStore {
             } else {
                 return 0L;
             }
-        } finally {
-            result.close();
         }
     }
 
+    /**
+     * Same as {@link #getMillisForTimestamp(KeyValueService, long)}, except that it first does a lookup for the
+     * first timestamp punched before lowerBound. If that value is lower than timestamp, we then look up the real time
+     * value in the KVS, otherwise, we return lowerBound to avoid doing a large range scan.
+     *
+     * @param kvs the KVS to query.
+     * @param timestamp timestamp to query for.
+     * @param lowerBound if the first timestamp punched before this real time is larger than the query timestamp, then
+     * do not do a range scan and instead return lowerBound.
+     */
+    public static long getMillisForTimestampIfNotPunchedBefore(KeyValueService kvs, long timestamp, long lowerBound) {
+        if (get(kvs, Math.max(0L, lowerBound)) < timestamp) {
+            return getMillisForTimestamp(kvs, timestamp);
+        } else {
+            return lowerBound;
+        }
+    }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStore.java
@@ -149,8 +149,6 @@ public final class KeyValueServicePuncherStore implements PuncherStore {
      */
     public static long getMillisForTimestamp(KeyValueService kvs, long timestamp) {
         long timestampExclusive = timestamp + 1;
-        // punch table is keyed by the real value we're trying to find so we have to do a whole table
-        // scan, which is fine because this table should be really small
         byte[] startRow = EncodingUtils.encodeUnsignedVarLong(Long.MAX_VALUE);
         EncodingUtils.flipAllBitsInPlace(startRow);
         RangeRequest rangeRequest = RangeRequest.builder().startRowInclusive(startRow).batchHint(1).build();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
@@ -23,6 +23,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.codahale.metrics.Gauge;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.AtlasDbMetricNames;
@@ -35,10 +38,12 @@ import com.palantir.atlasdb.util.CurrentValueMetric;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.time.Clock;
 import com.palantir.common.time.SystemClock;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.util.AggregatingVersionedSupplier;
 import com.palantir.util.CachedComposedSupplier;
 
 public final class TargetedSweepMetrics {
+    private static final Logger log = LoggerFactory.getLogger(TargetedSweepMetrics.class);
     private static final long ONE_WEEK = TimeUnit.DAYS.toMillis(7L);
     private final Map<TableMetadataPersistence.SweepStrategy, MetricsForStrategy> metricsForStrategyMap;
 
@@ -135,7 +140,16 @@ public final class TargetedSweepMetrics {
             if (timestamp == null) {
                 return null;
             }
-            return clock.getTimeMillis() - tsToMillis.apply(timestamp);
+            long timeBeforeRecomputing = System.currentTimeMillis();
+            long result = clock.getTimeMillis() - tsToMillis.apply(timestamp);
+
+            long timeTaken = System.currentTimeMillis() - timeBeforeRecomputing;
+            if (timeTaken > TimeUnit.SECONDS.toMillis(10)) {
+                log.warn("Recomputing the millisSinceLastSwept metric took {} ms.", SafeArg.of("timeTaken", timeTaken));
+            } else if (timeTaken > TimeUnit.SECONDS.toMillis(1)) {
+                log.info("Recomputing the millisSinceLastSwept metric took {} ms.", SafeArg.of("timeTaken", timeTaken));
+            }
+            return result;
         }
 
         private void updateEnqueuedWrites(long writes) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/KeyValueServicePuncherStoreTest.java
@@ -16,14 +16,22 @@
 package com.palantir.atlasdb.cleaner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 
 public class KeyValueServicePuncherStoreTest {
@@ -111,18 +119,24 @@ public class KeyValueServicePuncherStoreTest {
     }
 
     @Test
-    public void getMillisForTimestampIfNotPunchedBeforeWhenFirstPunchedBeforeHasLowerTimestampAndSamePunchEntry() {
+    public void getMillisForTimestampIfNotPunchedBeforeEdgeCase() {
         KeyValueService kvs = new InMemoryKeyValueService(false);
         puncherStore = initializePuncherStore(PUNCHER_HISTORY, kvs);
+        // Punched: (10, 100), (20, 200), (30, 300)
+        // Arguments: (15, 150)
+        // First ts punched before 150 is 10. 10 < 15, so we do the range scan and it returns 100.
         assertThat(KeyValueServicePuncherStore
                 .getMillisForTimestampIfNotPunchedBefore(kvs, TIMESTAMP_BETWEEN_1_AND_2, WALL_CLOCK_BETWEEN_1_AND_2))
                 .isEqualTo(WALL_CLOCK_1);
     }
 
     @Test
-    public void getMillisForTimestampIfNotPunchedBeforeWhenFirstPunchedBeforeHasLowerTimestampAndOlderPunchEntry() {
+    public void getMillisForTimestampIfNotPunchedBeforeWhenPunchedRecently() {
         KeyValueService kvs = new InMemoryKeyValueService(false);
         puncherStore = initializePuncherStore(PUNCHER_HISTORY, kvs);
+        // Punched: (10, 100), (20, 200), (30, 300)
+        // Arguments: (15, 99)
+        // First ts punched before 99 is Long.MIN_VALUE. Long.MIN_VALUE < 15, so we range scan and it returns 100.
         assertThat(KeyValueServicePuncherStore
                 .getMillisForTimestampIfNotPunchedBefore(kvs, TIMESTAMP_BETWEEN_1_AND_2, WALL_CLOCK_1 - 1))
                 .isEqualTo(WALL_CLOCK_1);
@@ -132,26 +146,39 @@ public class KeyValueServicePuncherStoreTest {
     public void getMillisForTimestampIfNotPunchedBeforeWhenLowerBoundIsNegative() {
         KeyValueService kvs = new InMemoryKeyValueService(false);
         puncherStore = initializePuncherStore(PUNCHER_HISTORY, kvs);
+        // Punched: (10, 100), (20, 200), (30, 300)
+        // Arguments: (15, -100)
+        // Same as above, but verifying we don't error out due to negative number.
         assertThat(KeyValueServicePuncherStore
                 .getMillisForTimestampIfNotPunchedBefore(kvs, TIMESTAMP_BETWEEN_1_AND_2, -100L))
                 .isEqualTo(WALL_CLOCK_1);
     }
 
     @Test
-    public void getMillisForTimestampIfNotPunchedBeforeWhenFirstPunchedBeforeHasGreaterTimestamp() {
-        KeyValueService kvs = new InMemoryKeyValueService(false);
+    public void getMillisForTimestampIfNotPunchedBeforeWhenPunchedLongAgo() {
+        KeyValueService kvs = Mockito.spy(new InMemoryKeyValueService(false));
         puncherStore = initializePuncherStore(PUNCHER_HISTORY, kvs);
+        // Punched: (10, 100), (20, 200), (30, 300)
+        // Arguments: (15, 201)
+        // First ts punched before 201 is 20. 20 > 15, so we don't range scan and return 201.
         assertThat(KeyValueServicePuncherStore
                 .getMillisForTimestampIfNotPunchedBefore(kvs, TIMESTAMP_BETWEEN_1_AND_2, WALL_CLOCK_2 + 1))
                 .isEqualTo(WALL_CLOCK_2 + 1);
+        verify(kvs, times(1)).getRange(eq(AtlasDbConstants.PUNCH_TABLE), any(RangeRequest.class), eq(Long.MAX_VALUE));
+        verify(kvs, times(1)).getRange(eq(AtlasDbConstants.PUNCH_TABLE), any(RangeRequest.class), anyLong());
     }
 
     @Test
-    public void getMillisForTimestampIfNotPunchedBeforeWhenFirstPunchedBeforeIsExactTimestamp() {
-        KeyValueService kvs = new InMemoryKeyValueService(false);
+    public void getMillisForTimestampIfNotPunchedBeforeWhenPunchedExactlyAtLowerBound() {
+        KeyValueService kvs = Mockito.spy(new InMemoryKeyValueService(false));
         puncherStore = initializePuncherStore(PUNCHER_HISTORY, kvs);
+        // Punched: (10, 100), (20, 200), (30, 300)
+        // Arguments: (10, 100)
+        // First ts punched at 100 is 10. 10 = 10, so we don't range scan and return 100.
         assertThat(KeyValueServicePuncherStore.getMillisForTimestampIfNotPunchedBefore(kvs, TIMESTAMP_1, WALL_CLOCK_1))
                 .isEqualTo(WALL_CLOCK_1);
+        verify(kvs, times(1)).getRange(eq(AtlasDbConstants.PUNCH_TABLE), any(RangeRequest.class), eq(Long.MAX_VALUE));
+        verify(kvs, times(1)).getRange(eq(AtlasDbConstants.PUNCH_TABLE), any(RangeRequest.class), anyLong());
     }
 
     private static long mean(long first, long second) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetricsTest.java
@@ -16,14 +16,25 @@
 
 package com.palantir.atlasdb.sweep.metrics;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import static com.palantir.atlasdb.sweep.metrics.SweepMetricsAssert.assertThat;
+
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.cleaner.KeyValueServicePuncherStore;
 import com.palantir.atlasdb.cleaner.PuncherStore;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -45,7 +56,7 @@ public class TargetedSweepMetricsTest {
     @Before
     public void setup() {
         clockTime = 100;
-        kvs = new InMemoryKeyValueService(true);
+        kvs = Mockito.spy(new InMemoryKeyValueService(true));
         puncherStore = KeyValueServicePuncherStore.create(kvs, false);
         metrics = TargetedSweepMetrics.createWithClock(metricsManager, kvs, () -> clockTime, RECOMPUTE_MILLIS);
     }
@@ -205,6 +216,20 @@ public class TargetedSweepMetricsTest {
         puncherStore.put(1, 10);
         waitForProgressToRecompute();
         assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(clockTime - 10);
+    }
+
+    @Test
+    public void millisSinceLastSweptDoesNotRangeScanForGivenTimestampIfSweepTsTooFarInThePast() {
+        metrics.updateProgressForShard(CONS_ZERO, 10);
+
+        // there was a great timestamp than sweep progress punched more than a week ago
+        clockTime = TimeUnit.DAYS.toMillis(14L);
+        puncherStore.put(15, 1);
+
+        // return the time from a week ago and only range scan for looking up the timestamp for the time a week ago
+        assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(clockTime - TimeUnit.DAYS.toMillis(7L));
+        verify(kvs, times(1)).getRange(eq(AtlasDbConstants.PUNCH_TABLE), any(RangeRequest.class), eq(Long.MAX_VALUE));
+        verify(kvs, times(1)).getRange(eq(AtlasDbConstants.PUNCH_TABLE), any(RangeRequest.class), anyLong());
     }
 
     @Test

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,22 @@ develop
     *    - Type
          - Change
 
+    *    -
+         -
+
+=======
+v0.95.0
+=======
+
+9 July 2018
+
+.. list-table::
+    :widths: 5 40
+    :header-rows: 1
+
+    *    - Type
+         - Change
+
     *    - |improved|
          - The atlas console metadata query now returns more table metadata, such as sweep strategy and conflict handler information.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3161>`__)

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,8 +50,10 @@ develop
     *    - Type
          - Change
 
-    *    -
-         -
+    *    - |fixed|
+         - Targeted sweep metrics will no longer range scan the punch table if the last swept timestamp was issued more than one week ago.
+           Previously, we would range scan the table even if the last swept timestamp was -1, which would force a range scan of the entire table.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3364>`__)
 
 =======
 v0.95.0


### PR DESCRIPTION
**Goals (and why)**:
Fix the issue where targeted sweep metrics excessively range scan the punch table.

**Implementation Description (bullets)**:
The issue should already have been fixed for most use cases, since we now do not default the last swept timestamp to -1, as we did in 0.93.0, but we now further reduce the danger by not range scanning if the timestamp could only have been punched more than a week ago.
Also, remove the misleading comment from `KeyValueServicePuncherStore` and add some docs on the issue.

**Concerns (what feedback would you like?)**:
Ideally, we'd do all the expensive computation for metrics asynchronously and cache instead of memoizing when the metric is requested, but that is a bit trickier to do and probably not necessary. Will open an issue to track.

**Where should we start reviewing?**:
KeyValueServicePuncherStore.java

**Priority (whenever / two weeks / yesterday)**:
Pretty high

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3364)
<!-- Reviewable:end -->
