### PR TITLE
Update advice when encountering invalid ts bound

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampBoundStore.java
@@ -156,10 +156,11 @@ public final class CassandraTimestampBoundStore implements TimestampBoundStore {
                 } catch (IllegalArgumentException e) {
                     String msg = "Caught an IllegalArgumentException trying to convert the stored value to a long. "
                             + "This can happen if you attempt to run AtlasDB without a timelock block after having "
-                            + "previously migrated to the TimeLock server. Please contact AtlasDB support. "
-                            + "If you are attempting a reverse migration, please consult the documentation here: "
-                            + "https://palantir.github.io/atlasdb/html/services/timelock_service/"
-                            + "reverse-migration.html (and also contact AtlasDB support).";
+                            + "previously migrated to the TimeLock server. Please adjust your configuration to allow "
+                            + "AtlasDB to talk to TimeLock, shut down all service nodes, and then restart. Consult the "
+                            + "documentation here: https://palantir.github.io/atlasdb/html/configuration/"
+                            + "external_timelock_service_configs/timelock_client_config.html#timelock-client-"
+                            + "configuration - contact AtlasDB support for additional guidance if necessary.";
                     throw new IllegalStateException(msg, e);
                 }
             }


### PR DESCRIPTION
[no release notes]

**Goals (and why)**: See https://github.com/palantir/atlasdb/pull/3290#pullrequestreview-130453393 - avoid P0s because people roll back, see the old message, and panic. Give them advice they can hopefully follow without paging us.

This is only really valuable for future cases where deployments have not yet migrated to timelock, but this is still possible for $internal_product and on-prem deployments that are less up to date than the bulk of customers.

**Implementation Description (bullets)**: Changed the error message

**Testing (What was existing testing like?  What have you done to improve it?)**: N/A, string literal change only

**Concerns (what feedback would you like?)**: Is the advice appropriate?

**Where should we start reviewing?**: one file

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3382)
<!-- Reviewable:end -->
