### PR TITLE
Allow multiple registration of TS metrics

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/util/MetricsManager.java
@@ -108,7 +108,7 @@ public class MetricsManager {
     /**
      * Add a new gauge metric of the given name or get the existing gauge if it is already registered.
      *
-     * If a non-gauge metric with the same name already exists, return the supplied gauge, but do not register it.
+     * @throws IllegalStateException if a non-gauge metric with the same name already exists.
      */
     public Gauge registerOrGet(Class clazz, String metricName, Gauge gauge, Map<String, String> tag) {
         MetricName metricToAdd = MetricName.builder()
@@ -119,11 +119,11 @@ public class MetricsManager {
         try {
             return taggedMetricRegistry.gauge(metricToAdd, gauge);
         } catch (IllegalArgumentException ex) {
-            log.warn("Tried to add a gauge to a metric name {} that has non-gauge metrics associated with it."
+            log.error("Tried to add a gauge to a metric name {} that has non-gauge metrics associated with it."
                     + " This indicates a product bug.",
                     SafeArg.of("metricName", metricName),
                     ex);
-            return gauge;
+            throw ex;
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolingContainer.java
@@ -284,7 +284,7 @@ public class CassandraClientPoolingContainer implements PoolingContainer<Cassand
     }
 
     private void registerPoolMetric(String metricName, Gauge gauge) {
-        metricsManager.registerIfNotExists(
+        metricsManager.registerOrGet(
                 CassandraClientPoolingContainer.class,
                 metricName,
                 gauge,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TimestampedAccumulatingValueMetric.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TimestampedAccumulatingValueMetric.java
@@ -20,6 +20,10 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.codahale.metrics.Gauge;
 
+/**
+ * A Gauge that takes a timestamp on each call to {@link #setValue(Long, long)} and {@link #setValue(Long, long)}, and
+ * exposes a method {@link #getLatestTimestamp()} to retrieve the greatest timestamp observed so far.
+ */
 public class TimestampedAccumulatingValueMetric implements Gauge<Long> {
     private final AccumulatingValueMetric delegate;
     private final AtomicLong latestTimestamp = new AtomicLong(0);

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TimestampedAccumulatingValueMetric.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/util/TimestampedAccumulatingValueMetric.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.util;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.codahale.metrics.Gauge;
+
+public class TimestampedAccumulatingValueMetric implements Gauge<Long> {
+    private final AccumulatingValueMetric delegate;
+    private final AtomicLong latestTimestamp = new AtomicLong(0);
+
+    public TimestampedAccumulatingValueMetric(AccumulatingValueMetric delegate) {
+        this.delegate = delegate;
+    }
+
+    public static TimestampedAccumulatingValueMetric create() {
+        return new TimestampedAccumulatingValueMetric(new AccumulatingValueMetric());
+    }
+
+    @Override
+    public Long getValue() {
+        return delegate.getValue();
+    }
+
+    public void setValue(Long newValue, long timestamp) {
+        forwardTimestampTo(timestamp);
+        delegate.setValue(newValue);
+    }
+
+    public void accumulateValue(Long newValue, long timestamp) {
+        forwardTimestampTo(timestamp);
+        delegate.accumulateValue(newValue);
+    }
+
+    private void forwardTimestampTo(long timestamp) {
+        latestTimestamp.accumulateAndGet(timestamp, Long::max);
+    }
+
+    public long getLatestTimestamp() {
+        return latestTimestamp.get();
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/util/AggregatingVersionedMetric.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/AggregatingVersionedMetric.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the BSD-3 License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util;
+
+import com.codahale.metrics.Gauge;
+
+/**
+ * A Gauge based off of {@link AggregatingVersionedSupplier} that exposes methods to interact with the underlying
+ * Supplier.
+ */
+public class AggregatingVersionedMetric<T> implements Gauge<T> {
+    private final AggregatingVersionedSupplier<T> delegate;
+
+    public AggregatingVersionedMetric(AggregatingVersionedSupplier<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public T getValue() {
+        return delegate.get().value();
+    }
+
+    public void update(Integer key, T value) {
+        delegate.update(key, value);
+    }
+
+    public VersionedType<T> getVersionedValue() {
+        return delegate.get();
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactionOutcomeMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/compact/CompactionOutcomeMetrics.java
@@ -31,7 +31,7 @@ class CompactionOutcomeMetrics {
 
     CompactionOutcomeMetrics(MetricsManager metricsManager) {
         Arrays.stream(BackgroundCompactor.CompactionOutcome.values()).forEach(outcome ->
-                metricsManager.registerIfNotExists(BackgroundCompactor.class, "outcome",
+                metricsManager.registerOrGet(BackgroundCompactor.class, "outcome",
                         () -> getOutcomeCount(outcome), ImmutableMap.of("status", outcome.name())));
         reservoir = new SlidingTimeWindowReservoir(60L, TimeUnit.SECONDS);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/SweepOutcomeMetrics.java
@@ -53,7 +53,7 @@ public final class SweepOutcomeMetrics {
     }
 
     private void registerMetric(MetricsManager manager, List<SweepOutcome> outcomes, Class<?> forClass) {
-        outcomes.forEach(outcome -> manager.registerIfNotExists(forClass, AtlasDbMetricNames.SWEEP_OUTCOME,
+        outcomes.forEach(outcome -> manager.registerOrGet(forClass, AtlasDbMetricNames.SWEEP_OUTCOME,
                 () -> getOutcomeCount(outcome), ImmutableMap.of(AtlasDbMetricNames.TAG_OUTCOME, outcome.name())));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
@@ -16,6 +16,13 @@
 
 package com.palantir.atlasdb.sweep.metrics;
 
+import static com.palantir.atlasdb.AtlasDbMetricNames.ABORTED_WRITES_DELETED;
+import static com.palantir.atlasdb.AtlasDbMetricNames.ENQUEUED_WRITES;
+import static com.palantir.atlasdb.AtlasDbMetricNames.ENTRIES_READ;
+import static com.palantir.atlasdb.AtlasDbMetricNames.SWEEP_TS;
+import static com.palantir.atlasdb.AtlasDbMetricNames.TAG_STRATEGY;
+import static com.palantir.atlasdb.AtlasDbMetricNames.TOMBSTONES_PUT;
+
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
@@ -37,9 +44,11 @@ import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.atlasdb.util.AccumulatingValueMetric;
 import com.palantir.atlasdb.util.CurrentValueMetric;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.atlasdb.util.TimestampedAccumulatingValueMetric;
 import com.palantir.common.time.Clock;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.util.AggregatingVersionedMetric;
 import com.palantir.util.AggregatingVersionedSupplier;
 import com.palantir.util.CachedComposedSupplier;
 
@@ -116,45 +125,53 @@ public class TargetedSweepMetrics {
     }
 
     private static final class MetricsForStrategy {
-        private final AccumulatingValueMetric enqueuedWrites = new AccumulatingValueMetric();
-        private final AccumulatingValueMetric entriesRead = new AccumulatingValueMetric();
-        private final AccumulatingValueMetric tombstonesPut = new AccumulatingValueMetric();
-        private final AccumulatingValueMetric abortedWritesDeleted = new AccumulatingValueMetric();
-        private final CurrentValueMetric<Long> sweepTimestamp = new CurrentValueMetric<>();
-        private final AggregatingVersionedSupplier<Long> lastSweptTsSupplier;
-        private final AtomicLong lastWrittenTs = new AtomicLong(0L);
+        private final MetricsManager manager;
+        private final TimestampedAccumulatingValueMetric enqueuedWrites;
+        private final AccumulatingValueMetric entriesRead;
+        private final AccumulatingValueMetric tombstonesPut;
+        private final AccumulatingValueMetric abortedWritesDeleted;
+        private final CurrentValueMetric<Long> sweepTimestamp;
+        private final AggregatingVersionedMetric<Long> lastSweptTs;
 
         private MetricsForStrategy(MetricsManager manager, String strategy, Function<Long, Long> tsToMillis,
                 Clock wallClock, long recomputeMillis) {
-            Map<String, String> tag = ImmutableMap.of(AtlasDbMetricNames.TAG_STRATEGY, strategy);
-            register(manager, AtlasDbMetricNames.ENQUEUED_WRITES, enqueuedWrites, tag);
-            register(manager, AtlasDbMetricNames.ENTRIES_READ, entriesRead, tag);
-            register(manager, AtlasDbMetricNames.TOMBSTONES_PUT, tombstonesPut, tag);
-            register(manager, AtlasDbMetricNames.ABORTED_WRITES_DELETED, abortedWritesDeleted, tag);
-            register(manager, AtlasDbMetricNames.SWEEP_TS, sweepTimestamp, tag);
+            Map<String, String> tag = ImmutableMap.of(TAG_STRATEGY, strategy);
+            this.manager = manager;
+            enqueuedWrites = register(ENQUEUED_WRITES, TimestampedAccumulatingValueMetric.create(), tag);
+            entriesRead = registerAccumulating(ENTRIES_READ, tag);
+            tombstonesPut = registerAccumulating(TOMBSTONES_PUT, tag);
+            abortedWritesDeleted = registerAccumulating(ABORTED_WRITES_DELETED, tag);
+            sweepTimestamp = register(SWEEP_TS, new CurrentValueMetric<>(), tag);
 
-            lastSweptTsSupplier = new AggregatingVersionedSupplier<>(TargetedSweepMetrics::minimum, recomputeMillis);
+            AggregatingVersionedSupplier<Long> lastSweptTsSupplier = new AggregatingVersionedSupplier<>(
+                    TargetedSweepMetrics::minimum, recomputeMillis);
+            lastSweptTs = register(AtlasDbMetricNames.LAST_SWEPT_TS,
+                    new AggregatingVersionedMetric<>(lastSweptTsSupplier), tag);
+
             Supplier<Long> millisSinceLastSweptTs = new CachedComposedSupplier<>(
-                    lastSweptTs -> estimateMillisSinceTs(lastSweptTs, wallClock, tsToMillis),
-                    lastSweptTsSupplier);
+                    swept -> estimateMillisSinceTs(swept, wallClock, tsToMillis), lastSweptTs::getVersionedValue);
 
-            register(manager, AtlasDbMetricNames.LAST_SWEPT_TS, () -> lastSweptTsSupplier.get().value(), tag);
-            register(manager, AtlasDbMetricNames.LAG_MILLIS, millisSinceLastSweptTs::get, tag);
+            register(AtlasDbMetricNames.LAG_MILLIS, millisSinceLastSweptTs::get, tag);
         }
 
-        private void register(MetricsManager manager, String name, Gauge<Long> metric, Map<String, String> tag) {
-            manager.registerMetric(TargetedSweepMetrics.class, name, metric, tag);
+        private AccumulatingValueMetric registerAccumulating(String name, Map<String, String> tag) {
+            return register(name, new AccumulatingValueMetric(), tag);
         }
 
-        private Long estimateMillisSinceTs(Long lastSweptTs, Clock clock, Function<Long, Long> tsToMillis) {
-            if (lastSweptTs == null) {
+        @SuppressWarnings("unchecked")
+        private <T extends Gauge<Long>> T register(String name, T metric, Map<String, String> tag) {
+            return (T) manager.registerOrGet(TargetedSweepMetrics.class, name, metric, tag);
+        }
+
+        private Long estimateMillisSinceTs(Long swept, Clock clock, Function<Long, Long> tsToMillis) {
+            if (swept == null) {
                 return null;
             }
-            if (lastSweptTs >= lastWrittenTs.get()) {
+            if (swept >= enqueuedWrites.getLatestTimestamp()) {
                 return 0L;
             }
             long timeBeforeRecomputing = System.currentTimeMillis();
-            long result = clock.getTimeMillis() - tsToMillis.apply(lastSweptTs);
+            long result = clock.getTimeMillis() - tsToMillis.apply(swept);
 
             long timeTaken = System.currentTimeMillis() - timeBeforeRecomputing;
             if (timeTaken > TimeUnit.SECONDS.toMillis(10)) {
@@ -166,8 +183,7 @@ public class TargetedSweepMetrics {
         }
 
         private void updateEnqueuedWrites(long writes, long timestamp) {
-            enqueuedWrites.accumulateValue(writes);
-            lastWrittenTs.accumulateAndGet(timestamp, Long::max);
+            enqueuedWrites.accumulateValue(writes, timestamp);
         }
 
         private void updateEntriesRead(long writes) {
@@ -186,8 +202,8 @@ public class TargetedSweepMetrics {
             sweepTimestamp.setValue(value);
         }
 
-        private void updateProgressForShard(int shard, long lastSweptTs) {
-            lastSweptTsSupplier.update(shard, lastSweptTs);
+        private void updateProgressForShard(int shard, long swept) {
+            lastSweptTs.update(shard, swept);
         }
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
@@ -16,18 +16,10 @@
 
 package com.palantir.atlasdb.sweep.metrics;
 
-import static com.palantir.atlasdb.AtlasDbMetricNames.ABORTED_WRITES_DELETED;
-import static com.palantir.atlasdb.AtlasDbMetricNames.ENQUEUED_WRITES;
-import static com.palantir.atlasdb.AtlasDbMetricNames.ENTRIES_READ;
-import static com.palantir.atlasdb.AtlasDbMetricNames.SWEEP_TS;
-import static com.palantir.atlasdb.AtlasDbMetricNames.TAG_STRATEGY;
-import static com.palantir.atlasdb.AtlasDbMetricNames.TOMBSTONES_PUT;
-
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -135,13 +127,14 @@ public class TargetedSweepMetrics {
 
         private MetricsForStrategy(MetricsManager manager, String strategy, Function<Long, Long> tsToMillis,
                 Clock wallClock, long recomputeMillis) {
-            Map<String, String> tag = ImmutableMap.of(TAG_STRATEGY, strategy);
+            Map<String, String> tag = ImmutableMap.of(AtlasDbMetricNames.TAG_STRATEGY, strategy);
             this.manager = manager;
-            enqueuedWrites = register(ENQUEUED_WRITES, TimestampedAccumulatingValueMetric.create(), tag);
-            entriesRead = registerAccumulating(ENTRIES_READ, tag);
-            tombstonesPut = registerAccumulating(TOMBSTONES_PUT, tag);
-            abortedWritesDeleted = registerAccumulating(ABORTED_WRITES_DELETED, tag);
-            sweepTimestamp = register(SWEEP_TS, new CurrentValueMetric<>(), tag);
+            enqueuedWrites = register(AtlasDbMetricNames.ENQUEUED_WRITES, TimestampedAccumulatingValueMetric.create(),
+                    tag);
+            entriesRead = registerAccumulating(AtlasDbMetricNames.ENTRIES_READ, tag);
+            tombstonesPut = registerAccumulating(AtlasDbMetricNames.TOMBSTONES_PUT, tag);
+            abortedWritesDeleted = registerAccumulating(AtlasDbMetricNames.ABORTED_WRITES_DELETED, tag);
+            sweepTimestamp = register(AtlasDbMetricNames.SWEEP_TS, new CurrentValueMetric<>(), tag);
 
             AggregatingVersionedSupplier<Long> lastSweptTsSupplier = new AggregatingVersionedSupplier<>(
                     TargetedSweepMetrics::minimum, recomputeMillis);


### PR DESCRIPTION
**Goals (and why)**:
Currently, if we register another instance of TS metrics, it will deregister the previous instance. This is fine if you do not have a separate writer and a sweeper, but gets messy if you want to have that, as the large internal products does.
 
**Implementation Description (bullets)**:
Instead of bulldozing over existing metrics, use registerOrGet. Needed to hack around a bit to put the additional information necessary (that was previously part of the class) into the metrics themselves so that information can be shared across instances of TSMetrics.

**Testing (What was existing testing like?  What have you done to improve it?)**:
Added a couple of tests to verify it behaves as expected.

**Concerns (what feedback would you like?)**:
Is there a nicer way of doing this?

**Where should we start reviewing?**:
TSMetrics

**Priority (whenever / two weeks / yesterday)**:
ASAP, because we need metrics to work correctly when we deploy with the large internal product.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/atlasdb/3462)
<!-- Reviewable:end -->
