### PR TITLE
FFT - _transactions2, Part 2: Preparing _transactions2 (no migration/usage yet!)

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -83,6 +83,7 @@ public final class AtlasDbConstants {
 
     public static final Set<TableReference> hiddenTables = ImmutableSet.of(
             TransactionConstants.TRANSACTION_TABLE,
+            TransactionConstants.TRANSACTION_TABLE_V2,
             PUNCH_TABLE,
             OLD_SCRUB_TABLE,
             SCRUB_TABLE,
@@ -99,6 +100,7 @@ public final class AtlasDbConstants {
      */
     public static final Set<TableReference> ATOMIC_TABLES = ImmutableSet.of(
             TransactionConstants.TRANSACTION_TABLE,
+            TransactionConstants.TRANSACTION_TABLE_V2,
             NAMESPACE_TABLE,
             PERSISTED_LOCKS_TABLE);
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionConstants.java
@@ -39,6 +39,8 @@ public class TransactionConstants {
     public static final byte[] COMMIT_TS_COLUMN = PtBytes.toBytes(COMMIT_TS_COLUMN_STRING);
     public static final long FAILED_COMMIT_TS = -1L;
 
+    public static final TableReference TRANSACTION_TABLE_V2 = TableReference.createWithEmptyNamespace("_transactions2");
+
     public static final long WARN_LEVEL_FOR_QUEUED_BYTES = 10 * 1024 * 1024;
 
     public static final long APPROX_IN_MEM_CELL_OVERHEAD_BYTES = 16;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/AbstractKeyValueServiceBackedTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/AbstractKeyValueServiceBackedTransactionService.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+
+public abstract class AbstractKeyValueServiceBackedTransactionService implements TransactionService {
+    // The maximum key-value store timestamp (exclusive) at which data is stored in the transactions table.
+    // All entries in transaction table are stored with timestamp 0
+    private static final long MAX_TIMESTAMP = 1L;
+
+    @Override
+    public final Long get(long startTimestamp) {
+        Cell cell = encodeTimestampAsCell(startTimestamp);
+        Map<Cell, Value> returnMap = getKeyValueService().get(
+                getTableReference(),
+                ImmutableMap.of(cell, MAX_TIMESTAMP));
+        if (returnMap.containsKey(cell)) {
+            return decodeValueAsTimestamp(returnMap.get(cell).getContents());
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public final Map<Long, Long> get(Iterable<Long> startTimestamps) {
+        Map<Cell, Long> startTsMap = Maps.newHashMap();
+        for (Long startTimestamp : startTimestamps) {
+            Cell cell = encodeTimestampAsCell(startTimestamp);
+            startTsMap.put(cell, MAX_TIMESTAMP);
+        }
+
+        Map<Cell, Value> rawResults = getKeyValueService().get(getTableReference(), startTsMap);
+        Map<Long, Long> result = Maps.newHashMapWithExpectedSize(rawResults.size());
+        for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
+            long startTs = decodeCellAsTimestamp(e.getKey());
+            long commitTs = decodeValueAsTimestamp(e.getValue().getContents());
+            result.put(startTs, commitTs);
+        }
+        return result;
+    }
+
+    @Override
+    public final void putUnlessExists(long startTimestamp, long commitTimestamp) throws KeyAlreadyExistsException {
+        Cell key = encodeTimestampAsCell(startTimestamp);
+        byte[] value = encodeTimestampAsValue(commitTimestamp);
+        getKeyValueService().putUnlessExists(getTableReference(), ImmutableMap.of(key, value));
+    }
+
+    public abstract KeyValueService getKeyValueService();
+
+    public abstract TableReference getTableReference();
+
+    public abstract Cell encodeTimestampAsCell(long startTimestamp);
+
+    public abstract long decodeCellAsTimestamp(Cell cell);
+
+    public abstract byte[] encodeTimestampAsValue(long startTimestamp);
+
+    public abstract long decodeValueAsTimestamp(byte[] value);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/DynamicSplittingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/DynamicSplittingTransactionService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.LongPredicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+
+/**
+ * A DynamicSplittingTransactionService delegates between two {@link TransactionService}s, depending on whether the
+ * start timestamp for a given transaction satisfies the {@link LongPredicate} provided.
+ *
+ * Note: We require that once the {@link LongPredicate} has been invoked on a given timestamp, it must return the
+ * same value for all future invocations on that timestamp. The behaviour of the {@link LongPredicate} on values that
+ * this {@link TransactionService} has not been queried for is allowed to change over time.
+ */
+public class DynamicSplittingTransactionService implements TransactionService {
+    private final LongPredicate shouldUseFirstService;
+    private final TransactionService firstService;
+    private final TransactionService secondService;
+
+    public DynamicSplittingTransactionService(
+            LongPredicate shouldUseFirstService,
+            TransactionService firstService,
+            TransactionService secondService) {
+        this.shouldUseFirstService = shouldUseFirstService;
+        this.firstService = firstService;
+        this.secondService = secondService;
+    }
+
+    @Override
+    public Long get(long startTimestamp) {
+        TransactionService targetService = getTargetServiceForStartTimestamp(startTimestamp);
+        return targetService.get(startTimestamp);
+    }
+
+    @Override
+    public Map<Long, Long> get(Iterable<Long> startTimestamps) {
+        // TODO (jkong): If this is slow, rewrite without streams
+        Map<Boolean, List<Long>> queries = StreamSupport.stream(startTimestamps.spliterator(), false)
+                .collect(Collectors.groupingBy(shouldUseFirstService::test));
+
+        return ImmutableMap.<Long, Long>builder()
+                .putAll(invokeGetIfNonNull(firstService, queries.get(true)))
+                .putAll(invokeGetIfNonNull(secondService, queries.get(false)))
+                .build();
+    }
+
+    @Override
+    public void putUnlessExists(long startTimestamp, long commitTimestamp) throws KeyAlreadyExistsException {
+        TransactionService targetService = getTargetServiceForStartTimestamp(startTimestamp);
+        targetService.putUnlessExists(startTimestamp, commitTimestamp);
+    }
+
+    private Map<Long, Long> invokeGetIfNonNull(TransactionService service, List<Long> startTimestamps) {
+        if (startTimestamps == null) {
+            return ImmutableMap.of();
+        }
+        return service.get(startTimestamps);
+    }
+
+    private TransactionService getTargetServiceForStartTimestamp(long startTimestamp) {
+        return shouldUseFirstService.test(startTimestamp) ? firstService : secondService;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -21,15 +21,9 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
 public final class SimpleTransactionService extends AbstractKeyValueServiceBackedTransactionService {
-    private final KeyValueService keyValueService;
 
-    public SimpleTransactionService(KeyValueService keyValueService) {
-        this.keyValueService = keyValueService;
-    }
-
-    @Override
-    public KeyValueService getKeyValueService() {
-        return keyValueService;
+    protected SimpleTransactionService(KeyValueService keyValueService) {
+        super(keyValueService);
     }
 
     @Override
@@ -38,24 +32,26 @@ public final class SimpleTransactionService extends AbstractKeyValueServiceBacke
     }
 
     @Override
-    public Cell encodeTimestampAsCell(long startTimestamp) {
+    public Cell encodeStartTimestampAsCell(long startTimestamp) {
         return Cell.create(
                 TransactionConstants.getValueForTimestamp(startTimestamp),
                 TransactionConstants.COMMIT_TS_COLUMN);
     }
 
     @Override
-    public long decodeCellAsTimestamp(Cell cell) {
+    public long decodeCellAsStartTimestamp(Cell cell) {
         return TransactionConstants.getTimestampForValue(cell.getRowName());
     }
 
     @Override
-    public byte[] encodeTimestampAsValue(long commitTimestamp) {
+    public byte[] encodeCommitTimestampAsValue(long startTimestamp, long commitTimestamp) {
+        // startTimestamp is unused
         return TransactionConstants.getValueForTimestamp(commitTimestamp);
     }
 
     @Override
-    public long decodeValueAsTimestamp(byte[] value) {
+    public long decodeValueAsCommitTimestamp(long startTimestamp, byte[] value) {
+        // startTimestamp is unused
         return TransactionConstants.getTimestampForValue(value);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -15,76 +15,47 @@
  */
 package com.palantir.atlasdb.transaction.service;
 
-import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
-public final class SimpleTransactionService implements TransactionService {
+public final class SimpleTransactionService extends AbstractKeyValueServiceBackedTransactionService {
     private final KeyValueService keyValueService;
 
     public SimpleTransactionService(KeyValueService keyValueService) {
         this.keyValueService = keyValueService;
     }
 
-    // The maximum key-value store timestamp (exclusive) at which data is stored
-    // in transaction table.
-    // All entries in transaction table are stored with timestamp 0
-    private static final long MAX_TIMESTAMP = 1L;
-
     @Override
-    public Long get(long startTimestamp) {
-        Cell cell = getTransactionCell(startTimestamp);
-        Map<Cell, Value> returnMap = keyValueService.get(
-                TransactionConstants.TRANSACTION_TABLE,
-                ImmutableMap.of(cell, MAX_TIMESTAMP));
-        if (returnMap.containsKey(cell)) {
-            return TransactionConstants.getTimestampForValue(returnMap
-                    .get(cell).getContents());
-        } else {
-            return null;
-        }
+    public KeyValueService getKeyValueService() {
+        return keyValueService;
     }
 
     @Override
-    public Map<Long, Long> get(Iterable<Long> startTimestamps) {
-        Map<Cell, Long> startTsMap = Maps.newHashMap();
-        for (Long startTimestamp : startTimestamps) {
-            Cell cell = getTransactionCell(startTimestamp);
-            startTsMap.put(cell, MAX_TIMESTAMP);
-        }
-
-        Map<Cell, Value> rawResults = keyValueService.get(
-                TransactionConstants.TRANSACTION_TABLE, startTsMap);
-        Map<Long, Long> result = Maps.newHashMapWithExpectedSize(rawResults
-                .size());
-        for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
-            long startTs = TransactionConstants.getTimestampForValue(e.getKey()
-                    .getRowName());
-            long commitTs = TransactionConstants.getTimestampForValue(e
-                    .getValue().getContents());
-            result.put(startTs, commitTs);
-        }
-
-        return result;
+    public TableReference getTableReference() {
+        return TransactionConstants.TRANSACTION_TABLE;
     }
 
     @Override
-    public void putUnlessExists(long startTimestamp, long commitTimestamp) {
-        Cell key = getTransactionCell(startTimestamp);
-        byte[] value = TransactionConstants
-                .getValueForTimestamp(commitTimestamp);
-        keyValueService.putUnlessExists(TransactionConstants.TRANSACTION_TABLE,
-                ImmutableMap.of(key, value));
-    }
-
-    private Cell getTransactionCell(long startTimestamp) {
+    public Cell encodeTimestampAsCell(long startTimestamp) {
         return Cell.create(
                 TransactionConstants.getValueForTimestamp(startTimestamp),
                 TransactionConstants.COMMIT_TS_COLUMN);
+    }
+
+    @Override
+    public long decodeCellAsTimestamp(Cell cell) {
+        return TransactionConstants.getTimestampForValue(cell.getRowName());
+    }
+
+    @Override
+    public byte[] encodeTimestampAsValue(long commitTimestamp) {
+        return TransactionConstants.getValueForTimestamp(commitTimestamp);
+    }
+
+    @Override
+    public long decodeValueAsTimestamp(byte[] value) {
+        return TransactionConstants.getTimestampForValue(value);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/SimpleTransactionService.java
@@ -21,8 +21,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
 public final class SimpleTransactionService extends AbstractKeyValueServiceBackedTransactionService {
-
-    protected SimpleTransactionService(KeyValueService keyValueService) {
+    public SimpleTransactionService(KeyValueService keyValueService) {
         super(keyValueService);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/v2/TicketingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/v2/TicketingTransactionService.java
@@ -16,7 +16,7 @@
 
 package com.palantir.atlasdb.transaction.service.v2;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
@@ -44,7 +44,7 @@ public class TicketingTransactionService extends AbstractKeyValueServiceBackedTr
     public static final long PARTITIONING_QUANTUM = 400_000_000;
     public static final long ROWS_PER_QUANTUM = 256;
 
-    protected TicketingTransactionService(KeyValueService keyValueService) {
+    public TicketingTransactionService(KeyValueService keyValueService) {
         super(keyValueService);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/v2/TicketingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/v2/TicketingTransactionService.java
@@ -30,9 +30,11 @@ import com.palantir.atlasdb.transaction.service.AbstractKeyValueServiceBackedTra
  *
  * We divide the first PARTITIONING_QUANTUM timestamps among the first ROW_PER_QUANTUM rows.
  * We aim to distribute start timestamps as evenly as possible among these rows as numbers increase, by taking the
- * least significant bits of the timestamp and using that as the row number. We store the row name as a little-endian
- * representation of the row number to ensure even distribution in key-value services that rely on consistent hashing
- * or similar mechanisms for partitioning.
+ * least significant bits of the timestamp and using that as the row number. For example, we might store timestamps
+ * 1, ROW_PER_QUANTUM + 1, 2 * ROW_PER_QUANTUM + 1 etc. in the same row.
+ *
+ * We store the row name as a little-endian representation of the row number to ensure even distribution in key-value
+ * services that rely on consistent hashing or similar mechanisms for partitioning.
  *
  * We also use a delta encoding for the commit timestamp as these differences are expected to be small.
  *
@@ -42,7 +44,7 @@ import com.palantir.atlasdb.transaction.service.AbstractKeyValueServiceBackedTra
 public class TicketingTransactionService extends AbstractKeyValueServiceBackedTransactionService {
     // DO NOT change the following without a transactions table migration!
     public static final long PARTITIONING_QUANTUM = 400_000_000;
-    public static final long ROWS_PER_QUANTUM = 256;
+    public static final int ROWS_PER_QUANTUM = 256;
 
     public TicketingTransactionService(KeyValueService keyValueService) {
         super(keyValueService);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/v2/TicketingTransactionService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/service/v2/TicketingTransactionService.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.service.v2;
+
+import org.apache.commons.lang.ArrayUtils;
+
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.service.AbstractKeyValueServiceBackedTransactionService;
+
+/**
+ * The ticketing algorithm distributes timestamps among rows and dynamic columns to avoid hot-spotting.
+ *
+ * We divide the first PARTITIONING_QUANTUM timestamps among the first ROW_PER_QUANTUM rows.
+ * We aim to distribute start timestamps as evenly as possible among these rows as numbers increase, by taking the
+ * least significant bits of the timestamp and using that as the row number. We store the row name as a little-endian
+ * representation of the row number to ensure even distribution in key-value services that rely on consistent hashing
+ * or similar mechanisms for partitioning.
+ *
+ * We also use a delta encoding for the commit timestamp as these differences are expected to be small.
+ *
+ * A long is 9 bytes at most, so one row here consists of at most 4 longs -> 36 bytes, and an individual row
+ * is probabilistically below 1M dynamic column keys. A row is expected to be about 6.5M (27M worst case).
+ */
+public class TicketingTransactionService extends AbstractKeyValueServiceBackedTransactionService {
+    // DO NOT change the following without a transactions table migration!
+    public static final long PARTITIONING_QUANTUM = 400_000_000;
+    public static final long ROWS_PER_QUANTUM = 256;
+
+    protected TicketingTransactionService(KeyValueService keyValueService) {
+        super(keyValueService);
+    }
+
+    @Override
+    public TableReference getTableReference() {
+        return TransactionConstants.TRANSACTION_TABLE_V2;
+    }
+
+    @Override
+    public Cell encodeStartTimestampAsCell(long startTimestamp) {
+        byte[] rowName = encodeRowName(startTimestamp);
+        byte[] columnName = encodeColumnName(startTimestamp);
+        return Cell.create(rowName, columnName);
+    }
+
+    @Override
+    public long decodeCellAsStartTimestamp(Cell cell) {
+        long rowComponent = decodeRowName(cell.getRowName());
+        long columnComponent = decodeColumnName(cell.getColumnName());
+
+        return (rowComponent / ROWS_PER_QUANTUM) * PARTITIONING_QUANTUM
+                + columnComponent * ROWS_PER_QUANTUM
+                + rowComponent % ROWS_PER_QUANTUM;
+    }
+
+    @Override
+    public byte[] encodeCommitTimestampAsValue(long startTimestamp, long commitTimestamp) {
+        return TransactionConstants.getValueForTimestamp(commitTimestamp - startTimestamp);
+    }
+
+    @Override
+    public long decodeValueAsCommitTimestamp(long startTimestamp, byte[] value) {
+        return startTimestamp + TransactionConstants.getTimestampForValue(value);
+    }
+
+    private byte[] encodeRowName(long startTimestamp) {
+        long row = (startTimestamp / PARTITIONING_QUANTUM) * ROWS_PER_QUANTUM
+                + (startTimestamp % PARTITIONING_QUANTUM) % ROWS_PER_QUANTUM;
+        byte[] rowName = ValueType.VAR_LONG.convertFromJava(row);
+        ArrayUtils.reverse(rowName);
+        return rowName;
+    }
+
+    private byte[] encodeColumnName(long startTimestamp) {
+        long column = (startTimestamp % PARTITIONING_QUANTUM) / ROWS_PER_QUANTUM;
+        return ValueType.VAR_LONG.convertFromJava(column);
+    }
+
+    private long decodeRowName(byte[] rowName) {
+        ArrayUtils.reverse(rowName);
+        return (long) ValueType.VAR_LONG.convertToJava(rowName, 0);
+    }
+
+    private long decodeColumnName(byte[] columnName) {
+        return (long) ValueType.VAR_LONG.convertToJava(columnName, 0);
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/service/DynamicSplittingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/service/DynamicSplittingTransactionServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongPredicate;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.transaction.service.DynamicSplittingTransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+
+public class DynamicSplittingTransactionServiceTest {
+    private static final long TIMESTAMP_1 = 71;
+    private static final long TIMESTAMP_2 = 82;
+    private static final long TIMESTAMP_3 = 113;
+    private static final long TIMESTAMP_4 = 144;
+
+    private final TransactionService service1 = mock(TransactionService.class);
+    private final TransactionService service2 = mock(TransactionService.class);
+    private TransactionService splittingService;
+
+    @Before
+    public void setUp() {
+        splittingService = forPredicate(ts -> ts < 100);
+    }
+
+    @After
+    public void checkNoMoreInteractions() {
+        verifyNoMoreInteractions(service1, service2);
+    }
+
+    @Test
+    public void getDelegatesToCorrectService() {
+        splittingService.get(TIMESTAMP_1);
+        splittingService.get(TIMESTAMP_3);
+
+        verify(service1).get(TIMESTAMP_1);
+        verify(service2).get(TIMESTAMP_3);
+    }
+
+    @Test
+    public void putUnlessExistsDelegatesToCorrectService() {
+        splittingService.putUnlessExists(TIMESTAMP_1, TIMESTAMP_2);
+        splittingService.putUnlessExists(TIMESTAMP_3, TIMESTAMP_4);
+
+        verify(service1).putUnlessExists(TIMESTAMP_1, TIMESTAMP_2);
+        verify(service2).putUnlessExists(TIMESTAMP_3, TIMESTAMP_4);
+    }
+
+    @Test
+    public void putUnlessExistsDelegatesBasedOnStartTimestamp() {
+        splittingService.putUnlessExists(TIMESTAMP_1, TIMESTAMP_3);
+        verify(service1).putUnlessExists(TIMESTAMP_1, TIMESTAMP_3);
+    }
+
+    @Test
+    public void getMultipleOnlyCallsUnderlyingServicesOnce() {
+        splittingService.get(ImmutableList.of(TIMESTAMP_1, TIMESTAMP_2, TIMESTAMP_3, TIMESTAMP_4));
+        verify(service1).get(eq(ImmutableList.of(TIMESTAMP_1, TIMESTAMP_2)));
+        verify(service2).get(eq(ImmutableList.of(TIMESTAMP_3, TIMESTAMP_4)));
+    }
+
+    @Test
+    public void getMultipleOnlyCallsUnderlyingServiceIfRelevant() {
+        splittingService.get(ImmutableList.of(TIMESTAMP_1, TIMESTAMP_2));
+        verify(service1).get(eq(ImmutableList.of(TIMESTAMP_1, TIMESTAMP_2)));
+    }
+
+    @Test
+    public void responsiveToChangesInPredicate() {
+        AtomicLong bound = new AtomicLong(100);
+        TransactionService dynamicSplitter = forPredicate(ts -> ts < bound.get());
+        dynamicSplitter.get(TIMESTAMP_1);
+        bound.set(Long.MAX_VALUE);
+        dynamicSplitter.get(TIMESTAMP_4);
+        verify(service1).get(TIMESTAMP_1);
+        verify(service1).get(TIMESTAMP_4);
+    }
+
+    @SuppressWarnings("unchecked") // Known safe mock invocation
+    @Test
+    public void propagatesExceptions() {
+        when(service1.get(anyLong())).thenThrow(IllegalStateException.class);
+        assertThatThrownBy(() -> splittingService.get(TIMESTAMP_1))
+                .isInstanceOf(IllegalStateException.class);
+        verify(service1).get(TIMESTAMP_1);
+    }
+
+    private TransactionService forPredicate(LongPredicate longPredicate) {
+        return new DynamicSplittingTransactionService(longPredicate, service1, service2);
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/service/v2/TicketingTransactionServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/service/v2/TicketingTransactionServiceTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.service.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.service.v2.TicketingTransactionService;
+
+public class TicketingTransactionServiceTest {
+    private static final long START_TS_1 = 7;
+    private static final long START_TS_2 = 77;
+    private static final long COMMIT_TS_1 = 42;
+    private static final long COMMIT_TS_2 = 422;
+
+    private KeyValueService kvs;
+    private TicketingTransactionService ticketingTransactionService;
+
+    @Before
+    public void setUp() {
+        kvs = new InMemoryKeyValueService(true);
+        ticketingTransactionService = new TicketingTransactionService(kvs);
+    }
+
+    @Test
+    public void returnsNullIfCommitTimestampNotKnown() {
+        assertThat(ticketingTransactionService.get(START_TS_1)).isNull();
+    }
+
+    @Test
+    public void returnsCommitTimestampIfStartTimestampKnown() {
+        ticketingTransactionService.putUnlessExists(START_TS_1, COMMIT_TS_1);
+        assertThat(ticketingTransactionService.get(START_TS_1)).isEqualTo(COMMIT_TS_1);
+    }
+
+    @Test
+    public void queriesAreDoneByStartTimestamp() {
+        ticketingTransactionService.putUnlessExists(START_TS_1, COMMIT_TS_1);
+        assertThat(ticketingTransactionService.get(COMMIT_TS_1)).isNull();
+    }
+
+    @Test
+    public void canPutMultipleTimestamps() {
+        ticketingTransactionService.putUnlessExists(START_TS_1, COMMIT_TS_1);
+        ticketingTransactionService.putUnlessExists(START_TS_2, COMMIT_TS_2);
+        assertThat(ticketingTransactionService.get(ImmutableList.of(START_TS_1, START_TS_2)))
+                .containsEntry(START_TS_1, COMMIT_TS_1)
+                .containsEntry(START_TS_2, COMMIT_TS_2);
+    }
+
+    @Test
+    public void getMultipleTimestampsDoesNotContainUncommittedStartTimestamps() {
+        ticketingTransactionService.putUnlessExists(START_TS_1, COMMIT_TS_1);
+        assertThat(ticketingTransactionService.get(ImmutableList.of(START_TS_1, START_TS_2)))
+                .containsEntry(START_TS_1, COMMIT_TS_1)
+                .doesNotContainKey(START_TS_2);
+    }
+
+    @Test
+    public void cannotReuseTimestamps() {
+        ticketingTransactionService.putUnlessExists(START_TS_1, COMMIT_TS_1);
+        assertThatThrownBy(() -> ticketingTransactionService.putUnlessExists(START_TS_1, COMMIT_TS_2))
+                .isInstanceOf(KeyAlreadyExistsException.class);
+
+        assertThat(ticketingTransactionService.get(START_TS_1)).isEqualTo(COMMIT_TS_1);
+    }
+
+    @Test
+    public void cannotReuseTimestampsEvenIfCommitTimestampMatches() {
+        ticketingTransactionService.putUnlessExists(START_TS_1, COMMIT_TS_1);
+        assertThatThrownBy(() -> ticketingTransactionService.putUnlessExists(START_TS_1, COMMIT_TS_1))
+                .isInstanceOf(KeyAlreadyExistsException.class);
+
+        assertThat(ticketingTransactionService.get(START_TS_1)).isEqualTo(COMMIT_TS_1);
+    }
+
+    @Test
+    public void canRetrieveTimestampsNearRowBoundary() {
+        long numRows = TicketingTransactionService.ROWS_PER_QUANTUM;
+        ensureTimestampsCanBeDistinguished(numRows - 1, numRows, numRows + 1);
+    }
+
+    @Test
+    public void canRetrieveTimestampsAcrossQuantumBoundary() {
+        long quantum = TicketingTransactionService.PARTITIONING_QUANTUM;
+        ensureTimestampsCanBeDistinguished(quantum - 1, quantum, quantum + 1);
+    }
+
+    @Test
+    public void canDistinguishTimestampsAcrossRows() {
+        long numRows = TicketingTransactionService.ROWS_PER_QUANTUM;
+        long offset = 318557;
+        ensureTimestampsCanBeDistinguished(offset, numRows + offset, 2 * numRows + offset);
+    }
+
+    @Test
+    public void canDistinguishTimestampsAcrossQuanta() {
+        long quantum = TicketingTransactionService.PARTITIONING_QUANTUM;
+        long offset = 318557;
+        ensureTimestampsCanBeDistinguished(offset, quantum + offset, 2 * quantum + offset);
+    }
+
+    @Test
+    public void canDistinguishTimestampsAcrossExtremesOfQuanta() {
+        long quantum = TicketingTransactionService.PARTITIONING_QUANTUM;
+        ensureTimestampsCanBeDistinguished(
+                quantum - 1, quantum, quantum + 1, 2 * quantum - 1, 2 * quantum, 2 * quantum + 1);
+    }
+
+    @Test
+    public void storesLargeCommitTimestampsCompactly() {
+        long highTimestamp = Long.MAX_VALUE - 1;
+        ticketingTransactionService.putUnlessExists(highTimestamp, highTimestamp + 1);
+
+        List<RowResult<Value>> values =
+                kvs.getRange(TransactionConstants.TRANSACTION_TABLE_V2, RangeRequest.all(), Long.MAX_VALUE)
+                        .stream()
+                        .collect(Collectors.toList());
+        byte[] data = Iterables.getOnlyElement(values).getOnlyColumnValue().getContents();
+        assertThat(data.length).isEqualTo(1);
+        assertThat(ticketingTransactionService.decodeValueAsCommitTimestamp(highTimestamp, data))
+                .isEqualTo(highTimestamp + 1);
+    }
+
+    @Test
+    public void distributesTimestampsAcrossRows() {
+        for (int timestamp = 0; timestamp < TicketingTransactionService.ROWS_PER_QUANTUM; timestamp++) {
+            ticketingTransactionService.putUnlessExists(
+                    timestamp, timestamp + TicketingTransactionService.ROWS_PER_QUANTUM);
+        }
+
+        List<RowResult<Value>> values =
+                kvs.getRange(TransactionConstants.TRANSACTION_TABLE_V2, RangeRequest.all(), Long.MAX_VALUE)
+                        .stream()
+                        .collect(Collectors.toList());
+
+        // each row is represented
+        assertThat(values.size()).isEqualTo(TicketingTransactionService.ROWS_PER_QUANTUM);
+    }
+
+    @Test
+    public void distributesTimestampsEvenlyAcrossRows() {
+        int elementsExpectedPerRow = 13;
+        int numTimestamps = TicketingTransactionService.ROWS_PER_QUANTUM * elementsExpectedPerRow;
+        int numPartitions = 10;
+
+        for (int partition = 0; partition < numPartitions; partition++) {
+            for (int timestamp = 0; timestamp < numTimestamps; timestamp++) {
+                ticketingTransactionService.putUnlessExists(
+                        TicketingTransactionService.PARTITIONING_QUANTUM * partition + timestamp,
+                        TicketingTransactionService.PARTITIONING_QUANTUM * partition + timestamp + 5);
+            }
+        }
+
+        List<Integer> rowSizes = kvs.getRange(
+                TransactionConstants.TRANSACTION_TABLE_V2, RangeRequest.all(), Long.MAX_VALUE)
+                .stream()
+                .map(rowResult -> rowResult.getColumns().size())
+                .collect(Collectors.toList());
+
+        assertThat(rowSizes)
+                .hasSize(TicketingTransactionService.ROWS_PER_QUANTUM * numPartitions)
+                .allMatch(size -> size == elementsExpectedPerRow);
+    }
+
+    @Test
+    public void cellEncodeAndDecodeAreInverses() {
+        fuzzOneThousandTrials(() -> {
+            long timestamp = ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+            Cell encoded = ticketingTransactionService.encodeStartTimestampAsCell(timestamp);
+            assertThat(ticketingTransactionService.decodeCellAsStartTimestamp(encoded)).isEqualTo(timestamp);
+        });
+    }
+
+    @Test
+    public void commitTimestampEncodeAndDecodeAreInverses() {
+        fuzzOneThousandTrials(() -> {
+            long startTimestamp = ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1);
+            long commitTimestamp = ThreadLocalRandom.current().nextLong(startTimestamp, Long.MAX_VALUE);
+            byte[] encoded = ticketingTransactionService.encodeCommitTimestampAsValue(
+                     startTimestamp, commitTimestamp);
+            assertThat(ticketingTransactionService.decodeValueAsCommitTimestamp(startTimestamp, encoded))
+                    .isEqualTo(commitTimestamp);
+        });
+    }
+
+    private void fuzzOneThousandTrials(Runnable test) {
+        IntStream.range(0, 1000)
+                .forEach(unused -> test.run());
+    }
+
+    private void ensureTimestampsCanBeDistinguished(long... timestamps) {
+        Map<Long, Long> startToCommitTs = Arrays.stream(timestamps)
+                .boxed()
+                .collect(Collectors.toMap(
+                        timestamp -> timestamp,
+                        timestamp -> timestamp));
+
+        startToCommitTs.forEach((start, commit) -> ticketingTransactionService.putUnlessExists(start, commit));
+
+        assertThat(ticketingTransactionService.get(startToCommitTs.keySet()))
+                .isEqualTo(startToCommitTs);
+    }
+}


### PR DESCRIPTION
**Goals (and why)**:
- Provide an implementation of the tickets algorithm for _transactions2, which avoids hotspotting
- Provide an implementation of a service-splitting transaction service, which will be essential for _transactions2

**Implementation Description (bullets)**:
- Refactor the _transactions1 transaction service to implement various translation methods of an abstract class
- Implement the tickets algorithm in _transactions2
- Implement a service-splitting service that switches on a long-predicate and hits the correct underlying service

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Transactions1 testing is very well covered by e.g. `AbstractKeyValueServiceTransactionIntegrationTest`
- Additional testing was added for the ticket encoding/decoding methods, and the dynamic splitter

**Concerns (what feedback would you like?)**:
- Is the test coverage for _transactions2 good enough?
- The guarantee on the dynamic splitter's long predicate is a little strange, but I think we need that. Does it make sense?
- We need to be careful with the `TransactionKvsWrapper` as we move to transactions2 as well. It's used by large internal product.

**Where should we start reviewing?**: AbstractKeyValueServiceBackedTransactionService

**Priority (whenever / two weeks / yesterday)**: Early next week

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3392)
<!-- Reviewable:end -->
