### PR TITLE
FFT - 1st ed., Part 9: Life of a Transaction

### DIFF
--- a/docs/source/transactions/index.rst
+++ b/docs/source/transactions/index.rst
@@ -9,3 +9,4 @@ Transactions
    isolation_levels
    performance_ideas
    transaction_protocol
+   life_of_a_transaction

--- a/docs/source/transactions/isolation_levels.rst
+++ b/docs/source/transactions/isolation_levels.rst
@@ -1,3 +1,5 @@
+.. _isolation-levels:
+
 ================
 Isolation Levels
 ================
@@ -11,6 +13,8 @@ transactional properties.
 -  Serializable
 
    -  Read and Writes to this table both happen at commit time
+   -  Implemented by checking that reads made at startTs return the
+      same results at commitTs. ABA scenarios are permitted.
 
 -  Snapshot
 

--- a/docs/source/transactions/life_of_a_transaction.rst
+++ b/docs/source/transactions/life_of_a_transaction.rst
@@ -95,5 +95,12 @@ The ordering of these steps is important:
 Cleanup
 =======
 
+We need to unlock the commit locks token and immutable timestamp lock. This need not be strictly immediate, though
+should be fast. Also, note that if we fail to do this (e.g. our server crashes), the locks will time-out (by default
+after 2 minutes).
+
+We unlock these locks asynchronously, placing them on a queue and periodically clearing them out. See ADR 15 for a
+more detailed discussion.
+
 Minimising TimeLock RPCs
 ------------------------

--- a/docs/source/transactions/life_of_a_transaction.rst
+++ b/docs/source/transactions/life_of_a_transaction.rst
@@ -88,7 +88,7 @@ The ordering of these steps is important:
    in between our start and commit, and someone else deleted the value after our commit. If we pass our lock check, but
    then lose our locks and have a very long GC, Thorough Sweep might clear all evidence of the conflict, meaning that
    we miss a read-write conflict. This would be safe for conservative sweep because of the deletion sentinel.
-8. The kock check may be run in parallel with pre-commit condition checks, though it must strictly be run before writing
+8. The lock check may be run in parallel with pre-commit condition checks, though it must strictly be run before writing
    to the transactions table, as we cannot finish our commit if we can't be certain we still have locks.
 9. We need to check that the pre-commit conditions still hold before we can finish committing.
 

--- a/docs/source/transactions/life_of_a_transaction.rst
+++ b/docs/source/transactions/life_of_a_transaction.rst
@@ -104,3 +104,35 @@ more detailed discussion.
 
 Minimising TimeLock RPCs
 ------------------------
+
+Principles
+==========
+
+1. RPCs are expensive, so we seek to minimise them.
+2. A sequence of exclusively TimeLock operations can be batched as a single call to TimeLock, even if there is an
+   ordering constraint on these operations (because TimeLock can enforce them).
+3. Suppose E1, E2 and E3 are three events that must occur in that order. E1 and E3 are TimeLock calls; E2 is not.
+   Then, E1 and E3 cannot be batched together.
+
+TimeLock Calls
+==============
+
+The transaction protocol requires several calls to timestamp and lock services:
+
+1. Startup: 3 calls (get immutable timestamp, lock immutable timestamp, get start timestamp)
+2. User task: 0 calls by default, though user code can call for timestamps or locks directly
+3. Commit: 3 calls (lock rows/cells, get commit timestamp, check locks)
+4. Cleanup: 2 calls (unlock rows, unlock immutable timestamp)
+
+However, some of these calls can be batched together, and others can be executed asynchronously.
+Our current implementation has:
+
+1. Startup: 1 call (startAtlasDbTransaction, which executes the three steps in order)
+2. User tasks: 0 calls
+3. Commit: 3 calls (lock rows/cells, get commit timestamp, check locks)
+4. Cleanup: 0 synchronous calls; <=2 asynchronous calls
+
+Optimality
+==========
+
+TODO

--- a/docs/source/transactions/life_of_a_transaction.rst
+++ b/docs/source/transactions/life_of_a_transaction.rst
@@ -93,7 +93,7 @@ The ordering of these steps is important:
 9. We need to check that the pre-commit conditions still hold before we can finish committing.
 
 Read-Only Variant
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 .. note::
 
@@ -150,7 +150,7 @@ Our current implementation has:
 4. Cleanup: 0 synchronous calls; <=2 asynchronous calls
 
 Efficiency
-~~~~~~~~~~
+==========
 
 We claim that for the current AtlasDB protocol, the remaining four synchronous RPCs must be separate.
 We show that each successive pair of timestamp calls has an event that must happen after the first call but before

--- a/docs/source/transactions/life_of_a_transaction.rst
+++ b/docs/source/transactions/life_of_a_transaction.rst
@@ -1,0 +1,44 @@
+.. _life-of-a-transaction:
+
+=====================
+Life of a Transaction
+=====================
+
+This document seeks to outline the efficiency of our implementation of the AtlasDB protocol for write transactions.
+We do this by establishing a strict ordering on the steps of the protocol.
+
+Stages of a Transaction
+-----------------------
+
+A user can run a ``TransactionTask`` through a ``TransactionManager``. Running the user's task in a transaction can be
+seen as a four step process.
+
+1. Start an AtlasDB transaction.
+2. Execute the user's transaction task (which has access to the transaction we started).
+3. Commit the transaction.
+4. Cleanup resources used by the transaction.
+
+Startup
+=======
+
+When a write transaction is created, we first need to perform some setup work. This involves locking the immutable
+timestamp and then getting a fresh timestamp. The ordering here is significant - if we get a fresh timestamp and then
+lock the immutable timestamp, our transaction's timestamp is smaller than the immutable timestamp. This is dangerous
+because the immutable timestamp is used by Sweep to determine which stale versions of data can be removed.
+If there is a cell that has a commit timestamp in between our start timestamp and the immutable timestamp we locked,
+then we may or may not read it.
+
+However, the operations can be batched as a single request to TimeLock - this improves performance particularly if one
+is using external TimeLock services.
+
+User Task
+=========
+
+Commit
+======
+
+Cleanup
+=======
+
+Minimising TimeLock RPCs
+------------------------


### PR DESCRIPTION
**Goals (and why)**:
- Document why the steps of the protocol are laid out as they are, so no one else has to waste time sifting through broken protocols
- Document why we think in the current state at least (well, after #3343) the four timelock RPCs we make in a single transaction is efficient

**Implementation Description (bullets)**:
- Docs change. Add discussion of protocol steps and why there are happens-before relationships.
- Add section on timelock RPCs.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Not really applicable. It's a docs change.

**Concerns (what feedback would you like?)**:
- Most of these justifications have been reviewed before in various internal places (RFC on Parallelising Checks) and external ones (SnapshotTransaction comments #3337). That said, are there some that are wrong or don't make sense?

**Where should we start reviewing?**: `life_of_a_transaction.rst`

**Priority (whenever / two weeks / yesterday)**: whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3385)
<!-- Reviewable:end -->
