### PR TITLE
[TimeLock] Bump Maximum Clients & Saturation Metrics

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,12 +63,12 @@ develop
          - TimeLock by default now has a client limit of 500.
            Previously, this used to be 100 - however we have run into issues internally where stacks legitimately reach this threshold.
            Note that we still need to maintain the client limit to avoid a possible DOS attack with users creating arbitrarily many clients.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3413>`__)
 
-    *    - |improved|
+    *    - |new| |metrics|
          - Added metrics for the number of active clients and maximum number of clients in TimeLock Server.
            These are useful to identify stacks that may be in danger of breaching their maxima.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3413>`__)
 
 
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -59,6 +59,18 @@ develop
          - Changed the range scan behavior for the sweep priority table so that reads scan less data in Cassandra.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3410>`__)
 
+    *    - |improved|
+         - TimeLock by default now has a client limit of 500.
+           Previously, this used to be 100 - however we have run into issues internally where stacks legitimately reach this threshold.
+           Note that we still need to maintain the client limit to avoid a possible DOS attack with users creating arbitrarily many clients.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+
+    *    - |improved|
+         - Added metrics for the number of active clients and maximum number of clients in TimeLock Server.
+           These are useful to identify stacks that may be in danger of breaching their maxima.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/qqqq>`__)
+
+
 =======
 v0.97.0
 =======

