### PR TITLE
Unflake STM tests

### DIFF
--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   compile project(":timestamp-client")
   compile project(":atlasdb-client")
   compile project(":qos-service-api")
-  compile project(":flake-rule")
 
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
   compile group: 'com.palantir.common', name: 'streams'

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -39,6 +39,10 @@ dependencies {
   testCompile group: 'org.mockito', name: 'mockito-core'
   testCompile group: 'org.hamcrest', name: 'hamcrest-library'
   testCompile group: 'org.awaitility', name: 'awaitility'
+  testCompile(group: "org.jmock", name: "jmock", version: libVersions.jmock) {
+    exclude group: 'org.hamcrest'
+    exclude group: 'org.ow2.asm'
+  }
 
   testRuntime group: 'ch.qos.logback', name: 'logback-classic'
 }

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   compile project(":timestamp-client")
   compile project(":atlasdb-client")
   compile project(":qos-service-api")
-
+  compile project(":flake-rule")
 
   compile 'com.palantir.patches.sourceforge:trove3:' + libVersions.trove
   compile group: 'com.palantir.common', name: 'streams'

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -57,15 +57,15 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
         private State status = State.INITIALIZING;
         private Throwable callbackThrowable = null;
 
-        private final ScheduledExecutorService executorService = PTExecutors.newSingleThreadScheduledExecutor(
-                new NamedThreadFactory("AsyncInitializer-SerializableTransactionManager", true));
+        private final ScheduledExecutorService executorService;
 
         InitializeCheckingWrapper(TransactionManager manager,
                 Supplier<Boolean> initializationPrerequisite,
-                Callback<TransactionManager> callBack) {
+                Callback<TransactionManager> callBack, ScheduledExecutorService initializer) {
             this.txManager = manager;
             this.initializationPrerequisite = initializationPrerequisite;
             this.callback = callBack;
+            this.executorService = initializer;
             scheduleInitializationCheckAndCallback();
         }
 
