### PR TITLE
Fix async puncher to not roll over and die on exceptions

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/AsyncPuncher.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Supplier;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.logsafe.SafeArg;
 
 /**
  * Wrap another Puncher, optimizing the #punch() operation to operate just on a local variable; the
@@ -56,12 +57,20 @@ public final class AsyncPuncher implements Puncher {
     }
 
     private void start() {
-        service.scheduleAtFixedRate(() -> {
-            long timestamp = lastTimestamp.getAndSet(INVALID_TIMESTAMP);
-            if (timestamp != INVALID_TIMESTAMP) {
+        service.scheduleAtFixedRate(this::punchWithRollback, 0, interval, TimeUnit.MILLISECONDS);
+    }
+
+    private void punchWithRollback() {
+        long timestamp = lastTimestamp.getAndSet(INVALID_TIMESTAMP);
+        if (timestamp != INVALID_TIMESTAMP) {
+            try {
                 delegate.punch(timestamp);
+            } catch (Throwable th) {
+                log.warn("Attempt to punch timestamp {} failed. Retrying in {} milliseconds.",
+                        SafeArg.of("timestamp", timestamp), SafeArg.of("interval", interval), th);
+                lastTimestamp.compareAndSet(INVALID_TIMESTAMP, timestamp);
             }
-        }, 0, interval, TimeUnit.MILLISECONDS);
+        }
     }
 
     @Override

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -66,6 +66,11 @@ v0.99.0
     *    - Type
          - Change
 
+    *    - |fixed|
+         - Fixed an issue where a failure to punch a value into the _punch table would suppress any future attempts to punch.
+           Previously, if the asynchronous job that punches a timestamp every minute ever threw an exception, the unreadable timestamp would be stuck until the service is restarted.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3427>`__)
+
     *    - |improved|
          - TimeLock by default now has a client limit of 500.
            Previously, this used to be 100 - however we have run into issues internally where stacks legitimately reach this threshold.


### PR DESCRIPTION
**Goals (and why)**:
We should not stop punching when we fail for any reason. This is probably the cause of the cases noticed recently where the unreadable timestamp gets stuck.

**Implementation Description (bullets)**:
Just catch, log, and retry later.

**Concerns (what feedback would you like?)**:
Anything?

**Priority (whenever / two weeks / yesterday)**:
ASAP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3427)
<!-- Reviewable:end -->