--- a/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/config/TimeLockRuntimeConfiguration.java
@@ -31,7 +31,7 @@ public abstract class TimeLockRuntimeConfiguration {
     @JsonProperty("max-number-of-clients")
     @Value.Default
     public Integer maxNumberOfClients() {
-        return 100;
+        return 500;
     }
 
     /**
@@ -46,6 +46,8 @@ public abstract class TimeLockRuntimeConfiguration {
 
     @Value.Check
     public void check() {
+        Preconditions.checkState(maxNumberOfClients() >= 0,
+                "Maximum number of clients must be nonnegative, but found %s", maxNumberOfClients());
         Preconditions.checkState(slowLockLogTriggerMillis() >= 0,
                 "Slow lock log trigger threshold must be nonnegative, but found %s", slowLockLogTriggerMillis());
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -120,7 +120,9 @@ public class TimeLockAgent {
 
         // Finally, register the health check, and endpoints associated with the clients.
         healthCheckSupplier = leadershipCreator.getHealthCheck();
-        resource = new TimeLockResource(this::createInvalidatingTimeLockServices,
+        resource = TimeLockResource.create(
+                metricsManager,
+                this::createInvalidatingTimeLockServices,
                 JavaSuppliers.compose(TimeLockRuntimeConfiguration::maxNumberOfClients, runtime));
         registrar.accept(resource);
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -40,12 +40,16 @@ import com.palantir.timestamp.TimestampService;
 public class TimeLockResource {
     private final Logger log = LoggerFactory.getLogger(TimeLockResource.class);
 
+    @VisibleForTesting
+    static final String ACTIVE_CLIENTS = "activeClients";
+    @VisibleForTesting
+    static final String MAX_CLIENTS = "maxClients";
+
     private final Function<String, TimeLockServices>  clientServicesFactory;
     private final ConcurrentMap<String, TimeLockServices> servicesByNamespace = Maps.newConcurrentMap();
     private final Supplier<Integer> maxNumberOfClients;
 
-    @VisibleForTesting
-    TimeLockResource(
+    private TimeLockResource(
             Function<String, TimeLockServices> clientServicesFactory,
             Supplier<Integer> maxNumberOfClients) {
         this.clientServicesFactory = clientServicesFactory;
@@ -109,7 +113,7 @@ public class TimeLockResource {
     }
 
     private static void registerClientCapacityMetrics(TimeLockResource resource, MetricsManager metricsManager) {
-        metricsManager.registerMetric(TimeLockResource.class, "activeClients", resource::numberOfClients);
-        metricsManager.registerMetric(TimeLockResource.class, "maxClients", () -> resource.maxNumberOfClients);
+        metricsManager.registerMetric(TimeLockResource.class, ACTIVE_CLIENTS, resource::numberOfClients);
+        metricsManager.registerMetric(TimeLockResource.class, MAX_CLIENTS, resource.maxNumberOfClients::get);
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
-import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -169,9 +168,7 @@ public class TimeLockResourceTest {
     private int getGaugeValueForTimeLockResource(String gaugeName) {
         Object value = Optional.ofNullable(metricsManager.getRegistry()
                 .getGauges()
-                .get(new StringJoiner(".").add(TimeLockResource.class.getCanonicalName())
-                        .add(gaugeName)
-                        .toString())
+                .get(TimeLockResource.class.getCanonicalName() + "." + gaugeName)
                 .getValue())
                 .orElseThrow(() -> new IllegalStateException("Gauge with gauge name " + gaugeName + " did not exist."));
         return (int) value;

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
@@ -24,12 +24,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 
 public class TimeLockResourceTest {
     private static final String CLIENT_A = "a-client";
@@ -42,7 +48,12 @@ public class TimeLockResourceTest {
 
     private final Function<String, TimeLockServices> serviceFactory = mock(Function.class);
     private final Supplier<Integer> maxNumberOfClientsSupplier = mock(Supplier.class);
-    private final TimeLockResource resource = new TimeLockResource(
+    private final MetricsManager metricsManager = new MetricsManager(
+            new MetricRegistry(),
+            DefaultTaggedMetricRegistry.getDefault(),
+            unused -> false);
+    private final TimeLockResource resource = TimeLockResource.create(
+            metricsManager,
             serviceFactory,
             maxNumberOfClientsSupplier);
 
@@ -103,6 +114,38 @@ public class TimeLockResourceTest {
         resource.getTimeService(uniqueClient());
     }
 
+    @Test
+    public void numberOfActiveClientsUpdatesAsNewClientsCreated() {
+        assertNumberOfActiveClientsIs(0);
+        assertMaxClientsIs(DEFAULT_MAX_NUMBER_OF_CLIENTS);
+
+        resource.getOrCreateServices(uniqueClient());
+
+        assertNumberOfActiveClientsIs(1);
+        assertMaxClientsIs(DEFAULT_MAX_NUMBER_OF_CLIENTS);
+
+        resource.getOrCreateServices(uniqueClient());
+
+        assertNumberOfActiveClientsIs(2);
+        assertMaxClientsIs(DEFAULT_MAX_NUMBER_OF_CLIENTS);
+    }
+
+    @Test
+    public void maxNumberOfClientsRespondsToChanges() {
+        assertNumberOfActiveClientsIs(0);
+        assertMaxClientsIs(DEFAULT_MAX_NUMBER_OF_CLIENTS);
+
+        when(maxNumberOfClientsSupplier.get()).thenReturn(1);
+
+        assertNumberOfActiveClientsIs(0);
+        assertMaxClientsIs(1);
+
+        when(maxNumberOfClientsSupplier.get()).thenReturn(77);
+
+        assertNumberOfActiveClientsIs(0);
+        assertMaxClientsIs(77);
+    }
+
     private void createMaximumNumberOfClients() {
         for (int i = 0; i < DEFAULT_MAX_NUMBER_OF_CLIENTS; i++) {
             resource.getTimeService(uniqueClient());
@@ -113,4 +156,24 @@ public class TimeLockResourceTest {
         return UUID.randomUUID().toString();
     }
 
+    private void assertNumberOfActiveClientsIs(int expected) {
+        assertThat(getGaugeValueForTimeLockResource(TimeLockResource.ACTIVE_CLIENTS))
+                .isEqualTo(expected);
+    }
+
+    private void assertMaxClientsIs(int expected) {
+        assertThat(getGaugeValueForTimeLockResource(TimeLockResource.MAX_CLIENTS))
+                .isEqualTo(expected);
+    }
+
+    private int getGaugeValueForTimeLockResource(String gaugeName) {
+        Object value = Optional.ofNullable(metricsManager.getRegistry()
+                .getGauges()
+                .get(new StringJoiner(".").add(TimeLockResource.class.getCanonicalName())
+                        .add(gaugeName)
+                        .toString())
+                .getValue())
+                .orElseThrow(() -> new IllegalStateException("Gauge with gauge name " + gaugeName + " did not exist."));
+        return (int) value;
+    }
 }


### PR DESCRIPTION
**Goals (and why)**:
- TimeLock has a max number of clients, which used to be 100 by default. However, internal usage of Atlas has grown to the point where 100 isn't enough.
- Also, TimeLock doesn't have a good way of telling you you're about to breach the threshold until you do, and then it hard-fails.

**Implementation Description (bullets)**:
- Bump client numbers to 500
- Add metrics for the number of active clients and maximum number of clients

**Testing (What was existing testing like?  What have you done to improve it?)**:
- The number is referenced as a constant (thankfully) so it shouldn't affect existing tests.
- Metrics is a new feature. I've written a pair of tests that verify that the metrics are updated when clients are registered or the config changes respectively.

**Concerns (what feedback would you like?)**:
- Nothing in particular. Is the live reloading correct?
- The tests are a little janky
- Is 500 too high?

**Where should we start reviewing?**: TimeLockResource.java

**Priority (whenever / two weeks / yesterday)**: today. It would have been nice to have caught this before it actually became a problem.

@samrogerson for SA - @tboam and I were actually discussing this this morning!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3413)
<!-- Reviewable:end -->
