### PR TITLE
Add versionId to SimpleTokenInfo for Lock State Logger

### DIFF
--- a/lock-impl/src/main/java/com/palantir/lock/logger/SimpleTokenInfo.java
+++ b/lock-impl/src/main/java/com/palantir/lock/logger/SimpleTokenInfo.java
@@ -17,6 +17,8 @@ package com.palantir.lock.logger;
 
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import org.immutables.value.Value;
 
 import com.google.common.base.Preconditions;
@@ -32,6 +34,7 @@ public abstract class SimpleTokenInfo {
                 .clientId(Preconditions.checkNotNull(token.getClient()).getClientId())
                 .requestThread(token.getRequestingThread())
                 .createAt(new Date(token.getCreationDateMs()).toString())
+                .versionId(token.getVersionId())
                 .build();
     }
 
@@ -52,4 +55,8 @@ public abstract class SimpleTokenInfo {
 
     @Value.Parameter
     public abstract String getCreateAt();
+
+    @Nullable
+    @Value.Parameter
+    public abstract Long getVersionId();
 }


### PR DESCRIPTION
**Goals (and why)**:
Improve ability to debug held locks when dumping the lock server state.

**Implementation Description (bullets)**:
Adds new field to SimpleTokenInfo.

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3435)
<!-- Reviewable:end -->
