### PR TITLE
Increase sweep sleep if nothing to sweep

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java
@@ -219,7 +219,7 @@ public class BackgroundSweepThread implements Runnable {
     }
 
     private long getBackoffTimeWhenNothingToSweep() {
-        return 5 * getBackoffTimeWhenSweepHasNotRun(); // 10 minutes by default
+        return TimeUnit.MINUTES.toMillis(10);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.sweep;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -103,7 +104,7 @@ public class BackgroundSweepThread implements Runnable {
         try (SingleLockService locks = createSweepLocks()) {
             // Wait a while before starting so short lived clis don't try to sweep.
             waitUntilSpecificTableSweeperIsInitialized();
-            sleepForMillis(getBackoffTimeWhenSweepHasNotRun());
+            sleepFor(getBackoffTimeWhenSweepHasNotRun());
             log.info("Starting background sweeper with thread index {}", SafeArg.of("threadIndex", threadIndex));
             while (true) {
                 // InterruptedException might be wrapped in RuntimeException (i.e. AtlasDbDependencyException),
@@ -142,7 +143,7 @@ public class BackgroundSweepThread implements Runnable {
             log.info("Sweep Priority Table and Sweep Progress Table are not initialized yet. If you have enabled "
                     + "asynchronous initialization, these tables are being initialized asynchronously. Background "
                     + "sweeper will start once the initialization is complete.");
-            sleepForMillis(getBackoffTimeWhenSweepHasNotRun());
+            sleepFor(getBackoffTimeWhenSweepHasNotRun());
         }
     }
 
@@ -176,13 +177,13 @@ public class BackgroundSweepThread implements Runnable {
     }
 
     private void sleepUntilNextRun(SweepOutcome outcome) throws InterruptedException {
-        long sleepDurationMillis = getBackoffTimeWhenSweepHasNotRun();
+        Duration sleepDuration = getBackoffTimeWhenSweepHasNotRun();
         if (outcome == SweepOutcome.SUCCESS) {
-            sleepDurationMillis = sweepPauseMillis.get();
+            sleepDuration = Duration.ofMillis(sweepPauseMillis.get());
         } else if (outcome == SweepOutcome.NOTHING_TO_SWEEP) {
-            sleepDurationMillis = getBackoffTimeWhenNothingToSweep();
+            sleepDuration = getBackoffTimeWhenNothingToSweep();
         }
-        sleepForMillis(sleepDurationMillis);
+        sleepFor(sleepDuration);
     }
 
     @VisibleForTesting
@@ -214,12 +215,12 @@ public class BackgroundSweepThread implements Runnable {
         }
     }
 
-    private long getBackoffTimeWhenSweepHasNotRun() {
-        return 20 * (1000 + sweepPauseMillis.get()); // 2 minutes by default
+    private Duration getBackoffTimeWhenSweepHasNotRun() {
+        return Duration.ofMillis(sweepPauseMillis.get()).plusSeconds(1).multipliedBy(20); // 2 minutes by default
     }
 
-    private long getBackoffTimeWhenNothingToSweep() {
-        return TimeUnit.MINUTES.toMillis(10);
+    private Duration getBackoffTimeWhenNothingToSweep() {
+        return Duration.ofMinutes(10);
     }
 
     @VisibleForTesting
@@ -346,8 +347,8 @@ public class BackgroundSweepThread implements Runnable {
         specificTableSweeper.getSweepProgressStore().clearProgress(tableRef);
     }
 
-    private void sleepForMillis(long millis) throws InterruptedException {
-        if (shuttingDown.await(millis, TimeUnit.MILLISECONDS)) {
+    private void sleepFor(Duration duration) throws InterruptedException {
+        if (shuttingDown.await(duration.toNanos(), TimeUnit.NANOSECONDS)) {
             throw new InterruptedException();
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java
@@ -179,6 +179,8 @@ public class BackgroundSweepThread implements Runnable {
         long sleepDurationMillis = getBackoffTimeWhenSweepHasNotRun();
         if (outcome == SweepOutcome.SUCCESS) {
             sleepDurationMillis = sweepPauseMillis.get();
+        } else if (outcome == SweepOutcome.NOTHING_TO_SWEEP) {
+            sleepDurationMillis = getBackoffTimeWhenNothingToSweep();
         }
         sleepForMillis(sleepDurationMillis);
     }
@@ -213,7 +215,11 @@ public class BackgroundSweepThread implements Runnable {
     }
 
     private long getBackoffTimeWhenSweepHasNotRun() {
-        return 20 * (1000 + sweepPauseMillis.get());
+        return 20 * (1000 + sweepPauseMillis.get()); // 2 minutes by default
+    }
+
+    private long getBackoffTimeWhenNothingToSweep() {
+        return 5 * getBackoffTimeWhenSweepHasNotRun(); // 10 minutes by default
     }
 
     @VisibleForTesting

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,7 +57,7 @@ develop
          - Sequential sweep now sleeps longer between iterations if there was nothing to sweep.
            Previously we would sleep for 2 minutes between runs, but it is unlikely that anything has changed dramatically in 2 minutes so we sleep for longer to prevent scanning the sweep priority table too often.  Going forward the most likely explanation for there being nothing to sweep is that we have switched to targeted sweep.
            We don't stop completely or sleep for too long just in case configuration changes and a table is eligible to sweep again.
-           (`Pull Request <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3429>`__)
 
 =======
 v0.99.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -53,6 +53,12 @@ develop
     *    -
          -
 
+    *    - |improved|
+         - Sequential sweep now sleeps longer between iterations if there was nothing to sweep.
+           Previously we would sleep for 2 minutes between runs, but it is unlikely that anything has changed dramatically in 2 minutes so we sleep for longer to prevent scanning the sweep priority table too often.  Going forward the most likely explanation for there being nothing to sweep is that we have switched to targeted sweep.
+           We don't stop completely or sleep for too long just in case configuration changes and a table is eligible to sweep again.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/XXXX>`__)
+
 =======
 v0.99.0
 =======


### PR DESCRIPTION
**Goals (and why)**: Reduce calls to sweep priority and other legacy sweep activity if there's nothing to do.  With the move to targeted sweep products will reach a point where there's nothing left for sweep to do.

**Implementation Description (bullets)**: When we get the status NOTHING_TO_SWEEP we wait longer between iterations.

**Testing (What was existing testing like?  What have you done to improve it?)**: No tests for this, but is a small change.

**Concerns (what feedback would you like?)**: Is 10 minutes the right amount of time.  I wanted to balance not looping too often with not having to wait too long if something changes (e.g. someone unblacklists a table).

**Where should we start reviewing?**: atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/BackgroundSweepThread.java

**Priority (whenever / two weeks / yesterday)**: Whenever

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3429)
<!-- Reviewable:end -->
