### PR TITLE
[no release notes] fix flaking test

### DIFF
--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -326,11 +326,14 @@ public class PaxosTimeLockServerIntegrationTest {
         long firstServiceFirstTimestamp = timestampService1.getFreshTimestamp();
         long secondServiceFirstTimestamp = timestampService2.getFreshTimestamp();
 
-        long firstServiceSecondTimestamp = timestampService1.getFreshTimestamp();
+        long firstServiceSecondTimestamp = timestampService1
+                .getFreshTimestamps(100)
+                .getUpperBound();
+
         long secondServiceSecondTimestamp = timestampService2.getFreshTimestamp();
 
-        assertEquals(firstServiceFirstTimestamp + 1, firstServiceSecondTimestamp);
-        assertEquals(secondServiceFirstTimestamp + 1, secondServiceSecondTimestamp);
+        assertThat(firstServiceSecondTimestamp - firstServiceFirstTimestamp).isGreaterThanOrEqualTo(100L);
+        assertThat(secondServiceSecondTimestamp - secondServiceFirstTimestamp).isBetween(0L, 100L);
     }
 
     @Test

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/PaxosTimeLockServerIntegrationTest.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.timelock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -326,14 +325,13 @@ public class PaxosTimeLockServerIntegrationTest {
         long firstServiceFirstTimestamp = timestampService1.getFreshTimestamp();
         long secondServiceFirstTimestamp = timestampService2.getFreshTimestamp();
 
-        long firstServiceSecondTimestamp = timestampService1
-                .getFreshTimestamps(100)
-                .getUpperBound();
+        getFortyTwoFreshTimestamps(timestampService1);
 
+        long firstServiceSecondTimestamp = timestampService1.getFreshTimestamp();
         long secondServiceSecondTimestamp = timestampService2.getFreshTimestamp();
 
-        assertThat(firstServiceSecondTimestamp - firstServiceFirstTimestamp).isGreaterThanOrEqualTo(100L);
-        assertThat(secondServiceSecondTimestamp - secondServiceFirstTimestamp).isBetween(0L, 100L);
+        assertThat(firstServiceSecondTimestamp - firstServiceFirstTimestamp).isGreaterThanOrEqualTo(FORTY_TWO);
+        assertThat(secondServiceSecondTimestamp - secondServiceFirstTimestamp).isBetween(0L, (long) FORTY_TWO);
     }
 
     @Test


### PR DESCRIPTION
**Goals (and why)**:
To prevent a test flake in timelockServer integration test. I believe the flake happens because of the assumption that difference between two successive getFreshTimestamp() calls should be strictly 1; but actually this can not be guaranteed. If client calls getFreshTimestamp(), and server receives the rpc, it will increment the timestamp by one, and respond to the client; but if the client cannot receive the response it will retry by calling getFreshTimestamp() again and the returned result will be bigger than the previous ts by 2.

**Implementation Description (bullets)**:
I think the code is easier to understand, but I will try explaining 😄 

Rather than calling getFreshTimestamp() twice, and asserting the difference is equal to one; first client calls getFreshTimestamps() with a range that is bigger than the number of retries can be made on client side (100 this case). If the request of first client affects second client's timestamp; then the second call of second client should return a timestamp that is bigger than the first timestamp of second client at least by 100. 

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3457)
<!-- Reviewable:end -->
