### PR TITLE
Bump default max number of clients to 200

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -31,7 +31,7 @@ public abstract class TimeLockRuntimeConfiguration {
     @JsonProperty("max-number-of-clients")
     @Value.Default
     public Integer maxNumberOfClients() {
-        return 100;
+        return 200;
     }
 
     /**


### PR DESCRIPTION
**Goals (and why)**: It's not uncommon to exhaust the number of clients in previous default configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3412)
<!-- Reviewable:end -->
