### PR TITLE
Expose Timelock client numbers so they can be used by health checks

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -63,6 +63,12 @@ develop
            We don't stop completely or sleep for too long just in case configuration changes and a table is eligible to sweep again.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3429>`__)
 
+    *    - |improved|
+         - TimeLockAgent now exposes the number of active clients and the configured maximum
+           This makes it easier for a service to expose these via a health check
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3431>`__)
+
+
 =======
 v0.99.0
 =======

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -131,11 +131,21 @@ public class TimeLockAgent {
 
     @SuppressWarnings("unused") // used by external health checks
     public TimeLockStatus getStatus() {
-        if (resource.numberOfClients() == 0) {
+        if (getNumberOfActiveClients() == 0) {
             return TimeLockStatus.PENDING_ELECTION;
         }
 
         return healthCheckSupplier.get().getStatus();
+    }
+
+    @SuppressWarnings("unused") // used by external health checks
+    public int getNumberOfActiveClients() {
+        return resource.getNumberOfActiveClients();
+    }
+
+    @SuppressWarnings("unused") // used by external health checks
+    public int getMaxNumberOfClients() {
+        return resource.getMaxNumberOfClients();
     }
 
     @SuppressWarnings("unused")

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -89,8 +89,12 @@ public class TimeLockResource {
         return servicesByNamespace.computeIfAbsent(namespace, this::createNewClient);
     }
 
-    public int numberOfClients() {
+    public int getNumberOfActiveClients() {
         return servicesByNamespace.size();
+    }
+
+    public int getMaxNumberOfClients() {
+        return maxNumberOfClients.get();
     }
 
     private TimeLockServices createNewClient(String namespace) {
@@ -99,7 +103,7 @@ public class TimeLockResource {
                         + "used.",
                 PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE);
 
-        if (numberOfClients() >= maxNumberOfClients.get()) {
+        if (getNumberOfActiveClients() >= maxNumberOfClients.get()) {
             log.error(
                     "Unable to create timelock services for client {}, as it would exceed the maximum number of "
                             + "allowed clients ({}). If this is intentional, the maximum number of clients can be "
@@ -113,7 +117,7 @@ public class TimeLockResource {
     }
 
     private static void registerClientCapacityMetrics(TimeLockResource resource, MetricsManager metricsManager) {
-        metricsManager.registerMetric(TimeLockResource.class, ACTIVE_CLIENTS, resource::numberOfClients);
+        metricsManager.registerMetric(TimeLockResource.class, ACTIVE_CLIENTS, resource::getNumberOfActiveClients);
         metricsManager.registerMetric(TimeLockResource.class, MAX_CLIENTS, resource.maxNumberOfClients::get);
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java
@@ -103,13 +103,13 @@ public class TimeLockResource {
                         + "used.",
                 PaxosTimeLockConstants.LEADER_ELECTION_NAMESPACE);
 
-        if (getNumberOfActiveClients() >= maxNumberOfClients.get()) {
+        if (getNumberOfActiveClients() >= getMaxNumberOfClients()) {
             log.error(
                     "Unable to create timelock services for client {}, as it would exceed the maximum number of "
                             + "allowed clients ({}). If this is intentional, the maximum number of clients can be "
                             + "increased via the maximum-number-of-clients runtime config property.",
                     SafeArg.of("client", namespace),
-                    SafeArg.of("maxNumberOfClients", maxNumberOfClients));
+                    SafeArg.of("maxNumberOfClients", getMaxNumberOfClients()));
             throw new IllegalStateException("Maximum number of clients exceeded");
         }
 
@@ -118,6 +118,6 @@ public class TimeLockResource {
 
     private static void registerClientCapacityMetrics(TimeLockResource resource, MetricsManager metricsManager) {
         metricsManager.registerMetric(TimeLockResource.class, ACTIVE_CLIENTS, resource::getNumberOfActiveClients);
-        metricsManager.registerMetric(TimeLockResource.class, MAX_CLIENTS, resource.maxNumberOfClients::get);
+        metricsManager.registerMetric(TimeLockResource.class, MAX_CLIENTS, resource::getMaxNumberOfClients);
     }
 }

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimeLockResourceTest.java
@@ -94,14 +94,14 @@ public class TimeLockResourceTest {
     @Test
     public void returnsMaxNumberOfClients() {
         createMaximumNumberOfClients();
-        assertThat(resource.numberOfClients()).isEqualTo(DEFAULT_MAX_NUMBER_OF_CLIENTS);
+        assertThat(resource.getNumberOfActiveClients()).isEqualTo(DEFAULT_MAX_NUMBER_OF_CLIENTS);
     }
 
     @Test
     public void onClientCreationIncreaseNumberOfClients() {
-        assertThat(resource.numberOfClients()).isEqualTo(0);
+        assertThat(resource.getNumberOfActiveClients()).isEqualTo(0);
         resource.getTimeService(uniqueClient());
-        assertThat(resource.numberOfClients()).isEqualTo(1);
+        assertThat(resource.getNumberOfActiveClients()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**: We want to create a health check for when the number of clients gets close to the configured maximum.  Exposing the values on the TimeLockAgent makes this easier.

**Implementation Description (bullets)**: Add getters, these are currently unused but will be used internally.

**Testing (What was existing testing like?  What have you done to improve it?)**: Adding getters so don't see value in testing.

**Concerns (what feedback would you like?)**: None

**Where should we start reviewing?**: timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimeLockResource.java

**Priority (whenever / two weeks / yesterday)**: Not urgent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3431)
<!-- Reviewable:end -->
