### PR TITLE
change documentation of ignore all conflict handler

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -17,7 +17,7 @@ package com.palantir.atlasdb.transaction.api;
 
 public enum ConflictHandler {
     /**
-     * If two transactions write to the same cell the one that was committed later will win.  We
+     * If two transactions write to the same cell the one that has started later will win.  We
      * are ignoring write conflicts in this case.
      */
     IGNORE_ALL(false, false, false, false),

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ConflictHandler.java
@@ -17,7 +17,7 @@ package com.palantir.atlasdb.transaction.api;
 
 public enum ConflictHandler {
     /**
-     * If two transactions write to the same cell the one that has started later will win.  We
+     * If two transactions concurrently write to the same cell the one that has started later will win.  We
      * are ignoring write conflicts in this case.
      */
     IGNORE_ALL(false, false, false, false),


### PR DESCRIPTION
**Goals (and why)**:
Documentation of `IGNORE_ALL` conflict handler is a bit misleading. It is stated that the transaction that is committed last wins, but actually it is the transaction that **started** last wins.

**Priority (whenever / two weeks / yesterday)**:
Whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3404)
<!-- Reviewable:end -->
