### PR TITLE
use conservative exception handler by default

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceRuntimeConfig.java
@@ -103,7 +103,7 @@ public abstract class CassandraKeyValueServiceRuntimeConfig implements KeyValueS
      */
     @Value.Default
     public boolean conservativeRequestExceptionHandler() {
-        return false;
+        return true;
     }
 
     public static CassandraKeyValueServiceRuntimeConfig getDefault() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandler.java
@@ -90,7 +90,7 @@ class CassandraRequestExceptionHandler {
         if (useConservativeHandler.get()) {
             return Conservative.INSTANCE;
         } else {
-            return Default.INSTANCE;
+            return LegacyExceptionHandler.INSTANCE;
         }
     }
 
@@ -245,8 +245,8 @@ class CassandraRequestExceptionHandler {
         boolean shouldRetryOnDifferentHost(Exception ex, int maxTriesSameHost, int numberOfAttempts);
     }
 
-    private static class Default implements RequestExceptionHandlerStrategy {
-        private static final RequestExceptionHandlerStrategy INSTANCE = new Default();
+    private static class LegacyExceptionHandler implements RequestExceptionHandlerStrategy {
+        private static final RequestExceptionHandlerStrategy INSTANCE = new LegacyExceptionHandler();
 
         private static final long BACKOFF_DURATION = Duration.ofSeconds(1).toMillis();
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
@@ -65,12 +65,12 @@ public class CassandraRequestExceptionHandlerTest {
             .collect(Collectors.toSet());
 
     private boolean currentMode = true;
-    private CassandraRequestExceptionHandler handlerDefault;
+    private CassandraRequestExceptionHandler handlerLegacy;
     private CassandraRequestExceptionHandler handlerConservative;
 
     @Before
     public void setup() {
-        handlerDefault = new CassandraRequestExceptionHandler(
+        handlerLegacy = new CassandraRequestExceptionHandler(
                 () -> MAX_RETRIES_PER_HOST,
                 () -> MAX_RETRIES_TOTAL,
                 () -> false,
@@ -86,33 +86,33 @@ public class CassandraRequestExceptionHandlerTest {
     @Test
     public void retryableExceptionsAreRetryableDefault() {
         for (Exception ex : ALL_EXCEPTIONS) {
-            assertTrue(String.format("Exception %s should be retryable", ex), handlerDefault.isRetryable(ex));
+            assertTrue(String.format("Exception %s should be retryable", ex), handlerLegacy.isRetryable(ex));
         }
-        assertFalse("RuntimeException is not retryable", handlerDefault.isRetryable(new RuntimeException()));
+        assertFalse("RuntimeException is not retryable", handlerLegacy.isRetryable(new RuntimeException()));
     }
 
     @Test
     public void connectionExceptionsWithSufficientAttemptsShouldBlacklistDefault() {
         for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertFalse("MAX_RETRIES_PER_HOST - 1 attempts should not blacklist",
-                    handlerDefault.shouldBlacklist(ex, MAX_RETRIES_PER_HOST - 1));
+                    handlerLegacy.shouldBlacklist(ex, MAX_RETRIES_PER_HOST - 1));
         }
 
         for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("MAX_RETRIES_PER_HOST attempts with exception %s should blacklist", ex),
-                    handlerDefault.shouldBlacklist(ex, MAX_RETRIES_PER_HOST));
+                    handlerLegacy.shouldBlacklist(ex, MAX_RETRIES_PER_HOST));
         }
 
         Exception ffException = Iterables.get(FAST_FAILOVER_EXCEPTIONS, 0);
         assertFalse(String.format("Exception %s should not blacklist", ffException),
-                handlerDefault.shouldBlacklist(ffException, MAX_RETRIES_PER_HOST));
+                handlerLegacy.shouldBlacklist(ffException, MAX_RETRIES_PER_HOST));
     }
 
     @Test
     public void connectionExceptionsShouldBackoffDefault() {
         for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should backoff", ex),
-                    handlerDefault.shouldBackoff(ex, handlerDefault.getStrategy()));
+                    handlerLegacy.shouldBackoff(ex, handlerLegacy.getStrategy()));
         }
     }
 
@@ -120,14 +120,14 @@ public class CassandraRequestExceptionHandlerTest {
     public void cassandraLoadExceptionsShouldBackoffDefault() {
         for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should backoff", ex),
-                    handlerDefault.shouldBackoff(ex, handlerDefault.getStrategy()));
+                    handlerLegacy.shouldBackoff(ex, handlerLegacy.getStrategy()));
         }
     }
 
     @Test
     public void transientExceptionsShouldNotBackoffDefault() {
         for (Exception ex : TRANSIENT_EXCEPTIONS) {
-            assertFalse(handlerDefault.shouldBackoff(ex, handlerDefault.getStrategy()));
+            assertFalse(handlerLegacy.shouldBackoff(ex, handlerLegacy.getStrategy()));
         }
     }
 
@@ -135,7 +135,7 @@ public class CassandraRequestExceptionHandlerTest {
     public void fastFailoverExceptionsShouldNotBackoffDefault() {
         for (Exception ex : FAST_FAILOVER_EXCEPTIONS) {
             assertFalse(String.format("Exception %s should not backoff", ex),
-                    handlerDefault.shouldBackoff(ex, handlerDefault.getStrategy()));
+                    handlerLegacy.shouldBackoff(ex, handlerLegacy.getStrategy()));
         }
     }
 
