### PR TITLE
Remove references to previously removed atlasdb-service-server

### DIFF
--- a/docs/source/overview/getting_started.rst
+++ b/docs/source/overview/getting_started.rst
@@ -70,19 +70,3 @@ include in a gradle project:
        dependencies {
            compile 'com.palantir.atlasdb:atlasdb-client:0.3.3'
        }
-
-Standalone JSON/REST Server
-===========================
-
-The standalone server is a lightweight way to try out AtlasDB and can be
-done by running AtlasDbServiceServer in the atlasdb-service-server project.
-The default configuration file uses an ephemeral in-memory DB;
-if you'd like to run tests with persisted data there is also an `atlasdb_standalone_postgres.yml`
-
-.. code:: bash
-
-    AtlasDbServiceServer server src/dist/atlasdb_standalone.yml
-
-This is Dropwizard service that runs all the needed parts and doesn't
-force you to use the Java client to get the benefits of AtlasDB. See the
-ref:`atlasdb-service-api` for more details.


### PR DESCRIPTION
**Goals (and why)**:
- Remove references to the atlasdb service server, which was removed in #3230 

**Implementation Description (bullets)**:
- Remove references.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- N/A, docs change

**Concerns (what feedback would you like?)**:
- N/A, docs change

**Where should we start reviewing?**: getting-started.rst

**Priority (whenever / two weeks / yesterday)**: whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3405)
<!-- Reviewable:end -->