@@ -149,7 +149,9 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
         private void runCallback() {
             try {
                 callback.runWithRetry(txManager);
-                checkAndSetStatus(ImmutableSet.of(State.INITIALIZING), State.READY);
+                if (checkAndSetStatus(ImmutableSet.of(State.INITIALIZING), State.READY)) {
+                    executorService.shutdown();
+                }
             } catch (Throwable e) {
                 log.error("Callback failed and was not able to perform its cleanup task. "
                         + "Closing the TransactionManager.", e);
@@ -197,7 +199,49 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
             TimestampCache timestampCache,
             MultiTableSweepQueueWriter sweepQueueWriter,
             Callback<TransactionManager> callback) {
-        TransactionManager serializableTransactionManager = new SerializableTransactionManager(
+
+        return create(metricsManager,
+                keyValueService,
+                timelockService,
+                lockService,
+                transactionService,
+                constraintModeSupplier,
+                conflictDetectionManager,
+                sweepStrategyManager,
+                cleaner,
+                initializationPrerequisite,
+                allowHiddenTableAccess,
+                lockAcquireTimeoutMs,
+                concurrentGetRangesThreadPoolSize,
+                defaultGetRangesConcurrency,
+                initializeAsync,
+                timestampCache,
+                sweepQueueWriter,
+                callback,
+                PTExecutors.newSingleThreadScheduledExecutor(
+                        new NamedThreadFactory("AsyncInitializer-SerializableTransactionManager", true)));
+    }
+
+    public static TransactionManager create(MetricsManager metricsManager,
+            KeyValueService keyValueService,
+            TimelockService timelockService,
+            LockService lockService,
+            TransactionService transactionService,
+            Supplier<AtlasDbConstraintCheckingMode> constraintModeSupplier,
+            ConflictDetectionManager conflictDetectionManager,
+            SweepStrategyManager sweepStrategyManager,
+            Cleaner cleaner,
+            Supplier<Boolean> initializationPrerequisite,
+            boolean allowHiddenTableAccess,
+            Supplier<Long> lockAcquireTimeoutMs,
+            int concurrentGetRangesThreadPoolSize,
+            int defaultGetRangesConcurrency,
+            boolean initializeAsync,
+            TimestampCache timestampCache,
+            MultiTableSweepQueueWriter sweepQueueWriter,
+            Callback<TransactionManager> callback,
+            ScheduledExecutorService initializer) {
+        TransactionManager transactionManager = new SerializableTransactionManager(
                 metricsManager,
                 keyValueService,
                 timelockService,
@@ -216,12 +260,12 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 PTExecutors.newSingleThreadExecutor(true));
 
         if (!initializeAsync) {
-            callback.runWithRetry(serializableTransactionManager);
+            callback.runWithRetry(transactionManager);
         }
 
         return initializeAsync
-                ? new InitializeCheckingWrapper(serializableTransactionManager, initializationPrerequisite, callback)
-                : serializableTransactionManager;
+                ? new InitializeCheckingWrapper(transactionManager, initializationPrerequisite, callback, initializer)
+                : transactionManager;
     }
 
     public static SerializableTransactionManager createForTest(MetricsManager metricsManager,

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -236,6 +236,7 @@ public class SerializableTransactionManagerTest {
 
         blockingCallback.stopBlocking();
         Awaitility.waitAtMost(THREE, TimeUnit.SECONDS).until(manager::isInitialized);
+        tickerThread.shutdown();
     }
 
     @Test
@@ -254,6 +255,7 @@ public class SerializableTransactionManagerTest {
         blockingCallback.stopBlocking();
         Awaitility.waitAtMost(THREE, TimeUnit.SECONDS).until(manager::isInitialized);
         assertThat(manager.getKeyValueServiceStatus()).isEqualTo(KeyValueServiceStatus.HEALTHY_ALL_OPERATIONS);
+        tickerThread.shutdown();
     }
 
     private TransactionManager getManagerWithCallback(boolean initializeAsync,

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -16,22 +16,25 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.awaitility.core.ConditionTimeoutException;
+import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,14 +45,15 @@ import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
+import com.palantir.atlasdb.transaction.api.KeyValueServiceStatus;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.exception.NotInitializedException;
 import com.palantir.lock.v2.TimelockService;
 
 public class SerializableTransactionManagerTest {
     private static final long THREE = 3L;
-    private static final long TEN = 10L;
 
     private KeyValueService mockKvs = mock(KeyValueService.class);
     private TimelockService mockTimelockService = mock(TimelockService.class);
@@ -57,87 +61,123 @@ public class SerializableTransactionManagerTest {
     private AsyncInitializer mockInitializer = mock(AsyncInitializer.class);
     private Callback<TransactionManager> mockCallback = mock(Callback.class);
 
+    private DeterministicScheduler executorService;
     private TransactionManager manager;
 
     @Before
     public void setUp() {
         nothingInitialized();
-        manager = getManagerWithCallback(true, mockCallback);
+        executorService = new DeterministicSchedulerWithShutdownFlag();
+        manager = getManagerWithCallback(true, mockCallback, executorService);
         when(mockKvs.getClusterAvailabilityStatus()).thenReturn(ClusterAvailabilityStatus.ALL_AVAILABLE);
     }
 
     @Test
+    public void transactionManagerCannotInitializeWhilePrerequisitesAreFalse() {
+        assertFalse(manager.isInitialized());
+        tickInitializingThread();
+        assertFalse(manager.isInitialized());
+        tickInitializingThread();
+        assertFalse(manager.isInitialized());
+    }
+
+    @Test
     public void uninitializedTransactionManagerThrowsNotInitializedException() {
-        assertNotInitializedWithinThreeSeconds();
-        Assertions.assertThatThrownBy(() -> manager.runTaskWithRetry($  -> null))
-                .isInstanceOf(NotInitializedException.class);
+        assertThatThrownBy(() -> manager.runTaskWithRetry(ignore -> null)).isInstanceOf(NotInitializedException.class);
     }
 
     @Test
     public void isInitializedAndCallbackHasRunWhenPrerequisitesAreInitialized() {
         everythingInitialized();
-        Awaitility.waitAtMost(TEN, TimeUnit.SECONDS).until(manager::isInitialized);
-        verify(mockCallback).runWithRetry(any(SerializableTransactionManager.class));
+        tickInitializingThread();
+        assertTrue(manager.isInitialized());
+        verify(mockCallback, times(1)).runWithRetry(any(SerializableTransactionManager.class));
     }
 
     @Test
-    public void switchBackToUninitializedWhenPrerequisitesSwitchToUninitialized() {
+    public void initializingExecutorShutsDownWhenInitialized() {
         everythingInitialized();
-        Awaitility.waitAtMost(TEN, TimeUnit.SECONDS).until(manager::isInitialized);
+        tickInitializingThread();
+        assertTrue(manager.isInitialized());
+
+        assertTrue(executorService.isShutdown());
+    }
+
+    @Test
+    public void switchBackToUninitializedImmediatelyWhenPrerequisitesBecomeFalse() {
+        everythingInitialized();
+        tickInitializingThread();
+        assertTrue(manager.isInitialized());
 
         nothingInitialized();
-        assertNotInitializedWithinThreeSeconds();
-        Assertions.assertThatThrownBy(() -> manager.runTaskWithRetry($  -> null))
-                .isInstanceOf(NotInitializedException.class);
+        assertFalse(manager.isInitialized());
+        assertThatThrownBy(() -> manager.runTaskWithRetry(ignore -> null)).isInstanceOf(NotInitializedException.class);
     }
 
     @Test
     public void callbackRunsOnlyOnceAsInitializationStatusChanges() {
         everythingInitialized();
-        Awaitility.waitAtMost(TEN, TimeUnit.SECONDS).until(manager::isInitialized);
+        tickInitializingThread();
+        assertTrue(manager.isInitialized());
 
         nothingInitialized();
-        assertNotInitializedWithinThreeSeconds();
+        assertFalse(manager.isInitialized());
 
         everythingInitialized();
         assertTrue(manager.isInitialized());
-        verify(mockCallback).runWithRetry(any(SerializableTransactionManager.class));
+
+        verify(mockCallback, times(1)).runWithRetry(any(SerializableTransactionManager.class));
     }
 
     @Test
-    public void closingPreventsInitializationAndCallback() {
+    public void closeShutsDownInitializingExecutorAndClosesTransactionManager() {
+        manager.close();
+
+        assertTrue(executorService.isShutdown());
+        assertThatThrownBy(() -> manager.runTaskWithRetry(ignore -> null)).isInstanceOf(IllegalStateException.class);
+        assertTrue(((SerializableTransactionManager.InitializeCheckingWrapper) manager).isClosedByClose());
+    }
+
+    @Test
+    public void closePreventsInitializationAndCallbacksEvenIfExecutorStillTicks() {
         manager.close();
         everythingInitialized();
-        assertNotInitializedWithinThreeSecondsBecauseClosed();
+        tickInitializingThread();
+
         verify(mockCallback, never()).runWithRetry(any(SerializableTransactionManager.class));
+        assertThatThrownBy(() -> manager.runTaskWithRetry(ignore -> null)).isInstanceOf(IllegalStateException.class);
         assertTrue(((SerializableTransactionManager.InitializeCheckingWrapper) manager).isClosedByClose());
     }
 
     @Test
     public void isNotInitializedWhenKvsIsNotInitialized() {
         setInitializationStatus(false, true, true, true);
-        assertNotInitializedWithinThreeSeconds();
+        tickInitializingThread();
+        assertFalse(manager.isInitialized());
         verify(mockCallback, never()).runWithRetry(any(SerializableTransactionManager.class));
     }
 
     @Test
     public void isNotInitializedWhenTimelockIsNotInitialized() {
         setInitializationStatus(true, false, true, true);
-        assertNotInitializedWithinThreeSeconds();
+        tickInitializingThread();
+        assertFalse(manager.isInitialized());
         verify(mockCallback, never()).runWithRetry(any(SerializableTransactionManager.class));
     }
 
     @Test
     public void isNotInitializedWhenCleanerIsNotInitialized() {
         setInitializationStatus(true, true, false, true);
-        assertNotInitializedWithinThreeSeconds();
+        tickInitializingThread();
+        assertFalse(manager.isInitialized());
         verify(mockCallback, never()).runWithRetry(any(SerializableTransactionManager.class));
     }
 
     @Test
     public void isNotInitializedWhenInitializerIsNotInitialized() {
         setInitializationStatus(true, true, true, false);
-        assertNotInitializedWithinThreeSeconds();
+        tickInitializingThread();
+        assertFalse(manager.isInitialized());
         verify(mockCallback, never()).runWithRetry(any(SerializableTransactionManager.class));
     }
 
@@ -146,10 +186,10 @@ public class SerializableTransactionManagerTest {
         RuntimeException cause = new RuntimeException("VALID REASON");
         doThrow(cause).when(mockCallback).runWithRetry(any(SerializableTransactionManager.class));
         everythingInitialized();
+        tickInitializingThread();
 
-        assertNotInitializedWithinThreeSecondsBecauseClosed();
         assertTrue(((SerializableTransactionManager.InitializeCheckingWrapper) manager).isClosedByCallbackFailure());
-        Assertions.assertThatThrownBy(() -> manager.runTaskWithRetry($  -> null))
+        assertThatThrownBy(() -> manager.runTaskWithRetry($  -> null))
                 .isInstanceOf(IllegalStateException.class)
                 .hasCause(cause);
     }
@@ -162,7 +202,7 @@ public class SerializableTransactionManagerTest {
     // BLAB: Synchronously initialised objects don't care if their constituent parts are initialised asynchronously.
     @Test
     public void synchronouslyInitializedManagerIsInitializedEvenIfNothingElseIs() {
-        manager = getManagerWithCallback(false, mockCallback);
+        manager = getManagerWithCallback(false, mockCallback, executorService);
         assertTrue(manager.isInitialized());
         verify(mockCallback).runWithRetry(manager);
     }
@@ -170,46 +210,54 @@ public class SerializableTransactionManagerTest {
     @Test
     public void callbackRunsAfterPreconditionsAreMet() {
         ClusterAvailabilityStatusBlockingCallback blockingCallback = new ClusterAvailabilityStatusBlockingCallback();
-        manager = getManagerWithCallback(true, blockingCallback);
+        blockingCallback.stopBlocking();
+        manager = getManagerWithCallback(true, blockingCallback, executorService);
 
-        assertNotInitializedWithinThreeSeconds();
+        tickInitializingThread();
+        assertFalse(manager.isInitialized());
         assertFalse(blockingCallback.wasInvoked());
 
         everythingInitialized();
-        Awaitility.waitAtMost(TEN, TimeUnit.SECONDS).until(blockingCallback::wasInvoked);
+        tickInitializingThread();
+        assertTrue(blockingCallback.wasInvoked());
     }
 
     @Test
     public void callbackBlocksInitializationUntilDone() {
         everythingInitialized();
         ClusterAvailabilityStatusBlockingCallback blockingCallback = new ClusterAvailabilityStatusBlockingCallback();
-        manager = getManagerWithCallback(true, blockingCallback);
+        manager = getManagerWithCallback(true, blockingCallback, executorService);
 
-        Awaitility.waitAtMost(TEN, TimeUnit.SECONDS).until(blockingCallback::wasInvoked);
+        ExecutorService tickerThread = PTExecutors.newSingleThreadExecutor(true);
+        tickerThread.submit(() -> executorService.tick(1000, TimeUnit.MILLISECONDS));
+
+        Awaitility.waitAtMost(THREE, TimeUnit.SECONDS).until(blockingCallback::wasInvoked);
         assertFalse(manager.isInitialized());
 
         blockingCallback.stopBlocking();
-        Awaitility.waitAtMost(TEN, TimeUnit.SECONDS).until(manager::isInitialized);
+        Awaitility.waitAtMost(THREE, TimeUnit.SECONDS).until(manager::isInitialized);
     }
 
     @Test
     public void callbackCanCallTmMethodsEvenThoughTmStillThrows() {
         everythingInitialized();
         ClusterAvailabilityStatusBlockingCallback blockingCallback = new ClusterAvailabilityStatusBlockingCallback();
-        manager = getManagerWithCallback(true, blockingCallback);
+        manager = getManagerWithCallback(true, blockingCallback, executorService);
 
-        Awaitility.waitAtMost(TEN, TimeUnit.SECONDS).until(blockingCallback::wasInvoked);
+        ExecutorService tickerThread = PTExecutors.newSingleThreadExecutor(true);
+        tickerThread.submit(() -> executorService.tick(1000, TimeUnit.MILLISECONDS));
+
+        Awaitility.waitAtMost(THREE, TimeUnit.SECONDS).until(blockingCallback::wasInvoked);
         verify(mockKvs, atLeast(1)).getClusterAvailabilityStatus();
-        Assertions.assertThatThrownBy(() -> manager.getKeyValueServiceStatus())
-                .isInstanceOf(NotInitializedException.class);
+        assertThatThrownBy(manager::getKeyValueServiceStatus).isInstanceOf(NotInitializedException.class);
 
         blockingCallback.stopBlocking();
-        Awaitility.waitAtMost(TEN, TimeUnit.SECONDS).until(manager::isInitialized);
-        manager.getKeyValueServiceStatus();
+        Awaitility.waitAtMost(THREE, TimeUnit.SECONDS).until(manager::isInitialized);
+        assertThat(manager.getKeyValueServiceStatus()).isEqualTo(KeyValueServiceStatus.HEALTHY_ALL_OPERATIONS);
     }
 
     private TransactionManager getManagerWithCallback(boolean initializeAsync,
-            Callback<TransactionManager> callBack) {
+            Callback<TransactionManager> callBack, ScheduledExecutorService executor) {
         return SerializableTransactionManager.create(
                 MetricsManagers.createForTests(),
                 mockKvs,
@@ -228,7 +276,8 @@ public class SerializableTransactionManagerTest {
                 initializeAsync,
                 TimestampCache.createForTests(),
                 MultiTableSweepQueueWriter.NO_OP,
-                callBack);
+                callBack,
+                executor);
     }
 
     private void nothingInitialized() {
@@ -246,24 +295,16 @@ public class SerializableTransactionManagerTest {
         when(mockInitializer.isInitialized()).thenReturn(initializer);
     }
 
-    private void assertNotInitializedWithinThreeSeconds() {
-        Assertions.assertThatThrownBy(() ->
-                Awaitility.waitAtMost(THREE, TimeUnit.SECONDS).until(manager::isInitialized))
-                .isInstanceOf(ConditionTimeoutException.class);
-    }
-
-    private void assertNotInitializedWithinThreeSecondsBecauseClosed() {
-        Assertions.assertThatThrownBy(() ->
-                Awaitility.waitAtMost(THREE, TimeUnit.SECONDS).until(manager::isInitialized))
-                .isInstanceOf(IllegalStateException.class);
+    private void tickInitializingThread() {
+        executorService.tick(1000, TimeUnit.MILLISECONDS);
     }
 
     private static class ClusterAvailabilityStatusBlockingCallback extends Callback<TransactionManager> {
-        private volatile boolean invoked = false;
+        private volatile boolean successfullyInvoked = false;
         private volatile boolean block = true;
 
         boolean wasInvoked() {
-            return invoked;
+            return successfullyInvoked;
         }
 
         void stopBlocking() {
@@ -272,8 +313,8 @@ public class SerializableTransactionManagerTest {
 
         @Override
         public void init(TransactionManager transactionManager) {
-            invoked = true;
-            transactionManager.getKeyValueServiceStatus();
+            successfullyInvoked =
+                    transactionManager.getKeyValueServiceStatus() == KeyValueServiceStatus.HEALTHY_ALL_OPERATIONS;
             if (block) {
                 throw new RuntimeException();
             }
@@ -281,11 +322,21 @@ public class SerializableTransactionManagerTest {
 
         @Override
         public void cleanup(TransactionManager transactionManager, Throwable initException) {
-            try {
-                Thread.sleep(500L);
-            } catch (InterruptedException e) {
-                fail();
-            }
+            // suppress
+        }
+    }
+
+    private static class DeterministicSchedulerWithShutdownFlag extends DeterministicScheduler {
+        private boolean hasShutdown = false;
+
+        @Override
+        public boolean isShutdown() {
+            return hasShutdown;
+        }
+
+        @Override
+        public void shutdown() {
+            hasShutdown = true;
         }
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -33,6 +33,7 @@ import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.palantir.async.initializer.AsyncInitializer;
@@ -45,8 +46,11 @@ import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.exception.NotInitializedException;
+import com.palantir.flake.FlakeRetryingRule;
+import com.palantir.flake.ShouldRetry;
 import com.palantir.lock.v2.TimelockService;
 
+@ShouldRetry(numAttempts = 2)
 public class SerializableTransactionManagerTest {
     private static final long THREE = 3L;
 
@@ -57,6 +61,9 @@ public class SerializableTransactionManagerTest {
     private Callback<TransactionManager> mockCallback = mock(Callback.class);
 
     private TransactionManager manager;
+
+    @Rule
+    public final FlakeRetryingRule flakeRetryingRule = new FlakeRetryingRule();
 
     @Before
     public void setUp() {


### PR DESCRIPTION
**Goals (and why)**:
These tests kept flaking so rewrote them using a DeterministicScheduler. Still have a few waits in there, but this should fix the flakes.

**Implementation Description (bullets)**:
Inject the ScheduledExecutorService  to use for the initialization task. Also shutdown the executor when we succeed, which we weren't doing.

**Concerns (what feedback would you like?)**:
Did I miss something?

**Priority (whenever / two weeks / yesterday)**:
Let's get this in asap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3417)
<!-- Reviewable:end -->
