### PR TITLE
Don't run in-process compaction from sweep CLI.

### DIFF
--- a/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
+++ b/atlasdb-cli/src/main/java/com/palantir/atlasdb/cli/command/SweepCommand.java
@@ -174,13 +174,6 @@ public class SweepCommand extends SingleBackendCommand {
                     cellsExamined.get(),
                     dryRun ? "would have " : "",
                     cellsDeleted.get());
-
-            if (!dryRun && cellsDeleted.get() > 0) {
-                Stopwatch watch = Stopwatch.createStarted();
-                services.getKeyValueService().compactInternally(tableToSweep);
-                printer.info("Finished performing compactInternally on {} in {} ms.",
-                        tableToSweep, watch.elapsed(TimeUnit.MILLISECONDS));
-            }
         }
         return 0;
 	}

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -95,6 +95,12 @@ develop
          - Added logging for leadership election code,
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3294>`__)
 
+    *    - |fixed|
+         - The sweep CLI will no longer perform in-process compactions after sweeping a table.
+           For DbKvs, this operation is handled by the background compaction thread; Cassandra performs its own compactions.
+           Note that the sweep CLI itself has been deprecated in favour of using the sweep priority override configuration, possibly in conjunction with the thread count (:ref:`Docs<sweep_tunable_parameters>`).
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3338>`__)
+
 =======
 v0.38.0
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -99,7 +99,7 @@ develop
          - The sweep CLI will no longer perform in-process compactions after sweeping a table.
            For DbKvs, this operation is handled by the background compaction thread; Cassandra performs its own compactions.
            Note that the sweep CLI itself has been deprecated in favour of using the sweep priority override configuration, possibly in conjunction with the thread count (:ref:`Docs<sweep_tunable_parameters>`).
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/3338>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3369>`__)
 
 =======
 v0.38.0


### PR DESCRIPTION
Where useful, this operation should be handled by the background compactor instead.

**Goals (and why)**:

**Implementation Description (bullets)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3369)
<!-- Reviewable:end -->
