### PR TITLE
Batch lock refreshes

### DIFF
--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -50,6 +50,12 @@ develop
     *    - Type
          - Change
 
+    *    - |fixed|
+         - LockRefreshingLockService now batches calls to refresh locks in batches of 750K.
+           Previously, trying to refresh a larger number of locks could trigger the 50MB limit in payload size.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/????>`__)
+
+
     *    - |improved|
          - AtlasDB now correctly closes the targeted sweeper on shutdown, and logs less by default.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/347>`__)

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -39,7 +39,7 @@ import com.palantir.lock.SimplifyingLockService;
 
 @SuppressWarnings("checkstyle:FinalClass") // Avoid breaking API in case someone extended this
 public class LockRefreshingLockService extends SimplifyingLockService {
-    public static final int REFRESH_BATCH_SIZE = 650_000;
+    public static final int REFRESH_BATCH_SIZE = 500_000;
     private static final Logger log = LoggerFactory.getLogger(LockRefreshingLockService.class);
 
     final LockService delegate;

--- a/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockRefreshingLockService.java
@@ -130,7 +130,7 @@ public class LockRefreshingLockService extends SimplifyingLockService {
         }
         Set<LockRefreshToken> refreshedTokens = new HashSet<>();
         // We batch refreshes to avoid sending payload of excessive size
-        for (List<LockRefreshToken> tokenBatch: Iterables.partition(refreshCopy, REFRESH_BATCH_SIZE)) {
+        for (List<LockRefreshToken> tokenBatch : Iterables.partition(refreshCopy, REFRESH_BATCH_SIZE)) {
             refreshedTokens.addAll(delegate.refreshLockRefreshTokens(tokenBatch));
         }
         for (LockRefreshToken token : refreshCopy) {

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LockServiceImplTest.java
@@ -21,9 +21,7 @@ import static org.junit.Assert.assertThat;
 import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
 import static uk.org.lidalia.slf4jtest.LoggingEvent.warn;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +35,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSortedMap;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockMode;
@@ -156,18 +155,7 @@ public final class LockServiceImplTest {
             tokens.add(lockServiceWithSlowLogDisabled.lock("test", request));
         }
 
-        Assertions.assertThat(approximateSizeInKB(tokens)).isLessThan(45);
-    }
-
-    private static int approximateSizeInKB(Set<LockRefreshToken> tokens) throws IOException {
-        ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-
-        try(ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteOutputStream)) {
-            objectOutputStream.writeObject(tokens);
-            objectOutputStream.flush();
-        }
-
-        return byteOutputStream.toByteArray().length / 1024;
+        Assertions.assertThat(new ObjectMapper().writeValueAsString(tokens).length()).isLessThan(45_000);
     }
 
     private static void assertContainsMatchingLoggingEvent(List<LoggingEvent> actuals, LoggingEvent expected) {


### PR DESCRIPTION
**Goals (and why)**:
Fix https://github.com/palantir/atlasdb/issues/3436

**Implementation Description (bullets)**:
Batch refresh calls in batches of 750K

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3450)
<!-- Reviewable:end -->
