### PR TITLE
Bump jfrog buildinfo extractor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3'
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.12'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.7.5'
         classpath 'gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.13.0'
         classpath 'com.palantir.baseline:gradle-baseline-java:0.18.0'
         classpath 'com.palantir.sls-packaging:gradle-sls-packaging:2.11.0'


### PR DESCRIPTION
**Goals (and why)**: fix gradle bump compatibility issue

**Priority (whenever / two weeks / yesterday)**: asap

**Concerns**: From the release notes, `4.7.3` declares support for gradle `4.8` but we bumped to `4.9`. The other releases have some other fixes. Hopefully this will fix the publishing issue, otherwise we could downgrade gradlew to `4.8`. 

Based on latest version at the time of opening: https://bintray.com/jfrog/jfrog-jars/build-info-extractor-gradle

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3421)
<!-- Reviewable:end -->
