### PR TITLE
Get currentTimeMillis for targeted sweep metrics from timelock

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
@@ -38,6 +38,7 @@ import com.palantir.atlasdb.util.CurrentValueMetric;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.time.Clock;
 import com.palantir.common.time.SystemClock;
+import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.util.AggregatingVersionedSupplier;
 import com.palantir.util.CachedComposedSupplier;
@@ -58,8 +59,9 @@ public final class TargetedSweepMetrics {
         outcomeMetrics = SweepOutcomeMetrics.registerTargeted(metricsManager);
     }
 
-    public static TargetedSweepMetrics create(MetricsManager metricsManager, KeyValueService kvs, long millis) {
-        return createWithClock(metricsManager, kvs, new SystemClock(), millis);
+    public static TargetedSweepMetrics create(MetricsManager metricsManager, TimelockService timelock,
+            KeyValueService kvs, long millis) {
+        return createWithClock(metricsManager, kvs, timelock::currentTimeMillis, millis);
     }
 
     public static TargetedSweepMetrics createWithClock(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
@@ -37,7 +37,6 @@ import com.palantir.atlasdb.util.AccumulatingValueMetric;
 import com.palantir.atlasdb.util.CurrentValueMetric;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.time.Clock;
-import com.palantir.common.time.SystemClock;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.util.AggregatingVersionedSupplier;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -121,7 +121,7 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter {
         Preconditions.checkState(kvs.isInitialized(),
                 "Attempted to initialize targeted sweeper with an uninitialized backing KVS.");
         Schemas.createTablesAndIndexes(TargetedSweepSchema.INSTANCE.getLatestSchema(), kvs);
-        metrics = TargetedSweepMetrics.create(metricsManager, kvs, SweepQueueUtils.REFRESH_INTERVAL);
+        metrics = TargetedSweepMetrics.create(metricsManager, timelockService, kvs, SweepQueueUtils.REFRESH_INTERVAL);
         queue = SweepQueue.create(metrics, kvs, shardsConfig, follower);
         timestampsSupplier = timestamps;
         timeLock = timelockService;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepMetricsAssert.java
@@ -22,7 +22,6 @@ import javax.annotation.CheckReturnValue;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.WritableAssertionInfo;
-import org.assertj.core.internal.Comparables;
 import org.assertj.core.internal.Objects;
 
 import com.codahale.metrics.Gauge;
@@ -36,7 +35,6 @@ import com.palantir.tritium.metrics.registry.MetricName;
 public final class SweepMetricsAssert extends AbstractAssert<SweepMetricsAssert, MetricsManager> {
     private final MetricsManager metrics;
     private final Objects objects = Objects.instance();
-    private final Comparables comparables = Comparables.instance();
     private final WritableAssertionInfo info = new WritableAssertionInfo();
 
     public SweepMetricsAssert(MetricsManager actual) {
@@ -75,11 +73,6 @@ public final class SweepMetricsAssert extends AbstractAssert<SweepMetricsAssert,
 
     public void hasMillisSinceLastSweptConservativeEqualTo(Long value) {
         objects.assertEqual(info, getGaugeConservative(AtlasDbMetricNames.LAG_MILLIS).getValue(), value);
-    }
-
-    public void hasMillisSinceLastSweptConservativeWithinOneSecondOf(long expected) {
-        comparables.assertIsBetween(info, getGaugeConservative(AtlasDbMetricNames.LAG_MILLIS).getValue(),
-                expected - 1000L, expected + 1000, true, false);
     }
 
     public void hasEnqueuedWritesThoroughEqualTo(long value) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetricsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetricsTest.java
@@ -16,6 +16,8 @@
 
 package com.palantir.atlasdb.sweep.metrics;
 
+import static org.mockito.Mockito.mock;
+
 import static com.palantir.atlasdb.sweep.metrics.SweepMetricsAssert.assertThat;
 
 import java.util.Arrays;
@@ -27,6 +29,7 @@ import org.junit.Test;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.lock.v2.TimelockService;
 
 public class SweepOutcomeMetricsTest {
     private MetricsManager metricsManager;
@@ -39,7 +42,7 @@ public class SweepOutcomeMetricsTest {
         metricsManager = MetricsManagers.createForTests();
         legacyMetrics = SweepOutcomeMetrics.registerLegacy(metricsManager);
         targetedSweepMetrics = TargetedSweepMetrics
-                .create(metricsManager, new InMemoryKeyValueService(true), Long.MAX_VALUE);
+                .create(metricsManager, mock(TimelockService.class), new InMemoryKeyValueService(true), Long.MAX_VALUE);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import static com.palantir.atlasdb.sweep.queue.ShardAndStrategy.conservative;
@@ -51,6 +52,7 @@ import com.palantir.atlasdb.schema.generated.SweepableCellsTable;
 import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
 import com.palantir.atlasdb.sweep.metrics.SweepMetricsAssert;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
+import com.palantir.lock.v2.TimelockService;
 
 public class SweepableCellsTest extends AbstractSweepQueueTest {
     private static final long SMALL_SWEEP_TS = TS + 200L;
@@ -64,7 +66,7 @@ public class SweepableCellsTest extends AbstractSweepQueueTest {
     @Before
     public void setup() {
         super.setup();
-        metrics = TargetedSweepMetrics.create(metricsManager, spiedKvs, 1);
+        metrics = TargetedSweepMetrics.create(metricsManager, mock(TimelockService.class), spiedKvs, 1);
         sweepableCells = new SweepableCells(spiedKvs, partitioner, metrics);
 
         shardCons = writeToDefaultCellCommitted(sweepableCells, TS, TABLE_CONS);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -87,6 +87,7 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
     private SweepableTimestamps sweepableTimestamps;
     private SweepableCells sweepableCells;
     private TargetedSweepFollower mockFollower;
+    private TimelockService timelockService;
     private PuncherStore puncherStore;
     private boolean enabled = true;
 
@@ -95,7 +96,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         super.setup();
         sweepQueue = TargetedSweeper.createUninitializedForTest(metricsManager, () -> enabled, () -> DEFAULT_SHARDS);
         mockFollower = mock(TargetedSweepFollower.class);
-        sweepQueue.initialize(timestampsSupplier, mock(TimelockService.class), spiedKvs, mockFollower);
+        timelockService = mock(TimelockService.class);
+        sweepQueue.initialize(timestampsSupplier, timelockService, spiedKvs, mockFollower);
 
         progress = new ShardProgress(spiedKvs);
         sweepableTimestamps = new SweepableTimestamps(spiedKvs, partitioner);
@@ -169,8 +171,9 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(
                 maxTsForFinePartition(0));
 
-        punchCurrentTimeMinusMillisAtTimestamp(2000, LOW_TS);
-        assertThat(metricsManager).hasMillisSinceLastSweptConservativeWithinOneSecondOf(2000L);
+        setTimelockTime(5_000L);
+        punchTimeAtTimestamp(2_000, LOW_TS);
+        assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(3000L);
         assertThat(metricsManager).hasTargetedOutcomeEqualTo(SweepOutcome.SUCCESS, 1L);
     }
 
@@ -348,8 +351,9 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(
                 maxTsForFinePartition(0));
 
-        punchCurrentTimeMinusMillisAtTimestamp(5000L, LOW_TS + 8);
-        assertThat(metricsManager).hasMillisSinceLastSweptConservativeWithinOneSecondOf(5000L);
+        setTimelockTime(10_000L);
+        punchTimeAtTimestamp(5_000L, LOW_TS + 8);
+        assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(5000L);
     }
 
     @Test
@@ -381,8 +385,9 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
         assertThat(metricsManager).hasEntriesReadConservativeEqualTo(4);
         assertThat(metricsManager).hasLastSweptTimestampConservativeEqualTo(maxTsForFinePartition(3));
 
-        punchCurrentTimeMinusMillisAtTimestamp(0L, tsFineFour + 1L);
-        assertThat(metricsManager).hasMillisSinceLastSweptConservativeWithinOneSecondOf(0L);
+        setTimelockTime(0L);
+        punchTimeAtTimestamp(0L, tsFineFour + 1L);
+        assertThat(metricsManager).hasMillisSinceLastSweptConservativeEqualTo(0L);
     }
 
     @Test
@@ -1040,8 +1045,12 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
                 .isEmpty();
     }
 
-    private void punchCurrentTimeMinusMillisAtTimestamp(long minusMillis, long timestamp) {
-        puncherStore.put(timestamp, System.currentTimeMillis() - minusMillis);
+    private void setTimelockTime(long timeMillis) {
+        when(timelockService.currentTimeMillis()).thenReturn(timeMillis);
+    }
+
+    private void punchTimeAtTimestamp(long timeMillis, long timestamp) {
+        puncherStore.put(timestamp, timeMillis);
     }
 
     private void commitTransactionsWithWritesIntoUniqueCells(int transactions, int writes, TargetedSweeper sweeper) {


### PR DESCRIPTION
**Goals (and why)**:
This should prevent metrics being off due to clock drift between the client and the timelock service

**Testing (What was existing testing like?  What have you done to improve it?)**:
Small, but can add tests if necessary

**Concerns (what feedback would you like?)**:
Sanity check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3428)
<!-- Reviewable:end -->
