### PR TITLE
Don't run in-process compaction from sweep CLI - 0.61.x

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -213,14 +213,6 @@ public class SweepCommand extends SingleBackendCommand {
                     LoggingArgs.tableRef(tableToSweep),
                     SafeArg.of("cellTs pairs examined", cellsExamined.get()),
                     SafeArg.of("cellTs pairs deleted", cellsDeleted.get()));
-
-            if (!dryRun && cellsDeleted.get() > 0) {
-                Stopwatch watch = Stopwatch.createStarted();
-                services.getKeyValueService().compactInternally(tableToSweep);
-                printer.info("Finished performing compactInternally on {} in {} ms.",
-                        LoggingArgs.tableRef(tableToSweep),
-                        SafeArg.of("time taken", watch.elapsed(TimeUnit.MILLISECONDS)));
-            }
         }
         return 0;
     }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -47,7 +47,11 @@ v0.61.9
     *    - |improved|
          - Added logging for leadership election code.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3275>`__)
-
+    *    - |fixed|
+         - The sweep CLI will no longer perform in-process compactions after sweeping a table.
+           For DbKvs, this operation is handled by the background compaction thread; Cassandra performs its own compactions.
+           Note that the sweep CLI itself has been deprecated in favour of using the sweep priority override configuration, possibly in conjunction with the thread count (:ref:`Docs<sweep_tunable_parameters>`).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3338>`__)
 =======
 v0.61.3
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -51,7 +51,8 @@ v0.61.9
          - The sweep CLI will no longer perform in-process compactions after sweeping a table.
            For DbKvs, this operation is handled by the background compaction thread; Cassandra performs its own compactions.
            Note that the sweep CLI itself has been deprecated in favour of using the sweep priority override configuration, possibly in conjunction with the thread count (:ref:`Docs<sweep_tunable_parameters>`).
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3338>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3368>`__)
+
 =======
 v0.61.3
 =======


### PR DESCRIPTION
Where useful, this operation should be handled by the background compactor instead.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3368)
<!-- Reviewable:end -->
