### PR TITLE
fix atlas docs?

### DIFF
--- a/docs/source/schemas/tables_and_indices.rst
+++ b/docs/source/schemas/tables_and_indices.rst
@@ -541,7 +541,7 @@ the setting, the more queries and the longer they are stored.
 
 .. code:: java
 
-    public void dbCompressionRequested();
+    public void explicitCompressionRequested();
 
 Cassandra only - specifies whether the table should be stored
 compressed.


### PR DESCRIPTION
the docs mention `dbCompressionRequested` but in the code this seems to be `explicitCompressionRequested` - is that correct?

**Goals (and why)**:
Fix the docs to match the code.

**Implementation Description (bullets)**:
n/a

**Concerns (what feedback would you like?)**:
Is this actually correct?

**Where should we start reviewing?**:
n/a

**Priority (whenever / two weeks / yesterday)**:
whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
