### PR TITLE
Remove unused sleepForBackoff()

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractConditionAwareTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractConditionAwareTransactionManager.java
@@ -83,7 +83,6 @@ public abstract class AbstractConditionAwareTransactionManager extends AbstractT
                 log.warn("[{}] RuntimeException while processing transaction.", SafeArg.of("runId", runId), e);
                 throw e;
             }
-            sleepForBackoff(failureCount);
         }
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionManager.java
@@ -51,10 +51,6 @@ public abstract class AbstractTransactionManager implements TransactionManager {
         this.timestampValidationReadCache = timestampCache;
     }
 
-    protected static void sleepForBackoff(@SuppressWarnings("unused") int numTimesFailed) {
-        // no-op
-    }
-
     protected boolean shouldStopRetrying(@SuppressWarnings("unused") int numTimesFailed) {
         return false;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockConditionSuppliers.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AdvisoryLockConditionSuppliers.java
@@ -83,7 +83,6 @@ public final class AdvisoryLockConditionSuppliers {
                     log.warn("Failing after {} tries", failureCount, ex);
                     throw ex;
                 }
-                AbstractTransactionManager.sleepForBackoff(failureCount);
             } else {
                 return response;
             }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -57,6 +57,12 @@ develop
            We now perform the operations correctly only considering the value (or absence of value) in the relevant cell.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3388>`__)
 
+    *    - |improved| |devbreak|
+         - We have removed the ``sleepForBackoff(int)`` method from ``AbstractTransactionManager`` as there were no known users and its presence led to user confusion.
+           AtlasDB does not actually backoff between attempts of running a user's transaction task.
+           If your service overrides this method, please contact the AtlasDB team.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/ABCD>`__)
+
     *    - |improved|
          - Sequential sweep now sleeps longer between iterations if there was nothing to sweep.
            Previously we would sleep for 2 minutes between runs, but it is unlikely that anything has changed dramatically in 2 minutes so we sleep for longer to prevent scanning the sweep priority table too often.  Going forward the most likely explanation for there being nothing to sweep is that we have switched to targeted sweep.


### PR DESCRIPTION
**Goals (and why)**:
- Fix #3402 (by removing the confusing method)

**Implementation Description (bullets)**:
- Remove the sleepForBackoff() method from `AbstractTransactionManager`, and calls to it when retrying

**Testing (What was existing testing like?  What have you done to improve it?)**:
- There wasn't a test that we backoff (but this is expected, since no implementations exist in the Atlas codebase, nor in internal repositories, looking at a code-search)

**Concerns (what feedback would you like?)**:
- Did I miss any places where this is actually used? I did a find-usages + a search for `sleepForBackoff()` on internal github.
- Should we support some kind of backoff?

**Where should we start reviewing?**: `AbstractTransactionManager.java`

**Priority (whenever / two weeks / yesterday)**: Whenever. This is more a cleanliness/hygiene thing.