### PR TITLE
Fix Benchmarks by dagger using a synchronous unlocker

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -636,7 +636,7 @@ public abstract class TransactionManagers {
                         time,
                         invalidator,
                         userAgent);
-        TimeLockClient timeLockClient = TimeLockClient.createWithSynchronousUnlocker(lockAndTimestampServices.timelock());
+        TimeLockClient timeLockClient = TimeLockClient.withSynchronousUnlocker(lockAndTimestampServices.timelock());
         return ImmutableLockAndTimestampServices.builder()
                 .from(lockAndTimestampServices)
                 .timelock(timeLockClient)

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -636,7 +636,13 @@ public abstract class TransactionManagers {
                         time,
                         invalidator,
                         userAgent);
-        return withRefreshingLockService(lockAndTimestampServices);
+        TimeLockClient timeLockClient = TimeLockClient.createWithSynchronousUnlocker(lockAndTimestampServices.timelock());
+        return ImmutableLockAndTimestampServices.builder()
+                .from(lockAndTimestampServices)
+                .timelock(timeLockClient)
+                .lock(LockRefreshingLockService.create(lockAndTimestampServices.lock()))
+                .close(timeLockClient::close)
+                .build();
     }
 
     @VisibleForTesting

--- a/lock-api/src/main/java/com/palantir/lock/client/AsyncTimeLockUnlocker.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/AsyncTimeLockUnlocker.java
@@ -44,7 +44,7 @@ import com.palantir.logsafe.SafeArg;
  * If T can pass the compareAndSet, then T itself is scheduled. If T does not, that means there is some other
  * thread that has scheduled the task, but the task has not yet retrieved the current contents of the queue.
  */
-public class AsyncTimeLockUnlocker implements AutoCloseable {
+public class AsyncTimeLockUnlocker implements TimeLockUnlocker, AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(AsyncTimeLockUnlocker.class);
     private static final int BACKPRESSURE = 1024;
 
@@ -68,6 +68,7 @@ public class AsyncTimeLockUnlocker implements AutoCloseable {
      *
      * @param tokens Lock tokens to schedule an unlock for.
      */
+    @Override
     public void enqueue(Set<LockToken> tokens) {
         try {
             outstandingLockTokens.put(tokens);

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -52,7 +52,7 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
         return new TimeLockClient(timelockService, createLockRefresher(timelockService), asyncUnlocker);
     }
 
-    public static TimeLockClient createWithSynchronousUnlocker(TimelockService timelockService) {
+    public static TimeLockClient withSynchronousUnlocker(TimelockService timelockService) {
         return new TimeLockClient(timelockService, createLockRefresher(timelockService), timelockService::unlock);
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockUnlocker.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockUnlocker.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import java.io.Closeable;
+import java.util.Set;
+
+import com.palantir.lock.v2.LockToken;
+
+public interface TimeLockUnlocker extends Closeable {
+    void enqueue(Set<LockToken> tokens);
+
+    @Override
+    default void close() {
+        // noop
+    }
+}

--- a/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
@@ -189,7 +189,7 @@ public class TimeLockClientTest {
 
     @Test
     public void clientWithSynchronousUnlockerDelegatesToUnlock() {
-        try (TimeLockClient client = TimeLockClient.createWithSynchronousUnlocker(timelock)) {
+        try (TimeLockClient client = TimeLockClient.withSynchronousUnlocker(timelock)) {
             UUID uuid = UUID.randomUUID();
             client.tryUnlock(ImmutableSet.of(LockToken.of(uuid)));
             verify(timelock, times(1)).unlock(ImmutableSet.of(LockToken.of(uuid)));

--- a/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -58,8 +60,8 @@ public class TimeLockClientTest {
 
     private final LockRefresher refresher = mock(LockRefresher.class);
     private final TimelockService delegate = mock(TimelockService.class);
-    private final AsyncTimeLockUnlocker unlocker = mock(AsyncTimeLockUnlocker.class);
-    private final TimelockService timelock = new TimeLockClient(delegate, refresher, unlocker);
+    private final TimeLockUnlocker unlocker = mock(TimeLockUnlocker.class);
+    private final TimelockService timelock = spy(new TimeLockClient(delegate, refresher, unlocker));
 
     private static final long TIMEOUT = 10_000;
 
@@ -183,5 +185,14 @@ public class TimeLockClientTest {
 
         assertThatThrownBy(timelock::getFreshTimestamp).isInstanceOf(RuntimeException.class)
             .isNotInstanceOf(AtlasDbDependencyException.class);
+    }
+
+    @Test
+    public void clientWithSynchronousUnlockerDelegatesToUnlock() {
+        try (TimeLockClient client = TimeLockClient.createWithSynchronousUnlocker(timelock)) {
+            UUID uuid = UUID.randomUUID();
+            client.tryUnlock(ImmutableSet.of(LockToken.of(uuid)));
+            verify(timelock, times(1)).unlock(ImmutableSet.of(LockToken.of(uuid)));
+        }
     }
 }


### PR DESCRIPTION
The asynchronous unlocker can cause a race condition in sweep benchmarks because we run sweep immediately after committing the transactions, so every once in a while the sweep timestamp is too low and we end up failing an assertion because we sweep the wrong number of things.

The fix is to use a synchronous unlocker in the dagger module which benchmarks use

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3386)
<!-- Reviewable:end -->
