### PR TITLE
Throw specific exception when transaction is committed

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommittedTransactionException.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommittedTransactionException.java
@@ -16,7 +16,7 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
-public final class CommittedTransactionException extends RuntimeException {
+public final class CommittedTransactionException extends IllegalStateException {
     public CommittedTransactionException() {
         super("Transaction must be uncommitted");
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommittedTransactionException.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommittedTransactionException.java
@@ -18,6 +18,6 @@ package com.palantir.atlasdb.transaction.impl;
 
 public final class CommittedTransactionException extends RuntimeException {
     public CommittedTransactionException() {
-        super("Transaction must not be committed");
+        super("Transaction must be uncommitted");
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommittedTransactionException.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommittedTransactionException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+public final class CommittedTransactionException extends RuntimeException {
+    public CommittedTransactionException() {
+        super("Transaction must not be committed");
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -304,7 +304,10 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             throw new TransactionFailedRetriableException("Transaction timed out.");
         }
         Preconditions.checkArgument(allowHiddenTableAccess || !AtlasDbConstants.hiddenTables.contains(tableRef));
-        ensureUncommitted();
+
+        if (!(state.get() == State.UNCOMMITTED || state.get() == State.COMMITTING)) {
+            throw new CommittedTransactionException();
+        }
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -304,8 +304,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             throw new TransactionFailedRetriableException("Transaction timed out.");
         }
         Preconditions.checkArgument(allowHiddenTableAccess || !AtlasDbConstants.hiddenTables.contains(tableRef));
-        Preconditions.checkState(state.get() == State.UNCOMMITTED || state.get() == State.COMMITTING,
-                "Transaction must be uncommitted.");
+        ensureUncommitted();
     }
 
     @Override
@@ -801,8 +800,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
                     int userRequestedSize,
                     ConsistentVisitor<RowResult<byte[]>, K> visitor)
                     throws K {
-                Preconditions.checkState(state.get() == State.UNCOMMITTED,
-                        "Transaction must be uncommitted.");
+                ensureUncommitted();
 
                 int requestSize = range.getBatchHint() != null ? range.getBatchHint() : userRequestedSize;
                 int preFilterBatchSize = getRequestHintToKvStore(requestSize);
@@ -996,7 +994,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
     private <T> SortedMap<Cell, T> postFilterRows(TableReference tableRef,
                                                   List<RowResult<Value>> rangeRows,
                                                   Function<Value, T> transformer) {
-        Preconditions.checkState(state.get() == State.UNCOMMITTED, "Transaction must be uncommitted.");
+        ensureUncommitted();
 
         if (rangeRows.isEmpty()) {
             return ImmutableSortedMap.of();
@@ -1182,7 +1180,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         numWriters.incrementAndGet();
         try {
             // We need to check the status after incrementing writers to ensure that we fail if we are committing.
-            Preconditions.checkState(state.get() == State.UNCOMMITTED, "Transaction must be uncommitted.");
+            ensureUncommitted();
 
             ConcurrentNavigableMap<Cell, byte[]> writes = getLocalWrites(tableRef);
 
@@ -1228,7 +1226,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             return;
         }
         while (true) {
-            Preconditions.checkState(state.get() == State.UNCOMMITTED, "Transaction must be uncommitted.");
+            ensureUncommitted();
             if (state.compareAndSet(State.UNCOMMITTED, State.ABORTED)) {
                 if (hasWrites()) {
                     throwIfPreCommitRequirementsNotMet(null, getStartTimestamp());
@@ -1249,6 +1247,12 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
         return state.get() == State.UNCOMMITTED;
     }
 
+    private void ensureUncommitted() {
+        if (!isUncommitted()) {
+            throw new CommittedTransactionException();
+        }
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     /// Committing
     ///////////////////////////////////////////////////////////////////////////
@@ -1267,7 +1271,7 @@ public class SnapshotTransaction extends AbstractTransaction implements Constrai
             throw new IllegalStateException("this transaction has already failed");
         }
         while (true) {
-            Preconditions.checkState(state.get() == State.UNCOMMITTED, "Transaction must be uncommitted.");
+            ensureUncommitted();
             if (state.compareAndSet(State.UNCOMMITTED, State.COMMITTING)) {
                 break;
             }

--- a/docs/source/release_notes/release-notes.rst
+++ b/docs/source/release_notes/release-notes.rst
@@ -55,6 +55,10 @@ develop
            Previously, trying to refresh a larger number of locks could trigger the 50MB limit in payload size.
            (`Pull Request <https://github.com/palantir/atlasdb/pull/3450>`__)
 
+    *    - |improved|
+         - Throw more specific CommittedTransactionException when operating on a committed transaction.
+           (`Pull Request <https://github.com/palantir/atlasdb/pull/3460>`__)
+
 ========
 v0.101.0
 ========


### PR DESCRIPTION
**Goals (and why)**:
We've run into issues where concurrent reads/writes operating on the same transaction, at which point on of the operations fails and aborts the transaction, causing the other reads/writes to throw due to the transaction no longer being uncommitted. We'd like to handle this case explicitly and therefore need an specific exception to catch.

**Implementation Description (bullets)**:

**Testing (What was existing testing like?  What have you done to improve it?)**:

**Concerns (what feedback would you like?)**:

**Where should we start reviewing?**:

**Priority (whenever / two weeks / yesterday)**:

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3460)
<!-- Reviewable:end -->
