### PR TITLE
prune dependencies of atlasdb-commons

### DIFF
--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -6,17 +6,10 @@ dependencies {
     compile project(":commons-executors")
     compile project(":commons-annotations")
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
-    compile group: 'com.google.code.findbugs', name: 'jsr305'
-    compile group: 'com.google.guava', name: 'guava'
-    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
     compile (group: 'io.dropwizard.metrics', name: 'metrics-core') {
         exclude (module: 'slf4j-api')
     }
-    compile group: 'javax.ws.rs', name: 'javax.ws.rs-api'
     compile group: 'net.jpountz.lz4', name: 'lz4'
-    compile group: 'org.slf4j', name: 'slf4j-api'
-    compile group: 'com.palantir.safe-logging', name: 'safe-logging'
 
     processor group: 'org.immutables', name: 'value'
 

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     compile group: 'net.jpountz.lz4', name: 'lz4'
     compile group: 'org.slf4j', name: 'slf4j-api'
     compile group: 'com.palantir.safe-logging', name: 'safe-logging'
-    compile group: 'org.apache.commons', name: 'commons-math3', version: '3.2'
 
     processor group: 'org.immutables', name: 'value'
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -74,6 +74,10 @@ develop
            This makes it easier for a service to expose these via a health check
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3431>`__)
 
+    *    - |improved| |devbreak|
+         - The atlasdb-commons package has had its dependency tree greatly pruned of unused cruft.
+           This may introduce a devreak to users transitively relying on these old dependencies.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3439>`__)
 
 =======
 v0.99.0


### PR DESCRIPTION
**Goals (and why)**:
rzheng wants to get rid of the unused dependency on apache commons-math3 which happens to be low-hanging fruit to get rid of the download time of an extra 1.6MiB package to download in our webstart.

**Testing (What was existing testing like?  What have you done to improve it?)**:
building atlas and some git-grepping around atlas' old mother project for non-explicitly declared dependency usage

**Concerns (what feedback would you like?)**:
could break the build for atlas' old mother project, but I can pinkie-promise to fix it myself with explicit dependency additions there if this happens

**Where should we start reviewing?**:
I broke it into multiple commits, one for commons-math3, and one for the rest of the unused junk we found.
If you don't want me rocking the boat too hard, we can omit the 'rest of the unused junk' commit.

**Priority (whenever / two weeks / yesterday)**:
whenever

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3439)
<!-- Reviewable:end -->