@@ -143,20 +143,20 @@ public class CassandraRequestExceptionHandlerTest {
     public void connectionExceptionRetriesOnDifferentHostAfterSufficientRetriesDefault() {
         for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertFalse(String.format("Exception %s should not retry on different host", ex),
-                    handlerDefault.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST - 1,
-                            handlerDefault.getStrategy()));
+                    handlerLegacy.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST - 1,
+                            handlerLegacy.getStrategy()));
         }
 
         for (Exception ex : CONNECTION_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should retry on different host", ex),
-                    handlerDefault.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST, handlerDefault.getStrategy()));
+                    handlerLegacy.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST, handlerLegacy.getStrategy()));
         }
     }
 
     @Test
     public void cassandraLoadExceptionRetriesOnSameHostDefault() {
         for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
-            assertFalse(handlerDefault.shouldRetryOnDifferentHost(ex, 0, handlerDefault.getStrategy()));
+            assertFalse(handlerLegacy.shouldRetryOnDifferentHost(ex, 0, handlerLegacy.getStrategy()));
         }
     }
 
@@ -164,7 +164,7 @@ public class CassandraRequestExceptionHandlerTest {
     public void cassandraLoadExceptionRetriesOnDifferentHostAfterSufficientRetriesDefault() {
         for (Exception ex : INDICATIVE_OF_CASSANDRA_LOAD_EXCEPTIONS) {
             assertTrue(String.format("Exception %s should retry on different host", ex),
-                    handlerDefault.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST, handlerDefault.getStrategy()));
+                    handlerLegacy.shouldRetryOnDifferentHost(ex, MAX_RETRIES_PER_HOST, handlerLegacy.getStrategy()));
         }
     }
 
@@ -172,7 +172,7 @@ public class CassandraRequestExceptionHandlerTest {
     public void fastFailoverExceptionAlwaysRetriesOnDifferentHostDefault() {
         for (Exception ex : FAST_FAILOVER_EXCEPTIONS) {
             assertTrue(String.format("Fast failover exception %s should always retry on different host", ex),
-                    handlerDefault.shouldRetryOnDifferentHost(ex, 0, handlerDefault.getStrategy()));
+                    handlerLegacy.shouldRetryOnDifferentHost(ex, 0, handlerLegacy.getStrategy()));
         }
     }
 
@@ -303,7 +303,7 @@ public class CassandraRequestExceptionHandlerTest {
             assertTrue(String.format("If the max retries per host has been exceeded, we should always retry on a"
                             + " different host - but we didn't for exception %s", ex),
                     handlerConservative.shouldRetryOnDifferentHost(
-                            ex, MAX_RETRIES_PER_HOST + 1, handlerDefault.getStrategy()));
+                            ex, MAX_RETRIES_PER_HOST + 1, handlerLegacy.getStrategy()));
         }
     }
 

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -79,6 +79,12 @@ develop
            This may introduce a devreak to users transitively relying on these old dependencies.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3439>`__)
 
+    *    - |changed|
+         - ``CassandraRequestExceptionHandler`` is set to use ``Conservative`` exception handler by default. Main differences are:
+            - Conservative exception handler backs off for larger subset of exceptions
+            - Backoff period is exponentially increasing (but cannot go beyond ``MAX_BACKOFF``)
+            - Retries are executed on a different host rather than the same host for a larger subset of exceptions
+
 =======
 v0.99.0
 =======

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -81,9 +81,11 @@ develop
 
     *    - |changed|
          - ``CassandraRequestExceptionHandler`` is set to use ``Conservative`` exception handler by default. Main differences are:
+
             - Conservative exception handler backs off for larger subset of exceptions
             - Backoff period is exponentially increasing (but cannot go beyond ``MAX_BACKOFF``)
             - Retries are executed on a different host rather than the same host for a larger subset of exceptions
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3444>`__)
 
 =======
 v0.99.0

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -85,6 +85,7 @@ develop
             - Conservative exception handler backs off for larger subset of exceptions
             - Backoff period is exponentially increasing (but cannot go beyond ``MAX_BACKOFF``)
             - Retries are executed on a different host rather than the same host for a larger subset of exceptions
+
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3444>`__)
 
 =======


### PR DESCRIPTION
**Goals (and why)**:
Use ``Conservative`` exception handler by default.

**Implementation Description (bullets)**:
- Set the default value returned by ``conservativeRequestExceptionHandler()`` to true in ``CassandraKeyValueServiceRuntimeConfig``. 
- Rename ``Default`` exception handler to ``LegacyExceptionHandler`` to avoid misunderstanding.

**Testing (What was existing testing like?  What have you done to improve it?)**:
- Unit tests were already there for Conservative strategy. We have also tested this on field for some services.

**Concerns (what feedback would you like?)**:
Even if this is the default strategy, we still have a runtime config option stated as ``conservativeRequestExceptionHandler``. I haven't removed this option for backwards compatibility in this PR, but I think we should be removing this in future versions.

**Where should we start reviewing?**:
``CassandraKeyValueServiceRuntimeConfig``

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3444)
<!-- Reviewable:end -->
